### PR TITLE
Udating for setuptools to address CVE-2024-6345

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==23.3 setuptools==65.6.3 setuptools_scm[toml]==8.0.4 wheel==0.38.4
+VENV_BOOTSTRAP ?= pip==23.3 setuptools==70.0.0 setuptools_scm[toml]==8.0.4 wheel==0.38.4
 
 NAME ?= awx
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -60,7 +60,7 @@ uWSGI>=2.0.22 # CVE-2023-27522
 uwsgitop
 wheel>=0.38.1  # CVE-2022-40898
 pip==23.3  # see CVE-2023-5752
-setuptools==65.6.3  # see UPGRADE BLOCKERs
+setuptools==70.0.0  # CVE-2024-6345
 setuptools_scm[toml]  # see UPGRADE BLOCKERs, xmlsec build dep
 setuptools-rust>=0.11.4  # cryptography build dep
 pkgconfig>=1.5.1  # xmlsec build dep - needed for offline build

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -467,7 +467,7 @@ zope-interface==7.0.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.3
     # via -r /awx_devel/requirements/requirements.in
-setuptools==65.6.3
+setuptools==70.0.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   asciichartpy


### PR DESCRIPTION
##### SUMMARY
* Resolve issues with setuptools.  Addresses CVE-2024-6345
* Introduces deprecation warnings around pkg_resources which will eventually have to be replace.
