### PR TITLE
Fix bug in scheduler with Job dependency leakage

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -387,8 +387,8 @@ class DependencyManager(TaskBase):
             if job_deps:
                 dependencies += job_deps
                 with disable_activity_stream():
-                    task.dependent_jobs.add(*dependencies)
-                logger.debug(f'Linked {[dep.log_format for dep in dependencies]} as dependencies of {task.log_format}')
+                    task.dependent_jobs.add(*job_deps)
+                logger.debug(f'Linked {[dep.log_format for dep in job_deps]} as dependencies of {task.log_format}')
 
         UnifiedJob.objects.filter(pk__in=[task.pk for task in undeped_tasks]).update(dependencies_processed=True)
 

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -371,6 +371,36 @@ def test_single_job_dependencies_inventory_update_launch(controlplane_instance_g
 
 
 @pytest.mark.django_db
+def test_generate_dependencies_are_scoped_to_each_job(controlplane_instance_group, job_template_factory, inventory_source_factory):
+    first_objects = job_template_factory('jt-one', organization='org-one', project='proj-one', inventory='inv-one', credential='cred-one')
+    second_objects = job_template_factory('jt-two', organization='org-two', project='proj-two', inventory='inv-two', credential='cred-two')
+
+    first_job = create_job(first_objects.job_template, dependencies_processed=False)
+    second_job = create_job(second_objects.job_template, dependencies_processed=False)
+
+    first_inventory_source = inventory_source_factory('ec2-one', source='ec2', inventory=first_objects.inventory)
+    second_inventory_source = inventory_source_factory('ec2-two', source='ec2', inventory=second_objects.inventory)
+
+    first_inventory_source.update_on_launch = True
+    first_inventory_source.update_cache_timeout = 0
+    first_inventory_source.save()
+    second_inventory_source.update_on_launch = True
+    second_inventory_source.update_cache_timeout = 0
+    second_inventory_source.save()
+
+    with mock.patch('awx.main.scheduler.TaskManager.start_task'):
+        DependencyManager().schedule()
+
+    first_deps = list(first_job.dependent_jobs.all())
+    second_deps = list(second_job.dependent_jobs.all())
+
+    assert len(first_deps) == 1
+    assert first_deps[0].inventory_source_id == first_inventory_source.id
+    assert len(second_deps) == 1
+    assert second_deps[0].inventory_source_id == second_inventory_source.id
+
+
+@pytest.mark.django_db
 def test_inventory_update_launches_project_update(controlplane_instance_group, scm_inventory_source):
     ii = scm_inventory_source
     project = scm_inventory_source.source_project


### PR DESCRIPTION
Job Dependency cascading leakage

This is the infamous job dependency failure bug, where if you launch multiple jobs at once, and one job depends on a project or inventory sync and is the first one processed, 1st, all the current pending jobs stay in pending even if they are not waiting on anything, and 2nd, if the sync fails all the jobs fail with the error about that dependency failing

So generate_dependencies is creating a list of all pending jobs and their dependencies.  The problem is that as it loops over each job, it is adding the current running full list of dependencies to each job, instead of just that jobs dependencies.

Ex:
```
Job 1 = Job 1 deps
Job 2 = Job 1 + Job 2 deps
Job 3 = Job 1 + 2 + 3
etc...
```

Simple fix, also added some tests to double check this to ensure that dependency leakage doesn't happen.  Verified that with reverting the change, the tests do indeed fail and detect the leakage.