### PR TITLE
Fix new service worker pathing

### DIFF
--- a/awx/ui/urls.py
+++ b/awx/ui/urls.py
@@ -1,7 +1,11 @@
 # Modifications Copyright (c) 2024 Ctrl IQ, Inc.
 
+from pathlib import Path
+
+from django.http import FileResponse, Http404
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
+from django.views import View
 from django.views.generic.base import TemplateView
 
 
@@ -23,6 +27,22 @@ class MigrationsNotran(TemplateView):
         return context
 
 
+class ServiceWorkerView(View):
+    def get(self, request, *args, **kwargs):
+        service_worker_path = Path(__file__).resolve().parent / 'build' / 'service-worker.js'
+        if not service_worker_path.is_file():
+            raise Http404()
+
+        response = FileResponse(service_worker_path.open('rb'), content_type='application/javascript')
+        response['Service-Worker-Allowed'] = '/'
+        response['Cache-Control'] = 'no-cache'
+        return response
+
+
 app_name = 'ui'
 
-urlpatterns = [path('', IndexView.as_view(), name='index'), path('migrations_notran/', MigrationsNotran.as_view(), name='migrations_notran')]
+urlpatterns = [
+    path('service-worker.js', ServiceWorkerView.as_view(), name='service-worker'),
+    path('', IndexView.as_view(), name='index'),
+    path('migrations_notran/', MigrationsNotran.as_view(), name='migrations_notran'),
+]

--- a/awx/ui/urls.py
+++ b/awx/ui/urls.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from django.http import FileResponse, Http404
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
-from django.views import View
+from django.views.generic import View
 from django.views.generic.base import TemplateView
 
 


### PR DESCRIPTION
Django wasn't able to access the new service worker, so add a mapping to it.  It has to be in the root, otherwise it breaks the scoping.