### PR TITLE
Start using Labels as Folders

### DIFF
--- a/awx/ui/src/components/LabelLists/LabelListItem.js
+++ b/awx/ui/src/components/LabelLists/LabelListItem.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Tr, Td } from '@patternfly/react-table';
+import { Link } from 'react-router-dom';
+import { msg } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+
+function LabelListItem({ label, searchOrg }) {
+  const { i18n } = useLingui();
+  let search = `?template.labels__name__icontains=${encodeURIComponent(label.name)}`;
+  if (searchOrg && label.summary_fields?.organization?.id) {
+    search += `&template.organization__id=${encodeURIComponent(label.summary_fields.organization.id)}`;
+  }
+  return (
+    <Tr key={label.id}>
+        <Td style={{ width: 46, minWidth: 0, maxWidth: 46 }} />
+        <Td dataLabel={i18n._(msg`Name`)}>
+            <b><Link to={{ pathname: '/templates', search }}>{label.name}</Link></b>
+        </Td>
+        <Td dataLabel={i18n._(msg`Organization`)}>
+            {label.summary_fields?.organization?.name || ''}
+        </Td>
+    </Tr>
+  );
+}
+
+export default LabelListItem;

--- a/awx/ui/src/components/LabelLists/LabelLists.js
+++ b/awx/ui/src/components/LabelLists/LabelLists.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useCallback } from 'react';
+import { Card } from '@patternfly/react-core';
+import { useLingui } from '@lingui/react';
+import { msg } from '@lingui/macro';
+import { useLocation } from 'react-router-dom';
+import useRequest from 'hooks/useRequest';
+import { LabelsAPI } from 'api';
+import { getQSConfig, parseQueryString } from 'util/qs';
+import PaginatedTable, { HeaderRow, HeaderCell } from '../PaginatedTable';
+import LabelListItem from './LabelListItem';
+
+const qsConfig = getQSConfig('labels', {
+        page: 1,
+        page_size: 20,
+        order_by: 'name' }, []);
+
+function LabelLists() {
+  const { i18n } = useLingui();
+  const location = useLocation();
+
+  const {
+    result: { results, count },
+    error: contentError,
+    isLoading,
+    request: fetchLabels,
+  } = useRequest(
+    useCallback(async () => {
+      const params = {
+        ...parseQueryString(qsConfig, location.search),
+        unifiedjobtemplate_labels__search: '',
+      };
+      const { data } = await LabelsAPI.read(params);
+      return {
+        results: data.results,
+        count: data.count,
+      };
+    }, [location.search]),
+    { results: [], count: 0 }
+  );
+
+  useEffect(() => {
+    fetchLabels();
+  }, [fetchLabels]);
+
+  return (
+    <Card>
+      <PaginatedTable
+        contentError={contentError}
+        hasContentLoading={isLoading}
+        items={results}
+        itemCount={count}
+        pluralizedItemName={i18n._(msg`Labels`)}
+        qsConfig={qsConfig}
+        toolbarSearchColumns={[
+          { name: i18n._(msg`Name`), key: 'name__icontains', isDefault: true },
+          { name: i18n._(msg`Organization`), key: 'organization__name__icontains' },
+        ]}
+        headerRow={
+          <HeaderRow qsConfig={qsConfig}>
+            <HeaderCell sortKey="name">{i18n._(msg`Name`)}</HeaderCell>
+            <HeaderCell>{i18n._(msg`Organization`)}</HeaderCell>
+          </HeaderRow>
+        }
+        renderRow={(label) => <LabelListItem label={label} searchOrg />}
+      />
+    </Card>
+  );
+}
+
+export default LabelLists;

--- a/awx/ui/src/routeConfig.js
+++ b/awx/ui/src/routeConfig.js
@@ -25,6 +25,7 @@ import Users from 'screens/User';
 import WorkflowApprovals from 'screens/WorkflowApproval';
 import { Jobs } from 'screens/Job';
 import HostMetrics from 'screens/HostMetrics';
+import Labels from 'screens/Labels';
 
 function getRouteConfig(userProfile = {}) {
   let routeConfig = [
@@ -73,6 +74,11 @@ function getRouteConfig(userProfile = {}) {
       groupTitle: <Trans>Resources</Trans>,
       groupId: 'resources_group',
       routes: [
+        {
+          title: <Trans>Labels</Trans>,
+          path: '/labels',
+          screen: Labels,
+        },
         {
           title: <Trans>Templates</Trans>,
           path: '/templates',

--- a/awx/ui/src/screens/Labels/Labels.js
+++ b/awx/ui/src/screens/Labels/Labels.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { PageSection } from '@patternfly/react-core';
+import { msg } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
+import LabelLists from 'components/LabelLists/LabelLists';
+
+function Labels() {
+  const { i18n } = useLingui();
+  return (
+    <>
+      <ScreenHeader
+        streamType="label"
+        breadcrumbConfig={{ '/labels': i18n._(msg`Labels`) }}
+      />
+      <PageSection>
+        <LabelLists />
+      </PageSection>
+    </>
+  );
+}
+
+export default Labels;

--- a/awx/ui/src/screens/Labels/index.js
+++ b/awx/ui/src/screens/Labels/index.js
@@ -1,0 +1,3 @@
+import Labels from './Labels';
+
+export default Labels;


### PR DESCRIPTION
We create a new Menu item to display all the Job/Workflow Template labels.  From here, when clicked, we can then redirect to a search for that Label on the Template.

Simplistic way of doing it, but works fine with the current labeling system.

In the future, we will create methods for more easily associating or disassociating templates in bulk.