### PR TITLE
chore(ci): bump GitHub Actions off Node 20 runtimes

### DIFF
--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -35,7 +35,7 @@ jobs:
         if: matrix.build-targets.image-name == 'awx' && !endsWith(github.repository, '/ascender')
 
       - name: Checkout ascender
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: ascender
           ref: main
@@ -44,7 +44,7 @@ jobs:
         run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
 
       - name: Install python ${{ env.py_version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.py_version }}
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -22,13 +22,13 @@ jobs:
       packages: write
     steps:
       - name: Checkout ascender
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Get python version from Makefile
         run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
 
       - name: Install python ${{ env.py_version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.py_version }}
 

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -43,7 +43,7 @@ jobs:
           exit 0
 
       - name: Checkout ascender
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: ascender
 
@@ -51,7 +51,7 @@ jobs:
         run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
 
       - name: Install python ${{ env.py_version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.py_version }}
 


### PR DESCRIPTION
## Summary

Node 20 reached EOL on 2026-04-30. This PR bumps GitHub Actions to current stable releases, pinned by full commit SHA with the target tag in a trailing comment.


## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v2` | `v6.0.2` |
| `actions/checkout` | `v3` | `v6.0.2` |
| `actions/setup-python` | `v2` | `v6.2.0` |
| `actions/setup-python` | `v4` | `v6.2.0` |

Files touched: **3** workflow file(s), **6** line change(s).

## Test plan

- [ ] Existing CI runs on this PR and stays green.
- [ ] If this repo's workflows aren't PR-triggered, dispatch them manually after merge or via `workflow_dispatch`.

---

Part of an org-wide bulk update across ~135 ctrliq repos to escape Node 20 EOL.
