### PR TITLE
Codecs.open() is being deprecated, and native open is faster in most situations

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -5,7 +5,6 @@
 from io import StringIO
 import datetime
 import decimal
-import codecs
 import json
 import logging
 import os
@@ -1115,7 +1114,7 @@ class UnifiedJob(
             fd.write(legacy_stdout_text)
             if hasattr(fd, 'name'):
                 fd.flush()
-                return codecs.open(fd.name, 'r', encoding='utf-8')
+                return open(fd.name, 'r', encoding='utf-8')
             else:
                 # we just wrote to this StringIO, so rewind it
                 fd.seek(0)
@@ -1158,7 +1157,7 @@ class UnifiedJob(
                     # up escaped line sequences
                     fd.flush()
                     subprocess.Popen("sed -i 's/\\\\r\\\\n/\\n/g' {}".format(fd.name), shell=True).wait()
-                    return codecs.open(fd.name, 'r', encoding='utf-8')
+                    return open(fd.name, 'r', encoding='utf-8')
                 else:
                     # If we're dealing with an in-memory string buffer, use
                     # string.replace()

--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -1,4 +1,3 @@
-import codecs
 import datetime
 import os
 import json
@@ -43,7 +42,7 @@ def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=No
             continue
 
         try:
-            with codecs.open(filepath, 'w', encoding='utf-8') as f:
+            with open(filepath, 'w', encoding='utf-8') as f:
                 os.chmod(f.name, 0o600)
                 json.dump(host.ansible_facts, f)
                 log_data['written_ct'] += 1
@@ -82,7 +81,7 @@ def finish_fact_cache(hosts_cached, destination, facts_write_time, log_data, job
             # If the file changed since we wrote the last facts file, pre-playbook run...
             modified = os.path.getmtime(filepath)
             if (not facts_write_time) or modified > facts_write_time:
-                with codecs.open(filepath, 'r', encoding='utf-8') as f:
+                with open(filepath, 'r', encoding='utf-8') as f:
                     try:
                         ansible_facts = json.load(f)
                     except ValueError:

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -2,7 +2,6 @@
 # All Rights Reserved.
 
 # Python
-import codecs
 import re
 import os
 import logging
@@ -48,7 +47,7 @@ def could_be_playbook(project_path, dir_path, filename):
     # show up.
     matched = False
     try:
-        for n, line in enumerate(codecs.open(playbook_path, 'r', encoding='utf-8', errors='ignore')):
+        for n, line in enumerate(open(playbook_path, 'r', encoding='utf-8', errors='ignore')):
             if valid_playbook_re.match(line):
                 matched = True
                 break


### PR DESCRIPTION
There are other instances of codecs being used, but those functions aren't deprecated at this time.  We can swap the codecs.encode function with something more native, but as its only in a test, not really necessary.