### PR TITLE
Pin GitHub Actions to SHAs [SRE-1802]

### DIFF
--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -55,9 +55,9 @@ jobs:
 
       - name: Get current date
         id: date
-        uses: Kaven-Universe/github-action-current-date-time@v1
+        uses: Kaven-Universe/github-action-current-date-time@7c1d8465d1bfd7d35466d2ee82a8e460780561ae # v1
 
-      - uses: benjlevesque/short-sha@v3.0
+      - uses: benjlevesque/short-sha@599815c8ee942a9616c92bcfb4f947a3b670ab0b # v3.0
         id: short-sha
         with:
           length: 6


### PR DESCRIPTION
## Summary
Pin GitHub Actions references in this repo to immutable commit SHAs (with the original tag/branch preserved in a trailing comment). Part of [SRE-1802](https://ciqinc.atlassian.net/browse/SRE-1802) — org-wide supply-chain hardening.

## Scope
This PR pins:
- Internal `ctrliq/*` reusable workflow and action references
- External actions **not** handled by clo-ciq's parallel Node 20 effort

_No actions in this repo were claimed by clo-ciq's effort — this PR pins everything._

## Files touched

- `.github/workflows/devel_images.yml`

## Test plan
- [ ] Workflow runs succeed on this branch (or on next trigger after merge)
- [ ] Once this and any companion clo-ciq PR merge, this repo has zero unpinned external/internal refs and `sha_pinning_required` can be enabled on it

[SRE-1802]: https://ciqinc.atlassian.net/browse/SRE-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