### PR TITLE
Fix issue with federated inventories when relaunch a single child job

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -715,7 +715,9 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         # Needed for job slice relaunch consistency, do no re-spawn workflow job
         # target same slice as original job
         new_prompts['_prevent_slicing'] = True
+        new_prompts['_prevent_federation'] = True
         new_prompts.setdefault('_eager_fields', {})
+        new_prompts['_eager_fields']['inventory_id'] = self.inventory_id
         new_prompts['_eager_fields']['job_slice_number'] = self.job_slice_number
         new_prompts['_eager_fields']['job_slice_count'] = self.job_slice_count
         return super(Job, self).copy_unified_job(**new_prompts)

--- a/awx/main/tests/functional/api/test_job.py
+++ b/awx/main/tests/functional/api/test_job.py
@@ -115,6 +115,14 @@ def test_job_relaunch_without_creds(post, inventory, project, admin_user):
 
 
 @pytest.mark.django_db
+def test_job_relaunch_slice_workflow_job(post, admin_user, project, slice_job_factory):
+    workflow_job = slice_job_factory(3, jt_kwargs={'project': project}, spawn=True)
+    job = workflow_job.workflow_nodes.first().job
+
+    post(url=reverse('api:job_relaunch', kwargs={'pk': job.pk}), data={}, user=admin_user, expect=201)
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "status,hosts",
     [

--- a/awx/main/tests/functional/models/test_job.py
+++ b/awx/main/tests/functional/models/test_job.py
@@ -214,6 +214,21 @@ class TestFederatedInventoryLaunch:
         assert isinstance(job, WorkflowJob)
         assert job.workflow_nodes.count() == 2
 
+    def test_relaunch_child_job_stays_job(self, federated_inv_factory, organization):
+        """Relaunching a workflow child job should not re-enter federated workflow creation."""
+        fed, _ = federated_inv_factory(2)
+        jt = JobTemplate.objects.create(name='fed-jt', inventory=fed, organization=organization)
+        workflow_job = jt.create_unified_job()
+        node = workflow_job.workflow_nodes.first()
+        child_job = node.unified_job_template.create_unified_job(**node.get_job_kwargs())
+
+        relaunched_job = child_job.copy_unified_job()
+
+        assert isinstance(relaunched_job, Job)
+        assert not isinstance(relaunched_job, WorkflowJob)
+        assert relaunched_job.inventory_id == child_job.inventory_id
+        assert relaunched_job.preferred_instance_groups_cache == child_job.preferred_instance_groups_cache
+
 
 @pytest.mark.django_db
 class TestFederatedInventoryHasMatchingHosts:


### PR DESCRIPTION
Fixes an issue where the child job was re-inheriting the parent inventory when relaunching.