### PR TITLE
Updating PIP to version 23.3 for CVE-2023-5752

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==65.6.3 setuptools_scm[toml]==8.0.4 wheel==0.38.4
+VENV_BOOTSTRAP ?= pip==23.3 setuptools==65.6.3 setuptools_scm[toml]==8.0.4 wheel==0.38.4
 
 NAME ?= awx
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -59,7 +59,7 @@ urllib3>=1.26.19 # CVE-2024-37891
 uWSGI>=2.0.22 # CVE-2023-27522
 uwsgitop
 wheel>=0.38.1  # CVE-2022-40898
-pip==21.2.4  # see UPGRADE BLOCKERs
+pip==23.3  # see CVE-2023-5752
 setuptools==65.6.3  # see UPGRADE BLOCKERs
 setuptools_scm[toml]  # see UPGRADE BLOCKERs, xmlsec build dep
 setuptools-rust>=0.11.4  # cryptography build dep

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -465,7 +465,7 @@ zope-interface==7.0.3
     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.4
+pip==23.3
     # via -r /awx_devel/requirements/requirements.in
 setuptools==65.6.3
     # via


### PR DESCRIPTION
##### SUMMARY
Correcting injection bug in Mercurial that affected PIP.  Does not affect our base.  Removing for scanning purposes.