### PR TITLE
Upstream 15970 - Revise start_fact_cache and finish_fact_cache to use JSON file

### DIFF
--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -20,26 +20,27 @@ system_tracking_logger = logging.getLogger('awx.analytics.system_tracking')
 
 
 @log_excess_runtime(logger, debug_cutoff=0.01, msg='Inventory {inventory_id} host facts prepared for {written_ct} hosts, took {delta:.3f} s', add_log_data=True)
-def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=None):
+def start_fact_cache(hosts, artifacts_dir, timeout=None, inventory_id=None, log_data=None):
+    log_data = log_data or {}
     log_data['inventory_id'] = inventory_id
     log_data['written_ct'] = 0
-    hosts_cached = list()
-    try:
-        os.makedirs(destination, mode=0o700)
-    except FileExistsError:
-        pass
+    hosts_cached = []
+
+    # Create the fact_cache directory inside artifacts_dir
+    fact_cache_dir = os.path.join(artifacts_dir, 'fact_cache')
+    os.makedirs(fact_cache_dir, mode=0o700, exist_ok=True)
 
     if timeout is None:
         timeout = settings.ANSIBLE_FACT_CACHE_TIMEOUT
 
-    last_filepath_written = None
+    last_write_time = None
     for host in hosts:
-        hosts_cached.append(host)
+        hosts_cached.append(host.name)
         if not host.ansible_facts_modified or (timeout and host.ansible_facts_modified < now() - datetime.timedelta(seconds=timeout)):
             continue  # facts are expired - do not write them
-        filepath = os.sep.join(map(str, [destination, host.name]))
-        if not os.path.realpath(filepath).startswith(destination):
-            system_tracking_logger.error('facts for host {} could not be cached'.format(smart_str(host.name)))
+        filepath = os.path.join(fact_cache_dir, host.name)
+        if not os.path.realpath(filepath).startswith(fact_cache_dir):
+            logger.error(f'facts for host {smart_str(host.name)} could not be cached')
             continue
 
         try:
@@ -47,15 +48,21 @@ def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=No
                 os.chmod(f.name, 0o600)
                 json.dump(host.ansible_facts, f)
                 log_data['written_ct'] += 1
-                last_filepath_written = filepath
+                last_write_time = os.path.getmtime(filepath)
         except IOError:
-            system_tracking_logger.error('facts for host {} could not be cached'.format(smart_str(host.name)))
+            logger.error(f'facts for host {smart_str(host.name)} could not be cached')
             continue
 
-    if last_filepath_written:
-        return os.path.getmtime(last_filepath_written), hosts_cached
-
-    return None, hosts_cached
+    # Write summary file directly to the artifacts_dir
+    if inventory_id is not None:
+        summary_file = os.path.join(artifacts_dir, 'host_cache_summary.json')
+        summary_data = {
+            'last_write_time': last_write_time,
+            'hosts_cached': hosts_cached,
+            'written_ct': log_data['written_ct'],
+        }
+        with open(summary_file, 'w', encoding='utf-8') as f:
+            json.dump(summary_data, f, indent=2)
 
 
 @log_excess_runtime(
@@ -64,34 +71,54 @@ def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=No
     msg='Inventory {inventory_id} host facts: updated {updated_ct}, cleared {cleared_ct}, unchanged {unmodified_ct}, took {delta:.3f} s',
     add_log_data=True,
 )
-def finish_fact_cache(hosts_cached, destination, facts_write_time, log_data, job_id=None, inventory_id=None):
+def finish_fact_cache(artifacts_dir, job_id=None, inventory_id=None, log_data=None):
+    log_data = log_data or {}
     log_data['inventory_id'] = inventory_id
     log_data['updated_ct'] = 0
     log_data['unmodified_ct'] = 0
     log_data['cleared_ct'] = 0
+    # The summary file is directly inside the artifacts dir
+    summary_path = os.path.join(artifacts_dir, 'host_cache_summary.json')
+    if not os.path.exists(summary_path):
+        logger.error(f'Missing summary file at {summary_path}')
+        return
 
