### PR TITLE
Url

### DIFF
--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -71,11 +71,11 @@ def emit_event_detail(event):
         InventoryUpdateEvent: 'inventory_update_id',
         SystemJobEvent: 'system_job_id',
     }[cls]
-    url = ''
+    url = event.get_absolute_url()
     if isinstance(event, JobEvent):
-        url = '/api/v2/job_events/{}'.format(event.id)
+        url += '/api/v2/job_events/{}'.format(event.id)
     if isinstance(event, AdHocCommandEvent):
-        url = '/api/v2/ad_hoc_command_events/{}'.format(event.id)
+        url += '/api/v2/ad_hoc_command_events/{}'.format(event.id)
     group = camelcase_to_underscore(cls.__name__) + 's'
     timestamp = event.created.isoformat()
     consumers.emit_channel_notification(


### PR DESCRIPTION
##### SUMMARY
Changing event handler so instead of relative path returns full URL 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - Collection

##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.0.4
```


##### ADDITIONAL INFORMATION
Having relative path instead of full URL becomes an issue when running multiple ascenders and need to get more details per event 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
