### PR TITLE
Hide the Workflow Visualizer button on Job Slices

### DIFF
--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
@@ -67,12 +67,17 @@ function WorkflowOutputToolbar({ job }) {
   const dispatch = useContext(WorkflowDispatchContext);
   const history = useHistory();
   const { nodes, showLegend, showTools } = useContext(WorkflowStateContext);
+  const workflowTemplateId =
+    job.summary_fields?.workflow_job_template?.id ??
+    job.summary_fields?.workflow_job_template?.[0]?.id;
 
   const totalNodes = nodes.reduce((n, node) => n + !node.isDeleted, 0) - 1;
   const navToWorkflow = () => {
-    history.push(
-      `/templates/workflow_job_template/${job.unified_job_template}/visualizer`
-    );
+    if (workflowTemplateId) {
+      history.push(
+        `/templates/workflow_job_template/${workflowTemplateId}/visualizer`
+      );
+    }
   };
   return (
     <Toolbar id="workflow-output-toolbar" ouiaId="workflow-output-toolbar">
@@ -93,15 +98,17 @@ function WorkflowOutputToolbar({ job }) {
           />
         ) : null}
 
-        <ActionButton
-          ouiaId="edit-workflow"
-          aria-label={t`Edit workflow`}
-          id="edit-workflow"
-          variant="plain"
-          onClick={navToWorkflow}
-        >
-          <ProjectDiagramIcon />
-        </ActionButton>
+        {workflowTemplateId && (
+          <ActionButton
+            ouiaId="edit-workflow"
+            aria-label={t`Edit workflow`}
+            id="edit-workflow"
+            variant="plain"
+            onClick={navToWorkflow}
+          >
+            <ProjectDiagramIcon />
+          </ActionButton>
+        )}
         <div>{t`Total Nodes`}</div>
         <Badge isRead>{totalNodes}</Badge>
         <Tooltip content={t`Toggle Legend`} position="bottom">

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
@@ -10,8 +10,13 @@ let wrapper;
 const dispatch = jest.fn();
 const job = {
   id: 1,
+  name: 'Workflow Job',
   status: 'running',
   summary_fields: {
+    workflow_job_template: {
+      id: 7,
+      name: 'Workflow Job Template',
+    },
     user_capabilities: {
       start: true,
     },
@@ -70,5 +75,38 @@ describe('WorkflowOutputToolbar', () => {
   test('Toggle Tools button dispatches as expected', () => {
     wrapper.find('WrenchIcon').simulate('click');
     expect(dispatch).toHaveBeenCalledWith({ type: 'TOGGLE_TOOLS' });
+  });
+
+  test('does not render the visualizer button when no workflow template exists', () => {
+    const nodes = [
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+      {
+        id: 3,
+        isDeleted: true,
+      },
+    ];
+    const slicedJob = {
+      ...job,
+      summary_fields: {
+        ...job.summary_fields,
+        workflow_job_template: null,
+      },
+    };
+    const slicedWrapper = mountWithContexts(
+      <WorkflowDispatchContext.Provider value={dispatch}>
+        <WorkflowStateContext.Provider value={{ ...workflowContext, nodes }}>
+          <WorkflowOutputToolbar job={slicedJob} />
+        </WorkflowStateContext.Provider>
+      </WorkflowDispatchContext.Provider>
+    );
+
+    expect(slicedWrapper.find('Button[ouiaId="edit-workflow"]')).toHaveLength(
+      0
+    );
   });
 });


### PR DESCRIPTION
Job slices create an "adhoc" Workflow, so there is no actual Workflow behind the scene.  The visualizer errors when clicking it on these job slices as there is no actual Workflow.