### PR TITLE
Fix some websocket issues and memory leaks in asyncs

### DIFF
--- a/awx/ui/src/components/JobList/JobList.js
+++ b/awx/ui/src/components/JobList/JobList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { msg, Plural } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
@@ -104,12 +104,21 @@ function JobList({
     fetchJobs();
   }, [fetchJobs]);
 
+  const isMounted = useRef(false);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
   const fetchJobsById = useCallback(
     async (ids) => {
       const params = parseQueryString(qsConfig, location.search);
       params.id__in = ids.join(',');
       try {
         const { data } = await UnifiedJobsAPI.read(params);
+        if (!isMounted.current) return [];
         return data.results;
       } catch (e) {
         return [];

--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { number, shape } from 'prop-types';
 import { msg } from '@lingui/macro';
@@ -50,6 +50,15 @@ function LaunchButton({ resource, children }) {
   const [error, setError] = useState(null);
   const { addToast, Toast, toastProps } = useToast();
 
+  // Add isMounted ref to prevent state updates after unmount
+  const isMounted = useRef(true);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
   const showToast = () => {
     addToast({
       id: resource.id,
@@ -80,12 +89,11 @@ function LaunchButton({ resource, children }) {
 
     try {
       const { data: launch } = await readLaunch;
-      setLaunchConfig(launch);
+      if (isMounted.current) setLaunchConfig(launch);
 
       if (launch.survey_enabled) {
         const { data } = await readSurvey;
-
-        setSurveyConfig(data);
+        if (isMounted.current) setSurveyConfig(data);
       }
 
       if (launch.ask_labels_on_launch) {
@@ -98,25 +106,25 @@ function LaunchButton({ resource, children }) {
           isReadOnly: true,
         }));
 
-        setLabels(allLabels);
+        if (isMounted.current) setLabels(allLabels);
       }
 
       if (launch.ask_credential_on_launch) {
         const {
           data: { results: templateCredentials },
         } = await JobTemplatesAPI.readCredentials(resource.id);
-        setResourceCredentials(templateCredentials);
+        if (isMounted.current) setResourceCredentials(templateCredentials);
       }
 
       if (canLaunchWithoutPrompt(launch)) {
         await launchWithParams({});
-      } else {
+      } else if (isMounted.current) {
         setShowLaunchPrompt(true);
       }
     } catch (err) {
-      setError(err);
+      if (isMounted.current) setError(err);
     } finally {
-      setIsLaunching(false);
+      if (isMounted.current) setIsLaunching(false);
     }
   };
 
@@ -151,11 +159,11 @@ function LaunchButton({ resource, children }) {
       }
 
       const { data: job } = await jobPromise;
-      history.push(`/jobs/${job.id}/output`);
+      if (isMounted.current) history.push(`/jobs/${job.id}/output`);
     } catch (launchError) {
-      setError(launchError);
+      if (isMounted.current) setError(launchError);
     } finally {
-      setIsLaunching(false);
+      if (isMounted.current) setIsLaunching(false);
     }
   };
 
@@ -186,7 +194,7 @@ function LaunchButton({ resource, children }) {
 
     try {
       const { data: relaunchConfig } = await readRelaunch;
-      setLaunchConfig(relaunchConfig);
+      if (isMounted.current) setLaunchConfig(relaunchConfig);
       if (
         !relaunchConfig.passwords_needed_to_start ||
         relaunchConfig.passwords_needed_to_start.length === 0
@@ -205,14 +213,14 @@ function LaunchButton({ resource, children }) {
           relaunch = JobsAPI.relaunch(resource.id, params || {});
         }
         const { data: job } = await relaunch;
-        history.push(`/jobs/${job.id}/output`);
-      } else {
+        if (isMounted.current) history.push(`/jobs/${job.id}/output`);
+      } else if (isMounted.current) {
         setShowLaunchPrompt(true);
       }
     } catch (err) {
-      setError(err);
+      if (isMounted.current) setError(err);
     } finally {
-      setIsLaunching(false);
+      if (isMounted.current) setIsLaunching(false);
     }
   };
 

--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -51,7 +51,7 @@ function LaunchButton({ resource, children }) {
   const { addToast, Toast, toastProps } = useToast();
 
   // Add isMounted ref to prevent state updates after unmount
-  const isMounted = useRef(true);
+  const isMounted = useRef(false);
   useEffect(() => {
     isMounted.current = true;
     return () => {

--- a/awx/ui/src/hooks/useWebsocket.js
+++ b/awx/ui/src/hooks/useWebsocket.js
@@ -50,7 +50,7 @@ export default function useWebsocket(subscribeGroups) {
     };
 
     // Delay initial connection by 50ms
-    const initialTimeout = setTimeout(connect, 200);
+    const initialTimeout = setTimeout(connect, 50);
 
     return () => {
       shouldReconnect = false;

--- a/awx/ui/src/hooks/useWebsocket.js
+++ b/awx/ui/src/hooks/useWebsocket.js
@@ -50,7 +50,7 @@ export default function useWebsocket(subscribeGroups) {
     };
 
     // Delay initial connection by 50ms
-    const initialTimeout = setTimeout(connect, 50);
+    const initialTimeout = setTimeout(connect, 200);
 
     return () => {
       shouldReconnect = false;

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { msg, Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import { useLocation, useParams } from 'react-router-dom';
@@ -44,6 +44,7 @@ function InstanceList({ instanceGroup }) {
   const [canRunHealthCheck, setCanRunHealthCheck] = useState(true);
   const location = useLocation();
   const { id: instanceGroupId } = useParams();
+  const isMounted = useRef(false);
 
   const policyRulesDocsLink = `${getDocsBaseUrl(
     config
@@ -70,7 +71,7 @@ function InstanceList({ instanceGroup }) {
       const isPending = response.data.results.some(
         (i) => i.health_check_pending === true
       );
-      setPendingHealthCheck(isPending);
+      if (isMounted.current) setPendingHealthCheck(isPending);
       return {
         instances: response.data.results,
         count: response.data.count,
@@ -108,7 +109,7 @@ function InstanceList({ instanceGroup }) {
           .filter(({ node_type }) => node_type === 'execution')
           .map(({ id }) => InstancesAPI.healthCheck(id))
       );
-      if (response) {
+      if (isMounted.current && response) {
         setShowHealthCheckAlert(true);
       }
     }, [selected])
@@ -203,6 +204,13 @@ function InstanceList({ instanceGroup }) {
 
   const { expanded, isAllExpanded, handleExpand, expandAll } =
     useExpanded(instances);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   return (
     <>

--- a/awx/ui/src/screens/Job/JobOutput/connectJobSocket.js
+++ b/awx/ui/src/screens/Job/JobOutput/connectJobSocket.js
@@ -1,7 +1,5 @@
-let ws;
-
 export default function connectJobSocket({ type, id }, onMessage) {
-  ws = new WebSocket(
+  const ws = new WebSocket(
     `${window.location.protocol === 'http:' ? 'ws:' : 'wss:'}//${
       window.location.host
     }${window.location.pathname}websocket/`
@@ -41,9 +39,11 @@ export default function connectJobSocket({ type, id }, onMessage) {
     console.debug('Socket error: ', err, 'Disconnecting...');
     ws.close();
   };
+
+  return ws; // Return the ws instance so the caller can manage it
 }
 
-export function closeWebSocket() {
+export function closeWebSocket(ws) {
   if (ws) {
     ws.close();
   }

--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
 import { DateTime, Duration } from 'luxon';
 import { msg } from '@lingui/macro';
@@ -79,21 +79,26 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
     : 0;
   const { me } = useConfig();
 
+  const isMounted = useRef(false);
+
   useEffect(() => {
+    isMounted.current = true;
     let secTimer;
-    let isMounted = true;
     if (job.finished) {
-      return () => clearInterval(secTimer);
+      return () => {
+        isMounted.current = false;
+        clearInterval(secTimer);
+      };
     }
 
     secTimer = setInterval(() => {
-      if (!isMounted) return;
+      if (!isMounted.current) return;
       const elapsedTime = calculateElapsed(job.started);
       setActiveJobElapsedTime(elapsedTime);
     }, 1000);
 
     return () => {
-      isMounted = false;
+      isMounted.current = false;
       clearInterval(secTimer);
     };
   }, [job.started, job.finished]);

--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
@@ -81,16 +81,21 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
 
   useEffect(() => {
     let secTimer;
+    let isMounted = true;
     if (job.finished) {
       return () => clearInterval(secTimer);
     }
 
     secTimer = setInterval(() => {
+      if (!isMounted) return;
       const elapsedTime = calculateElapsed(job.started);
       setActiveJobElapsedTime(elapsedTime);
     }, 1000);
 
-    return () => clearInterval(secTimer);
+    return () => {
+      isMounted = false;
+      clearInterval(secTimer);
+    };
   }, [job.started, job.finished]);
 
   return (


### PR DESCRIPTION
The websockets have been troublesome for a long time, even upstream.

The issue seemed to stem from using a global for the websocket, whereas we should instead be storing the socket in a ref and manage its lifecycle ourselves.  That way we can ensure to always close the previous socket before opening a new one.  We also add in a tiny delay on initialization, which seems to fix a few of the "could not connect" errors (it would then retry and connect, but that took longer than adding a delay).

Now when launching a job, its output seems to fully load and complete without issue.

Also starting to clean up some of these errors by ensuring things are mounted before trying to update them.  There are a lot more to fix, but its a start.

> "Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function."

