### PR TITLE
Fix: canceled jobs that never started should not set finished time

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -873,10 +873,13 @@ class UnifiedJob(
         # Sanity check: Has the job just completed? If so, mark down its
         # completion time, and record its output to the database.
         if self.status in ('successful', 'failed', 'error', 'canceled') and not self.finished:
-            # Record the `finished` time.
-            self.finished = now()
-            if 'finished' not in update_fields:
-                update_fields.append('finished')
+            # Only record a finished time if the job actually started.
+            # Jobs canceled before starting (e.g. pending) should not
+            # have a finished timestamp. (Resolves #3988 from AWX main repo)
+            if self.started is not None:
+                self.finished = now()
+                if 'finished' not in update_fields:
+                    update_fields.append('finished')
 
         dq = decimal.Decimal('1.000')
         if self.elapsed is None:

--- a/awx/main/tests/functional/models/test_unified_job.py
+++ b/awx/main/tests/functional/models/test_unified_job.py
@@ -282,3 +282,51 @@ class TestTaskImpact:
         # recalculate task_impact
         jobs[0].task_impact = jobs[0]._get_task_impact()
         assert [job.task_impact for job in jobs] == [3, 2, 2]
+
+
+@pytest.mark.django_db
+class TestCanceledJobFinishedTime:
+    """Tests for ansible/awx#3988 — canceled pending jobs should not set finished."""
+
+    def test_cancel_pending_job_no_finished_time(self):
+        """A job canceled before it ever started should have finished=None."""
+        jt = JobTemplate.objects.create(name='test-jt-3988')
+        job = jt.create_unified_job()
+        assert job.started is None
+        job.status = 'canceled'
+        job.save()
+        job.refresh_from_db()
+        assert job.status == 'canceled'
+        assert job.started is None
+        assert job.finished is None
+
+    def test_cancel_running_job_sets_finished_time(self):
+        """A job canceled while running should record a finished time."""
+        from django.utils.timezone import now
+        jt = JobTemplate.objects.create(name='test-jt-3988-running')
+        job = jt.create_unified_job()
+        job.status = 'running'
+        job.started = now()
+        job.save()
+        job.status = 'canceled'
+        job.save()
+        job.refresh_from_db()
+        assert job.status == 'canceled'
+        assert job.started is not None
+        assert job.finished is not None
+        assert job.finished >= job.started
+
+    def test_successful_job_still_sets_finished(self):
+        """Regression: normal completion still sets finished correctly."""
+        from django.utils.timezone import now
+        jt = JobTemplate.objects.create(name='test-jt-3988-success')
+        job = jt.create_unified_job()
+        job.status = 'running'
+        job.started = now()
+        job.save()
+        job.status = 'successful'
+        job.save()
+        job.refresh_from_db()
+        assert job.finished is not None
+
+


### PR DESCRIPTION
## Summary

Fixes ansible/awx#3988 — Jobs canceled before starting should not show a
finished time.

## Problem

When a job is canceled while in `pending` state (e.g., blocked by another
job or queued to an instance group without capacity), the API returns:

```json
{
  "status": "canceled",
  "started": null,
  "finished": "2019-06-03T12:39:05.272329Z",
  "elapsed": 0.0
}
```

A job that never started should not have a `finished` timestamp.

## Root Cause

In `UnifiedJob.save()`, the completion timestamp is set unconditionally
whenever the status transitions to a terminal state (`successful`,
`failed`, `error`, `canceled`), without checking whether the job ever
started.

## Fix

Added a guard in `UnifiedJob.save()` to only set `self.finished = now()`
when `self.started is not None`. Jobs canceled before starting will now
have `finished = null`, `elapsed = 0.0`.

## Testing

- `test_cancel_pending_job_no_finished_time` — verifies the fix
- `test_cancel_running_job_sets_finished_time` — regression test
- `test_successful_job_still_sets_finished` — regression test