### PR TITLE
Fixing pyopenssl dependencies

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -38,7 +38,7 @@ prometheus_client
 psycopg
 psutil
 pygerduty
-pyopenssl>=23.2.0  # resolve dep conflict from cryptography pin above
+pyopenssl>=24.3.0  # resolve dep conflict from cryptography pin above
 pyparsing==2.4.6  # Upgrading to v3 of pyparsing introduce errors on smart host filtering: Expected 'or' term, found 'or'  (at char 15), (line:1, col:16)
 python-daemon>3.0.0
 python-dsv-sdk>=1.0.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -301,7 +301,7 @@ pyjwt==2.9.0
     #   adal
     #   social-auth-core
     #   twilio
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   twisted


### PR DESCRIPTION
##### SUMMARY
After updating cryptography>=44.0.1 pip build fails due to `pyopenssl` needing update as well
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.0.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
