### PR TITLE
Fix missing columns on User List table

### DIFF
--- a/awx/ui/src/screens/User/UserList/UserList.js
+++ b/awx/ui/src/screens/User/UserList/UserList.js
@@ -169,6 +169,7 @@ function UserList() {
                 </HeaderCell>
                 <HeaderCell>{t`Email`}</HeaderCell>
                 <HeaderCell>{t`Organization`}</HeaderCell>
+                <HeaderCell>{t`Role`}</HeaderCell>
                 <HeaderCell>{t`Actions`}</HeaderCell>
               </HeaderRow>
             }

--- a/awx/ui/src/screens/User/UserList/UserListItem.js
+++ b/awx/ui/src/screens/User/UserList/UserListItem.js
@@ -57,6 +57,8 @@ function UserListItem({ user, isSelected, onSelect, detailUrl, rowIndex }) {
       </TdBreakWord>
       <Td dataLabel={t`First Name`}>{user.first_name}</Td>
       <Td dataLabel={t`Last Name`}>{user.last_name}</Td>
+      <Td dataLabel={t`Email`}>{user.email}</Td>
+      <Td dataLabel={t`Organization`}>{user.summary_fields?.organization?.name || '—'}</Td>
       <Td dataLabel={t`Role`}>{user_type}</Td>
       <ActionsTd dataLabel={t`Actions`}>
         <ActionItem


### PR DESCRIPTION
Seems the Users List has a mismatch between the Headers and the actual columns outputted by the User list item.  This combine the 2 to ensure we have them all.