### PR TITLE
Update defaults.py to increase rsyslog max size

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -213,7 +213,7 @@ UI_LIVE_UPDATES_ENABLED = True
 
 # The maximum size of the ansible callback event's res data structure
 # beyond this limit and the value will be removed
-MAX_EVENT_RES_DATA = 700000
+MAX_EVENT_RES_DATA = 25000000
 
 # Note: These settings may be overridden by database settings.
 EVENT_STDOUT_MAX_BYTES_DISPLAY = 1024


### PR DESCRIPTION
Rsyslog by default for Ascender is set to send a max size of 700k for the results data.  This can be problematic with playbooks that made changes with large file diffs or for servers that have over 2000 packages installed and you run package_facts on them.  So we will increase to 25M to ensure we don't improperly drop data in the future.