### PR TITLE
Update requirements.txt for sqlparse 0.5.2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -414,7 +414,7 @@ social-auth-core[openidconnect]==4.4.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   social-auth-app-django
-sqlparse==0.5.1
+sqlparse==0.5.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Unable to build latest ansible due to the latest django-ansible-base requiring sqlparse 0.5.2 and above.  Previously we were requiring 0.5.1 which fails the pip install during the container build process.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - Other

##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
24.0.1
```
