### PR TITLE
Fix issue on notificaitons when viewing a notification for a webhook

### DIFF
--- a/awx/ui/src/components/DetailList/CodeDetail.js
+++ b/awx/ui/src/components/DetailList/CodeDetail.js
@@ -64,7 +64,7 @@ CodeDetail.propTypes = {
   dataCy: string,
   helpText: string,
   rows: oneOfType([number, string]),
-  mode: oneOf(['javascript', 'yaml', 'jinja2']).isRequired,
+  mode: oneOf(['json', 'javascript', 'yaml', 'jinja2']).isRequired,
 };
 CodeDetail.defaultProps = {
   rows: null,


### PR DESCRIPTION
When viewing a notification of type webhook, a javascript error occurs as the CodeDetail is set to json, but the CodeDetail doesn't allow it.

**_Failed prop type: Invalid prop `mode` of value `json` supplied to `CodeEditor`, expected one of ["javascript","yaml","jinja2"]_**

This simply allows json as an option.