### PR TITLE
Fix __pycache__ directory removal in clean target - Upstream #16196

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ clean-api:
 	rm -rf build $(NAME)-$(VERSION) *.egg-info
 	rm -rf .tox
 	find . -type f -regex ".*\.py[co]$$" -delete
-	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -depth -type d -name "__pycache__" -delete
 	rm -f awx/awx_test.sqlite3*
 	rm -rf requirements/vendor
 	rm -rf awx/projects


### PR DESCRIPTION
Replaces the use of 'find -delete' with 'find -exec rm -rf {} +' to ensure all pycache directories are properly removed during the clean process.