### PR TITLE
Upgrade lxml to resolves CVE-2026-41066

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,7 +51,6 @@ python-daemon>3.0.0
 python-dsv-sdk>=1.0.4
 python-tss-sdk>=1.2.1
 python-ldap>=3.4.5  # CVE-2025-61911 CVE-2025-61912
-python3-saml==1.16.0
 pyyaml>=6.0.1
 receptorctl
 social-auth-core[openidconnect]==4.5.0  # see UPGRADE BLOCKERs

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,6 +51,7 @@ python-daemon>3.0.0
 python-dsv-sdk>=1.0.4
 python-tss-sdk>=1.2.1
 python-ldap>=3.4.5  # CVE-2025-61911 CVE-2025-61912
+python3-saml==1.16.0
 pyyaml>=6.0.1
 receptorctl
 social-auth-core[openidconnect]==4.5.0  # see UPGRADE BLOCKERs

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -383,8 +383,8 @@ python-tss-sdk==1.2.2
     # via -r /awx_devel/requirements/requirements.in
 python3-openid==3.2.0
     # via social-auth-core
-python3-saml==1.16.0
-    # via -r /awx_devel/requirements/requirements.in
+# python3-saml @ git+https://github.com/SAML-Toolkits/python3-saml.git@52d2ac8da3f35262755f6e1c32ba7c62a6011fe1  # git requirements installed separately
+    # via -r /awx_devel/requirements/requirements_git.txt
 pytz==2024.1
     # via
     #   irc

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -258,7 +258,7 @@ libvalkey==4.0.1
     # via valkey
 lockfile==0.12.2
     # via python-daemon
-lxml==4.9.4
+lxml==6.1.0
     # via
     #   python3-saml
     #   xmlsec
@@ -383,8 +383,8 @@ python-tss-sdk==1.2.2
     # via -r /awx_devel/requirements/requirements.in
 python3-openid==3.2.0
     # via social-auth-core
-# python3-saml @ git+https://github.com/ansible/python3-saml.git@devel  # git requirements installed separately
-    # via -r /awx_devel/requirements/requirements_git.txt
+python3-saml==1.16.0
+    # via -r /awx_devel/requirements/requirements.in
 pytz==2024.1
     # via
     #   irc
@@ -520,7 +520,7 @@ websocket-client==1.7.0
     # via kubernetes
 wheel==0.46.3
     # via -r /awx_devel/requirements/requirements.in
-xmlsec==1.3.13
+xmlsec==1.3.17
     # via python3-saml
 yarl==1.18.3
     # via aiohttp

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -19,5 +19,4 @@
 #
 certifi @ git+https://github.com/ansible/system-certifi.git@devel
 ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel
-python3-saml @ git+https://github.com/ansible/python3-saml.git@devel
 django-ansible-base[jwt-consumer,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -19,4 +19,5 @@
 #
 certifi @ git+https://github.com/ansible/system-certifi.git@devel
 ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel
+python3-saml @ git+https://github.com/SAML-Toolkits/python3-saml.git@52d2ac8da3f35262755f6e1c32ba7c62a6011fe1
 django-ansible-base[jwt-consumer,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel


### PR DESCRIPTION
python3-saml was deprecated by OneLogin and at the time, it was dependent on an old version of lxml.  So Ansible forked the repo, and fixed the issue there and swapped to using their own repo.

Ansible has deprecated their own repo now, so this CVE isn't going to be fixed there.  Luckily OneLogin handed the python3-saml repo off to a new developer, and the lxml issue was fixed and unpinned a few years ago.

I am still using git to pull it, as the author has made a few fixes to the master branch, but hasn't released a new version in a few years.  So pinning to the SHA.

*Note* - We should also look into removing the certifi git pin, as Ansible has deprecated that repo too, and I believe it was only being pinned to their minimal fork (which used the OS certs instead of Mozilla) because of virtual environments, which we have now removed.