### PR TITLE
Update jinja2 to fix CVE-2024-56326 and CVE-2024-56201

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,7 +28,7 @@ djangorestframework-yaml
 filelock
 GitPython>=3.1.37  # CVE-2023-41040
 irc
-jinja2>=3.1.4  # CVE-2024-34064
+jinja2>=3.1.5  # CVE-2024-56326
 JSON-log-formatter
 jsonschema
 Markdown  # used for formatting API help

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -204,7 +204,7 @@ jaraco-text==3.11.0
     # via
     #   irc
     #   jaraco-collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r /awx_devel/requirements/requirements.in
 jmespath==1.0.1
     # via


### PR DESCRIPTION
##### SUMMARY
Update jinja2 to fix CVE-2024-56326 and CVE-2024-56201