### PR TITLE
Upgrade styled-components from 5 to 6

### DIFF
--- a/awx/ui/config/jest/babelTransform.js
+++ b/awx/ui/config/jest/babelTransform.js
@@ -24,6 +24,11 @@ module.exports = babelJest.createTransformer({
       },
     ],
   ],
+  plugins: [
+    // styled-components v6 removed the babel macro; the plugin provides
+    // the css-prop transform the codebase relies on.
+    require.resolve('babel-plugin-styled-components'),
+  ],
   babelrc: false,
   configFile: false,
 });

--- a/awx/ui/config/webpack.config.js
+++ b/awx/ui/config/webpack.config.js
@@ -418,6 +418,9 @@ module.exports = function (webpackEnv) {
                 ],
                 
                 plugins: [
+                  // styled-components v6 removed the babel macro; the plugin
+                  // provides the css-prop transform the codebase relies on.
+                  require.resolve('babel-plugin-styled-components'),
                   isEnvDevelopment &&
                     shouldUseReactRefresh &&
                     require.resolve('react-refresh/babel'),

--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -31,7 +31,7 @@
         "react-router-dom": "^5.3.3",
         "react-virtualized": "^9.22.6",
         "rrule": "2.8.1",
-        "styled-components": "5.3.11"
+        "styled-components": "^6.4.2"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -56,6 +56,7 @@
         "babel-loader": "^10.1.1",
         "babel-plugin-macros": "3.1.0",
         "babel-plugin-named-asset-import": "^0.3.8",
+        "babel-plugin-styled-components": "^2.3.0",
         "babel-preset-react-app": "^10.1.0",
         "bfj": "^9.1.3",
         "browserslist": "^4.28.2",
@@ -106,7 +107,7 @@
         "sass-loader": "^16.0.8",
         "semver": "^7.8.0",
         "style-loader": "^4.0.0",
-        "styled-components": "5.3.11",
+        "styled-components": "^6.4.2",
         "tailwindcss": "^4.3.0",
         "terser-webpack-plugin": "^5.6.0",
         "webpack": "^5.106.2",
@@ -2822,9 +2823,9 @@
       }
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
-      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2835,20 +2836,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8394,20 +8381,33 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.3.0.tgz",
+      "integrity": "sha512-nP/y6PbBqS/qtKROnJCgpGo8hYUzlBAVXN1QAjSBANL6vZiQXPQN7FYW/nUwoxY7nZhBEGm9T5tjL9gbzwulDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "lodash": "^4.17.21",
-        "picomatch": "^2.3.1"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "picomatch": "^4.0.2"
       },
       "peerDependencies": {
+        "@babel/core": "^7.0.0",
         "styled-components": ">= 2"
+      }
+    },
+    "node_modules/babel-plugin-styled-components/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
@@ -10000,9 +10000,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/d3": {
@@ -21318,14 +21318,6 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "license": "MIT"
     },
-    "node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -22480,13 +22472,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -23079,56 +23064,40 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.2.tgz",
+      "integrity": "sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
+        "@emotion/is-prop-valid": "1.4.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 16"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
-      }
-    },
-    "node_modules/styled-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/styled-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
+        "react-native": ">= 0.68.0"
       },
