### PR TITLE
Fix 404 error when logging in

### DIFF
--- a/awx/ui/src/api/models/Root.js
+++ b/awx/ui/src/api/models/Root.js
@@ -14,7 +14,9 @@ class Root extends Base {
     
     // Ensure 'next' is an absolute path based on the current location
     const next = encodeURIComponent(
-      redirect.startsWith('/') ? redirect : `${window.location.pathname}${redirect}`
+      redirect.startsWith('/') 
+        ? redirect 
+        : `${window.location.pathname.endsWith('/') ? window.location.pathname : window.location.pathname + '/'}${redirect}`
     );
 
     const data = `username=${un}&password=${pw}&next=${next}`;

--- a/awx/ui/src/api/models/Root.js
+++ b/awx/ui/src/api/models/Root.js
@@ -11,7 +11,11 @@ class Root extends Base {
     const loginUrl = `${this.baseUrl}login/`;
     const un = encodeURIComponent(username);
     const pw = encodeURIComponent(password);
-    const next = encodeURIComponent(redirect);
+    
+    // Ensure 'next' is an absolute path based on the current location
+    const next = encodeURIComponent(
+      redirect.startsWith('/') ? redirect : `${window.location.pathname}${redirect}`
+    );
 
     const data = `username=${un}&password=${pw}&next=${next}`;
     const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };


### PR DESCRIPTION
Error caused by upstream PR #14020 that was added to support running in a sub directory (which that PR is actually incomplete, as there are a lot of hard coded paths still (like redirects to /login).

GET https://ASCENDERHOST:3001/api/login/api/v2/config/

After logging in, React is appending the "next" url to the "current" url as its not an absolute path.  This happens when we initially call /api/login/ so that we end up trying to call /api/login/api/v2/config when it redirects.  This only happens during the login process.  I have stepped through the javascript execution and it happens in React, not in our code, so this is a small workaround to fix it.  This will still support running Ascender in a sub directory, but will will force an absolute path based upon the current window path (which is / if not running in a sub directory, otherwise its the /subdirectory/).