### PR TITLE
Upgrade lxml to resolve CVE-2026-41066

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,14 +151,14 @@ virtualenv_awx:
 # this does not use system site packages intentionally
 requirements_awx: virtualenv_awx
 	if [[ "$(PIP_OPTIONS)" == *"--no-index"* ]]; then \
-	    cat requirements/requirements.txt requirements/requirements_local.txt | $(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) -r /dev/stdin ; \
+	    cat requirements/requirements.txt requirements/requirements_local.txt | UWSGI_PROFILE_OVERRIDE=xml=false $(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) -r /dev/stdin ; \
 	else \
-	    cat requirements/requirements.txt requirements/requirements_git.txt | $(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) -r /dev/stdin ; \
+	    cat requirements/requirements.txt requirements/requirements_git.txt | UWSGI_PROFILE_OVERRIDE=xml=false $(VENV_BASE)/awx/bin/pip install $(PIP_OPTIONS) --no-binary $(SRC_ONLY_PKGS) -r /dev/stdin ; \
 	fi
 	$(VENV_BASE)/awx/bin/pip uninstall --yes -r requirements/requirements_tower_uninstall.txt
 
 requirements_awx_dev:
-	$(VENV_BASE)/awx/bin/pip install -r requirements/requirements_dev.txt
+	UWSGI_PROFILE_OVERRIDE=xml=false $(VENV_BASE)/awx/bin/pip install -r requirements/requirements_dev.txt
 
 requirements: requirements_awx
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -258,7 +258,7 @@ libvalkey==4.0.1
     # via valkey
 lockfile==0.12.2
     # via python-daemon
-lxml==5.4.0
+lxml==6.1.0
     # via
     #   python3-saml
     #   xmlsec
@@ -520,7 +520,7 @@ websocket-client==1.7.0
     # via kubernetes
 wheel==0.46.3
     # via -r /awx_devel/requirements/requirements.in
-xmlsec==1.3.13
+xmlsec==1.3.17
     # via python3-saml
 yarl==1.18.3
     # via aiohttp


### PR DESCRIPTION
2nd crack at this one.  This resolves the error from UWSGI about mismatched libxml2 after upgrading lxml and xmlsec.