### PR TITLE
Attempt to force packaging version to allow SHA versions

### DIFF
--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -51,7 +51,7 @@ jobs:
       # Downgrade requests to fix https://github.com/docker/docker-py/issues/3256
       - name: Install playbook dependencies
         run: |
-          python3 -m pip install docker==6.1.3 requests==2.31.0 --force-reinstall
+          python3 -m pip install docker==6.1.3 requests==2.31.0 packaging==21.3 --force-reinstall
 
       - name: Build Ascender Devel Image
         working-directory: ascender


### PR DESCRIPTION
Trying to force packages to a lower version so we can use SHA checksums as versions.