### PR TITLE
Ledger authentication

### DIFF
--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -113,6 +113,10 @@ def construct_rsyslog_conf_template(settings=settings):
                 # > arbitrary header key/value lists.
                 params.append('httpheaderkey="Authorization"')
                 params.append(f'httpheadervalue="Splunk {password}"')
+        if getattr(settings, 'LOG_AGGREGATOR_TYPE', None) == 'ledger':
+            if password:
+                params.append('httpheaderkey="Authorization"')
+                params.append(f'httpheadervalue="Ledger {password}"')
         elif username:
             params.append(f'uid="{username}"')
             if password:


### PR DESCRIPTION

Add an authorization header for Ledger if a token is set. This will allow us to change ledger to use tokens instead of setting trusted servers.