### PR TITLE
Add dark mode support to the UI (PatternFly 4)

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -139,6 +139,12 @@ export function ProtectedRoute({ children, ...rest }) {
 
 function App() {
   const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('pf-theme-dark');
+    }
+  }, []);
   const history = useHistory();
   const { hash, search, pathname } = useLocation();
   const searchParams = Object.fromEntries(new URLSearchParams(search));

--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
@@ -19,7 +19,7 @@ import {
   PageHeaderToolsItem,
   Tooltip,
 } from '@patternfly/react-core';
-import { QuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
+import { MoonIcon, QuestionCircleIcon, SunIcon, UserIcon } from '@patternfly/react-icons';
 import { WorkflowApprovalsAPI } from 'api';
 import useRequest from 'hooks/useRequest';
 import getDocsBaseUrl from 'util/getDocsBaseUrl';
@@ -42,6 +42,21 @@ function PageHeaderToolbar({
   const { t } = useLingui();
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isUserOpen, setIsUserOpen] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(
+    () => localStorage.getItem('darkMode') === 'true'
+  );
+
+  const toggleDarkMode = () => {
+    const next = !isDarkMode;
+    setIsDarkMode(next);
+    if (next) {
+      document.documentElement.classList.add('pf-theme-dark');
+    } else {
+      document.documentElement.classList.remove('pf-theme-dark');
+    }
+    localStorage.setItem('darkMode', next);
+    window.dispatchEvent(new Event('resize'));
+  };
   const config = useConfig();
 
   const { request: fetchPendingApprovalCount, result: pendingApprovals } =
@@ -77,6 +92,27 @@ function PageHeaderToolbar({
   return (
     <PageHeaderTools>
       <PageHeaderToolsGroup>
+        <Tooltip position="bottom" content={isDarkMode ? t`Switch to light mode` : t`Switch to dark mode`}>
+          <PageHeaderToolsItem>
+            <button
+              type="button"
+              onClick={toggleDarkMode}
+              aria-label={isDarkMode ? t`Switch to light mode` : t`Switch to dark mode`}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '10px',
+                color: 'var(--pf-global--Color--100)',
+                fontSize: '16px',
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            >
+              {isDarkMode ? <SunIcon /> : <MoonIcon />}
+            </button>
+          </PageHeaderToolsItem>
+        </Tooltip>
         <Tooltip
           position="bottom"
           content={t`Pending Workflow Approvals`}

--- a/awx/ui/src/components/ExpandCollapse/ExpandCollapse.js
+++ b/awx/ui/src/components/ExpandCollapse/ExpandCollapse.js
@@ -17,7 +17,7 @@ const Button = styled(PFButton)`
   ${(props) =>
     props.isActive
       ? `
-      background-color: #007bba;
+      background-color: var(--pf-global--primary-color--100);
       --pf-c-button--m-plain--active--Color: white;
       --pf-c-button--m-plain--focus--Color: white;`
       : null};

--- a/awx/ui/src/components/FormLayout/FormLayout.js
+++ b/awx/ui/src/components/FormLayout/FormLayout.js
@@ -39,7 +39,7 @@ export const FormCheckboxLayout = styled.div`
 
 export const SubFormLayout = styled.div`
   grid-column: 1 / -1;
-  background-color: #f5f5f5;
+  background-color: var(--pf-global--BackgroundColor--200);
   margin-right: calc(var(--pf-c-card--child--PaddingRight) * -1);
   margin-left: calc(var(--pf-c-card--child--PaddingLeft) * -1);
   padding: var(--pf-c-card--child--PaddingRight);

--- a/awx/ui/src/components/FullPage/FullPage.js
+++ b/awx/ui/src/components/FullPage/FullPage.js
@@ -6,6 +6,6 @@ export default styled.div`
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: white;
+  background-color: var(--pf-global--BackgroundColor--100);
   z-index: 300;
 `;

--- a/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
+++ b/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
@@ -45,7 +45,7 @@ const PromptDetailList = styled(DetailList)`
 `;
 
 const FrequencyDetailsContainer = styled.div`
-  background-color: var(--pf-global--palette--black-150);
+  background-color: var(--pf-global--BackgroundColor--200);
   margin-top: var(--pf-global--spacer--lg);
   margin-bottom: var(--pf-global--spacer--lg);
   margin-right: calc(var(--pf-c-card--child--PaddingRight) * -1);
@@ -59,7 +59,7 @@ const FrequencyDetailsContainer = styled.div`
   & > *:not(:first-child):not(:last-child) {
     margin-bottom: var(--pf-global--spacer--md);
     padding-bottom: var(--pf-global--spacer--md);
-    border-bottom: 1px solid var(--pf-global--palette--black-300);
+    border-bottom: 1px solid var(--pf-global--BorderColor--100);
   }
 
   & + & {

--- a/awx/ui/src/components/Schedule/ScheduleList/ScheduleListItem.js
+++ b/awx/ui/src/components/Schedule/ScheduleList/ScheduleListItem.js
@@ -19,7 +19,7 @@ import { ActionsTd, ActionItem, TdBreakWord } from '../../PaginatedTable';
 import { ScheduleToggle } from '..';
 
 const ExclamationTriangleIcon = styled(PFExclamationTriangleIcon)`
-  color: #c9190b;
+  color: var(--pf-global--danger-color--100);
   margin-left: 20px;
 `;
 

--- a/awx/ui/src/components/TemplateList/TemplateListItem.js
+++ b/awx/ui/src/components/TemplateList/TemplateListItem.js
@@ -133,7 +133,7 @@ function TemplateListItem({
                 content={t`Resources are missing from this template.`}
                 position="right"
               >
-                <ExclamationTriangleIcon css="color: #c9190b; margin-left: 20px;" />
+                <ExclamationTriangleIcon css="color: var(--pf-global--danger-color--100); margin-left: 20px;" />
               </Tooltip>
             </span>
           )}

--- a/awx/ui/src/components/Workflow/WorkflowActionTooltip.js
+++ b/awx/ui/src/components/Workflow/WorkflowActionTooltip.js
@@ -12,7 +12,7 @@ const TooltipArrow = styled.div`
 
 const TooltipArrowOuter = styled.div`
   border-bottom: 10px solid transparent;
-  border-right: 10px solid #c4c4c4;
+  border-right: 10px solid var(--pf-global--BorderColor--100);
   border-top: 10px solid transparent;
   height: 0;
   margin: auto;
@@ -23,7 +23,7 @@ const TooltipArrowOuter = styled.div`
 
 const TooltipArrowInner = styled.div`
   border-bottom: 10px solid transparent;
-  border-right: 10px solid white;
+  border-right: 10px solid var(--pf-global--BackgroundColor--100);
   border-top: 10px solid transparent;
   height: 0;
   left: 2px;
@@ -34,9 +34,9 @@ const TooltipArrowInner = styled.div`
 `;
 
 const TooltipActions = styled.div`
-  background-color: white;
+  background-color: var(--pf-global--BackgroundColor--100);
   border-radius: 2px;
-  border: 1px solid #c4c4c4;
+  border: 1px solid var(--pf-global--BorderColor--100);
   padding: 5px;
 `;
 

--- a/awx/ui/src/components/Workflow/WorkflowActionTooltipItem.js
+++ b/awx/ui/src/components/Workflow/WorkflowActionTooltipItem.js
@@ -13,8 +13,8 @@ const TooltipItem = styled.div`
   width: 25px;
 
   &:hover {
-    color: white;
-    background-color: #c4c4c4;
+    color: var(--pf-global--Color--100);
+    background-color: var(--pf-global--BackgroundColor--200);
   }
 
   &:not(:last-of-type) {

--- a/awx/ui/src/components/Workflow/WorkflowLegend.js
+++ b/awx/ui/src/components/Workflow/WorkflowLegend.js
@@ -10,15 +10,15 @@ import {
 import { WorkflowDispatchContext } from 'contexts/Workflow';
 
 const Wrapper = styled.div`
-  background-color: white;
-  border: 1px solid #c7c7c7;
+  background-color: var(--pf-global--BackgroundColor--100);
+  border: 1px solid var(--pf-global--BorderColor--100);
   margin-left: 20px;
   min-width: 100px;
   position: relative;
 `;
 
 const Header = styled.div`
-  border-bottom: 1px solid #c7c7c7;
+  border-bottom: 1px solid var(--pf-global--BorderColor--100);
   padding: 10px;
   position: relative;
 `;
@@ -46,7 +46,7 @@ const NodeTypeLetter = styled.div`
 `;
 
 const StyledExclamationTriangleIcon = styled(ExclamationTriangleIcon)`
-  color: #f0ad4d;
+  color: var(--pf-global--warning-color--100);
   height: 20px;
   margin-right: 10px;
   width: 20px;

--- a/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
@@ -25,7 +25,7 @@ const ResourceDeleted = styled.p`
 `;
 
 const StyledExclamationTriangleIcon = styled(ExclamationTriangleIcon)`
-  color: #f0ad4d;
+  color: var(--pf-global--warning-color--100);
   height: 20px;
   margin-right: 10px;
   width: 20px;

--- a/awx/ui/src/components/Workflow/WorkflowTools.js
+++ b/awx/ui/src/components/Workflow/WorkflowTools.js
@@ -18,14 +18,14 @@ import {
 import { WorkflowDispatchContext } from 'contexts/Workflow';
 
 const Wrapper = styled.div`
-  background-color: white;
-  border: 1px solid #c7c7c7;
+  background-color: var(--pf-global--BackgroundColor--100);
+  border: 1px solid var(--pf-global--BorderColor--100);
   height: 215px;
   position: relative;
 `;
 
 const Header = styled.div`
-  border-bottom: 1px solid #c7c7c7;
+  border-bottom: 1px solid var(--pf-global--BorderColor--100);
   padding: 10px;
 `;
 

--- a/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginSelected.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginSelected.js
@@ -10,7 +10,7 @@ import { Credential } from 'types';
 const SelectedCredential = styled.div`
   display: flex;
   justify-content: space-between;
-  background-color: white;
+  background-color: var(--pf-global--BackgroundColor--100);
   border-bottom-color: var(--pf-global--BorderColor--200);
 `;
 

--- a/awx/ui/src/screens/Dashboard/shared/Count.js
+++ b/awx/ui/src/screens/Dashboard/shared/Count.js
@@ -10,17 +10,17 @@ const CountCard = styled(Card)`
   padding-top: var(--pf-global--spacer--sm);
   cursor: pointer;
   text-align: center;
-  color: var(--pf-global--palette--black-1000);
+  color: var(--pf-global--Color--100);
   text-decoration: none;
 
   & h2 {
     font-size: var(--pf-global--FontSize--4xl);
-    color: var(--pf-global--palette--blue-400);
+    color: var(--pf-global--primary-color--100);
     text-decoration: none;
   }
 
   & h2.failed {
-    color: var(--pf-global--palette--red-200);
+    color: var(--pf-global--danger-color--100);
   }
 `;
 

--- a/awx/ui/src/screens/Dashboard/shared/LineChart.js
+++ b/awx/ui/src/screens/Dashboard/shared/LineChart.js
@@ -33,6 +33,15 @@ function LineChart({ id, data, height, pageContext, jobStatus }) {
     d3.selectAll(`#${id} > *`).remove();
     const width = getWidth();
 
+    const textColor =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--pf-global--Color--100')
+        .trim() || '#151515';
+    const gridColor =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--pf-global--BorderColor--100')
+        .trim() || '#d7d7d7';
+
     function transition(path) {
       path.transition().duration(1000).attrTween('stroke-dasharray', tweenDash);
     }
@@ -115,8 +124,8 @@ function LineChart({ id, data, height, pageContext, jobStatus }) {
           .tickFormat(d3.format('d'))
       )
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
-    svg.selectAll('.y-axis .tick text').attr('x', -5);
+      .attr('stroke', gridColor);
+    svg.selectAll('.y-axis .tick text').attr('x', -5).style('fill', textColor);
 
     // text label for the y axis
     svg
@@ -126,6 +135,7 @@ function LineChart({ id, data, height, pageContext, jobStatus }) {
       .attr('x', 0 - height / 2)
       .attr('dy', '1em')
       .style('text-anchor', 'middle')
+      .style('fill', textColor)
       .text(t`Job Runs`);
 
     // Add the X Axis
@@ -140,7 +150,7 @@ function LineChart({ id, data, height, pageContext, jobStatus }) {
         .filter((item) => item);
     }
 
-    svg.select('.domain').attr('stroke', '#d7d7d7');
+    svg.select('.domain').attr('stroke', gridColor);
 
     svg
       .append('g')
@@ -154,9 +164,9 @@ function LineChart({ id, data, height, pageContext, jobStatus }) {
           .tickFormat(d3.timeFormat('%-m/%-d')) // "1/19"
       ) // "Jan-01"
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
+      .attr('stroke', gridColor);
 
-    svg.selectAll('.x-axis .tick text').attr('y', 10);
+    svg.selectAll('.x-axis .tick text').attr('y', 10).style('fill', textColor);
 
     // text label for the x axis
     svg
@@ -166,11 +176,12 @@ function LineChart({ id, data, height, pageContext, jobStatus }) {
         `translate(${width / 2} , ${height + margin.top + 20})`
       )
       .style('text-anchor', 'middle')
+      .style('fill', textColor)
       .text(t`Date`);
     const vertical = svg
       .append('path')
       .attr('class', 'mouse-line')
-      .style('stroke', 'black')
+      .style('stroke', textColor)
       .style('stroke-width', '3px')
       .style('stroke-dasharray', '3, 3')
       .style('opacity', '0');

--- a/awx/ui/src/screens/Inventory/shared/ConstructedInventoryHint.js
+++ b/awx/ui/src/screens/Inventory/shared/ConstructedInventoryHint.js
@@ -74,8 +74,8 @@ function ConstructedInventoryHint() {
           <Tr ouiaId="plugin-row">
             <Td dataLabel={t`name`}>
               <code>plugin</code>
-              <p style={{ color: 'blue' }}>{t`string`}</p>
-              <p style={{ color: 'red' }}>{t`required`}</p>
+              <p style={{ color: 'var(--pf-global--primary-color--100)' }}>{t`string`}</p>
+              <p style={{ color: 'var(--pf-global--danger-color--100)' }}>{t`required`}</p>
             </Td>
             <Td dataLabel={t`description`}>
               {t`Token that ensures this is a source file
@@ -85,7 +85,7 @@ function ConstructedInventoryHint() {
           <Tr key="strict">
             <Td dataLabel={t`name`}>
               <code>strict</code>
-              <p style={{ color: 'blue' }}>{t`boolean`}</p>
+              <p style={{ color: 'var(--pf-global--primary-color--100)' }}>{t`boolean`}</p>
             </Td>
             <Td dataLabel={t`description`}>
               {t`If yes make invalid entries a fatal error, otherwise skip and
@@ -99,7 +99,7 @@ function ConstructedInventoryHint() {
           <Tr key="groups">
             <Td dataLabel={t`name`}>
               <code>groups</code>
-              <p style={{ color: 'blue' }}>{t`dictionary`}</p>
+              <p style={{ color: 'var(--pf-global--primary-color--100)' }}>{t`dictionary`}</p>
             </Td>
             <Td dataLabel={t`description`}>
               {t`Add hosts to group based on Jinja2 conditionals.`}
@@ -108,7 +108,7 @@ function ConstructedInventoryHint() {
           <Tr key="compose">
             <Td dataLabel={t`name`}>
               <code>compose</code>
-              <p style={{ color: 'blue' }}>{t`dictionary`}</p>
+              <p style={{ color: 'var(--pf-global--primary-color--100)' }}>{t`dictionary`}</p>
             </Td>
             <Td dataLabel={t`description`}>
               {t`Create vars from jinja2 expressions. This can be useful

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -64,13 +64,13 @@ const OutputHeader = styled.div`
 `;
 
 const OutputWrapper = styled.div`
-  background-color: #ffffff;
+  background-color: var(--pf-global--BackgroundColor--100);
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   font-family: monospace;
   font-size: 15px;
-  outline: 1px solid #d7d7d7;
+  outline: 1px solid var(--pf-global--BorderColor--100);
   ${({ cssMap }) =>
     Object.keys(cssMap).map(
       (className) => `.${className}{${cssMap[className]}}`
@@ -78,8 +78,8 @@ const OutputWrapper = styled.div`
 `;
 
 const OutputFooter = styled.div`
-  background-color: #ebebeb;
-  border-right: 1px solid #d7d7d7;
+  background-color: var(--pf-global--BackgroundColor--200);
+  border-right: 1px solid var(--pf-global--BorderColor--100);
   width: 75px;
   flex: 1;
 `;

--- a/awx/ui/src/screens/Job/JobOutput/PageControls.js
+++ b/awx/ui/src/screens/Job/JobOutput/PageControls.js
@@ -15,7 +15,7 @@ import styled from 'styled-components';
 const ControllsWrapper = styled.div`
   display: flex;
   height: 35px;
-  border: 1px solid #d7d7d7;
+  border: 1px solid var(--pf-global--BorderColor--100);
   width: 100%;
   justify-content: space-between;
 `;

--- a/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.js
@@ -5,7 +5,7 @@ import { useLingui } from '@lingui/react/macro';
 import { Badge, Tooltip } from '@patternfly/react-core';
 
 const BarWrapper = styled.div`
-  background-color: #d7d7d7;
+  background-color: var(--pf-global--BackgroundColor--200);
   display: flex;
   height: 5px;
   margin-top: 16px;

--- a/awx/ui/src/screens/Job/JobOutput/shared/JobEventLineNumber.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/JobEventLineNumber.js
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
 const JobEventLineNumber = styled.div`
-  color: #161b1f;
-  background-color: #ebebeb;
+  color: var(--pf-global--Color--200);
+  background-color: var(--pf-global--BackgroundColor--200);
   flex: 0 0 45px;
   text-align: right;
   vertical-align: top;
   padding-right: 5px;
-  border-right: 1px solid #d7d7d7;
+  border-right: 1px solid var(--pf-global--BorderColor--100);
   user-select: none;
 `;
 

--- a/awx/ui/src/screens/Job/JobOutput/shared/JobEventLineText.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/JobEventLineText.js
@@ -10,7 +10,7 @@ const JobEventLineText = styled.div`
     font-size: 14px;
     font-weight: 600;
     user-select: none;
-    background-color: #ebebeb;
+    background-color: var(--pf-global--BackgroundColor--200);
     border-radius: 12px;
     padding: 2px 10px;
     margin-left: 15px;
@@ -20,9 +20,9 @@ const JobEventLineText = styled.div`
     background: var(--pf-global--disabled-color--200);
     background: linear-gradient(
       to right,
-      #f5f5f5 10%,
-      #e8e8e8 18%,
-      #f5f5f5 33%
+      var(--pf-global--BackgroundColor--100) 10%,
+      var(--pf-global--BackgroundColor--200) 18%,
+      var(--pf-global--BackgroundColor--100) 33%
     );
     border-radius: 5px;
   }

--- a/awx/ui/src/screens/Job/JobOutput/shared/JobEventLineToggle.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/JobEventLineToggle.js
@@ -4,8 +4,8 @@ import { useLingui } from '@lingui/react/macro';
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 
 const Wrapper = styled.div`
-  background-color: #ebebeb;
-  color: #646972;
+  background-color: var(--pf-global--BackgroundColor--200);
+  color: var(--pf-global--Color--200);
   display: flex;
   flex: 0 0 30px;
   font-size: 18px;

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputGraph.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputGraph.js
@@ -142,7 +142,7 @@ function WorkflowOutputGraph() {
       <svg
         id="workflow-svg"
         ref={svgRef}
-        css="display: flex; height: 100%; background-color: #F6F6F6"
+        css="display: flex; height: 100%; background-color: var(--pf-global--BackgroundColor--200)"
       >
         <g id="workflow-g" ref={gRef}>
           {nodePositions && [

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputLink.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputLink.js
@@ -11,7 +11,7 @@ function WorkflowOutputLink({ link, mouseEnter, mouseLeave }) {
   const ref = useRef(null);
   const [hovering, setHovering] = useState(false);
   const [pathD, setPathD] = useState();
-  const [pathStroke, setPathStroke] = useState('#CCCCCC');
+  const [pathStroke, setPathStroke] = useState('var(--pf-global--BorderColor--100)');
   const { nodePositions } = useContext(WorkflowStateContext);
 
   const handleLinkMouseEnter = () => {
@@ -28,13 +28,13 @@ function WorkflowOutputLink({ link, mouseEnter, mouseLeave }) {
 
   useEffect(() => {
     if (link.linkType === 'failure') {
-      setPathStroke('#d9534f');
+      setPathStroke('var(--pf-global--danger-color--100)');
     }
     if (link.linkType === 'success') {
-      setPathStroke('#5cb85c');
+      setPathStroke('var(--pf-global--success-color--100)');
     }
     if (link.linkType === 'always') {
-      setPathStroke('#337ab7');
+      setPathStroke('var(--pf-global--primary-color--100)');
     }
   }, [link.linkType]);
 
@@ -51,7 +51,7 @@ function WorkflowOutputLink({ link, mouseEnter, mouseLeave }) {
       onMouseLeave={handleLinkMouseLeave}
     >
       <polygon
-        fill="#E1E1E1"
+        style={{ fill: 'var(--pf-global--BackgroundColor--200)' }}
         id={`link-${link.source.id}-${link.target.id}-overlay`}
         opacity={hovering ? '1' : '0'}
         points={getLinkOverlayPoints(link, nodePositions)}

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.js
@@ -38,7 +38,7 @@ const Elapsed = styled.div`
   span {
     font-size: 12px;
     font-weight: bold;
-    background-color: #ededed;
+    background-color: var(--pf-global--BackgroundColor--200);
     padding: 3px 12px;
     border-radius: 14px;
   }
@@ -70,7 +70,7 @@ function WorkflowOutputNode({ mouseEnter, mouseLeave, node }) {
   const { nodePositions } = useContext(WorkflowStateContext);
   const job = node?.originalNodeObject?.summary_fields?.job;
 
-  let borderColor = '#93969A';
+  let borderColor = 'var(--pf-global--BorderColor--100)';
 
   if (job) {
     if (
@@ -78,10 +78,10 @@ function WorkflowOutputNode({ mouseEnter, mouseLeave, node }) {
       job.status === 'error' ||
       job.status === 'canceled'
     ) {
-      borderColor = '#d9534f';
+      borderColor = 'var(--pf-global--danger-color--100)';
     }
     if (job.status === 'successful' || job.status === 'ok') {
-      borderColor = '#5cb85c';
+      borderColor = 'var(--pf-global--success-color--100)';
     }
   }
 
@@ -146,7 +146,7 @@ function WorkflowOutputNode({ mouseEnter, mouseLeave, node }) {
         </>
       )}
       <rect
-        fill="#FFFFFF"
+        fill="var(--pf-global--BackgroundColor--100)"
         height={wfConstants.nodeH}
         rx="2"
         ry="2"

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
@@ -19,7 +19,7 @@ import {
 
 const Toolbar = styled.div`
   align-items: center;
-  border-bottom: 1px solid grey;
+  border-bottom: 1px solid var(--pf-global--BorderColor--100);
   display: flex;
   height: 56px;
 `;
@@ -53,13 +53,13 @@ const ActionButton = styled(Button)`
   margin: 0px 6px;
   padding: 6px 10px;
   &:hover {
-    background-color: #0066cc;
-    color: white;
+    background-color: var(--pf-global--primary-color--100);
+    color: #fff;
   }
 
   &.pf-m-active {
-    background-color: #0066cc;
-    color: white;
+    background-color: var(--pf-global--primary-color--100);
+    color: #fff;
   }
 `;
 function WorkflowOutputToolbar({ job }) {

--- a/awx/ui/src/screens/Setting/SettingList.js
+++ b/awx/ui/src/screens/Setting/SettingList.js
@@ -39,7 +39,7 @@ const CardHeader = styled(_CardHeader)`
   }
 `;
 const CardDescription = styled.div`
-  color: var(--pf-global--palette--black-600);
+  color: var(--pf-global--Color--200);
   font-size: var(--pf-global--FontSize--xs);
 `;
 

--- a/awx/ui/src/screens/Setting/shared/SharedFields.js
+++ b/awx/ui/src/screens/Setting/shared/SharedFields.js
@@ -43,7 +43,7 @@ const FormGroup = styled(PFFormGroup)`
 const Selected = styled.div`
   display: flex;
   justify-content: space-between;
-  background-color: white;
+  background-color: var(--pf-global--BackgroundColor--100);
   border-bottom-color: var(--pf-global--BorderColor--200);
 `;
 

--- a/awx/ui/src/screens/SubscriptionUsage/ChartComponents/UsageChart.js
+++ b/awx/ui/src/screens/SubscriptionUsage/ChartComponents/UsageChart.js
@@ -34,6 +34,15 @@ function UsageChart({ id, data, height, pageContext }) {
     d3.selectAll(`#${id} > *`).remove();
     const width = getWidth();
 
+    const gridColor =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--pf-global--BorderColor--100')
+        .trim() || '#d7d7d7';
+    const textColor =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--pf-global--Color--100')
+        .trim() || '#151515';
+
     function transition(path) {
       path.transition().duration(1000).attrTween('stroke-dasharray', tweenDash);
     }
@@ -117,8 +126,12 @@ function UsageChart({ id, data, height, pageContext }) {
           .tickFormat(d3.format('d'))
       )
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
-    svg.selectAll('.y-axis .tick text').attr('x', -5).attr('font-size', '14');
+      .attr('stroke', gridColor);
+    svg
+      .selectAll('.y-axis .tick text')
+      .attr('x', -5)
+      .attr('font-size', '14')
+      .style('fill', textColor);
 
     // text label for the y axis
     svg
@@ -128,6 +141,7 @@ function UsageChart({ id, data, height, pageContext }) {
       .attr('x', 0 - height / 2)
       .attr('dy', '1em')
       .style('text-anchor', 'middle')
+      .style('fill', textColor)
       .text(t`Unique Hosts`);
 
     // Add the X Axis
@@ -142,7 +156,7 @@ function UsageChart({ id, data, height, pageContext }) {
         .filter((item) => item);
     }
 
-    svg.select('.domain').attr('stroke', '#d7d7d7');
+    svg.select('.domain').attr('stroke', gridColor);
 
     svg
       .append('g')
@@ -156,13 +170,14 @@ function UsageChart({ id, data, height, pageContext }) {
           .tickFormat(d3.timeFormat('%m/%y'))
       )
       .selectAll('line')
-      .attr('stroke', '#d7d7d7');
+      .attr('stroke', gridColor);
 
     svg
       .selectAll('.x-axis .tick text')
       .attr('x', -25)
       .attr('font-size', '14')
-      .attr('transform', 'rotate(-65)');
+      .attr('transform', 'rotate(-65)')
+      .style('fill', textColor);
 
     // text label for the x axis
     svg
@@ -172,11 +187,12 @@ function UsageChart({ id, data, height, pageContext }) {
         `translate(${width / 2} , ${height + margin.top + 50})`
       )
       .style('text-anchor', 'middle')
+      .style('fill', textColor)
       .text(t`Month`);
     const vertical = svg
       .append('path')
       .attr('class', 'mouse-line')
-      .style('stroke', 'black')
+      .style('stroke', textColor)
       .style('stroke-width', '3px')
       .style('stroke-dasharray', '3, 3')
       .style('opacity', '0');
@@ -279,7 +295,8 @@ function UsageChart({ id, data, height, pageContext }) {
       .append('text')
       .text((d) => d)
       .attr('font-size', '14')
-      .attr('transform', 'translate(15,9)'); // align texts with boxes
+      .attr('transform', 'translate(15,9)') // align texts with boxes
+      .style('fill', textColor);
 
     lineLegend
       .append('rect')

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerGraph.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerGraph.js
@@ -28,7 +28,7 @@ const PotentialLink = styled.polyline`
   pointer-events: none;
 `;
 const WorkflowSVG = styled.svg`
-  background-color: #f6f6f6;
+  background-color: var(--pf-global--BackgroundColor--200);
   display: flex;
   height: 100%;
 `;
@@ -231,7 +231,7 @@ function VisualizerGraph({ readOnly }) {
             refX="10"
             viewBox="0 -5 10 10"
           >
-            <path d="M0,-5L10,0L0,5" fill="#93969A" />
+            <path d="M0,-5L10,0L0,5" style={{ fill: 'var(--pf-global--BorderColor--100)' }} />
           </marker>
         </defs>
         <rect
@@ -296,7 +296,7 @@ function VisualizerGraph({ readOnly }) {
             <PotentialLink
               id="workflow-potentialLink"
               markerEnd="url(#workflow-triangle)"
-              stroke="#93969A"
+              style={{ stroke: 'var(--pf-global--BorderColor--100)' }}
               strokeDasharray="5,5"
               strokeWidth="2"
             />

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.js
@@ -27,7 +27,7 @@ function VisualizerLink({ link, updateLinkHelp, readOnly, updateHelpText }) {
   const ref = useRef(null);
   const [hovering, setHovering] = useState(false);
   const [pathD, setPathD] = useState();
-  const [pathStroke, setPathStroke] = useState('#CCCCCC');
+  const [pathStroke, setPathStroke] = useState('var(--pf-global--BorderColor--100)');
   const [tooltipX, setTooltipX] = useState();
   const [tooltipY, setTooltipY] = useState();
   const dispatch = useContext(WorkflowDispatchContext);
@@ -101,13 +101,13 @@ function VisualizerLink({ link, updateLinkHelp, readOnly, updateHelpText }) {
 
   useEffect(() => {
     if (link.linkType === 'failure') {
-      setPathStroke('#d9534f');
+      setPathStroke('var(--pf-global--danger-color--100)');
     }
     if (link.linkType === 'success') {
-      setPathStroke('#5cb85c');
+      setPathStroke('var(--pf-global--success-color--100)');
     }
     if (link.linkType === 'always') {
-      setPathStroke('#337ab7');
+      setPathStroke('var(--pf-global--primary-color--100)');
     }
   }, [link.linkType]);
 
@@ -127,7 +127,7 @@ function VisualizerLink({ link, updateLinkHelp, readOnly, updateHelpText }) {
       ref={ref}
     >
       <polygon
-        fill="#E1E1E1"
+        style={{ fill: 'var(--pf-global--BackgroundColor--200)' }}
         id={`link-${link.source.id}-${link.target.id}-background`}
         opacity={hovering ? '1' : '0'}
         points={getLinkOverlayPoints(link, nodePositions)}

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
@@ -34,7 +34,7 @@ const NodeContents = styled.div`
   font-size: 13px;
   padding: 0px 10px;
   background-color: ${(props) =>
-    props.isInvalidLinkTarget ? '#D7D7D7' : '#FFFFFF'};
+    props.isInvalidLinkTarget ? 'var(--pf-global--BackgroundColor--200)' : 'var(--pf-global--BackgroundColor--100)'};
   height: 100%;
   display: flex;
   justify-content: center;
@@ -302,21 +302,21 @@ function VisualizerNode({
           : node?.originalNodeObject?.all_parents_must_converge) && (
           <>
             <rect
-              fill={
-                hovering && addingLink && !node.isInvalidLinkTarget
-                  ? '#007ABC'
-                  : '#93969A'
-              }
+              style={{
+                fill:
+                  hovering && addingLink && !node.isInvalidLinkTarget
+                    ? 'var(--pf-global--primary-color--100)'
+                    : 'var(--pf-global--BorderColor--100)',
+                stroke:
+                  hovering && addingLink && !node.isInvalidLinkTarget
+                    ? 'var(--pf-global--primary-color--100)'
+                    : 'var(--pf-global--BorderColor--100)',
+              }}
               height={wfConstants.nodeH / 4}
               rx={2}
               ry={2}
               x={wfConstants.nodeW / 2 - wfConstants.nodeW / 10}
               y={-wfConstants.nodeH / 4 + 2}
-              stroke={
-                hovering && addingLink && !node.isInvalidLinkTarget
-                  ? '#007ABC'
-                  : '#93969A'
-              }
               strokeWidth="2px"
               width={wfConstants.nodeW / 5}
             />
@@ -333,15 +333,16 @@ function VisualizerNode({
           </>
         )}
         <rect
-          fill="#FFFFFF"
+          style={{
+            fill: 'var(--pf-global--BackgroundColor--100)',
+            stroke:
+              hovering && addingLink && !node.isInvalidLinkTarget
+                ? 'var(--pf-global--primary-color--100)'
+                : 'var(--pf-global--BorderColor--100)',
+          }}
           height={wfConstants.nodeH}
           rx="2"
           ry="2"
-          stroke={
-            hovering && addingLink && !node.isInvalidLinkTarget
-              ? '#007ABC'
-              : '#93969A'
-          }
           strokeWidth="2px"
           width={wfConstants.nodeW}
         />

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js
@@ -16,15 +16,15 @@ const Button = styled(PFButton)`
 `;
 
 const StartPanel = styled.div`
-  background-color: white;
-  border: 1px solid #c7c7c7;
+  background-color: var(--pf-global--BackgroundColor--100);
+  border: 1px solid var(--pf-global--BorderColor--100);
   padding: 60px 80px;
   text-align: center;
 `;
 
 const StartPanelWrapper = styled.div`
   align-items: center;
-  background-color: #f6f6f6;
+  background-color: var(--pf-global--BackgroundColor--200);
   display: flex;
   height: 100%;
   justify-content: center;

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js
@@ -38,13 +38,13 @@ const ActionButton = styled(Button)`
   margin: 0px 6px;
   border: none;
   &:hover {
-    background-color: #0066cc;
-    color: white;
+    background-color: var(--pf-global--primary-color--100);
+    color: #fff;
   }
 
   &.pf-m-active {
-    background-color: #0066cc;
-    color: white;
+    background-color: var(--pf-global--primary-color--100);
+    color: #fff;
   }
 `;
 ActionButton.displayName = 'ActionButton';
@@ -65,7 +65,7 @@ function VisualizerToolbar({
 
   return (
     <div id="visualizer-toolbar">
-      <div css="align-items: center; border-bottom: 1px solid grey; display: flex; height: 56px; padding: 0px 20px;">
+      <div css="align-items: center; border-bottom: 1px solid var(--pf-global--BorderColor--100); display: flex; height: 56px; padding: 0px 20px;">
         <Title
           headingLevel="h2"
           size="xl"

--- a/awx/ui/src/screens/TopologyView/ContentLoading.js
+++ b/awx/ui/src/screens/TopologyView/ContentLoading.js
@@ -20,7 +20,7 @@ const EmptyState = styled(PFEmptyState)`
 
 const TopologyIcon = styled(PFTopologyIcon)`
   font-size: 3em;
-  fill: #6a6e73;
+  fill: var(--pf-global--Color--200);
 `;
 
 const ContentLoading = ({ className, progress }) => {
@@ -37,7 +37,7 @@ const ContentLoading = ({ className, progress }) => {
       <TextContent style={{ margin: '20px' }}>
         <Text
           component={TextVariants.small}
-          style={{ fontWeight: 'bold', color: 'black' }}
+          style={{ fontWeight: 'bold', color: 'var(--pf-global--Color--100)' }}
         >
           {t`Please wait until the topology view is populated...`}
         </Text>

--- a/awx/ui/src/screens/TopologyView/Legend.js
+++ b/awx/ui/src/screens/TopologyView/Legend.js
@@ -27,7 +27,7 @@ const Wrapper = styled.div`
   left: 0;
   padding: 0 10px;
   min-width: 150px;
-  background-color: rgba(255, 255, 255, 0.85);
+  background-color: var(--pf-global--BackgroundColor--100);
   overflow: auto;
   height: 100%;
 `;
@@ -38,9 +38,9 @@ const Button = styled(PFButton)`
     border-radius: 10px;
     padding: 0;
     font-size: 11px;
-    background-color: white;
-    border: 1px solid #ccc;
-    color: black;
+    background-color: var(--pf-global--BackgroundColor--100);
+    border: 1px solid var(--pf-global--BorderColor--100);
+    color: var(--pf-global--Color--100);
   }
 `;
 const DescriptionListDescription = styled(PFDescriptionListDescription)`
@@ -63,7 +63,7 @@ function Legend() {
       <TextContent>
         <Text
           component={TextVariants.small}
-          style={{ fontWeight: 'bold', color: 'black', marginTop: 0 }}
+          style={{ fontWeight: 'bold', color: 'var(--pf-global--Color--100)', marginTop: 0 }}
         >
           {t`Legend`}
         </Text>
@@ -205,14 +205,14 @@ function Legend() {
                 cy="10"
                 fill="transparent"
                 strokeWidth="1px"
-                stroke="#ccc"
+                style={{ stroke: 'var(--pf-global--BorderColor--100)' }}
               />
               <text
                 x="10"
                 y="10"
                 textAnchor="middle"
                 dominantBaseline="central"
-                fill="black"
+                style={{ fill: 'var(--pf-global--Color--100)' }}
                 fontSize="11px"
                 fontFamily="inherit"
                 fontWeight="400"
@@ -235,14 +235,14 @@ function Legend() {
                 fill="transparent"
                 strokeDasharray="5"
                 strokeWidth="1px"
-                stroke="#ccc"
+                style={{ stroke: 'var(--pf-global--BorderColor--100)' }}
               />
               <text
                 x="10"
                 y="10"
                 textAnchor="middle"
                 dominantBaseline="central"
-                fill="black"
+                style={{ fill: 'var(--pf-global--Color--100)' }}
                 fontSize="11px"
                 fontFamily="inherit"
                 fontWeight="400"

--- a/awx/ui/src/screens/TopologyView/MeshGraph.js
+++ b/awx/ui/src/screens/TopologyView/MeshGraph.js
@@ -39,7 +39,7 @@ const Loader = styled(ContentLoading)`
   height: 100%;
   position: absolute;
   width: 100%;
-  background: white;
+  background: var(--pf-global--BackgroundColor--100);
 `;
 function MeshGraph({
   data,

--- a/awx/ui/src/screens/TopologyView/Tooltip.js
+++ b/awx/ui/src/screens/TopologyView/Tooltip.js
@@ -36,7 +36,7 @@ const Wrapper = styled.div`
   right: 0;
   padding: 0 10px;
   width: 25%;
-  background-color: rgba(255, 255, 255, 0.85);
+  background-color: var(--pf-global--BackgroundColor--100);
   overflow: auto;
   height: 100%;
 `;
@@ -47,9 +47,9 @@ const Button = styled(PFButton)`
     border-radius: 15px;
     padding: 0;
     font-size: 16px;
-    background-color: white;
-    border: 1px solid #ccc;
-    color: black;
+    background-color: var(--pf-global--BackgroundColor--100);
+    border: 1px solid var(--pf-global--BorderColor--100);
+    color: var(--pf-global--Color--100);
   }
 `;
 const DescriptionList = styled(PFDescriptionList)`
@@ -182,7 +182,7 @@ function Tooltip({
         <TextContent>
           <Text
             component={TextVariants.small}
-            style={{ fontWeight: 'bold', color: 'black', marginTop: 0 }}
+            style={{ fontWeight: 'bold', color: 'var(--pf-global--Color--100)', marginTop: 0 }}
           >
             {t`Details`}
           </Text>
@@ -208,7 +208,7 @@ function Tooltip({
           <TextContent>
             <Text
               component={TextVariants.small}
-              style={{ fontWeight: 'bold', color: 'black' }}
+              style={{ fontWeight: 'bold', color: 'var(--pf-global--Color--100)' }}
             >
               {t`Details`}
             </Text>


### PR DESCRIPTION
##### SUMMARY

The AWX Team started porting PatternFly 4 to PatternFly 5 (which ships dark mode natively) but they didn't finish the port, and I've been waiting for dark mode in AWX since forever, so here's a dark mode for PatternFly 4 - I added a toggle to the Ascender UI and fixed all the hardcoded colors that break when dark mode is active.

**Toggle button:** A moon/sun icon button has been added to the left of the notification bell in the page header toolbar. Clicking it applies PatternFly 4's `pf-theme-dark` class to the document root, which activates all of PF4's built-in dark theme CSS variables. The preference is persisted to `localStorage` and restored on page load. D3-rendered charts (Dashboard line chart, Subscription Usage chart) are forced to redraw immediately on toggle via a synthetic `resize` event.

**Color fixes (39 files):** Every hardcoded color that does not respond to the `pf-theme-dark` class has been replaced with the appropriate PF4 semantic variable:

- Raw hex values and named colors (`#ffffff`, `white`, `#d7d7d7`, `grey`, etc.) in styled-components and inline `style` props replaced with `--pf-global--BackgroundColor--100/200`, `--pf-global--BorderColor--100`, `--pf-global--Color--100/200`, etc.
- SVG presentation attributes (`fill="#FFFFFF"`, `stroke="#93969A"`) which cannot use CSS variables, converted to `style={{ fill/stroke: 'var(...)' }}` props.
- D3 chart text and grid colors read via `getComputedStyle(document.documentElement).getPropertyValue('--pf-global--...')` at draw time so they pick up the active theme.
- PF palette variables (`--pf-global--palette--blue-400`) replaced with semantic equivalents (`--pf-global--primary-color--100`).

Areas covered: dashboard cards and charts, job output view, workflow output graph, workflow job template visualizer, topology view, schedule lists, credential plugins, settings, and shared layout components.

Status indicator colors (red/green/blue for success/failure/running states), intentional dark-themed workflow canvas backgrounds (`#393f43`), and white text on colored buttons were left unchanged as they are correct in both themes.

##### ISSUE TYPE
- New or Enhanced Feature

##### COMPONENT NAME
- UI

##### ASCENDER VERSION
```
awx: 25.3.7.dev33+g480d6d5
```

##### ADDITIONAL INFORMATION

To test:
1. Log in and click the moon icon in the top-right toolbar (left of the notification bell).
2. Verify the UI switches to dark mode and the sun icon appears.
3. Refresh the page - dark mode should be restored from `localStorage`.
4. Click the sun icon - UI returns to light mode.
5. Navigate to: Dashboard (check Job Runs / Date chart labels), Job Output, Workflow Visualizer, Topology View, Subscription Usage chart - confirm text and borders are readable in both modes.
6. Click the moon icon, then edit a user / open a workflow template / view the topology - no white boxes, black-on-black text, or invisible borders should appear.