### PR TITLE
Migrate away from pkg_resources as it's deprecated

### DIFF
--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import warnings
-
+from importlib_metadata import PackageNotFoundError, version as _get_version
 
 def get_version():
     version_from_file = get_version_from_file()
@@ -34,10 +34,8 @@ def version_file():
 
 
 try:
-    import pkg_resources
-
-    __version__ = pkg_resources.get_distribution('awx').version
-except pkg_resources.DistributionNotFound:
+    __version__ = _get_version('awx')
+except PackageNotFoundError:
     __version__ = get_version()
 
 __all__ = ['__version__']

--- a/awx/main/db/profiled_pg/base.py
+++ b/awx/main/db/profiled_pg/base.py
@@ -1,9 +1,9 @@
 import os
-import pkg_resources
 import sqlite3
 import sys
 import traceback
 import uuid
+from importlib_metadata import version as _get_version
 
 from django.core.cache import cache
 from django.core.cache.backends.locmem import LocMemCache
@@ -70,7 +70,7 @@ class RecordedQueryLog(object):
             else:
                 progname = os.path.basename(sys.argv[0])
             filepath = os.path.join(self.dest, '{}.sqlite'.format(progname))
-            version = pkg_resources.get_distribution('awx').version
+            version = _get_version('awx')
             log = sqlite3.connect(filepath, timeout=3)
             log.execute(
                 'CREATE TABLE IF NOT EXISTS queries ('

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -7,7 +7,7 @@ import functools
 import inspect
 import logging
 import os
-from pkg_resources import iter_entry_points
+from importlib_metadata import entry_points
 import re
 import stat
 import tempfile
@@ -50,7 +50,7 @@ from . import injectors as builtin_injectors
 __all__ = ['Credential', 'CredentialType', 'CredentialInputSource', 'build_safe_env']
 
 logger = logging.getLogger('awx.main.models.credential')
-credential_plugins = dict((ep.name, ep.load()) for ep in iter_entry_points('awx.credential_plugins'))
+credential_plugins = {entry_point.name: entry_point.load() for entry_point in entry_points(group='awx.credential_plugins')}
 
 HIDDEN_PASSWORD = '**********'
 

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -19,6 +19,7 @@ import threading
 import contextlib
 import tempfile
 import functools
+from importlib_metadata import version as _get_version
 
 # Django
 from django.core.exceptions import ObjectDoesNotExist, FieldDoesNotExist
@@ -223,9 +224,7 @@ def get_awx_version():
     from awx import __version__
 
     try:
-        import pkg_resources
-
-        return pkg_resources.require('awx')[0].version
+        return _get_version('awx')
     except Exception:
         return __version__
 

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -2,8 +2,8 @@ from __future__ import print_function
 
 import logging
 import os
-import pkg_resources
 import sys
+from importlib_metadata import version as _get_version
 
 from requests.exceptions import RequestException
 
@@ -16,7 +16,7 @@ from awxkit.cli.utils import HelpfulArgumentParser, cprint, disable_color, color
 from awxkit.awx.utils import uses_sessions  # noqa
 
 
-__version__ = pkg_resources.get_distribution('awxkit').version
+__version__ = _get_version('awxkit')
 
 
 class CLI(object):

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -244,7 +244,8 @@ ADD tools/scripts/awx-python /usr/bin/awx-python
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
 RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.9/site-packages/awx.egg-link
-ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
+RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.9/site-packages/awx.pth
+RUN ln -sf /awx_devel/tools/docker-compose/awx-manage /usr/local/bin/awx-manage
 RUN ln -sf /awx_devel/tools/scripts/awx-python /usr/bin/awx-python
 RUN ln -sf /awx_devel/tools/scripts/rsyslog-4xx-recovery /usr/bin/rsyslog-4xx-recovery
 {% endif %}

--- a/tools/docker-compose/awx-manage
+++ b/tools/docker-compose/awx-manage
@@ -1,8 +1,16 @@
 #!/usr/bin/awx-python
-# EASY-INSTALL-ENTRY-SCRIPT: 'awx','console_scripts','awx-manage'
 import sys
-from pkg_resources import load_entry_point
-__requires__ = 'awx'
+from importlib_metadata import distribution
+
+def load_entry_point(dist, group, name):
+    dist_name, _, _ = dist.partition('==')
+    matches = (
+        entry_point
+        for entry_point in distribution(dist_name).entry_points
+        if entry_point.group == group and entry_point.name == name
+    )
+    return next(matches).load()
+
 
 if __name__ == '__main__':
     sys.exit(

--- a/tools/scripts/firehose.py
+++ b/tools/scripts/firehose.py
@@ -30,8 +30,7 @@ import datetime
 import itertools
 import json
 import multiprocessing
-import pkg_resources
-import random
+import site
 import subprocess
 import sys
 from io import StringIO
@@ -132,7 +131,7 @@ def cleanup(sql):
 
 def generate_jobs(jobs, batch_size, time_delta):
     print(f'inserting {jobs} job(s)')
-    sys.path.insert(0, pkg_resources.get_distribution('awx').module_path)
+    sys.path[:0] = site.getsitepackages()
     from awx import prepare_env
 
     prepare_env()


### PR DESCRIPTION
This resolves the pkg_resources deprecation warnings.

Commits pulled from upstream minus a few minor changes as we are on an older version of python (utilize importlib_metadata instead of importlib.metadata)


Upstream
https://github.com/ansible/awx/commit/e68370f2aa2dc0fb435de39835beb0edc1c55225
https://github.com/ansible/awx/commit/3edaaebba22ba8137340eace28b14deedc7da69b