### PR TITLE
Update logo in installing.html to use Ascender logo SVG

### DIFF
--- a/awx/ui/public/installing.html
+++ b/awx/ui/public/installing.html
@@ -28,7 +28,7 @@
       <div class="pf-l-bullseye pf-m-gutter">
          <div class="pf-l-bullseye__item">
             <div class="pf-l-bullseye">
-            <img src="{% static 'media/AscenderAuto_logo_h_rev_S_side_black.png' %}" width="300px" alt={{image_alt}} />
+            <img src="{% static 'media/Ascender_logo.svg' %}" width="300px" alt={{image_alt}} />
             </div>
             <div class="pf-l-bullseye">
               <span class="pf-c-spinner" role="progressbar" aria-valuetext={{aria_spinner}}>


### PR DESCRIPTION
##### SUMMARY
With the recent UI update, the Install/Upgrading page was referencing a deleted image. This now referenced the standard SVG.