### PR TITLE
Upgrade to latest Node 20 LTS

### DIFF
--- a/awx/ui/Dockerfile
+++ b/awx/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.1
+FROM node:20.19.4
 ARG NPMRC_FILE=.npmrc
 ENV NPMRC_FILE=${NPMRC_FILE}
 ARG TARGET='https://awx:8043'

--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -70,7 +70,7 @@
         "react-scripts": "5.0.1"
       },
       "engines": {
-        "node": ">=16.13.1"
+        "node": ">=20.18.2"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -3,7 +3,7 @@
   "homepage": ".",
   "private": true,
   "engines": {
-    "node": ">=16.13.1"
+    "node": ">=20.18.2"
   },
   "dependencies": {
     "@lingui/react": "4.14.0",

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -86,7 +86,7 @@ RUN cd /tmp && make requirements_awx_dev
 # Use the distro provided npm to bootstrap our required version of node
 
 {% if not headless|bool %}
-RUN npm install -g n && n 16.13.1
+RUN npm install -g n && n 20.19.4
 {% endif %}
 
 # Copy source into builder, build sdist, install it into awx venv

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -151,7 +151,9 @@ RUN rm -rf /root/.cache && rm -rf /tmp/*
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
 # Install development/test requirements
-RUN dnf -y install \
+RUN dnf module reset nodejs -y && \
+    dnf module enable nodejs:20 -y && \
+    dnf -y install \
     crun \
     gdb \
     gtk3 \
@@ -175,7 +177,7 @@ RUN dnf -y install \
     wget \
     diffutils \
     unzip && \
-    npm install -g n && n 16.13.1 && npm install -g npm@8.5.0 && dnf remove -y nodejs
+    npm install -g n && n 20.19.4 && npm install -g npm@10.8.2 && dnf remove -y nodejs
 
 RUN pip3.11 install -vv git+https://github.com/coderanger/supervisor-stdout.git@973ba19967cdaf46d9c1634d1675fc65b9574f6e
 RUN pip3.11 install -vv black setuptools-scm build

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -26,6 +26,8 @@ USER root
 # Install build dependencies
 RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
+    dnf module reset nodejs -y && \
+    dnf module enable nodejs:20 -y && \
     dnf -y install \
     iputils \
     gcc \


### PR DESCRIPTION
We purposely set the package.json to specify a slightly lower node version, as that is what Rocky9 installs by default.  You still get the latest via npm, but that resolves a warning when running in Dev.

This gets us up to a supported version of NodeJS.