### PR TITLE
Upgrade aiohttp to resolve CVE-2025-53643

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
-aiohttp>=3.10.11  # CVE-2024-52304
+aiohttp>=3.12.14  # CVE-2025-53643
 ansiconv==1.0.0  # UPGRADE BLOCKER: from 2013, consider replacing instead of upgrading
 asciichartpy
 asn1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,15 +1,15 @@
 adal==1.2.7
     # via msrestazure
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.12.14
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   aiohttp-retry
     #   twilio
 aiohttp-retry==2.8.3
     # via twilio
-aiosignal==1.3.1
+aiosignal==1.4.0
     # via aiohttp
 annotated-types==0.6.0
     # via pydantic
@@ -471,6 +471,7 @@ txaio==23.1.1
     # via autobahn
 typing-extensions==4.12.2
     # via
+    #   aiosignal
     #   azure-core
     #   azure-keyvault-certificates
     #   azure-keyvault-keys


### PR DESCRIPTION
This also upgrades aiohappyeyeballs and aiosignal as dependencies