### PR TITLE
Adding toast handler to fix errors when using list approve or deny buttons

### DIFF
--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { msg } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
+import useToast, { AlertVariant } from 'hooks/useToast';
 import { string, bool, func } from 'prop-types';
 import { Tr, Td } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
@@ -25,6 +26,7 @@ function WorkflowApprovalListItem({
   rowIndex,
 }) {
   const { i18n } = useLingui();
+  const { addToast } = useToast();
   const hasBeenActedOn =
     workflowApproval.status === 'successful' ||
     workflowApproval.status === 'failed' ||
@@ -32,6 +34,15 @@ function WorkflowApprovalListItem({
   const labelId = `check-action-${workflowApproval.id}`;
   const workflowJob = workflowApproval?.summary_fields?.source_workflow_job;
   const status = getStatus(workflowApproval);
+  // Toast handler for approve/deny actions (PatternFly style)
+  const handleToast = (id, message) => {
+    addToast({
+      id,
+      title: message,
+      variant: AlertVariant.success,
+      hasTimeout: true,
+    });
+  };
   return (
     <Tr id={`workflow-approval-row-${workflowApproval.id}`}>
       <Td
@@ -84,13 +95,13 @@ function WorkflowApprovalListItem({
             hasBeenActedOn ? i18n._(msg`This has already been acted on`) : i18n._(msg`Approve`)
           }
         >
-          <WorkflowApprovalButton workflowApproval={workflowApproval} />
+          <WorkflowApprovalButton workflowApproval={workflowApproval} onHandleToast={handleToast} />
         </ActionItem>
         <ActionItem
           visible
           tooltip={hasBeenActedOn ? i18n._(msg`This has already been acted on`) : i18n._(msg`Deny`)}
         >
-          <WorkflowDenyButton workflowApproval={workflowApproval} />
+          <WorkflowDenyButton workflowApproval={workflowApproval} onHandleToast={handleToast} />
         </ActionItem>
         <ActionItem visible>
           <JobCancelButton


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When workflow is pending approval using the approval buttons in https://localhost:3001/#/workflow_approvals is not working for both approve and deny. Error: 
```
WorkflowApprovalButton.js:28 Uncaught (in promise) TypeError: onHandleToast is not a function
    at handleApprove (WorkflowApprovalButton.js:28:1)
handleApprove	@	WorkflowApprovalButton.js:28
await in handleApprove		
onClick	@	WorkflowApprovalButton.js:40
```
This change fixes that 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
25.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
![95a77a50-23e8-4163-8771-7b058408e5f7](https://github.com/user-attachments/assets/73a3206a-2a66-405a-86e7-ed5cc87389e7)


<!--- Paste verbatim command output below, e.g. before and after your change -->

