### PR TITLE
Upgrade http-proxy-middleware to resolve CVEs

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -61,7 +61,7 @@
         "eslint-plugin-jsx-a11y": "6.5.1",
         "eslint-plugin-react": "7.28.0",
         "eslint-plugin-react-hooks": "4.3.0",
-        "http-proxy-middleware": "2.0.7",
+        "http-proxy-middleware": "2.0.9",
         "jest-websocket-mock": "^2.0.2",
         "mock-socket": "^9.1.3",
         "prettier": "2.3.2",
@@ -11255,9 +11255,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -30847,9 +30847,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
       "requires": {
         "@types/http-proxy": "^1.17.8",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
-    "http-proxy-middleware": "2.0.7",
+    "http-proxy-middleware": "2.0.9",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.1.3",
     "prettier": "2.3.2",


### PR DESCRIPTION
CVE-2025-32996
CVE-2025-32997

##### SUMMARY
Bringing devel changes for CVE-2025-32996 and CVE-2025-32997 into main so we can sync both branches

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI


##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
25.0.0
```

