### PR TITLE
Upstream 16417 - Balance controller node selection during capacity ties

### DIFF
--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -151,7 +151,9 @@ class TaskManagerInstances:
         if execution_instance and execution_instance.node_type in ('hybrid', 'execution'):
             self.instances_by_hostname[task.execution_node].consume_capacity(task.task_impact, job_impact=True)
         if control_instance and control_instance.node_type in ('hybrid', 'control'):
-            self.instances_by_hostname[task.controller_node].consume_capacity(self.control_task_impact)
+            # Track jobs_running on the controller unless it was already counted as the execution node
+            count_as_job = (control_instance != execution_instance)
+            self.instances_by_hostname[task.controller_node].consume_capacity(self.control_task_impact, job_impact=count_as_job)
 
     def __getitem__(self, hostname):
         return self.instances_by_hostname.get(hostname)
@@ -220,7 +222,11 @@ class TaskManagerInstanceGroups:
             # hybrid nodes _always_ control their own tasks
             if add_hybrid_control_cost and i.node_type == 'hybrid':
                 would_be_remaining -= self.control_task_impact
-            if would_be_remaining >= 0 and (instance_most_capacity is None or would_be_remaining > most_remaining_capacity):
+            if would_be_remaining >= 0 and (
+                instance_most_capacity is None
+                or would_be_remaining > most_remaining_capacity
+                or (would_be_remaining == most_remaining_capacity and i.jobs_running < instance_most_capacity.jobs_running)
+            ):
                 instance_most_capacity = i
                 most_remaining_capacity = would_be_remaining
         return instance_most_capacity

--- a/awx/main/tests/unit/test_capacity.py
+++ b/awx/main/tests/unit/test_capacity.py
@@ -177,10 +177,21 @@ class TestSelectBestInstanceForTask(object):
         'task,instances,instance_fit_index,reason',
         [
             (Job(task_impact=100), Is([100]), 0, "Only one, pick it"),
-            (Job(task_impact=100), Is([100, 100]), 0, "Two equally good fits, pick the first"),
+            (Job(task_impact=100), Is([100, 100]), 0, "Two equally good fits and equal jobs_running, pick the first"),
             (Job(task_impact=100), Is([50, 100]), 1, "First instance not as good as second instance"),
             (Job(task_impact=100), Is([50, 0, 20, 100, 100, 100, 30, 20]), 3, "Pick Instance [3] as it is the first that the task fits in."),
             (Job(task_impact=100), Is([50, 0, 20, 99, 11, 1, 5, 99]), None, "The task don't a fit, you must a quit!"),
+            # Tie-breaking: equal would_be_remaining but different jobs_running
+            # capacity=243 with 1 running (impact 43) → remaining 200 → would_be 100
+            # capacity=200 with 0 running → remaining 200 → would_be 100
+            (Job(task_impact=100), Is([(1, 243), (0, 200)]), 1, "Equal would_be_remaining, pick instance with fewer jobs running"),
+            # Three-way tie: capacities chosen so that remaining after consumption yields equal would_be
+            # (2 running, cap 286): remaining=286-86=200, would_be=100
+            # (0 running, cap 200): remaining=200, would_be=100
+            # (1 running, cap 243): remaining=243-43=200, would_be=100
+            (Job(task_impact=100), Is([(2, 286), (0, 200), (1, 243)]), 1, "Three-way tie, pick instance with fewest jobs running"),
+            (Job(task_impact=100), Is([(0, 200), (0, 300)]), 1, "Different capacity, pick higher capacity regardless of jobs"),
+            (Job(task_impact=100), Is([(5, 600), (0, 200)]), 0, "Higher remaining capacity wins even with more jobs running"),
         ],
     )
     def test_fit_task_to_most_remaining_capacity_instance(self, task, instances, instance_fit_index, reason):
@@ -197,6 +208,69 @@ class TestSelectBestInstanceForTask(object):
             assert instance_picked is None, reason
         else:
             assert instance_picked.hostname == instances[instance_fit_index].hostname, reason
