### PR TITLE
Exclude service worker from HTMLWebpack

### DIFF
--- a/awx/ui/config/webpack.config.js
+++ b/awx/ui/config/webpack.config.js
@@ -568,6 +568,7 @@ module.exports = function (webpackEnv) {
           {
             inject: true,
             template: paths.appHtml,
+            excludeChunks: ['service-worker'],
           },
           isEnvProduction
             ? {
@@ -637,6 +638,11 @@ module.exports = function (webpackEnv) {
         publicPath: paths.publicUrlOrPath,
         generate: (seed, files, entrypoints) => {
           const manifestFiles = files.reduce((manifest, file) => {
+            // Exclude the hashed service-worker chunk — it gets moved to the
+            // build root by InjectManifestPlugin, so the static/js/ path is wrong.
+            if (/service-worker\.[a-f0-9]+\.js/.test(file.name)) {
+              return manifest;
+            }
             manifest[file.name] = file.path;
             return manifest;
           }, seed);


### PR DESCRIPTION
Service Worker is working, but HTMLwebpack adds it to the asset list, but it doesn't exist in that location, so exclude it.