### PR TITLE
Add option for DR deployments for disabling all Schedules

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5419,6 +5419,12 @@ class ScheduleSerializer(LaunchConfigurationBaseSerializer, SchedulePreviewSeria
     def get_until(self, obj):
         return obj.until
 
+    def to_representation(self, obj):
+        data = super(ScheduleSerializer, self).to_representation(obj)
+        if getattr(settings, 'DISABLE_ALL_SCHEDULES', False):
+            data['enabled'] = False
+        return data
+
     def get_related(self, obj):
         res = super(ScheduleSerializer, self).get_related(obj)
         res.update(dict(unified_jobs=self.reverse('api:schedule_unified_jobs_list', kwargs={'pk': obj.pk})))

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -725,6 +725,10 @@ def awx_periodic_scheduler():
         state.schedule_last_run = run_now
         state.save()
 
+        if getattr(settings, 'DISABLE_ALL_SCHEDULES', False):
+            logger.info("Skipping periodic scheduler because DISABLE_ALL_SCHEDULES is enabled")
+            return
+
         old_schedules = Schedule.objects.enabled().before(last_run)
         for schedule in old_schedules:
             schedule.update_computed_fields()

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -726,7 +726,7 @@ def awx_periodic_scheduler():
         state.save()
 
         if getattr(settings, 'DISABLE_ALL_SCHEDULES', False):
-            logger.info("Skipping periodic scheduler because DISABLE_ALL_SCHEDULES is enabled")
+            logger.debug("Skipping periodic scheduler because DISABLE_ALL_SCHEDULES is enabled")
             return
 
         old_schedules = Schedule.objects.enabled().before(last_run)

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -1,6 +1,7 @@
 import datetime
 import pytest
 
+from django.test import override_settings
 from django.utils.encoding import smart_str
 from django.utils.timezone import now
 
@@ -127,6 +128,19 @@ def test_survey_password_default(post, patch, admin_user, project, inventory, su
     # test an unrelated change
     patch(schedule.get_absolute_url(), data={'enabled': False}, user=admin_user, expect=200)
     patch(schedule.get_absolute_url(), data={'enabled': True}, user=admin_user, expect=200)
+
+
+@pytest.mark.django_db
+def test_schedule_detail_returns_disabled_when_all_schedules_are_globally_disabled(get, admin_user, project, inventory):
+    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+    schedule = Schedule.objects.create(name='test sch', rrule=RRULE_EXAMPLE, unified_job_template=job_template, enabled=True)
+
+    with override_settings(DISABLE_ALL_SCHEDULES=True):
+        response = get(schedule.get_absolute_url(), admin_user, expect=200)
+
+    assert response.data['enabled'] is False
+    schedule.refresh_from_db()
+    assert schedule.enabled is True
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/unit/tasks/test_system.py
+++ b/awx/main/tests/unit/tasks/test_system.py
@@ -1,6 +1,8 @@
 import pytest
+from contextlib import contextmanager
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
-from awx.main.tasks.system import update_inventory_computed_fields
+from awx.main.tasks.system import awx_periodic_scheduler, update_inventory_computed_fields
 from awx.main.models import Inventory
 from django.db import DatabaseError
 
@@ -62,3 +64,24 @@ def test_update_inventory_computed_fields_database_error_nosqlstate(mock_logger,
             mock_filter.assert_called_once_with(id=1)
             mock_update_computed_fields.assert_called_once()
             mock_inventory.update_computed_fields.assert_called_once()
+
+
+def test_awx_periodic_scheduler_skips_schedule_processing_when_all_schedules_disabled():
+    run_now = datetime(2026, 5, 7, tzinfo=timezone.utc)
+    state = MagicMock()
+    state.schedule_last_run = datetime(2026, 5, 6, tzinfo=timezone.utc)
+
+    @contextmanager
+    def mock_advisory_lock(*args, **kwargs):
+        yield True
+
+    with patch("awx.main.tasks.system.advisory_lock", mock_advisory_lock):
+        with patch("awx.main.tasks.system.TowerScheduleState.get_solo", return_value=state):
+            with patch("awx.main.tasks.system.now", return_value=run_now):
+                with patch("awx.main.tasks.system.Schedule.objects.enabled") as mock_enabled:
+                    with patch("awx.main.tasks.system.settings.DISABLE_ALL_SCHEDULES", True):
+                        awx_periodic_scheduler()
+
+    assert state.schedule_last_run == run_now
+    state.save.assert_called_once_with()
+    mock_enabled.assert_not_called()

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -272,6 +272,11 @@ K8S_POD_REAPER_GRACE_PERIOD = 60
 # Disallow sending session cookies over insecure connections
 SESSION_COOKIE_SECURE = True
 
+# When enabled, schedules remain stored as configured in the database, but
+# they are treated as disabled by the API and periodic scheduler. This is
+# intended for DR restore testing to prevent scheduled jobs from firing.
+DISABLE_ALL_SCHEDULES = True
+
 # Seconds before sessions expire.
 # Note: This setting may be overridden by database settings.
 SESSION_COOKIE_AGE = 1800

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -275,7 +275,7 @@ SESSION_COOKIE_SECURE = True
 # When enabled, schedules remain stored as configured in the database, but
 # they are treated as disabled by the API and periodic scheduler. This is
 # intended for DR restore testing to prevent scheduled jobs from firing.
-DISABLE_ALL_SCHEDULES = True
+DISABLE_ALL_SCHEDULES = False
 
 # Seconds before sessions expire.
 # Note: This setting may be overridden by database settings.


### PR DESCRIPTION
When deploying Ascender into a DR environment, any jobs that were supposed to fire between the time the backup was taken and when the restore happens, will fire when the application comes up.  This can cause many issues, especially if you are only testing a restoration to DR, as it will fire jobs against production servers.

New variable DISABLE_ALL_SCHEDULES will be created.

We will set this via the Operator (PR forthcoming) and thus be able to set it via the installer.

When set, it will cause it to treat every schedule as disabled.  The schedules show as disabled in the UI (though they are still enabled in the backend) and they will not fire.