+
+    def test_controller_node_tie_break_with_container_group_jobs(self):
+        """Verify that controller nodes managing container-group jobs track jobs_running
+        and tie-break correctly. Container-group jobs have controller_node set but no
+        execution_node, simulating the real burst workload scenario."""
+        ig = InstanceGroup(id=10, name='controlplane')
+        ctrl_a = Instance(hostname='ctrl-a', capacity=200, node_type='control')
+        ctrl_b = Instance(hostname='ctrl-b', capacity=200, node_type='control')
+        ctrl_c = Instance(hostname='ctrl-c', capacity=200, node_type='control')
+        ig.instances.add(ctrl_a, ctrl_b, ctrl_c)
+
+        # Simulate container-group jobs: ctrl-a has 3, ctrl-b has 1, ctrl-c has 0
+        tasks = [
+            Job(controller_node='ctrl-a', execution_node='', instance_group=ig),
+            Job(controller_node='ctrl-a', execution_node='', instance_group=ig),
+            Job(controller_node='ctrl-a', execution_node='', instance_group=ig),
+            Job(controller_node='ctrl-b', execution_node='', instance_group=ig),
+        ]
+        tm_models = TaskManagerModels.init_with_consumed_capacity(
+            tasks=tasks, instances=[ctrl_a, ctrl_b, ctrl_c], instance_groups=[ig]
+        )
+
+        # ctrl-a: consumed=3, jobs_running=3, remaining=197
+        # ctrl-b: consumed=1, jobs_running=1, remaining=199
+        # ctrl-c: consumed=0, jobs_running=0, remaining=200
+        # New task with impact=1 (control): ctrl-c has most remaining (200) → wins by capacity
+        task = Job(task_impact=1, capacity_type='control')
+        picked = tm_models.instance_groups.fit_task_to_most_remaining_capacity_instance(task, 'controlplane')
+        assert picked.hostname == 'ctrl-c', "Should pick the node with most remaining capacity"
+
+    def test_controller_node_tie_break_equal_capacity(self):
+        """When control nodes have exactly equal remaining capacity, prefer the one
+        with fewer jobs_running. This is the core burst-distribution scenario."""
+        ig = InstanceGroup(id=10, name='controlplane')
+        ctrl_a = Instance(hostname='ctrl-a', capacity=200, node_type='control')
+        ctrl_b = Instance(hostname='ctrl-b', capacity=200, node_type='control')
+        ig.instances.add(ctrl_a, ctrl_b)
+
+        # Both nodes have same consumed capacity (1 each) but ctrl-a has 1 job, ctrl-b has 1 job
+        # After this, both have remaining=199, jobs_running=1 → tie → first wins
+        tasks = [
+            Job(controller_node='ctrl-a', execution_node='', instance_group=ig),
+            Job(controller_node='ctrl-b', execution_node='', instance_group=ig),
+        ]
+        tm_models = TaskManagerModels.init_with_consumed_capacity(
+            tasks=tasks, instances=[ctrl_a, ctrl_b], instance_groups=[ig]
+        )
+        task = Job(task_impact=1, capacity_type='control')
+        picked = tm_models.instance_groups.fit_task_to_most_remaining_capacity_instance(task, 'controlplane')
+        # Both tied on capacity (199) and jobs_running (1) → first in iteration wins
+        assert picked.hostname == 'ctrl-a', "Equal capacity and jobs: first in iteration wins"
+
+        # Now give ctrl-a one more job, making it 2 vs 1
+        tasks.append(Job(controller_node='ctrl-a', execution_node='', instance_group=ig))
+        tm_models = TaskManagerModels.init_with_consumed_capacity(
+            tasks=tasks, instances=[ctrl_a, ctrl_b], instance_groups=[ig]
+        )
+        # ctrl-a: consumed=2, jobs_running=2, remaining=198
+        # ctrl-b: consumed=1, jobs_running=1, remaining=199
+        # ctrl-b wins by capacity (199 > 198)
+        task = Job(task_impact=1, capacity_type='control')
+        picked = tm_models.instance_groups.fit_task_to_most_remaining_capacity_instance(task, 'controlplane')
+        assert picked.hostname == 'ctrl-b', "Node with fewer jobs has more remaining capacity, wins"
 
     @pytest.mark.parametrize(
         'instances,instance_fit_index,reason',


### PR DESCRIPTION
## Upstream Summary

- Add least-connections tie-breaking to `fit_task_to_most_remaining_capacity_instance`: when `would_be_remaining` is equal, prefer the instance with fewer `jobs_running`
- Backwards-compatible: when capacity clearly differs, existing "most remaining capacity" logic dominates unchanged
- Add 4 new parametrised test cases exercising the tie-breaking behaviour

## Problem

When multiple control-plane instances have equal remaining capacity (the common scenario for container-group workloads where `AWX_CONTROL_NODE_TASK_IMPACT = 1`), all burst jobs are assigned to the same controller node. This concentrates job management overhead (event processing, callbacks, output streaming) on one pod while others sit idle.

Tested with 3 controller replicas and 20 concurrent container-group jobs: 100% were managed by a single node.

## Fix

One additional condition in the selection loop:

```python
or (would_be_remaining == most_remaining_capacity and i.jobs_running < instance_most_capacity.jobs_running)
```

When capacity is tied, the node currently running fewer jobs is preferred. This uses existing in-memory state (`jobs_running` on `TaskManagerInstance`) which is already tracked per-cycle and initialised from the database.

## Issue Type

 - Bug, Docs Fix or other nominal change

## Test plan

- [x] Existing `test_fit_task_to_most_remaining_capacity_instance` cases pass (no behaviour change when capacity differs)
- [x] New test: equal `would_be_remaining`, prefer instance with fewer `jobs_running`
- [x] New test: three-way tie, pick instance with fewest `jobs_running`
- [x] New test: higher remaining capacity wins regardless of `jobs_running`
- [x] New test: capacity difference dominates even when one node has more jobs
- [x] Manual verification: 20 concurrent jobs distributed across 3 controller replicas on OCP
