### PR TITLE
Update azure-identity to resolve CVE-2024-35255

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,7 +3,7 @@ ansiconv==1.0.0  # UPGRADE BLOCKER: from 2013, consider replacing instead of upg
 asciichartpy
 asn1
 asyncpg
-azure-identity
+azure-identity==1.16.1
 azure-keyvault
 boto3
 botocore

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -57,7 +57,7 @@ azure-core==1.30.0
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
     #   msrest
-azure-identity==1.15.0
+azure-identity==1.16.1
     # via -r /awx_devel/requirements/requirements.in
 azure-keyvault==4.2.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
This updates azure-identity to 1.6.1 to resolve a Medium score CVE.
Updater has been ran.
Containers build properly after upgrades.