-      "engines": {
-        "node": ">=4"
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/stylehacks": {
@@ -23147,6 +23116,13 @@
       "peerDependencies": {
         "postcss": "^8.4.32"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -23760,7 +23736,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -31,7 +31,7 @@
     "react-router-dom": "^5.3.3",
     "react-virtualized": "^9.22.6",
     "rrule": "2.8.1",
-    "styled-components": "5.3.11"
+    "styled-components": "^6.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
@@ -56,6 +56,7 @@
     "babel-loader": "^10.1.1",
     "babel-plugin-macros": "3.1.0",
     "babel-plugin-named-asset-import": "^0.3.8",
+    "babel-plugin-styled-components": "^2.3.0",
     "babel-preset-react-app": "^10.1.0",
     "bfj": "^9.1.3",
     "browserslist": "^4.28.2",
@@ -106,7 +107,7 @@
     "sass-loader": "^16.0.8",
     "semver": "^7.8.0",
     "style-loader": "^4.0.0",
-    "styled-components": "5.3.11",
+    "styled-components": "^6.4.2",
     "tailwindcss": "^4.3.0",
     "terser-webpack-plugin": "^5.6.0",
     "webpack": "^5.106.2",

--- a/awx/ui/src/components/AlertModal/AlertModal.js
+++ b/awx/ui/src/components/AlertModal/AlertModal.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { Modal, Title } from '@patternfly/react-core';
 import {

--- a/awx/ui/src/components/CheckboxListItem/CheckboxListItem.js
+++ b/awx/ui/src/components/CheckboxListItem/CheckboxListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/CodeEditor/VariablesDetail.js
+++ b/awx/ui/src/components/CodeEditor/VariablesDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState } from 'react';
 import { node, number, oneOfType, shape, string, arrayOf } from 'prop-types';
 

--- a/awx/ui/src/components/DetailList/ArrayDetail.js
+++ b/awx/ui/src/components/DetailList/ArrayDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import styled from 'styled-components';
 import { TextListItemVariants } from '@patternfly/react-core';

--- a/awx/ui/src/components/DetailList/CodeDetail.js
+++ b/awx/ui/src/components/DetailList/CodeDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import {
   arrayOf,

--- a/awx/ui/src/components/ErrorDetail/ErrorDetail.js
+++ b/awx/ui/src/components/ErrorDetail/ErrorDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';

--- a/awx/ui/src/components/FormLayout/FormLayout.js
+++ b/awx/ui/src/components/FormLayout/FormLayout.js
@@ -12,7 +12,7 @@ export const FormColumnLayout = styled.div`
   }
 
   ${(props) =>
-    props.stacked &&
+    props.$stacked &&
     `border-bottom: 1px solid var(--pf-global--BorderColor--100);
     padding: var(--pf-global--spacer--sm) 0 var(--pf-global--spacer--md) `}
 `;

--- a/awx/ui/src/components/HostToggle/HostToggle.js
+++ b/awx/ui/src/components/HostToggle/HostToggle.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useEffect, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useCallback, useEffect } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/Lookup/Lookup.js
+++ b/awx/ui/src/components/Lookup/Lookup.js
@@ -31,7 +31,7 @@ import reducer, { initReducer } from './shared/reducer';
 const ChipHolder = styled.div`
   --pf-c-form-control--Height: auto;
   background-color: ${(props) =>
-    props.isDisabled ? 'var(--pf-global--disabled-color--300)' : null};
+    props.$isDisabled ? 'var(--pf-global--disabled-color--300)' : null};
 `;
 function Lookup(props) {
   const {
@@ -151,7 +151,7 @@ function Lookup(props) {
           <SearchIcon />
         </Button>
         {multiple ? (
-          <ChipHolder isDisabled={isDisabled} className="pf-c-form-control">
+          <ChipHolder $isDisabled={isDisabled} className="pf-c-form-control">
             <ChipGroup
               numChips={5}
               totalChips={items.length}

--- a/awx/ui/src/components/Lookup/MultiCredentialsLookup.js
+++ b/awx/ui/src/components/Lookup/MultiCredentialsLookup.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useCallback, useEffect } from 'react';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/awx/ui/src/components/PaginatedTable/ActionItem.js
+++ b/awx/ui/src/components/PaginatedTable/ActionItem.js
@@ -1,6 +1,11 @@
-import 'styled-components/macro';
 import React from 'react';
+import styled from 'styled-components';
 import { Tooltip } from '@patternfly/react-core';
+
+const ColumnItem = styled.div`
+  grid-column: ${(props) => props.$column};
+`;
+ColumnItem.displayName = 'ColumnItem';
 
 export default function ActionItem({ column, tooltip, visible, children }) {
   if (!visible) {
@@ -8,11 +13,7 @@ export default function ActionItem({ column, tooltip, visible, children }) {
   }
 
   return (
-    <div
-      css={`
-        grid-column: ${column};
-      `}
-    >
+    <ColumnItem $column={column}>
       {tooltip ? (
         <Tooltip content={tooltip} position="top">
           <div>{children}</div>
@@ -20,6 +21,6 @@ export default function ActionItem({ column, tooltip, visible, children }) {
       ) : (
         children
       )}
-    </div>
+    </ColumnItem>
   );
 }

--- a/awx/ui/src/components/PaginatedTable/ActionsTd.js
+++ b/awx/ui/src/components/PaginatedTable/ActionsTd.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { Td } from '@patternfly/react-table';
 import styled, { css } from 'styled-components';
@@ -10,7 +9,7 @@ const ActionsGrid = styled.div`
   padding-right: 20px
     ${(props) => {
       const columns =
-        props.gridColumns || '40px '.repeat(props.numActions || 1);
+        props.$gridColumns || '40px '.repeat(props.$numActions || 1);
       return css`
         grid-template-columns: ${columns};
       `;
@@ -18,27 +17,27 @@ const ActionsGrid = styled.div`
 `;
 ActionsGrid.displayName = 'ActionsGrid';
 
+const ActionsCell = styled(Td)`
+  text-align: right;
+  --pf-c-table--cell--Width: ${(props) => props.$width}px;
+
+  [role='presentation'] {
+    color: var(--pf-global--Color--300);
+    opacity: 0.5;
+  }
+
+  &:hover [role='presentation'] {
+    opacity: 1;
+  }
+`;
+ActionsCell.displayName = 'ActionsCell';
+
 export default function ActionsTd({ children, gridColumns, ...props }) {
   const numActions = children.length || 1;
   const width = numActions * 40;
   return (
-    <Td
-      css={`
-        text-align: right;
-        --pf-c-table--cell--Width: ${width}px;
-
-        [role='presentation'] {
-          color: var(--pf-global--Color--300);
-          opacity: 0.5;
-        }
-
-        &:hover [role='presentation'] {
-          opacity: 1;
-        }
-      `}
-      {...props}
-    >
-      <ActionsGrid numActions={numActions} gridColumns={gridColumns}>
+    <ActionsCell $width={width} {...props}>
+      <ActionsGrid $numActions={numActions} $gridColumns={gridColumns}>
         {React.Children.map(children, (child, i) =>
           child
             ? React.cloneElement(child, {
@@ -47,6 +46,6 @@ export default function ActionsTd({ children, gridColumns, ...props }) {
             : null
         )}
       </ActionsGrid>
-    </Td>
+    </ActionsCell>
   );
 }

--- a/awx/ui/src/components/PaginatedTable/HeaderRow.js
+++ b/awx/ui/src/components/PaginatedTable/HeaderRow.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { Thead, Tr, Th as PFTh } from '@patternfly/react-table';
@@ -8,6 +7,7 @@ import { parseQueryString, updateQueryString } from 'util/qs';
 const Th = styled(PFTh)`
   --pf-c-table--cell--Overflow: initial;
   --pf-c-table--cell--MaxWidth: none;
+  ${(props) => (props.$alignRight ? 'text-align: right;' : '')}
 `;
 
 export default function HeaderRow({
@@ -89,7 +89,7 @@ export function HeaderCell({
       id={sortKey ? `${idPrefix}-${sortKey}` : null}
       className={className}
       sort={sort}
-      css={children === 'Actions' ? 'text-align: right' : null}
+      $alignRight={children === 'Actions'}
     >
       {children}
     </Th>

--- a/awx/ui/src/components/PaginatedTable/PaginatedTable.js
+++ b/awx/ui/src/components/PaginatedTable/PaginatedTable.js
@@ -1,7 +1,6 @@
 //
 // Modifications Copyright (c) 2023 Ctrl IQ, Inc.
 //
-import 'styled-components/macro';
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { TableComposable, Tbody } from '@patternfly/react-table';

--- a/awx/ui/src/components/PromptDetail/PromptDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { shape } from 'prop-types';
 import { Trans, useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/ResourceAccessList/ResourceAccessListItem.js
+++ b/awx/ui/src/components/ResourceAccessList/ResourceAccessListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { func } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
+++ b/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useCallback, useEffect } from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import styled from 'styled-components';

--- a/awx/ui/src/components/Schedule/ScheduleList/ScheduleListItem.js
+++ b/awx/ui/src/components/Schedule/ScheduleList/ScheduleListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { bool, func } from 'prop-types';
 

--- a/awx/ui/src/components/Schedule/ScheduleOccurrences/ScheduleOccurrences.js
+++ b/awx/ui/src/components/Schedule/ScheduleOccurrences/ScheduleOccurrences.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState } from 'react';
 import { shape, string } from 'prop-types';
 import styled from 'styled-components';

--- a/awx/ui/src/components/Schedule/ScheduleToggle/ScheduleToggle.js
+++ b/awx/ui/src/components/Schedule/ScheduleToggle/ScheduleToggle.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Switch, Tooltip } from '@patternfly/react-core';

--- a/awx/ui/src/components/Schedule/shared/FrequencyDetailSubform.js
+++ b/awx/ui/src/components/Schedule/shared/FrequencyDetailSubform.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import styled from 'styled-components';
 import { useField } from 'formik';

--- a/awx/ui/src/components/Schedule/shared/ScheduleFormFields.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleFormFields.js
@@ -3,7 +3,6 @@ import { useField } from 'formik';
 import { FormGroup, Title } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
-import 'styled-components/macro';
 import FormField from 'components/FormField';
 import { required } from 'util/validators';
 import { useConfig } from 'contexts/Config';
@@ -151,7 +150,7 @@ export default function ScheduleFormFields({
             {t`Frequency Details`}
           </Title>
           {frequency.value.map((val) => (
-            <FormColumnLayout key={val} stacked>
+            <FormColumnLayout key={val} $stacked>
               <FrequencyDetailSubform
                 frequency={val}
                 prefix={`frequencyOptions.${val}`}
@@ -165,7 +164,7 @@ export default function ScheduleFormFields({
           >
             {t`Exceptions`}
           </Title>
-          <FormColumnLayout stacked>
+          <FormColumnLayout $stacked>
             <FormGroup
               name="exceptions"
               fieldId="exception-frequency"
@@ -203,7 +202,7 @@ export default function ScheduleFormFields({
             </FormGroup>
           </FormColumnLayout>
           {exceptionFrequency.value.map((val) => (
-            <FormColumnLayout key={val} stacked>
+            <FormColumnLayout key={val} $stacked>
               <FrequencyDetailSubform
                 frequency={val}
                 prefix={`exceptionOptions.${val}`}

--- a/awx/ui/src/components/Search/AdvancedSearch.js
+++ b/awx/ui/src/components/Search/AdvancedSearch.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useEffect, useState } from 'react';
 import { string, func, bool, arrayOf } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
@@ -22,6 +21,11 @@ import getDocsBaseUrl from 'util/getDocsBaseUrl';
 import { SearchableKeys } from 'types';
 import RelatedLookupTypeInput from './RelatedLookupTypeInput';
 import LookupTypeInput from './LookupTypeInput';
+
+const SubmitButtonWrapper = styled.div`
+  ${(props) => (props.$disabled ? 'cursor: not-allowed;' : '')}
+`;
+SubmitButtonWrapper.displayName = 'SubmitButtonWrapper';
 
 const AdvancedGroup = styled.div`
   display: flex;
@@ -311,7 +315,7 @@ function AdvancedSearch({
 
       <InputGroup>
         {renderTextInput()}
-        <div css={!searchValue && `cursor:not-allowed`}>
+        <SubmitButtonWrapper $disabled={!searchValue}>
           <Button
             ouiaId="advanced-search-text-input"
             variant={ButtonVariant.control}
@@ -321,7 +325,7 @@ function AdvancedSearch({
           >
             <SearchIcon />
           </Button>
-        </div>
+        </SubmitButtonWrapper>
       </InputGroup>
       <Tooltip
         content={t`Advanced search documentation`}

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
@@ -22,6 +21,11 @@ import { parseQueryString } from 'util/qs';
 import { QSConfig, SearchColumns, SearchableKeys } from 'types';
 import AdvancedSearch from './AdvancedSearch';
 import getChipsByKey from './getChipsByKey';
+
+const SubmitButtonWrapper = styled.div`
+  ${(props) => (props.$disabled ? 'cursor: not-allowed;' : '')}
+`;
+SubmitButtonWrapper.displayName = 'SubmitButtonWrapper';
 
 const NoOptionDropdown = styled.div`
   align-self: stretch;
@@ -252,7 +256,7 @@ function Search({
                   onKeyDown={handleTextKeyDown}
                   isDisabled={isDisabled}
                 />
-                <div css={!searchValue && `cursor:not-allowed`}>
+                <SubmitButtonWrapper $disabled={!searchValue}>
                   <Button
                     ouiaId="search-submit-button"
                     variant={ButtonVariant.control}
@@ -262,7 +266,7 @@ function Search({
                   >
                     <SearchIcon />
                   </Button>
-                </div>
+                </SubmitButtonWrapper>
               </InputGroup>
             )}
         </ToolbarFilter>

--- a/awx/ui/src/components/SelectableCard/SelectableCard.js
+++ b/awx/ui/src/components/SelectableCard/SelectableCard.js
@@ -8,7 +8,7 @@ const SelectableItem = styled.div`
   border-radius: var(--pf-global--BorderRadius--sm);
   border: 1px solid;
   border-color: ${(props) =>
-    props.isSelected
+    props.$isSelected
       ? 'var(--pf-global--active-color--100)'
       : 'var(--pf-global--BorderColor--200)'};
   margin-right: 20px;
@@ -20,7 +20,7 @@ const Indicator = styled.div`
   display: flex;
   flex: 0 0 5px;
   background-color: ${(props) =>
-    props.isSelected ? 'var(--pf-global--active-color--100)' : null};
+    props.$isSelected ? 'var(--pf-global--active-color--100)' : null};
 `;
 
 const Contents = styled.div`
@@ -46,10 +46,10 @@ function SelectableCard({
       role="button"
       tabIndex="0"
       data-cy={dataCy}
-      isSelected={isSelected}
+      $isSelected={isSelected}
       aria-label={ariaLabel}
     >
-      <Indicator isSelected={isSelected} />
+      <Indicator $isSelected={isSelected} />
       <Contents>
         <b>{label}</b>
         <Description>{description}</Description>

--- a/awx/ui/src/components/StatusLabel/StatusLabel.js
+++ b/awx/ui/src/components/StatusLabel/StatusLabel.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-no-useless-fragment */
-import 'styled-components/macro';
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { oneOf } from 'prop-types';

--- a/awx/ui/src/components/TemplateList/TemplateListItem.js
+++ b/awx/ui/src/components/TemplateList/TemplateListItem.js
@@ -2,7 +2,6 @@
   Modifications Copyright (c) 2023 Ctrl IQ, Inc.
 */
 
-import 'styled-components/macro';
 import React, { useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Tooltip, Chip } from '@patternfly/react-core';

--- a/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';

--- a/awx/ui/src/components/Workflow/WorkflowStartNode.js
+++ b/awx/ui/src/components/Workflow/WorkflowStartNode.js
@@ -11,7 +11,7 @@ import WorkflowActionTooltip from './WorkflowActionTooltip';
 import WorkflowActionTooltipItem from './WorkflowActionTooltipItem';
 
 const StartG = styled.g`
-  pointer-events: ${(props) => (props.ignorePointerEvents ? 'none' : 'auto')};
+  pointer-events: ${(props) => (props.$ignorePointerEvents ? 'none' : 'auto')};
 `;
 
 const StartForeignObject = styled.foreignObject`
@@ -46,7 +46,7 @@ function WorkflowStartNode({ onUpdateHelpText, showActionTooltip }) {
   return (
     <StartG
       id="node-1"
-      ignorePointerEvents={addingLink}
+      $ignorePointerEvents={addingLink}
       onMouseEnter={handleNodeMouseEnter}
       onMouseLeave={() => setHovering(false)}
       ref={ref}

--- a/awx/ui/src/components/Workflow/WorkflowTools.js
+++ b/awx/ui/src/components/Workflow/WorkflowTools.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useContext } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';

--- a/awx/ui/src/screens/Host/HostDetail/HostDetail.js
+++ b/awx/ui/src/screens/Host/HostDetail/HostDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 

--- a/awx/ui/src/screens/Host/HostList/HostListItem.js
+++ b/awx/ui/src/screens/Host/HostList/HostListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { string, bool, func } from 'prop-types';
 

--- a/awx/ui/src/screens/HostMetrics/HostMetricsListItem.js
+++ b/awx/ui/src/screens/HostMetrics/HostMetricsListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { Tr, Td } from '@patternfly/react-table';
 import { formatDateString } from 'util/dates';

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js
@@ -4,7 +4,6 @@ import { string, bool, func } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
 
 import { Link } from 'react-router-dom';
-import 'styled-components/macro';
 import {
   Button,
   Progress,

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { useLocation, useParams } from 'react-router-dom';
-import 'styled-components/macro';
 
 import useExpanded from 'hooks/useExpanded';
 import DataListToolbar from 'components/DataListToolbar';

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
@@ -4,7 +4,6 @@ import { bool, func } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
 
 import styled from 'styled-components';
-import 'styled-components/macro';
 import {
   Progress,
   ProgressMeasureLocation,

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceList.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceList.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { useLocation } from 'react-router-dom';
-import 'styled-components/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 
 import useExpanded from 'hooks/useExpanded';

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import { bool, func } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
-import 'styled-components/macro';
 import {
   Progress,
   ProgressMeasureLocation,

--- a/awx/ui/src/screens/Instances/InstanceListenerAddressList/InstanceListenerAddressListItem.js
+++ b/awx/ui/src/screens/Instances/InstanceListenerAddressList/InstanceListenerAddressListItem.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import 'styled-components/macro';
 import { Tr, Td } from '@patternfly/react-table';
 
 function InstanceListenerAddressListItem({

--- a/awx/ui/src/screens/Instances/InstancePeers/InstancePeerListItem.js
+++ b/awx/ui/src/screens/Instances/InstancePeers/InstancePeerListItem.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useLingui } from '@lingui/react/macro';
-import 'styled-components/macro';
 import { Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { formatDateString } from 'util/dates';
 import { Detail, DetailList } from 'components/DetailList';

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHostListItem.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHostListItem.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { string, bool, func } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
-import 'styled-components/macro';
 import { Tr, Td } from '@patternfly/react-table';
 import Sparkline from 'components/Sparkline';
 import { Host } from 'types';

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { string, bool, func, number } from 'prop-types';

--- a/awx/ui/src/screens/Inventory/InventoryHostDetail/InventoryHostDetail.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostDetail/InventoryHostDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { string, bool, func, number } from 'prop-types';

--- a/awx/ui/src/screens/Inventory/shared/InventoryGroupsDeleteModal.js
+++ b/awx/ui/src/screens/Inventory/shared/InventoryGroupsDeleteModal.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useContext, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { func, bool, arrayOf } from 'prop-types';

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 

--- a/awx/ui/src/screens/Job/JobOutput/EmptyOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/EmptyOutput.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import 'styled-components/macro';
 import {
   SearchIcon,
   ExclamationCircleIcon as PFExclamationCircleIcon,

--- a/awx/ui/src/screens/Job/JobOutput/JobEvent.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEvent.js
@@ -66,8 +66,7 @@ const JobEvent = React.forwardRef(
             <JobEventLine
               onClick={isClickable ? handleClick : undefined}
               key={`${event.counter}-${lineNumber}`}
-              isFirst={lineNumber === 0}
-              isClickable={isClickable}
+              $isClickable={isClickable}
             >
               <JobEventLineToggle
                 canToggle={canToggle}

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -71,9 +71,9 @@ const OutputWrapper = styled.div`
   font-family: monospace;
   font-size: 15px;
   outline: 1px solid var(--pf-global--BorderColor--100);
-  ${({ cssMap }) =>
-    Object.keys(cssMap).map(
-      (className) => `.${className}{${cssMap[className]}}`
+  ${({ $cssMap }) =>
+    Object.keys($cssMap).map(
+      (className) => `.${className}{${$cssMap[className]}}`
     )}
 `;
 
@@ -883,7 +883,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
           isTemplateJob={job.type === 'job'}
           isAllCollapsed={isAllCollapsed}
         />
-        <OutputWrapper ref={outputRef} cssMap={cssMap}>
+        <OutputWrapper ref={outputRef} $cssMap={cssMap}>
           <InfiniteLoader
             isRowLoaded={isRowLoaded}
             loadMoreRows={loadMoreRows}

--- a/awx/ui/src/screens/Job/JobOutput/PageControls.js
+++ b/awx/ui/src/screens/Job/JobOutput/PageControls.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import 'styled-components/macro';
 import { Button } from '@patternfly/react-core';
 import {
   AngleDoubleUpIcon,

--- a/awx/ui/src/screens/Job/JobOutput/shared/JobEventLine.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/JobEventLine.js
@@ -4,7 +4,7 @@ export default styled.div`
   display: flex;
 
   &:hover {
-    cursor: ${(props) => (props.isClickable ? 'pointer' : 'default')};
+    cursor: ${(props) => (props.$isClickable ? 'pointer' : 'default')};
   }
 
   &--hidden {

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputGraph.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputGraph.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { WorkflowStateContext } from 'contexts/Workflow';

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
@@ -80,7 +80,7 @@ function WorkflowOutputToolbar({ job }) {
     }
   };
   return (
-    <Toolbar id="workflow-output-toolbar" ouiaId="workflow-output-toolbar">
+    <Toolbar id="workflow-output-toolbar">
       <ToolbarJob>
         <h1>{job.name}</h1>
         <StatusLabel status={job.status} />

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Link } from 'react-router-dom';

--- a/awx/ui/src/screens/NotificationTemplate/shared/CustomMessagesSubForm.js
+++ b/awx/ui/src/screens/NotificationTemplate/shared/CustomMessagesSubForm.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useEffect, useRef } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { useField, useFormikContext } from 'formik';

--- a/awx/ui/src/screens/Project/ProjectList/ProjectListItem.js
+++ b/awx/ui/src/screens/Project/ProjectList/ProjectListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState, useCallback } from 'react';
 import { string, bool, func } from 'prop-types';
 import { Button, ClipboardCopy, Tooltip } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Project/shared/ProjectSubForms/ArchiveSubForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSubForms/ArchiveSubForm.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import getProjectHelpText from '../Project.helptext';
 

--- a/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import FormField from 'components/FormField';

--- a/awx/ui/src/screens/Project/shared/ProjectSubForms/ManualSubForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSubForms/ManualSubForm.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { useField } from 'formik';

--- a/awx/ui/src/screens/Project/shared/ProjectSubForms/SvnSubForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSubForms/SvnSubForm.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import getProjectHelpStrings from '../Project.helptext';

--- a/awx/ui/src/screens/Team/TeamList/TeamListItem.js
+++ b/awx/ui/src/screens/Team/TeamList/TeamListItem.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import 'styled-components/macro';
 import { string, bool, func } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/Template/Survey/SurveyListItem.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyListItem.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Chip, Tooltip, Button } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeDeleteModal.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useContext } from 'react';
 import { Button } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-no-useless-fragment */
-import 'styled-components/macro';
 import React, { useContext, useState, useEffect, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useState } from 'react';
 import { Trans, useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerGraph.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerGraph.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerLink.js
@@ -19,7 +19,7 @@ import {
 } from 'components/Workflow';
 
 const LinkG = styled.g`
-  pointer-events: ${(props) => (props.ignorePointerEvents ? 'none' : 'auto')};
+  pointer-events: ${(props) => (props.$ignorePointerEvents ? 'none' : 'auto')};
 `;
 
 function VisualizerLink({ link, updateLinkHelp, readOnly, updateHelpText }) {
@@ -121,7 +121,7 @@ function VisualizerLink({ link, updateLinkHelp, readOnly, updateHelpText }) {
   return (
     <LinkG
       id={`link-${link.source.id}-${link.target.id}`}
-      ignorePointerEvents={addingLink}
+      $ignorePointerEvents={addingLink}
       onMouseEnter={handleLinkMouseEnter}
       onMouseLeave={handleLinkMouseLeave}
       ref={ref}

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
@@ -26,7 +26,7 @@ import {
 import getNodeType from './shared/WorkflowJobTemplateVisualizerUtils';
 
 const NodeG = styled.g`
-  pointer-events: ${(props) => (props.noPointerEvents ? 'none' : 'initial')};
+  pointer-events: ${(props) => (props.$noPointerEvents ? 'none' : 'initial')};
   cursor: ${(props) => (props.job ? 'pointer' : 'default')};
 `;
 
@@ -286,7 +286,7 @@ function VisualizerNode({
       <NodeG
         id={`node-${node.id}`}
         job={node.job}
-        noPointerEvents={isAddLinkSourceNode}
+        $noPointerEvents={isAddLinkSourceNode}
         onMouseEnter={handleNodeMouseEnter}
         onMouseLeave={handleNodeMouseLeave}
         ref={ref}

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerStartScreen.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useContext } from 'react';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerToolbar.js
@@ -1,4 +1,3 @@
-import 'styled-components/macro';
 import React, { useContext } from 'react';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.js
+++ b/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.js
@@ -242,7 +242,7 @@ function WorkflowJobTemplateForm({
         </FieldWithPrompt>
       </FormFullWidthLayout>
       <FormGroup fieldId="options" label={t`Options`}>
-        <FormCheckboxLayout isInline>
+        <FormCheckboxLayout>
           <Checkbox
             aria-label={t`Enable Webhook`}
             label={

--- a/awx/ui/src/screens/User/UserList/UserListItem.js
+++ b/awx/ui/src/screens/User/UserList/UserListItem.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import 'styled-components/macro';
 import { string, bool, func } from 'prop-types';
 
 import { useLingui } from '@lingui/react/macro';


### PR DESCRIPTION
## SUMMARY
Upgrades styled-components 5.3.11 → 6.4.2. This is the first stage of modernizing the React stack (styled-components 5 does not even compile against React 18/19, so it has to move first). v6 has two breaking changes that affect this codebase, both handled here:

**1. The babel macro was removed.** ~50 files relied on `styled-components/macro` for the css-prop transform (`css="..."` on plain JSX elements). The macro's direct replacement, `babel-plugin-styled-components`, is now wired into the jest babel transform and the webpack babel-loader, so those usages keep working unchanged. Macro imports become plain imports; dead side-effect macro imports are removed. The `css={\`...\`}` template-literal usages (ActionsTd, ActionItem, Search, AdvancedSearch) are converted to explicit styled components.

**2. v6 no longer filters non-HTML props from styled DOM elements** — everything is forwarded to the DOM, producing React unknown-prop warnings (which this test suite treats as failures). Custom props on styled DOM elements are converted to transient (`$`-prefixed) props per the v6 migration guide: `ActionsGrid` (`$numActions`/`$gridColumns`), `ChipHolder` (`$isDisabled`), `SelectableItem`/`Indicator` (`$isSelected`), `JobEventLine` (`$isClickable`), `OutputWrapper` (`$cssMap`), `LinkG`/`StartG` (`$ignorePointerEvents`), `NodeG` (`$noPointerEvents`), `FormColumnLayout` (`$stacked`), HeaderRow's `Th` (`$alignRight`). Three props that were never consumed and only existed to be swallowed by v5's filtering are dropped (`isFirst` on JobEventLine, `isInline` on FormCheckboxLayout, `ouiaId` on a styled div — none ever reached the DOM in v5).

Rendering output is unchanged: every conversion preserves the exact CSS the component produced under v5.

**Independent of every other open PR** — verified conflict-free via pairwise `git merge-tree`.

## ISSUE TYPE
- New or Enhanced Feature

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev5+gcda0899.d20260610
```

## ADDITIONAL INFORMATION
All UI gates run against exactly this branch state (unmodified main + only this change):
```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 544 suites passed (1 skipped), 2855 tests passed (19 skipped)
npm --prefix awx/ui run build    # production build succeeds
```
The unknown-prop warnings the suite surfaces are an exhaustive detector here: `setupTests.js` fails any test that logs a console error, so the passing suite demonstrates no styled component leaks props to the DOM anywhere the tests render.

Pre-existing oddity left untouched: `Project.helptext.js` uses `css={{...}}` objects on `<ul>` elements without ever having imported the macro — those styles never applied in v5 either and remain inert.








