### PR TITLE
Resolve issue where Elapsed Timer doesn't start on Launch

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
@@ -42,6 +42,7 @@ const Wrapper = styled.div`
   font-size: 14px;
 `;
 const calculateElapsed = (started) => {
+  if (!started) return '00:00:00';
   const now = DateTime.now();
   const duration = now
     .diff(DateTime.fromISO(`${started}`), [

--- a/awx/ui/src/screens/Job/useWsJob.js
+++ b/awx/ui/src/screens/Job/useWsJob.js
@@ -20,7 +20,9 @@ export default function useWsJob(initialJob) {
     }
 
     if (
-      ['successful', 'failed', 'error', 'cancelled'].includes(message.status)
+      ['successful', 'failed', 'error', 'cancelled', 'running'].includes(
+        message.status
+      )
     ) {
       fetchJob();
     }

--- a/awx/ui/src/screens/Job/useWsJob.js
+++ b/awx/ui/src/screens/Job/useWsJob.js
@@ -20,7 +20,7 @@ export default function useWsJob(initialJob) {
     }
 
     if (
-      ['successful', 'failed', 'error', 'cancelled', 'running'].includes(
+      ['successful', 'failed', 'error', 'canceled', 'running'].includes(
         message.status
       )
     ) {


### PR DESCRIPTION
* When a job is Launched, the initial fetch gets "started: null" (job is pending).
* The WebSocket status_changed message for 'running' only includes status and instance_group_name, not started
* The updateJob function in useWsJob.js only copies finished and status, so job.started stays null.
* A full refetch only happens on terminal statuses (successful, failed, etc.)
* OutputToolbar's timer tries calculateElapsed(null) which produces an invalid DateTime, so activeJobElapsedTime never updates from '00:00:00'

Resolved by updating the ws to also force a fetch when it transitions to Running (and verified that it only sends this status once).  Also fixed the calculateElapsed function doesn't produce an invalid datetime.



