### PR TITLE
Fix Issue #51 - Unable to upload more than 1500 packages to ledger due to rsyslog defaults

### DIFF
--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -113,6 +113,10 @@ def construct_rsyslog_conf_template(settings=settings):
                 # > arbitrary header key/value lists.
                 params.append('httpheaderkey="Authorization"')
                 params.append(f'httpheadervalue="Splunk {password}"')
+        if getattr(settings, 'LOG_AGGREGATOR_TYPE', None) == 'ledger':
+            if password:
+                params.append('httpheaderkey="Authorization"')
+                params.append(f'httpheadervalue="Ledger {password}"')
         elif username:
             params.append(f'uid="{username}"')
             if password:

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -45,9 +45,7 @@ def construct_rsyslog_conf_template(settings=settings):
         parts.append('$DebugLevel 2')
     parts.extend(
         [
-            '$WorkDirectory /var/lib/awx/rsyslog',
-            f'$MaxMessageSize {max_bytes}',
-            '$IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf',
+            f'global (maxMessageSize="{max_bytes}" workDirectory="/var/lib/awx/rsyslog")',
             'module(load="imptcp")',
             'input(type="imptcp" Path="' + settings.LOGGING['handlers']['external_logger']['address'] + '")',
             'template(name="awx" type="string" string="%rawmsg-after-pri%")',

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -48,8 +48,8 @@ def construct_rsyslog_conf_template(settings=settings):
             '$WorkDirectory /var/lib/awx/rsyslog',
             f'$MaxMessageSize {max_bytes}',
             '$IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf',
-            'module(load="imuxsock" SysSock.Use="off")',
-            'input(type="imuxsock" Socket="' + settings.LOGGING['handlers']['external_logger']['address'] + '" unlink="on" RateLimit.Burst="0")',
+            'module(load="imptcp")',
+            'input(type="imptcp" Path="' + settings.LOGGING['handlers']['external_logger']['address'] + '")',
             'template(name="awx" type="string" string="%rawmsg-after-pri%")',
         ]
     )

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -169,6 +169,8 @@ class LogstashFormatter(LogstashFormatterBase):
         if isinstance(data, str):
             data = json.loads(data)
         data_for_log = {}
+        data_for_log['install_uuid'] = settings.INSTALL_UUID
+        data_for_log['install_url'] = settings.TOWER_URL_BASE
 
         if kind == 'job_events' and raw_data.get('python_objects', {}).get('job_event'):
             job_event = raw_data['python_objects']['job_event']

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -143,10 +143,6 @@ class LogstashFormatterBase(logging.Formatter):
 class LogstashFormatter(LogstashFormatterBase):
     def __init__(self, *args, **kwargs):
         self.cluster_host_id = settings.CLUSTER_HOST_ID
-        self.tower_uuid = None
-        uuid = getattr(settings, 'LOG_AGGREGATOR_TOWER_UUID', None) or getattr(settings, 'INSTALL_UUID', None)
-        if uuid:
-            self.tower_uuid = uuid
         super(LogstashFormatter, self).__init__(*args, **kwargs)
 
     def reformat_data_for_log(self, raw_data, kind=None):
@@ -169,8 +165,6 @@ class LogstashFormatter(LogstashFormatterBase):
         if isinstance(data, str):
             data = json.loads(data)
         data_for_log = {}
-        data_for_log['install_uuid'] = settings.INSTALL_UUID
-        data_for_log['install_url'] = settings.TOWER_URL_BASE
 
         if kind == 'job_events' and raw_data.get('python_objects', {}).get('job_event'):
             job_event = raw_data['python_objects']['job_event']
@@ -260,7 +254,8 @@ class LogstashFormatter(LogstashFormatterBase):
             fields = self.reformat_data_for_log(fields, kind=log_kind)
         # General AWX metadata
         fields['cluster_host_id'] = self.cluster_host_id
-        fields['tower_uuid'] = self.tower_uuid
+        fields['tower_uuid'] = settings.INSTALL_UUID
+        fields['tower_url'] = settings.TOWER_URL_BASE
         return fields
 
     def format(self, record):

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -2,6 +2,7 @@
 # All Rights Reserved.
 
 # Python
+import socket
 import logging
 import sys
 import traceback
@@ -15,13 +16,11 @@ from django.utils.encoding import force_str
 # AWX
 from awx.main.exceptions import PostRunError
 
-
 class RSysLogHandler(logging.handlers.SysLogHandler):
     append_nul = False
 
-    def _connect_unixsocket(self, address):
-        super(RSysLogHandler, self)._connect_unixsocket(address)
-        self.socket.setblocking(False)
+    def __init__(self, address=('/var/run/awx-rsyslog/rsyslog.sock'), facility=logging.handlers.SysLogHandler.LOG_USER, socktype=socket.SOCK_STREAM):
+        super(RSysLogHandler, self).__init__(address, facility, socktype)
 
     def handleError(self, record):
         # for any number of reasons, rsyslogd has gone to lunch;

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -19,7 +19,7 @@ from awx.main.exceptions import PostRunError
 class RSysLogHandler(logging.handlers.SysLogHandler):
     append_nul = False
 
-    def __init__(self, address=('/var/run/awx-rsyslog/rsyslog.sock'), facility=logging.handlers.SysLogHandler.LOG_USER, socktype=socket.SOCK_STREAM):
+    def __init__(self, address=(settings.LOGGING['handlers']['external_logger']['address']), facility=logging.handlers.SysLogHandler.LOG_USER, socktype=socket.SOCK_STREAM):
         super(RSysLogHandler, self).__init__(address, facility, socktype)
 
     def handleError(self, record):

--- a/tools/ansible/roles/dockerfile/files/rsyslog.conf
+++ b/tools/ansible/roles/dockerfile/files/rsyslog.conf
@@ -1,5 +1,5 @@
 $WorkDirectory /var/lib/awx/rsyslog
-$MaxMessageSize 1400000
+$MaxMessageSize 700000
 $IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf
 module(load="imuxsock" SysSock.Use="off")
 input(type="imuxsock" Socket="/var/run/awx-rsyslog/rsyslog.sock" unlink="on")

--- a/tools/ansible/roles/dockerfile/files/rsyslog.conf
+++ b/tools/ansible/roles/dockerfile/files/rsyslog.conf
@@ -1,5 +1,5 @@
 $WorkDirectory /var/lib/awx/rsyslog
-$MaxMessageSize 700000
+$MaxMessageSize 1400000
 $IncludeConfig /var/lib/awx/rsyslog/conf.d/*.conf
 module(load="imuxsock" SysSock.Use="off")
 input(type="imuxsock" Socket="/var/run/awx-rsyslog/rsyslog.sock" unlink="on")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change updates rsyslog to use the imptcp input module over the legacy socket input module.  It does this to avoid Message too long errors (Errno 90) that occur with large packet sizes.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other - Logging