-    hosts_cached = sorted((h for h in hosts_cached if h.id is not None), key=lambda h: h.id)
+    try:
+        with open(summary_path, 'r', encoding='utf-8') as f:
+            summary = json.load(f)
+        facts_write_time = os.path.getmtime(summary_path)  # After successful read
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error(f'Error reading summary file at {summary_path}: {e}')
+        return
 
+    host_names = summary.get('hosts_cached', [])
+    hosts_cached = Host.objects.filter(name__in=host_names).order_by('id').iterator()
+    # Path where individual fact files were written
+    fact_cache_dir = os.path.join(artifacts_dir, 'fact_cache')
     hosts_to_update = []
+
     for host in hosts_cached:
-        filepath = os.sep.join(map(str, [destination, host.name]))
-        if not os.path.realpath(filepath).startswith(destination):
-            system_tracking_logger.error('facts for host {} could not be cached'.format(smart_str(host.name)))
+        filepath = os.path.join(fact_cache_dir, host.name)
+        if not os.path.realpath(filepath).startswith(fact_cache_dir):
+            logger.error(f'Invalid path for facts file: {filepath}')
             continue
+
         if os.path.exists(filepath):
             # If the file changed since we wrote the last facts file, pre-playbook run...
             modified = os.path.getmtime(filepath)
-            if (not facts_write_time) or modified > facts_write_time:
-                with codecs.open(filepath, 'r', encoding='utf-8') as f:
-                    try:
+            if not facts_write_time or modified >= facts_write_time:
+                try:
+                    with codecs.open(filepath, 'r', encoding='utf-8') as f:
                         ansible_facts = json.load(f)
-                    except ValueError:
-                        continue
+                except ValueError:
+                    continue
+
+                if ansible_facts != host.ansible_facts:
                     host.ansible_facts = ansible_facts
                     host.ansible_facts_modified = now()
                     hosts_to_update.append(host)
