### PR TITLE
Continue reload when add user permissions to team

### DIFF
--- a/awx/ui/src/components/AddRole/SelectResourceStep.js
+++ b/awx/ui/src/components/AddRole/SelectResourceStep.js
@@ -38,6 +38,10 @@ function SelectResourceStep({
   const location = useLocation();
   const { i18n } = useLingui();
 
+  // Store stable references to fetchItems and fetchOptions
+  const fetchItemsRef = React.useRef(fetchItems);
+  const fetchOptionsRef = React.useRef(fetchOptions);
+
   const {
     isLoading,
     error,
@@ -55,7 +59,10 @@ function SelectResourceStep({
           data: { count, results },
         },
         actionsResponse,
-      ] = await Promise.all([fetchItems(queryParams), fetchOptions()]);
+      ] = await Promise.all([
+        fetchItemsRef.current(queryParams),
+        fetchOptionsRef.current()
+      ]);
       return {
         resources: results,
         itemCount: count,
@@ -64,7 +71,7 @@ function SelectResourceStep({
         ).map((val) => val.slice(0, -8)),
         searchableKeys: getSearchableKeys(actionsResponse.data.actions?.GET),
       };
-    }, [location, fetchItems, fetchOptions, sortColumns]),
+    }, [location, sortColumns]),
     {
       resources: [],
       itemCount: 0,
@@ -73,9 +80,11 @@ function SelectResourceStep({
     }
   );
 
+  // Remove readResourceList from deps, use location.search and sortColumns instead
   useEffect(() => {
     readResourceList();
-  }, [readResourceList]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search, JSON.stringify(sortColumns)]);
 
   return (
     <>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixing a bug introduced during `lingui4` migration where when trying to add user to team permissions the `fetchItems` function is called in a loop regardless of the response received form the back end.
This pr is fixing that behavior 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI


##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
25.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
To reproduce the issue: 
Go to Teams → Select a team → click Access tap → click Add → Select Users and click Next 

You will now observe that users API is keep called even though it returns 200 first time around 
[Add User Roles to Team.webm](https://github.com/user-attachments/assets/21a83f18-48a3-4930-b4ff-0d9321128e52)

