### PR TITLE
Add CIQ Depot credential

### DIFF
--- a/awx/main/migrations/0191a_add_depot_credential.py
+++ b/awx/main/migrations/0191a_add_depot_credential.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+from awx.main.models import CredentialType
+from awx.main.utils.common import set_current_apps
+
+
+def setup_tower_managed_defaults(apps, schema_editor):
+    set_current_apps(apps)
+    CredentialType.setup_tower_managed_defaults(apps)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('main', '0191_alter_inventorysource_source_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(setup_tower_managed_defaults),
+    ]

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1029,7 +1029,7 @@ ManagedCredentialType(
 )
 
 ManagedCredentialType(
-    namespace='ciq',
+    namespace='ciq_depot',
     kind='cloud',
     name=gettext_noop('CIQ Depot'),
     managed=True,

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1029,6 +1029,45 @@ ManagedCredentialType(
 )
 
 ManagedCredentialType(
+    namespace='ciq',
+    kind='cloud',
+    name=gettext_noop('CIQ Depot'),
+    managed=True,
+    inputs={
+        'fields': [
+            {
+                'id': 'depot_server',
+                'label': gettext_noop('CIQ Depot Server'),
+                'type': 'string',
+                'help_text': gettext_noop('A CIQ Depot server.'),
+                'default': 'depot.ciq.com'
+            },
+            {
+                'id': 'depot_user',
+                'label': gettext_noop('CIQ Depot User'),
+                'type': 'string',
+                'help_text': gettext_noop('A CIQ Depot user.'),
+            },
+            {
+                'id': 'depot_token',
+                'label': gettext_noop('CIQ Depot Token'),
+                'type': 'string',
+                'secret': True,
+                'help_text': gettext_noop('A CIQ Depot Token.'),
+            },
+        ],
+        'required': ['depot_server', 'depot_user', 'depot_token'],
+    },
+    injectors={
+        'env': {
+            'DEPOT_SERVER': '{{depot_server}}',
+            'DEPOT_USER': '{{depot_user}}',
+            'DEPOT_TOKEN': '{{depot_token}}'
+        }
+    },
+)
+
+ManagedCredentialType(
     namespace='kubernetes_bearer_token',
     kind='kubernetes',
     name=gettext_noop('OpenShift or Kubernetes API Bearer Token'),


### PR DESCRIPTION
##### SUMMARY

Support CIQ Depot credentials out of the box in Ascender. With this PR, users would no longer need to set up CIQ Depot credentials as a custom credential. 
