### PR TITLE
Resolve issue where highlighting Job Output text can cause the event popup

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/JobEvent.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEvent.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   JobEventLine,
   JobEventLineToggle,
@@ -36,6 +36,14 @@ const JobEvent = React.forwardRef(
       };
     }, [numOutputLines, isCollapsed, measure, jobStatus]);
 
+    const handleClick = useCallback(() => {
+      const selection = window.getSelection();
+      if (selection && selection.toString().length > 0) {
+        return;
+      }
+      onJobEventClick();
+    }, [onJobEventClick]);
+
     let toggleLineIndex = -1;
     if (hasChildren) {
       lineTextHtml.forEach(({ html }, index) => {
@@ -56,7 +64,7 @@ const JobEvent = React.forwardRef(
           const canToggle = index === toggleLineIndex && !event.isTracebackOnly;
           return (
             <JobEventLine
-              onClick={isClickable ? onJobEventClick : undefined}
+              onClick={isClickable ? handleClick : undefined}
               key={`${event.counter}-${lineNumber}`}
               isFirst={lineNumber === 0}
               isClickable={isClickable}

--- a/awx/ui/src/screens/Job/JobOutput/JobEvent.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEvent.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import JobEvent from './JobEvent';
 
 const mockOnPlayStartEvent = {
@@ -95,5 +96,76 @@ describe('<JobEvent />', () => {
       <JobEvent lineTextHtml={[]} event={missingStdoutEvent} />
     );
     expect(wrapper.find('JobEventLineText')).toHaveLength(0);
+  });
+
+  describe('click handling with text selection', () => {
+    let originalGetSelection;
+
+    beforeEach(() => {
+      originalGetSelection = window.getSelection;
+    });
+
+    afterEach(() => {
+      window.getSelection = originalGetSelection;
+    });
+
+    test('click fires onJobEventClick when no text is selected', () => {
+      window.getSelection = jest.fn().mockReturnValue({
+        toString: () => '',
+      });
+      const onJobEventClick = jest.fn();
+      const wrapper = mountWithContexts(
+        <JobEvent
+          lineTextHtml={mockAnsiLineTextHtml}
+          event={mockRunnerOnOkEvent}
+          isClickable
+          onJobEventClick={onJobEventClick}
+          measure={jest.fn()}
+        />
+      );
+      // Find the clickable div rendered by the styled JobEventLine
+      const clickable = wrapper.find('div[onClick]');
+      expect(clickable.length).toBeGreaterThan(0);
+      clickable.first().simulate('click');
+      expect(onJobEventClick).toHaveBeenCalledTimes(1);
+      wrapper.unmount();
+    });
+
+    test('click is suppressed when text is selected', () => {
+      window.getSelection = jest.fn().mockReturnValue({
+        toString: () => 'selected text',
+      });
+      const onJobEventClick = jest.fn();
+      const wrapper = mountWithContexts(
+        <JobEvent
+          lineTextHtml={mockAnsiLineTextHtml}
+          event={mockRunnerOnOkEvent}
+          isClickable
+          onJobEventClick={onJobEventClick}
+          measure={jest.fn()}
+        />
+      );
+      const clickable = wrapper.find('div[onClick]');
+      expect(clickable.length).toBeGreaterThan(0);
+      clickable.first().simulate('click');
+      expect(onJobEventClick).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    test('no click handler when isClickable is false', () => {
+      const onJobEventClick = jest.fn();
+      const wrapper = mountWithContexts(
+        <JobEvent
+          lineTextHtml={mockAnsiLineTextHtml}
+          event={mockRunnerOnOkEvent}
+          isClickable={false}
+          onJobEventClick={onJobEventClick}
+          measure={jest.fn()}
+        />
+      );
+      const clickable = wrapper.find('div[onClick]');
+      expect(clickable).toHaveLength(0);
+      wrapper.unmount();
+    });
   });
 });


### PR DESCRIPTION
##### SUMMARY
Its always been a problem that if I wanted to highlight a small section of text in a Job Output event, if that event is clickable (has even data), then highlighting the text will cause the even popup to fire.

This resolves this by checking for this scenario.  It will still fire if you highlight the text and then deliberately click the event.  It will not fire if only highlighting the text.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

