### PR TITLE
Hide the SSH Password text that is displayed on every playbook run

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/JobEvent.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEvent.js
@@ -7,6 +7,11 @@ import {
   JobEventEllipsis,
 } from './shared';
 
+const HIDDEN_PASSWORD_PROMPTS = [
+  "SSH password: ",
+  "BECOME password[defaults to SSH password]: "
+];
+
 const JobEvent = React.forwardRef(
   (
     {
@@ -43,6 +48,9 @@ const JobEvent = React.forwardRef(
       <div ref={ref} style={style} type={event.type}>
         {lineTextHtml.map(({ lineNumber, html }, index) => {
           if (lineNumber < 0) {
+            return null;
+          }
+          if (HIDDEN_PASSWORD_PROMPTS.includes(html)) {
             return null;
           }
           const canToggle = index === toggleLineIndex && !event.isTracebackOnly;


### PR DESCRIPTION
This has bothered me for almost the last decade.  This is an Ansible artifact that has never been fixed.  This text even displays on Windows, when you don't even use SSH.

Hardcoded for now, added as an array so we can add other text later if necessary.

Right now we return null, which is fine, but the lines are completely hidden and the count now starts at 1 or 2 (2 if using BECOME PASSWORD).  We could also just return blank, and the lines wouldn't be hidden, but you now have multiple blank lines at the top.

If you download the output, its still there, I didn't want to remove it there.