### PR TITLE
Upgrade uuid to resolve CVE-2026-41907

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -23953,13 +23953,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -113,6 +113,11 @@
     "webpack-dev-server": "^5.2.4",
     "webpack-manifest-plugin": "^6.0.1"
   },
+  "overrides": {
+    "sockjs": {
+      "uuid": "11.1.1"
+    }
+  },
   "scripts": {
     "prelint": "lingui compile",
     "prestart": "lingui compile",


### PR DESCRIPTION
It is brought in via webpack-dev-server > sockjs but we don't use the portion of the app that uses the code, so its safe to override the package until next major version of webpack-dev-server which drops sockjs completely.
