### PR TITLE
Downgrade djangorestframework to resolve issue with django-ansible-base

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -162,7 +162,7 @@ django-split-settings==1.0.0
     # via -r /awx_devel/requirements/requirements.in
 django-valkey==0.4.1
     # via -r /awx_devel/requirements/requirements.in
-djangorestframework==3.17.1
+djangorestframework==3.15.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django-ansible-base


### PR DESCRIPTION
djangorestframework is pinned to < 3.16 on django-ansible-base because of "problem with OAuth2Application.organization null handling".