-                    system_tracking_logger.info(
-                        'New fact for inventory {} host {}'.format(smart_str(host.inventory.name), smart_str(host.name)),
+                    logger.info(
+                        f'New fact for inventory {smart_str(host.inventory.name)} host {smart_str(host.name)}',
                         extra=dict(
                             inventory_id=host.inventory.id,
                             host_name=host.name,
@@ -101,6 +128,8 @@ def finish_fact_cache(hosts_cached, destination, facts_write_time, log_data, job
                         ),
                     )
                     log_data['updated_ct'] += 1
+                else:
+                    log_data['unmodified_ct'] += 1
             else:
                 log_data['unmodified_ct'] += 1
         else:
@@ -109,9 +138,11 @@ def finish_fact_cache(hosts_cached, destination, facts_write_time, log_data, job
             host.ansible_facts = {}
             host.ansible_facts_modified = now()
             hosts_to_update.append(host)
-            system_tracking_logger.info('Facts cleared for inventory {} host {}'.format(smart_str(host.inventory.name), smart_str(host.name)))
+            logger.info(f'Facts cleared for inventory {smart_str(host.inventory.name)} host {smart_str(host.name)}')
             log_data['cleared_ct'] += 1
-        if len(hosts_to_update) > 100:
+
+        if len(hosts_to_update) >= 100:
             bulk_update_sorted_by_id(Host, hosts_to_update, fields=['ansible_facts', 'ansible_facts_modified'])
             hosts_to_update = []
+
     bulk_update_sorted_by_id(Host, hosts_to_update, fields=['ansible_facts', 'ansible_facts_modified'])

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1092,8 +1092,8 @@ class RunJob(SourceControlMixin, BaseTask):
         # where ansible expects to find it
         if self.should_use_fact_cache():
             job.log_lifecycle("start_job_fact_cache")
-            self.facts_write_time, self.hosts_with_facts_cached = start_fact_cache(
-                job.get_hosts_for_fact_cache(), os.path.join(private_data_dir, 'artifacts', str(job.id), 'fact_cache'), inventory_id=job.inventory_id
+            self.hosts_with_facts_cached = start_fact_cache(
+                job.get_hosts_for_fact_cache(), artifacts_dir=os.path.join(private_data_dir, 'artifacts', str(job.id)), inventory_id=job.inventory_id
             )
 
     def build_project_dir(self, job, private_data_dir):
@@ -1103,7 +1103,7 @@ class RunJob(SourceControlMixin, BaseTask):
         super(RunJob, self).post_run_hook(job, status)
         job.refresh_from_db(fields=['job_env'])
         private_data_dir = job.job_env.get('AWX_PRIVATE_DATA_DIR')
-        if (not private_data_dir) or (not hasattr(self, 'facts_write_time')):
+        if not private_data_dir:
             # If there's no private data dir, that means we didn't get into the
             # actual `run()` call; this _usually_ means something failed in
             # the pre_run_hook method
@@ -1111,9 +1111,7 @@ class RunJob(SourceControlMixin, BaseTask):
         if self.should_use_fact_cache() and self.runner_callback.artifacts_processed:
             job.log_lifecycle("finish_job_fact_cache")
             finish_fact_cache(
-                self.hosts_with_facts_cached,
-                os.path.join(private_data_dir, 'artifacts', str(job.id), 'fact_cache'),
-                facts_write_time=self.facts_write_time,
+                artifacts_dir=os.path.join(private_data_dir, 'artifacts', str(job.id)),
                 job_id=job.id,
                 inventory_id=job.inventory_id,
             )
@@ -1563,7 +1561,7 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
                 # Include any facts from input inventories so they can be used in filters
                 start_fact_cache(
                     input_inventory.hosts.only(*HOST_FACTS_FIELDS),
-                    os.path.join(private_data_dir, 'artifacts', str(inventory_update.id), 'fact_cache'),
+                    artifacts_dir=os.path.join(private_data_dir, 'artifacts', str(inventory_update.id)),
                     inventory_id=input_inventory.id,
                 )
 

--- a/awx/main/tests/unit/models/test_jobs.py
+++ b/awx/main/tests/unit/models/test_jobs.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import os
-import time
-
 import pytest
 
 from awx.main.models import (
@@ -14,6 +12,8 @@ from awx.main.tasks.facts import start_fact_cache, finish_fact_cache
 from django.utils.timezone import now
 
 from datetime import timedelta
+
+import time
 
 
 @pytest.fixture
@@ -33,15 +33,23 @@ def hosts(ref_time):
 
 
 def test_start_job_fact_cache(hosts, tmpdir):
-    fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
+    # Create artifacts dir inside tmpdir
+    artifacts_dir = tmpdir.mkdir("artifacts")
+
+    # Assign a mock inventory ID
+    inventory_id = 42
+
+    # Call the function WITHOUT log_data — the decorator handles it
+    start_fact_cache(hosts, artifacts_dir=str(artifacts_dir), timeout=0, inventory_id=inventory_id)
+
+    # Fact files are written into artifacts_dir/fact_cache/
+    fact_cache_dir = os.path.join(artifacts_dir, 'fact_cache')
 
     for host in hosts:
-        filepath = os.path.join(fact_cache, host.name)
+        filepath = os.path.join(fact_cache_dir, host.name)
         assert os.path.exists(filepath)
-        with open(filepath, 'r') as f:
-            assert f.read() == json.dumps(host.ansible_facts)
-        assert os.path.getmtime(filepath) <= last_modified
+        with open(filepath, 'r', encoding='utf-8') as f:
+            assert json.load(f) == host.ansible_facts
 
 
 def test_fact_cache_with_invalid_path_traversal(tmpdir):
@@ -51,44 +59,62 @@ def test_fact_cache_with_invalid_path_traversal(tmpdir):
             ansible_facts={"a": 1, "b": 2},
         ),
     ]
+    artifacts_dir = tmpdir.mkdir("artifacts")
+    inventory_id = 42
 
-    fact_cache = os.path.join(tmpdir, 'facts')
-    start_fact_cache(hosts, fact_cache, timeout=0)
-    # a file called "foo" should _not_ be written outside the facts dir
-    assert os.listdir(os.path.join(fact_cache, '..')) == ['facts']
+    start_fact_cache(hosts, artifacts_dir=str(artifacts_dir), timeout=0, inventory_id=inventory_id)
+
+    # Fact cache directory (safe location)
+    fact_cache_dir = os.path.join(artifacts_dir, 'fact_cache')
+
+    # The bad host name should not produce a file
+    assert not os.path.exists(os.path.join(fact_cache_dir, '../foo'))
+
+    # Make sure the fact_cache dir exists and is still empty
+    assert os.listdir(fact_cache_dir) == []
 
 
 def test_start_job_fact_cache_past_timeout(hosts, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
-    # the hosts fixture was modified 5s ago, which is more than 2s
-    last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=2)
-    assert last_modified is None
+    start_fact_cache(hosts, fact_cache, timeout=2)
 
     for host in hosts:
         assert not os.path.exists(os.path.join(fact_cache, host.name))
-
+    ret = start_fact_cache(hosts, fact_cache, timeout=2)
+    assert ret is None
 
 def test_start_job_fact_cache_within_timeout(hosts, tmpdir):
-    fact_cache = os.path.join(tmpdir, 'facts')
-    # the hosts fixture was modified 5s ago, which is less than 7s
-    last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=7)
-    assert last_modified
+    artifacts_dir = tmpdir.mkdir("artifacts")
+
+    # The hosts fixture was modified 5s ago, which is less than 7s
+    start_fact_cache(hosts, str(artifacts_dir), timeout=7)
+
+    fact_cache_dir = os.path.join(artifacts_dir, 'fact_cache')
 
     for host in hosts:
-        assert os.path.exists(os.path.join(fact_cache, host.name))
-
+        filepath = os.path.join(fact_cache_dir, host.name)
+        assert os.path.exists(filepath)
+        with open(filepath, 'r') as f:
+            assert json.load(f) == host.ansible_facts
 
 def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
+    start_fact_cache(hosts, fact_cache, timeout=0)
 
     bulk_update = mocker.patch('awx.main.tasks.facts.bulk_update_sorted_by_id')
+
+    # Mock the os.path.exists behavior for host deletion
+    # Let's assume the fact file for hosts[1] is missing.    
     mocker.patch('os.path.exists', side_effect=lambda path: hosts[1].name not in path)
 
-    # Simulate one host's fact file getting deleted
-    os.remove(os.path.join(fact_cache, hosts[1].name))
+    # Simulate one host's fact file getting deleted manually
+    host_to_delete_filepath = os.path.join(fact_cache, hosts[1].name)
 
-    finish_fact_cache(hosts, fact_cache, last_modified)
+    # Simulate the file being removed by checking existence first, to avoid FileNotFoundError
+    if os.path.exists(host_to_delete_filepath):
+        os.remove(host_to_delete_filepath)
+
+    finish_fact_cache(fact_cache)
 
     # Simulate side effects that would normally be applied during bulk update
     hosts[1].ansible_facts = {}
@@ -103,12 +129,13 @@ def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
     assert hosts[1].ansible_facts == {}
     assert hosts[1].ansible_facts_modified > ref_time
 
-    bulk_update.assert_called_once_with(Host, [], fields=['ansible_facts', 'ansible_facts_modified'])
+    # Current implementation skips the call entirely if hosts_to_update == []
+    bulk_update.assert_not_called()
 
 
 def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
+    start_fact_cache(hosts, fact_cache, timeout=0)
 
     bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
 
@@ -120,6 +147,6 @@ def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
             new_modification_time = time.time() + 3600
             os.utime(filepath, (new_modification_time, new_modification_time))
 
-    finish_fact_cache(hosts, fact_cache, last_modified)
+    finish_fact_cache(fact_cache)
 
     bulk_update.assert_not_called()


### PR DESCRIPTION
**Note: This upstream PR had some issues that were corrected in later PRs, so we will need to pull them in also before release.  Fixed in 16318 and we will also want to bring in 16408**

### UPSTREAM SUMMARY

This proposes a revision to our fact caching mechanics. Description of the change:

- for start_fact_cache: Instead of returning the tuple of 2 items (host-list, write-time), at the end of the method (after the loop completes), we write a JSON format file with the host list inside of it
- This JSON format file will be in the "artifacts" directory, but not inside of the host_facts directory
- for finish_fact_cache: Instead of accepting (host-list, write-time) as arguments, it obtains:
- host-list from a load of the JSON format file
- write-time as the modtime of that same file
- Corresponding change is that the "destination" function arguments is changed from the host_facts directory to the artifacts directory so that we can write and read this extra file.

