### PR TITLE
Fix the about page

### DIFF
--- a/awx/ui/src/components/About/About.js
+++ b/awx/ui/src/components/About/About.js
@@ -41,7 +41,7 @@ function About({ version, isOpen, onClose }) {
   const copyright = i18n._(msg`Copyright`);
   const redHatInc = i18n._(msg`Red Hat, Inc.`);
   const CIQInc = i18n._(msg`Ctrl IQ, Inc.`);
-
+  const currentyear = new Date().getFullYear();
   return (
     <AboutModal
       isOpen={isOpen}
@@ -63,10 +63,10 @@ function About({ version, isOpen, onClose }) {
                   ||     ||
                     `}
       </pre>
-      <div style={{ marginTop: 16, whiteSpace: 'pre-line' }}>
-        {copyright} {new Date().getFullYear()} {CIQInc}
+      <div style={{ marginTop: 16 }}>
+        {copyright} {currentyear} {CIQInc}
         <br />
-        {copyright} {new Date().getFullYear()} {redHatInc}
+        {copyright} {currentyear} {redHatInc}
       </div>
     </AboutModal>
   );

--- a/awx/ui/src/components/About/About.js
+++ b/awx/ui/src/components/About/About.js
@@ -40,13 +40,14 @@ function About({ version, isOpen, onClose }) {
   const speechBubble = createSpeechBubble();
   const copyright = i18n._(msg`Copyright`);
   const redHatInc = i18n._(msg`Red Hat, Inc.`);
+  const CIQInc = i18n._(msg`Ctrl IQ, Inc.`);
 
   return (
     <AboutModal
       isOpen={isOpen}
       onClose={onClose}
       productName={brandName}
-      trademark={`${copyright} ${new Date().getFullYear()} ${redHatInc} ----- ${copyright} ${new Date().getFullYear()} Ctrl IQ, Inc.`}
+      trademark=""
       brandImageSrc="static/media/AscenderAuto_logo_h_rev_M.png"
       brandImageAlt={i18n._(msg`Brand Image`)}
       backgroundImageSrc="static/media/CIQ_grayscale_bkgd.jpg"
@@ -62,6 +63,11 @@ function About({ version, isOpen, onClose }) {
                   ||     ||
                     `}
       </pre>
+      <div style={{ marginTop: 16, whiteSpace: 'pre-line' }}>
+        {copyright} {new Date().getFullYear()} {CIQInc}
+        <br />
+        {copyright} {new Date().getFullYear()} {redHatInc}
+      </div>
     </AboutModal>
   );
 }


### PR DESCRIPTION
Resolves #54

Changes to not use the trademark instead insert a DIV that allows us to split the About Copyrights onto new lines.