### PR TITLE
Fix race condition in project directory creation

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -377,8 +377,7 @@ class BaseTask(object):
         self.lock_fd = None
 
     def acquire_lock(self, project, unified_job_id=None):
-        if not os.path.exists(settings.PROJECTS_ROOT):
-            os.mkdir(settings.PROJECTS_ROOT)
+        os.makedirs(settings.PROJECTS_ROOT, exist_ok=True)
 
         lock_path = project.get_lock_file()
         if lock_path is None:


### PR DESCRIPTION
When testing with multiple task replicas I noticed this error

```
File "awx/main/tasks/jobs.py", line 380, in acquire_lock
os.mkdir(settings.PROJECTS_ROOT)
FileExistsError: [Errno 17] File exists: '/var/lib/awx/projects'
```

Looking upstream it was also just reported in ansible/awx#16447

This small change will fix the race condition.  We already include in Pathlib, so a more modern fix might be
```
Path(settings.PROJECTS_ROOT).mkdir(parents=True, exist_ok=True)
```
but I will keep with what is currently the norm in the codebase for now.
