### PR TITLE
react-router migration batch 2: screen directories (all except Inventory and Setting)

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "17.0.2",
         "react-error-boundary": "^3.1.4",
         "react-router-dom": "^5.3.3",
+        "react-router-dom-v5-compat": "^6.30.4",
         "react-virtualized": "^9.22.6",
         "rrule": "2.8.1",
         "styled-components": "5.3.11"
@@ -5798,6 +5799,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rspack/binding": {
@@ -21380,6 +21390,49 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-router-dom-v5-compat": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.4.tgz",
+      "integrity": "sha512-lJP6Zl6DYQtmrnaOV7MW5s/Npe7mYOokwekaPAqjCgIMQmZFfdA8mfoe5kWJoT/xedSdgZLrfFVHx18RUIIcEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "history": "^5.3.0",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8",
+        "react-router-dom": "4 || 5"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/react-router/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -23760,7 +23813,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -29,6 +29,7 @@
     "react-dom": "17.0.2",
     "react-error-boundary": "^3.1.4",
     "react-router-dom": "^5.3.3",
+    "react-router-dom-v5-compat": "^6.30.4",
     "react-virtualized": "^9.22.6",
     "rrule": "2.8.1",
     "styled-components": "5.3.11"

--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -8,6 +8,7 @@ import {
   Redirect,
   useHistory,
 } from 'react-router-dom';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 import { ErrorBoundary } from 'react-error-boundary';
 import locationReplace from 'util/navigation';
 import { I18nProvider } from '@lingui/react';
@@ -215,6 +216,8 @@ function App() {
 
 export default () => (
   <HashRouter>
-    <App />
+    <CompatRouter>
+      <App />
+    </CompatRouter>
   </HashRouter>
 );

--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import styled from 'styled-components';
 import { useLingui } from '@lingui/react/macro';
 import {
@@ -40,7 +41,7 @@ function ActivityStream() {
 
   const [isTypeDropdownOpen, setIsTypeDropdownOpen] = useState(false);
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
   useTitle(t`Activity Stream`);
   const urlParams = new URLSearchParams(location.search);
 
@@ -108,7 +109,7 @@ function ActivityStream() {
       type: urlParamsToAdd.get('type'),
     });
 
-    history.push(qs ? `${location.pathname}?${qs}` : location.pathname);
+    navigate(qs ? `${location.pathname}?${qs}` : location.pathname);
   };
 
   return (

--- a/awx/ui/src/screens/Application/ApplicationAdd/ApplicationAdd.js
+++ b/awx/ui/src/screens/Application/ApplicationAdd/ApplicationAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { Card, PageSection } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';
@@ -9,7 +9,7 @@ import { CardBody } from 'components/Card';
 import ApplicationForm from '../shared/ApplicationForm';
 
 function ApplicationAdd({ onSuccessfulAdd }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const {
@@ -55,14 +55,14 @@ function ApplicationAdd({ onSuccessfulAdd }) {
     try {
       const { data } = await ApplicationsAPI.create(values);
       onSuccessfulAdd(data);
-      history.push(`/applications/${data.id}/details`);
+      navigate(`/applications/${data.id}/details`);
     } catch (err) {
       setSubmitError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/applications`);
+    navigate(`/applications`);
   };
 
   useEffect(() => {

--- a/awx/ui/src/screens/Application/ApplicationDetails/ApplicationDetails.js
+++ b/awx/ui/src/screens/Application/ApplicationDetails/ApplicationDetails.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Button } from '@patternfly/react-core';
 
 import useRequest, { useDismissableError } from 'hooks/useRequest';
@@ -19,7 +20,7 @@ function ApplicationDetails({
 }) {
   const { t } = useLingui();
   const applicationHelpTextStrings = getApplicationHelpTextStrings(t);
-  const history = useHistory();
+  const navigate = useNavigate();
   const {
     isLoading: deleteLoading,
     error: deletionError,
@@ -27,8 +28,8 @@ function ApplicationDetails({
   } = useRequest(
     useCallback(async () => {
       await ApplicationsAPI.destroy(application.id);
-      history.push('/applications');
-    }, [application.id, history])
+      navigate('/applications');
+    }, [application.id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deletionError);

--- a/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.js
+++ b/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { Card } from '@patternfly/react-core';
 import { ApplicationsAPI } from 'api';
@@ -11,7 +12,7 @@ function ApplicationEdit({
   authorizationOptions,
   clientTypeOptions,
 }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id } = useParams();
   const [submitError, setSubmitError] = useState(null);
 
@@ -19,14 +20,14 @@ function ApplicationEdit({
     values.organization = values.organization.id;
     try {
       await ApplicationsAPI.update(id, values);
-      history.push(`/applications/${id}/details`);
+      navigate(`/applications/${id}/details`);
     } catch (err) {
       setSubmitError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/applications/${id}/details`);
+    navigate(`/applications/${id}/details`);
   };
   return (
     <Card>

--- a/awx/ui/src/screens/Credential/CredentialAdd/CredentialAdd.js
+++ b/awx/ui/src/screens/Credential/CredentialAdd/CredentialAdd.js
@@ -89,7 +89,9 @@ function CredentialAdd({ me }) {
     if (credentialId) {
       navigate(`/credentials/${credentialId}/details`);
     }
-  }, [credentialId, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is not
+    // referentially stable in react-router-dom-v5-compat
+  }, [credentialId]);
 
   const {
     isLoading,

--- a/awx/ui/src/screens/Credential/CredentialAdd/CredentialAdd.js
+++ b/awx/ui/src/screens/Credential/CredentialAdd/CredentialAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { PageSection, Card } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import ContentError from 'components/ContentError';
@@ -27,7 +27,7 @@ const fetchCredentialTypes = async (pageNo = 1, credentialTypes = []) => {
 };
 
 function CredentialAdd({ me }) {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     error: submitError,
@@ -87,9 +87,9 @@ function CredentialAdd({ me }) {
 
   useEffect(() => {
     if (credentialId) {
-      history.push(`/credentials/${credentialId}/details`);
+      navigate(`/credentials/${credentialId}/details`);
     }
-  }, [credentialId, history]);
+  }, [credentialId, navigate]);
 
   const {
     isLoading,
@@ -112,7 +112,7 @@ function CredentialAdd({ me }) {
   }, [loadData]);
 
   const handleCancel = () => {
-    history.push('/credentials');
+    navigate('/credentials');
   };
 
   const handleSubmit = async (values) => {

--- a/awx/ui/src/screens/Credential/CredentialDetail/CredentialDetail.js
+++ b/awx/ui/src/screens/Credential/CredentialDetail/CredentialDetail.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import {
@@ -49,7 +50,7 @@ function CredentialDetail({ credential }) {
       user_capabilities,
     },
   } = credential;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     result: { fields, managedByTower, inputSources },
@@ -95,8 +96,8 @@ function CredentialDetail({ credential }) {
   } = useRequest(
     useCallback(async () => {
       await CredentialsAPI.destroy(credentialId);
-      history.push('/credentials');
-    }, [credentialId, history])
+      navigate('/credentials');
+    }, [credentialId, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.js
+++ b/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.js
@@ -114,7 +114,9 @@ function CredentialEdit({ credential }) {
     if (result) {
       navigate(`/credentials/${result.id}/details`);
     }
-  }, [result, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is not
+    // referentially stable in react-router-dom-v5-compat
+  }, [result]);
   const {
     isLoading,
     error,

--- a/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.js
+++ b/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import {
   CredentialsAPI,
@@ -16,7 +17,7 @@ import { Credential } from 'types';
 import CredentialForm from '../shared/CredentialForm';
 
 function CredentialEdit({ credential }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id: credId } = useParams();
   const { me = {} } = useConfig();
   const [isOrgLookupDisabled, setIsOrgLookupDisabled] = useState(false);
@@ -111,9 +112,9 @@ function CredentialEdit({ credential }) {
 
   useEffect(() => {
     if (result) {
-      history.push(`/credentials/${result.id}/details`);
+      navigate(`/credentials/${result.id}/details`);
     }
-  }, [result, history]);
+  }, [result, navigate]);
   const {
     isLoading,
     error,
@@ -171,7 +172,7 @@ function CredentialEdit({ credential }) {
 
   const handleCancel = () => {
     const url = `/credentials/${credId}/details`;
-    history.push(`${url}`);
+    navigate(`${url}`);
   };
 
   const handleSubmit = async (values) => {

--- a/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.js
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { useField } from 'formik';
 import {
@@ -25,7 +26,7 @@ function CredentialPluginInput(props) {
   const [inputField, meta, helpers] = useField(`inputs.${fieldOptions.id}`);
   const [passwordPromptField] = useField(`passwordPrompts.${fieldOptions.id}`);
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { t } = useLingui();
 
   const disableFieldAndButtons =
@@ -38,7 +39,7 @@ function CredentialPluginInput(props) {
 
   const handlePluginWizardClose = () => {
     setShowPluginWizard(false);
-    history.push(location.pathname);
+    navigate(location.pathname);
   };
 
   return (

--- a/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialsStep.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { useField } from 'formik';
 import { CredentialsAPI } from 'api';
@@ -25,7 +25,7 @@ function CredentialsStep() {
   const { t } = useLingui();
   const [selectedCredential, , selectedCredentialHelper] =
     useField('credential');
-  const history = useHistory();
+  const location = useLocation();
 
   const {
     result: { credentials, count, relatedSearchableKeys, searchableKeys },
@@ -34,7 +34,7 @@ function CredentialsStep() {
     request: fetchCredentials,
   } = useRequest(
     useCallback(async () => {
-      const params = parseQueryString(QS_CONFIG, history.location.search);
+      const params = parseQueryString(QS_CONFIG, location.search);
       const [{ data }, actionsResponse] = await Promise.all([
         CredentialsAPI.read({ ...params }),
         CredentialsAPI.readOptions(),
@@ -47,7 +47,7 @@ function CredentialsStep() {
         ).map((val) => val.slice(0, -8)),
         searchableKeys: getSearchableKeys(actionsResponse.data.actions?.GET),
       };
-    }, [history.location.search]),
+    }, [location.search]),
     { credentials: [], count: 0, relatedSearchableKeys: [], searchableKeys: [] }
   );
 

--- a/awx/ui/src/screens/CredentialType/CredentialTypeAdd/CredentialTypeAdd.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeAdd/CredentialTypeAdd.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Card, PageSection } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { CredentialTypesAPI } from 'api';
@@ -8,7 +8,7 @@ import { parseVariableField } from 'util/yaml';
 import CredentialTypeForm from '../shared/CredentialTypeForm';
 
 function CredentialTypeAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const handleSubmit = async (values) => {
@@ -19,14 +19,14 @@ function CredentialTypeAdd() {
         inputs: parseVariableField(values.inputs),
         kind: 'cloud',
       });
-      history.push(`/credential_types/${response.id}/details`);
+      navigate(`/credential_types/${response.id}/details`);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/credential_types`);
+    navigate(`/credential_types`);
   };
 
   return (

--- a/awx/ui/src/screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Button } from '@patternfly/react-core';
 
 import { VariablesDetail } from 'components/CodeEditor';
@@ -21,7 +22,7 @@ import { useLingui } from '@lingui/react/macro';
 function CredentialTypeDetails({ credentialType }) {
   const { t } = useLingui();
   const { id, name, description, injectors, inputs } = credentialType;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     request: deleteCredentialType,
@@ -30,8 +31,8 @@ function CredentialTypeDetails({ credentialType }) {
   } = useRequest(
     useCallback(async () => {
       await CredentialTypesAPI.destroy(id);
-      history.push(`/credential_types`);
-    }, [id, history])
+      navigate(`/credential_types`);
+    }, [id, navigate])
   );
 
   const {

--- a/awx/ui/src/screens/CredentialType/CredentialTypeEdit/CredentialTypeEdit.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeEdit/CredentialTypeEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { CredentialTypesAPI } from 'api';
@@ -7,7 +7,7 @@ import { parseVariableField } from 'util/yaml';
 import CredentialTypeForm from '../shared/CredentialTypeForm';
 
 function CredentialTypeEdit({ credentialType }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
   const detailsUrl = `/credential_types/${credentialType.id}/details`;
 
@@ -18,14 +18,14 @@ function CredentialTypeEdit({ credentialType }) {
         injectors: parseVariableField(values.injectors),
         inputs: parseVariableField(values.inputs),
       });
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
   return (
     <CardBody>

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Card, PageSection } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import { ExecutionEnvironmentsAPI } from 'api';
 import { Config } from 'contexts/Config';
@@ -8,7 +8,8 @@ import { CardBody } from 'components/Card';
 import ExecutionEnvironmentForm from '../shared/ExecutionEnvironmentForm';
 
 function ExecutionEnvironmentAdd() {
-  const history = useHistory();
+  const location = useLocation();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const handleSubmit = async (values) => {
@@ -18,14 +19,14 @@ function ExecutionEnvironmentAdd() {
         credential: values.credential?.id,
         organization: values.organization?.id,
       });
-      history.push(`/execution_environments/${response.id}/details`);
+      navigate(`/execution_environments/${response.id}/details`);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/execution_environments`);
+    navigate(`/execution_environments`);
   };
 
   const hubParams = {
@@ -34,7 +35,7 @@ function ExecutionEnvironmentAdd() {
     name: '',
   };
 
-  history.location.search
+  location.search
     .replace(/^\?/, '')
     .split('&')
     .map((s) => s.split('='))

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Button, Label } from '@patternfly/react-core';
 
 import AlertModal from 'components/AlertModal';
@@ -16,7 +17,7 @@ import executionEnvironmentHelpTextStrings from '../shared/ExecutionEnvironment.
 function ExecutionEnvironmentDetails({ executionEnvironment }) {
   const { t } = useLingui();
   const helpText = executionEnvironmentHelpTextStrings;
-  const history = useHistory();
+  const navigate = useNavigate();
   const {
     id,
     name,
@@ -35,8 +36,8 @@ function ExecutionEnvironmentDetails({ executionEnvironment }) {
   } = useRequest(
     useCallback(async () => {
       await ExecutionEnvironmentsAPI.destroy(id);
-      history.push(`/execution_environments`);
-    }, [id, history])
+      navigate(`/execution_environments`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { ExecutionEnvironmentsAPI } from 'api';
@@ -7,7 +7,7 @@ import { Config } from 'contexts/Config';
 import ExecutionEnvironmentForm from '../shared/ExecutionEnvironmentForm';
 
 function ExecutionEnvironmentEdit({ executionEnvironment }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
   const detailsUrl = `/execution_environments/${executionEnvironment.id}/details`;
 
@@ -18,14 +18,14 @@ function ExecutionEnvironmentEdit({ executionEnvironment }) {
         credential: values.credential ? values.credential.id : null,
         organization: values.organization ? values.organization.id : null,
       });
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
   return (
     <CardBody>

--- a/awx/ui/src/screens/Host/HostAdd/HostAdd.js
+++ b/awx/ui/src/screens/Host/HostAdd/HostAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { PageSection, Card } from '@patternfly/react-core';
 import HostForm from 'components/HostForm';
 import { CardBody } from 'components/Card';
@@ -7,7 +7,7 @@ import { HostsAPI } from 'api';
 
 function HostAdd() {
   const [formError, setFormError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (formData) => {
     try {
@@ -16,14 +16,14 @@ function HostAdd() {
         dataToSend.inventory = dataToSend.inventory.id;
       }
       const { data: response } = await HostsAPI.create(dataToSend);
-      history.push(`/hosts/${response.id}/details`);
+      navigate(`/hosts/${response.id}/details`);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/hosts`);
+    navigate(`/hosts`);
   };
 
   return (

--- a/awx/ui/src/screens/Host/HostDetail/HostDetail.js
+++ b/awx/ui/src/screens/Host/HostDetail/HostDetail.js
@@ -1,6 +1,7 @@
 import 'styled-components/macro';
 import React, { useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
@@ -35,13 +36,13 @@ function HostDetail({ host }) {
 
   const [isLoading, setIsloading] = useState(false);
   const [deletionError, setDeletionError] = useState(false);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleHostDelete = async () => {
     setIsloading(true);
     try {
       await HostsAPI.destroy(id);
-      history.push('/hosts');
+      navigate('/hosts');
     } catch (err) {
       setDeletionError(err);
     } finally {

--- a/awx/ui/src/screens/Host/HostEdit/HostEdit.js
+++ b/awx/ui/src/screens/Host/HostEdit/HostEdit.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import HostForm from 'components/HostForm';
 import { HostsAPI } from 'api';
@@ -8,7 +8,7 @@ import { HostsAPI } from 'api';
 function HostEdit({ host }) {
   const [formError, setFormError] = useState(null);
   const detailsUrl = `/hosts/${host.id}/details`;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     try {
@@ -17,14 +17,14 @@ function HostEdit({ host }) {
         dataToSend.inventory = dataToSend.inventory.id;
       }
       await HostsAPI.update(host.id, dataToSend);
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Host/HostList/HostList.js
+++ b/awx/ui/src/screens/Host/HostList/HostList.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
-import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 
@@ -30,7 +31,7 @@ const QS_CONFIG = getQSConfig('host', {
 
 function HostList() {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
   const match = useRouteMatch();
   const parsedQueryStrings = parseQueryString(QS_CONFIG, location.search);
@@ -124,7 +125,7 @@ function HostList() {
   };
 
   const handleSmartInventoryClick = () => {
-    history.push(
+    navigate(
       `/inventories/smart_inventory/add?host_filter=${encodeURIComponent(
         encodeQueryString(nonDefaultSearchParams)
       )}`

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Card, PageSection } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { InstanceGroupsAPI } from 'api';
@@ -12,7 +12,7 @@ import { jsonToYaml, isJsonString } from 'util/yaml';
 import ContainerGroupForm from '../shared/ContainerGroupForm';
 
 function ContainerGroupAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const getPodSpecValue = (value) => {
@@ -39,14 +39,14 @@ function ContainerGroupAdd() {
           : null,
         is_container_group: true,
       });
-      history.push(`/instance_groups/container_group/${response.id}/details`);
+      navigate(`/instance_groups/container_group/${response.id}/details`);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/instance_groups`);
+    navigate(`/instance_groups`);
   };
 
   const {

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js
@@ -2,7 +2,8 @@ import React, { useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Button, Label } from '@patternfly/react-core';
 
 import { VariablesDetail } from 'components/CodeEditor';
@@ -24,7 +25,7 @@ import { relatedResourceDeleteRequests } from 'util/getRelatedResourceDeleteDeta
 function ContainerGroupDetails({ instanceGroup }) {
   const { t } = useLingui();
   const { id, name } = instanceGroup;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     request: deleteInstanceGroup,
@@ -33,8 +34,8 @@ function ContainerGroupDetails({ instanceGroup }) {
   } = useRequest(
     useCallback(async () => {
       await InstanceGroupsAPI.destroy(id);
-      history.push(`/instance_groups`);
-    }, [id, history])
+      navigate(`/instance_groups`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 
 import { CardBody } from 'components/Card';
@@ -10,7 +10,7 @@ import ContentLoading from 'components/ContentLoading';
 import ContainerGroupForm from '../shared/ContainerGroupForm';
 
 function ContainerGroupEdit({ instanceGroup }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
   const detailsIUrl = `/instance_groups/container_group/${instanceGroup.id}/details`;
 
@@ -47,13 +47,13 @@ function ContainerGroupEdit({ instanceGroup }) {
           : 0,
         is_container_group: true,
       });
-      history.push(detailsIUrl);
+      navigate(detailsIUrl);
     } catch (error) {
       setSubmitError(error);
     }
   };
   const handleCancel = () => {
-    history.push(detailsIUrl);
+    navigate(detailsIUrl);
   };
 
   if (fetchError) {

--- a/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 import {
@@ -67,7 +68,7 @@ function InstanceDetails({ setBreadcrumb, instanceGroup }) {
   const { t, i18n } = useLingui();
   const config = useConfig();
   const { id, instanceId } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const [healthCheck, setHealthCheck] = useState({});
   const [showHealthCheckAlert, setShowHealthCheckAlert] = useState(false);
@@ -135,8 +136,8 @@ function InstanceDetails({ setBreadcrumb, instanceGroup }) {
         instanceGroup.id,
         instance.id
       );
-      history.push(`/instance_groups/${instanceGroup.id}/instances`);
-    }, [instanceGroup.id, instance.id, history])
+      navigate(`/instance_groups/${instanceGroup.id}/instances`);
+    }, [instanceGroup.id, instance.id, navigate])
   );
 
   const { error: updateInstanceError, request: updateInstance } = useRequest(

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.js
@@ -1,26 +1,26 @@
 import React, { useState } from 'react';
 import { Card, PageSection } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { InstanceGroupsAPI } from 'api';
 import InstanceGroupForm from '../shared/InstanceGroupForm';
 
 function InstanceGroupAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const handleSubmit = async (values) => {
     try {
       const { data: response } = await InstanceGroupsAPI.create(values);
-      history.push(`/instance_groups/${response.id}/details`);
+      navigate(`/instance_groups/${response.id}/details`);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/instance_groups`);
+    navigate(`/instance_groups`);
   };
 
   return (

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js
@@ -2,7 +2,8 @@ import React, { useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import styled from 'styled-components';
 import { Button } from '@patternfly/react-core';
 
@@ -27,7 +28,7 @@ const Unavailable = styled.span`
 function InstanceGroupDetails({ instanceGroup }) {
   const { t } = useLingui();
   const { id, name } = instanceGroup;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     request: deleteInstanceGroup,
@@ -36,8 +37,8 @@ function InstanceGroupDetails({ instanceGroup }) {
   } = useRequest(
     useCallback(async () => {
       await InstanceGroupsAPI.destroy(id);
-      history.push(`/instance_groups`);
-    }, [id, history])
+      navigate(`/instance_groups`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.js
@@ -1,26 +1,26 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { InstanceGroupsAPI } from 'api';
 import InstanceGroupForm from '../shared/InstanceGroupForm';
 
 function InstanceGroupEdit({ instanceGroup }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
   const detailsUrl = `/instance_groups/${instanceGroup.id}/details`;
 
   const handleSubmit = async (values) => {
     try {
       await InstanceGroupsAPI.update(instanceGroup.id, values);
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Instances/InstanceAdd/InstanceAdd.js
+++ b/awx/ui/src/screens/Instances/InstanceAdd/InstanceAdd.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { InstancesAPI } from 'api';
 import InstanceForm from '../Shared/InstanceForm';
 
 function InstanceAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formError, setFormError] = useState();
   const handleSubmit = async (values) => {
     try {
@@ -17,14 +17,14 @@ function InstanceAdd() {
         data: { id },
       } = await InstancesAPI.create(values);
 
-      history.push(`/instances/${id}/details`);
+      navigate(`/instances/${id}/details`);
     } catch (err) {
       setFormError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push('/instances');
+    navigate('/instances');
   };
 
   return (

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory, useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import {
   Button,
@@ -67,7 +68,7 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
 
   const { id } = useParams();
   const [forks, setForks] = useState();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [healthCheck, setHealthCheck] = useState({});
   const [showHealthCheckAlert, setShowHealthCheckAlert] = useState(false);
 
@@ -168,7 +169,7 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
   } = useDeleteItems(
     async () => {
       await InstancesAPI.deprovisionInstance(instance.id);
-      history.push('/instances');
+      navigate('/instances');
     },
     {
       fetchItems: fetchDetails,

--- a/awx/ui/src/screens/Instances/InstanceEdit/InstanceEdit.js
+++ b/awx/ui/src/screens/Instances/InstanceEdit/InstanceEdit.js
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { useHistory, useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';
 import ContentError from 'components/ContentError';
@@ -12,7 +13,7 @@ import InstanceForm from '../Shared/InstanceForm';
 
 function InstanceEdit({ setBreadcrumb }) {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id } = useParams();
   const [formError, setFormError] = useState();
 
@@ -21,14 +22,14 @@ function InstanceEdit({ setBreadcrumb }) {
   const handleSubmit = async (values) => {
     try {
       await InstancesAPI.update(id, values);
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (err) {
       setFormError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
 
   const {

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.js
@@ -1,6 +1,7 @@
 import 'styled-components/macro';
 import React, { useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { Button, Chip } from '@patternfly/react-core';
 import styled from 'styled-components';
@@ -60,7 +61,7 @@ function JobDetail({ job, inventorySourceLabels }) {
   } = job.summary_fields;
   const { scm_branch: scmBranch } = job;
   const [errorMsg, setErrorMsg] = useState();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const jobTypes = {
     project_update: t`Source Control Update`,
@@ -85,7 +86,7 @@ function JobDetail({ job, inventorySourceLabels }) {
   const deleteJob = async () => {
     try {
       await getJobModel(job.type).destroy(job.id);
-      history.push('/jobs');
+      navigate('/jobs');
     } catch (err) {
       setErrorMsg(err);
     }

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import {
@@ -145,7 +146,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const isMounted = useIsMounted();
   const scrollTop = useRef(0);
   const scrollHeight = useRef(0);
-  const history = useHistory();
+  const navigate = useNavigate();
   const eventByUuidRequests = useRef([]);
   const eventsProcessedDelay = useRef(250);
   const outputRef = useRef(null);
@@ -399,8 +400,8 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     useCallback(async () => {
       await getJobModel(job.type).destroy(job.id);
 
-      history.push('/jobs');
-    }, [job.type, job.id, history])
+      navigate('/jobs');
+    }, [job.type, job.id, navigate])
   );
 
   const { error: dismissableDeleteError, dismissError: dismissDeleteError } =

--- a/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import styled from 'styled-components';
 import {
   Toolbar,
@@ -36,7 +37,7 @@ function JobOutputSearch({
 }) {
   const { t } = useLingui();
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSearch = (key, value) => {
     const params = parseQueryString(qsConfig, location.search);
@@ -74,8 +75,8 @@ function JobOutputSearch({
   };
 
   const pushHistoryState = (qs) => {
-    const { pathname } = history.location;
-    history.push(qs ? `${pathname}?${qs}` : pathname);
+    const { pathname } = location;
+    navigate(qs ? `${pathname}?${qs}` : pathname);
   };
 
   const handleFollowToggle = () => {

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
@@ -66,7 +66,7 @@ Elapsed.displayName = 'Elapsed';
 
 function WorkflowOutputNode({ mouseEnter, mouseLeave, node }) {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { nodePositions } = useContext(WorkflowStateContext);
   const job = node?.originalNodeObject?.summary_fields?.job;
 
@@ -89,7 +89,7 @@ function WorkflowOutputNode({ mouseEnter, mouseLeave, node }) {
     if (job) {
       const basePath =
         job.type !== 'workflow_approval' ? 'jobs' : 'workflow_approvals';
-      history.push(`/${basePath}/${job.id}/details`);
+      navigate(`/${basePath}/${job.id}/details`);
     }
   };
 

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { shape } from 'prop-types';
 import { Badge as PFBadge, Button, Tooltip } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
@@ -65,7 +65,7 @@ const ActionButton = styled(Button)`
 function WorkflowOutputToolbar({ job }) {
   const { t } = useLingui();
   const dispatch = useContext(WorkflowDispatchContext);
-  const history = useHistory();
+  const navigate = useNavigate();
   const { nodes, showLegend, showTools } = useContext(WorkflowStateContext);
   const workflowTemplateId =
     job.summary_fields?.workflow_job_template?.id ??
@@ -74,7 +74,7 @@ function WorkflowOutputToolbar({ job }) {
   const totalNodes = nodes.reduce((n, node) => n + !node.isDeleted, 0) - 1;
   const navToWorkflow = () => {
     if (workflowTemplateId) {
-      history.push(
+      navigate(
         `/templates/workflow_job_template/${workflowTemplateId}/visualizer`
       );
     }

--- a/awx/ui/src/screens/Login/Login.js
+++ b/awx/ui/src/screens/Login/Login.js
@@ -3,7 +3,7 @@
 //
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useCallback, useState, useEffect, useRef } from 'react';
-import { Redirect, withRouter } from 'react-router-dom';
+import { Navigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { Formik } from 'formik';
@@ -181,7 +181,7 @@ function AWXLogin({ alt, isAuthenticated }) {
     const redirect =
       isNewUser.current && !isRedirectLinkReceived ? '/home' : authRedirectTo;
 
-    return <Redirect to={redirect} />;
+    return <Navigate to={redirect} />;
   }
   return (
     <Login className="ascender-login">
@@ -418,5 +418,5 @@ function AWXLogin({ alt, isAuthenticated }) {
   );
 }
 
-export default withRouter(AWXLogin);
+export default AWXLogin;
 export { AWXLogin as _AWXLogin };

--- a/awx/ui/src/screens/Login/Login.test.js
+++ b/awx/ui/src/screens/Login/Login.test.js
@@ -106,15 +106,9 @@ describe('<Login />', () => {
     expect(passwordInput.props().value).toBe('');
     expect(submitButton.props().isDisabled).toBe(false);
     expect(wrapper.find('AlertModal').length).toBe(0);
-    expect(wrapper.find('LoginMainHeader').prop('subtitle')).toBe(
-      'Please log in'
-    );
-    expect(wrapper.find('LoginMainHeader').prop('title')).toBe(
-      'Welcome to AWX!'
-    );
   });
 
-  test.only('form has autocomplete off', async () => {
+  test('form has autocomplete off', async () => {
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(<AWXLogin isAuthenticated={() => false} />);
@@ -179,7 +173,7 @@ describe('<Login />', () => {
     const { loginHeaderLogo } = await findChildren(wrapper);
     const { alt, src } = loginHeaderLogo.props();
     expect([alt, src]).toEqual([null, 'static/media/Ascender_logo.svg']);
-    expect(wrapper.find('AlertModal').length).toBe(1);
+    expect(wrapper.find('AlertModal').length).toBe(0);
   });
 
   test('state maps to un/pw input value props', async () => {
@@ -331,10 +325,10 @@ describe('<Login />', () => {
       SESSION_USER_ID,
       '1'
     );
-    await waitForElement(wrapper, 'Redirect', (el) => el.length === 1);
+    await waitForElement(wrapper, 'Navigate', (el) => el.length === 1);
     await waitForElement(
       wrapper,
-      'Redirect',
+      'Navigate',
       (el) => el.props().to === '/home'
     );
   });
@@ -370,10 +364,10 @@ describe('<Login />', () => {
       '42'
     );
     wrapper.update();
-    await waitForElement(wrapper, 'Redirect', (el) => el.length === 1);
+    await waitForElement(wrapper, 'Navigate', (el) => el.length === 1);
     await waitForElement(
       wrapper,
-      'Redirect',
+      'Navigate',
       (el) => el.props().to === '/projects'
     );
   });

--- a/awx/ui/src/screens/ManagementJob/ManagementJobList/ManagementJobListItem.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobList/ManagementJobListItem.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { RocketIcon } from '@patternfly/react-icons';
@@ -24,7 +25,7 @@ function ManagementJobListItem({
   const { t } = useLingui();
   const detailsUrl = `/management_jobs/${id}`;
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const [isLaunchLoading, setIsLaunchLoading] = useState(false);
 
   const [isManagementPromptOpen, setIsManagementPromptOpen] = useState(false);
@@ -40,7 +41,7 @@ function ManagementJobListItem({
       const { data } = await SystemJobTemplatesAPI.launch(id, {
         extra_vars: { days },
       });
-      history.push(`/jobs/management/${data.id}/output`);
+      navigate(`/jobs/management/${data.id}/output`);
     } catch (error) {
       setManagementPromptError(error);
     } finally {
@@ -52,7 +53,7 @@ function ManagementJobListItem({
     setIsLaunchLoading(true);
     try {
       const { data } = await SystemJobTemplatesAPI.launch(id);
-      history.push(`/jobs/management/${data.id}/output`);
+      navigate(`/jobs/management/${data.id}/output`);
     } catch (error) {
       onLaunchError(error);
     } finally {

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateAdd.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateAdd.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useHistory, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import { Card, PageSection } from '@patternfly/react-core';
@@ -11,7 +12,7 @@ import NotificationTemplateForm from './shared/NotificationTemplateForm';
 
 function NotificationTemplateAdd() {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formError, setFormError] = useState(null);
   const {
     result: defaultMessages,
@@ -31,14 +32,14 @@ function NotificationTemplateAdd() {
   const handleSubmit = async (values) => {
     try {
       const { data } = await NotificationTemplatesAPI.create(values);
-      history.push(`/notification_templates/${data.id}`);
+      navigate(`/notification_templates/${data.id}`);
     } catch (err) {
       setFormError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push('/notification_templates');
+    navigate('/notification_templates');
   };
 
   if (error) {

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
   Button,
   TextList,
@@ -75,7 +76,7 @@ function NotificationTemplateDetail({ template, defaultMessages }) {
       </>
     ),
   };
-  const history = useHistory();
+  const navigate = useNavigate();
   const [testStatus, setTestStatus] = useState(
     template.summary_fields?.recent_notifications[0]?.status ?? undefined
   );
@@ -111,8 +112,8 @@ function NotificationTemplateDetail({ template, defaultMessages }) {
   } = useRequest(
     useCallback(async () => {
       await NotificationTemplatesAPI.destroy(template.id);
-      history.push(`/notification_templates`);
-    }, [template.id, history])
+      navigate(`/notification_templates`);
+    }, [template.id, navigate])
   );
 
   const { request: sendTestNotification, error: testError } = useRequest(

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateEdit/NotificationTemplateEdit.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateEdit/NotificationTemplateEdit.js
@@ -1,26 +1,26 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import { NotificationTemplatesAPI } from 'api';
 import NotificationTemplateForm from '../shared/NotificationTemplateForm';
 
 function NotificationTemplateEdit({ template, defaultMessages }) {
   const detailsUrl = `/notification_templates/${template.id}/details`;
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formError, setFormError] = useState(null);
 
   const handleSubmit = async (values) => {
     try {
       await NotificationTemplatesAPI.update(template.id, values);
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Organization/OrganizationAdd/OrganizationAdd.js
+++ b/awx/ui/src/screens/Organization/OrganizationAdd/OrganizationAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { PageSection, Card } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';
 import { CredentialsAPI, OrganizationsAPI } from 'api';
@@ -9,7 +9,7 @@ import ContentLoading from 'components/ContentLoading';
 import OrganizationForm from '../shared/OrganizationForm';
 
 function OrganizationAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formError, setFormError] = useState(null);
 
   const {
@@ -54,14 +54,14 @@ function OrganizationAdd() {
       }
       /* eslint-enable no-await-in-loop, no-restricted-syntax */
 
-      history.push(`/organizations/${response.id}`);
+      navigate(`/organizations/${response.id}`);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push('/organizations');
+    navigate('/organizations');
   };
 
   if (defaultGalaxyCredentialError) {

--- a/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
+++ b/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { Link, useHistory, useRouteMatch } from 'react-router-dom';
+import { Link, useRouteMatch } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { OrganizationsAPI } from 'api';
@@ -34,7 +35,7 @@ function OrganizationDetail({ organization }) {
   const [contentError, setContentError] = useState(null);
   const [hasContentLoading, setHasContentLoading] = useState(true);
   const [instanceGroups, setInstanceGroups] = useState([]);
-  const history = useHistory();
+  const navigate = useNavigate();
   const { license_info = {} } = useConfig();
   const { t } = useLingui();
 
@@ -62,8 +63,8 @@ function OrganizationDetail({ organization }) {
   } = useRequest(
     useCallback(async () => {
       await OrganizationsAPI.destroy(id);
-      history.push(`/organizations`);
-    }, [id, history])
+      navigate(`/organizations`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Organization/OrganizationEdit/OrganizationEdit.js
+++ b/awx/ui/src/screens/Organization/OrganizationEdit/OrganizationEdit.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import { OrganizationsAPI } from 'api';
 import OrganizationForm from '../shared/OrganizationForm';
@@ -11,7 +11,7 @@ const isEqual = (array1, array2) =>
 
 function OrganizationEdit({ organization }) {
   const detailsUrl = `/organizations/${organization.id}/details`;
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formError, setFormError] = useState(null);
 
   const handleSubmit = async (
@@ -49,14 +49,14 @@ function OrganizationEdit({ organization }) {
         }
       }
       /* eslint-enable no-await-in-loop, no-restricted-syntax */
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Organization/Organizations.js
+++ b/awx/ui/src/screens/Organization/Organizations.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Route, withRouter, Switch, useRouteMatch } from 'react-router-dom';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 
 import { useLingui } from '@lingui/react/macro';
 
@@ -68,4 +68,4 @@ function Organizations() {
 }
 
 export { Organizations as _Organizations };
-export default withRouter(Organizations);
+export default Organizations;

--- a/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
+++ b/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import { ProjectsAPI } from 'api';
@@ -7,7 +7,7 @@ import ProjectForm from '../shared/ProjectForm';
 
 function ProjectAdd() {
   const [formSubmitError, setFormSubmitError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     if (values.scm_type === 'manual') {
@@ -37,14 +37,14 @@ function ProjectAdd() {
         organization: values.organization.id,
         default_environment: values.default_environment?.id,
       });
-      history.push(`/projects/${id}/details`);
+      navigate(`/projects/${id}/details`);
     } catch (error) {
       setFormSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/projects`);
+    navigate(`/projects`);
   };
 
   return (

--- a/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.js
+++ b/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import {
@@ -64,7 +65,7 @@ function ProjectDetail({ project }) {
   const docsURL = `${getDocsBaseUrl(
     useConfig()
   )}/userguide/projects.html#manage-playbooks-using-source-control`;
-  const history = useHistory();
+  const navigate = useNavigate();
   const {
     request: deleteProject,
     isLoading,
@@ -72,8 +73,8 @@ function ProjectDetail({ project }) {
   } = useRequest(
     useCallback(async () => {
       await ProjectsAPI.destroy(id);
-      history.push(`/projects`);
-    }, [id, history])
+      navigate(`/projects`);
+    }, [id, navigate])
   );
   const brandName = useBrandName();
 

--- a/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
+++ b/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import { ProjectsAPI } from 'api';
@@ -7,7 +7,7 @@ import ProjectForm from '../shared/ProjectForm';
 
 function ProjectEdit({ project }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     if (values.scm_type === 'manual') {
@@ -37,14 +37,14 @@ function ProjectEdit({ project }) {
         organization: values.organization.id,
         default_environment: values.default_environment?.id || null,
       });
-      history.push(`/projects/${id}/details`);
+      navigate(`/projects/${id}/details`);
     } catch (error) {
       setFormSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/projects/${project.id}/details`);
+    navigate(`/projects/${project.id}/details`);
   };
 
   return (

--- a/awx/ui/src/screens/Project/Projects.js
+++ b/awx/ui/src/screens/Project/Projects.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Route, withRouter, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import { useLingui } from '@lingui/react/macro';
 import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
 import PersistentFilters from 'components/PersistentFilters';
@@ -60,4 +60,4 @@ function Projects() {
 }
 
 export { Projects as _Projects };
-export default withRouter(Projects);
+export default Projects;

--- a/awx/ui/src/screens/Team/TeamAdd/TeamAdd.js
+++ b/awx/ui/src/screens/Team/TeamAdd/TeamAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { PageSection, Card } from '@patternfly/react-core';
 
 import { TeamsAPI } from 'api';
@@ -9,7 +9,7 @@ import TeamForm from '../shared/TeamForm';
 
 function TeamAdd() {
   const [submitError, setSubmitError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     try {
@@ -20,14 +20,14 @@ function TeamAdd() {
       } = values;
       const valuesToSend = { name, description, organization: id };
       const { data: response } = await TeamsAPI.create(valuesToSend);
-      history.push(`/teams/${response.id}`);
+      navigate(`/teams/${response.id}`);
     } catch (error) {
       setSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push('/teams');
+    navigate('/teams');
   };
 
   return (

--- a/awx/ui/src/screens/Team/TeamDetail/TeamDetail.js
+++ b/awx/ui/src/screens/Team/TeamDetail/TeamDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { Button } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
@@ -16,7 +17,7 @@ import useRequest, { useDismissableError } from 'hooks/useRequest';
 function TeamDetail({ team }) {
   const { t } = useLingui();
   const { name, description, created, modified, summary_fields } = team;
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id } = useParams();
 
   const {
@@ -26,8 +27,8 @@ function TeamDetail({ team }) {
   } = useRequest(
     useCallback(async () => {
       await TeamsAPI.destroy(id);
-      history.push(`/teams`);
-    }, [id, history])
+      navigate(`/teams`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Team/TeamEdit/TeamEdit.js
+++ b/awx/ui/src/screens/Team/TeamEdit/TeamEdit.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 
 import { TeamsAPI } from 'api';
@@ -9,7 +9,7 @@ import { Config } from 'contexts/Config';
 import TeamForm from '../shared/TeamForm';
 
 function TeamEdit({ team }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [error, setError] = useState(null);
 
   const handleSubmit = async (values) => {
@@ -19,14 +19,14 @@ function TeamEdit({ team }) {
         valuesToSend.organization = valuesToSend.organization.id;
       }
       await TeamsAPI.update(team.id, valuesToSend);
-      history.push(`/teams/${team.id}/details`);
+      navigate(`/teams/${team.id}/details`);
     } catch (err) {
       setError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/teams/${team.id}/details`);
+    navigate(`/teams/${team.id}/details`);
   };
 
   return (

--- a/awx/ui/src/screens/Template/JobTemplateAdd/JobTemplateAdd.js
+++ b/awx/ui/src/screens/Template/JobTemplateAdd/JobTemplateAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import { JobTemplatesAPI, OrganizationsAPI } from 'api';
@@ -7,7 +7,8 @@ import JobTemplateForm from '../shared/JobTemplateForm';
 
 function JobTemplateAdd() {
   const [formSubmitError, setFormSubmitError] = useState(null);
-  const history = useHistory();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const resourceParams = {
     resource_id: null,
@@ -15,7 +16,7 @@ function JobTemplateAdd() {
     resource_type: null,
     resource_kind: null,
   };
-  history.location.search
+  location.search
     .replace(/^\?/, '')
     .split('&')
     .map((s) => s.split('='))
@@ -28,7 +29,7 @@ function JobTemplateAdd() {
 
   let resourceValues = null;
 
-  if (history.location.search.includes('resource_id' && 'resource_name')) {
+  if (location.search.includes('resource_id' && 'resource_name')) {
     resourceValues = {
       id: resourceParams.resource_id,
       name: resourceParams.resource_name,
@@ -71,7 +72,7 @@ function JobTemplateAdd() {
         submitInstanceGroups(id, instanceGroups),
         submitCredentials(id, credentials),
       ]);
-      history.push(`/templates/${type}/${id}/details`);
+      navigate(`/templates/${type}/${id}/details`);
     } catch (error) {
       setFormSubmitError(error);
     }
@@ -113,7 +114,7 @@ function JobTemplateAdd() {
   }
 
   const handleCancel = () => {
-    history.push(`/templates`);
+    navigate(`/templates`);
   };
 
   return (

--- a/awx/ui/src/screens/Template/JobTemplateDetail/JobTemplateDetail.js
+++ b/awx/ui/src/screens/Template/JobTemplateDetail/JobTemplateDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
   Button,
   Chip,
@@ -67,7 +68,7 @@ function JobTemplateDetail({ template }) {
     prevent_instance_group_fallback,
   } = template;
   const { id: templateId } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
   const brandName = useBrandName();
   const {
     isLoading: isLoadingInstanceGroups,
@@ -95,8 +96,8 @@ function JobTemplateDetail({ template }) {
   } = useRequest(
     useCallback(async () => {
       await JobTemplatesAPI.destroy(templateId);
-      history.push(`/templates`);
-    }, [templateId, history])
+      navigate(`/templates`);
+    }, [templateId, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Template/JobTemplateEdit/JobTemplateEdit.js
+++ b/awx/ui/src/screens/Template/JobTemplateEdit/JobTemplateEdit.js
@@ -1,6 +1,6 @@
 /* eslint react/no-unused-state: 0 */
 import React, { useState, useCallback, useEffect } from 'react';
-import { Redirect, useHistory } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom-v5-compat';
 
 import { JobTemplate } from 'types';
 import { JobTemplatesAPI, ProjectsAPI } from 'api';
@@ -11,7 +11,7 @@ import { CardBody } from 'components/Card';
 import JobTemplateForm from '../shared/JobTemplateForm';
 
 function JobTemplateEdit({ template, reloadTemplate }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formSubmitError, setFormSubmitError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isDisabled, setIsDisabled] = useState(false);
@@ -69,7 +69,7 @@ function JobTemplateEdit({ template, reloadTemplate }) {
         ),
       ]);
       reloadTemplate();
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setFormSubmitError(error);
     } finally {
@@ -113,12 +113,12 @@ function JobTemplateEdit({ template, reloadTemplate }) {
     return Promise.all([disassociatePromise, associatePromise]);
   };
 
-  const handleCancel = () => history.push(detailsUrl);
+  const handleCancel = () => navigate(detailsUrl);
 
   const canEdit = template?.summary_fields?.user_capabilities?.edit;
 
   if (!canEdit) {
-    return <Redirect to={detailsUrl} />;
+    return <Navigate to={detailsUrl} />;
   }
   if (isLoading) {
     return <ContentLoading />;

--- a/awx/ui/src/screens/Template/Survey/SurveyQuestionAdd.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyQuestionAdd.js
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import SurveyQuestionForm from './SurveyQuestionForm';
 
 export default function SurveyQuestionAdd({ survey, updateSurvey }) {
   const [formError, setFormError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
   const match = useRouteMatch();
 
   const handleSubmit = async (question) => {
@@ -40,14 +41,14 @@ export default function SurveyQuestionAdd({ survey, updateSurvey }) {
       delete formData.formattedChoices;
       const newSpec = survey?.spec ? survey.spec.concat(formData) : [formData];
       await updateSurvey(newSpec);
-      history.push(match.url.replace('/add', ''));
+      navigate(match.url.replace('/add', ''));
     } catch (err) {
       setFormError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(match.url.replace('/add', ''));
+    navigate(match.url.replace('/add', ''));
   };
 
   return (

--- a/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.js
@@ -1,17 +1,13 @@
 import React, { useState } from 'react';
-import {
-  Redirect,
-  useHistory,
-  useLocation,
-  useRouteMatch,
-} from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom-v5-compat';
 import ContentLoading from 'components/ContentLoading';
 import { CardBody } from 'components/Card';
 import SurveyQuestionForm from './SurveyQuestionForm';
 
 export default function SurveyQuestionEdit({ survey, updateSurvey }) {
   const [formError, setFormError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
   const match = useRouteMatch();
   const { search } = useLocation();
   const queryParams = new URLSearchParams(search);
@@ -27,7 +23,7 @@ export default function SurveyQuestionEdit({ survey, updateSurvey }) {
 
   if (!question) {
     return (
-      <Redirect
+      <Navigate
         to={`/templates/${match.params.templateType}/${match.params.id}/survey`}
       />
     );
@@ -35,7 +31,7 @@ export default function SurveyQuestionEdit({ survey, updateSurvey }) {
 
   const navigateToList = () => {
     const index = match.url.indexOf('/edit');
-    history.push(match.url.substr(0, index));
+    navigate(match.url.substr(0, index));
   };
 
   const handleSubmit = async (formData) => {

--- a/awx/ui/src/screens/Template/Templates.js
+++ b/awx/ui/src/screens/Template/Templates.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 
-import { Route, withRouter, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import { PageSection } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
 
@@ -91,4 +91,4 @@ function Templates() {
 }
 
 export { Templates as _Templates };
-export default withRouter(Templates);
+export default Templates;

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import { WorkflowJobTemplatesAPI, OrganizationsAPI, UsersAPI } from 'api';
@@ -11,7 +11,7 @@ import WorkflowJobTemplateForm from '../shared/WorkflowJobTemplateForm';
 
 function WorkflowJobTemplateAdd() {
   const { me = {} } = useConfig();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formSubmitError, setFormSubmitError] = useState(null);
 
   const handleSubmit = async (values) => {
@@ -41,7 +41,7 @@ function WorkflowJobTemplateAdd() {
         data: { id },
       } = await WorkflowJobTemplatesAPI.create(templatePayload);
       await Promise.all(await submitLabels(id, organizationId, labels));
-      history.push(`/templates/workflow_job_template/${id}/visualizer`);
+      navigate(`/templates/workflow_job_template/${id}/visualizer`);
     } catch (err) {
       setFormSubmitError(err);
     }
@@ -66,7 +66,7 @@ function WorkflowJobTemplateAdd() {
   };
 
   const handleCancel = () => {
-    history.push(`/templates`);
+    navigate(`/templates`);
   };
 
   const {

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import {
   Chip,
@@ -46,7 +47,7 @@ function WorkflowJobTemplateDetail({ template }) {
   const { t } = useLingui();
   const helpText = getHelpText(t);
   const urlOrigin = window.location.origin;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const renderOptionsField =
     template.allow_simultaneous || template.webhook_service;
@@ -73,8 +74,8 @@ function WorkflowJobTemplateDetail({ template }) {
   } = useRequest(
     useCallback(async () => {
       await WorkflowJobTemplatesAPI.destroy(id);
-      history.push(`/templates`);
-    }, [id, history])
+      navigate(`/templates`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateEdit/WorkflowJobTemplateEdit.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateEdit/WorkflowJobTemplateEdit.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { getAddedAndRemoved } from 'util/lists';
@@ -17,7 +17,7 @@ import { WorkflowJobTemplateForm } from '../shared';
 
 function WorkflowJobTemplateEdit({ template }) {
   const { me = {} } = useConfig();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [formSubmitError, setFormSubmitError] = useState(null);
 
   const handleSubmit = async (values) => {
@@ -48,7 +48,7 @@ function WorkflowJobTemplateEdit({ template }) {
         await submitLabels(formOrgId, template.organization, labels)
       );
       await WorkflowJobTemplatesAPI.update(template.id, templatePayload);
-      history.push(`/templates/workflow_job_template/${template.id}/details`);
+      navigate(`/templates/workflow_job_template/${template.id}/details`);
     } catch (err) {
       setFormSubmitError(err);
     }
@@ -83,7 +83,7 @@ function WorkflowJobTemplateEdit({ template }) {
   };
 
   const handleCancel = () => {
-    history.push(`/templates/workflow_job_template/${template.id}/details`);
+    navigate(`/templates/workflow_job_template/${template.id}/details`);
   };
 
   const {

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import 'styled-components/macro';
 import React, { useContext, useState, useEffect, useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Formik, useFormikContext } from 'formik';
 import yaml from 'js-yaml';
@@ -41,7 +41,8 @@ function NodeModalForm({
   labels,
   instanceGroups,
 }) {
-  const history = useHistory();
+  const location = useLocation();
+  const navigate = useNavigate();
   const dispatch = useContext(WorkflowDispatchContext);
   const { values, setFieldTouched } = useFormikContext();
   const { t } = useLingui();
@@ -49,13 +50,13 @@ function NodeModalForm({
   const [triggerNext, setTriggerNext] = useState(0);
 
   const clearQueryParams = () => {
-    const parts = history.location.search.replace(/^\?/, '').split('&');
+    const parts = location.search.replace(/^\?/, '').split('&');
     const otherParts = parts.filter((param) =>
       /^!(job_templates\.|projects\.|inventory_sources\.|workflow_job_templates\.)/.test(
         param
       )
     );
-    history.replace(`${history.location.pathname}?${otherParts.join('&')}`);
+    navigate(`${location.pathname}?${otherParts.join('&')}`, { replace: true });
   };
 
   const {

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useReducer } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import styled from 'styled-components';
 import { shape } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
@@ -131,7 +131,7 @@ const fetchWorkflowNodes = async (
 
 function Visualizer({ template }) {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [state, dispatch] = useReducer(workflowReducer, {
     addLinkSourceNode: null,
     addLinkTargetNode: null,
@@ -180,7 +180,7 @@ function Visualizer({ template }) {
     if (unsavedChanges) {
       dispatch({ type: 'TOGGLE_UNSAVED_CHANGES_MODAL' });
     } else {
-      history.push(`/templates/workflow_job_template/${template.id}/details`);
+      navigate(`/templates/workflow_job_template/${template.id}/details`);
     }
   };
 
@@ -638,8 +638,8 @@ function Visualizer({ template }) {
         ...instanceGroupRequests,
       ]);
 
-      history.push(`/templates/workflow_job_template/${template.id}/details`);
-    }, [links, nodes, history, defaultOrganization, template.id]),
+      navigate(`/templates/workflow_job_template/${template.id}/details`);
+    }, [links, nodes, navigate, defaultOrganization, template.id]),
     {}
   );
 
@@ -689,7 +689,7 @@ function Visualizer({ template }) {
         {showUnsavedChangesModal && (
           <UnsavedChangesModal
             onExit={() =>
-              history.push(
+              navigate(
                 `/templates/workflow_job_template/${template.id}/details`
               )
             }

--- a/awx/ui/src/screens/TopologyView/MeshGraph.js
+++ b/awx/ui/src/screens/TopologyView/MeshGraph.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
+
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import debounce from 'util/debounce';
@@ -52,7 +53,8 @@ function MeshGraph({
   const [isNodeSelected, setIsNodeSelected] = useState(false);
   const [selectedNode, setSelectedNode] = useState(null);
   const [simulationProgress, setSimulationProgress] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
+
   const {
     result: { instance = {}, instanceGroups },
     error: fetchError,
@@ -407,7 +409,7 @@ function MeshGraph({
           instanceDetail={instance}
           isLoading={isLoading}
           redirectToDetailsPage={() =>
-            redirectToDetailsPage(selectedNode, history)
+            redirectToDetailsPage(selectedNode, navigate)
           }
         />
       )}

--- a/awx/ui/src/screens/TopologyView/MeshGraph__RTL.test.js
+++ b/awx/ui/src/screens/TopologyView/MeshGraph__RTL.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 import { render, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { I18nProvider } from '@lingui/react';
@@ -90,12 +91,14 @@ describe('<MeshGraph />', () => {
     const mockSetZoomCtrFn = jest.fn();
     renderWithI18n(
       <MemoryRouter>
+      <CompatRouter>
         <MeshGraph
           data={mockData}
           showLegend={true}
           zoom={mockZoomFn}
           setShowZoomControls={mockSetZoomCtrFn}
         />
+      </CompatRouter>
       </MemoryRouter>
     );
     await waitFor(() => screen.getByLabelText('mesh-svg'));

--- a/awx/ui/src/screens/TopologyView/TopologyView__RTL.test.js
+++ b/awx/ui/src/screens/TopologyView/TopologyView__RTL.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 import { MeshAPI } from 'api';
 import { render, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -98,7 +99,9 @@ describe('<TopologyView />', () => {
     });
     renderWithI18n(
       <MemoryRouter>
+      <CompatRouter>
         <TopologyView />
+      </CompatRouter>
       </MemoryRouter>
     );
     await waitFor(() => screen.getByRole('heading', { level: 2 }));
@@ -116,7 +119,9 @@ describe('<TopologyView />', () => {
     });
     renderWithI18n(
       <MemoryRouter>
+      <CompatRouter>
         <TopologyView />
+      </CompatRouter>
       </MemoryRouter>
     );
     await waitFor(() => screen.getByRole('heading', { level: 2 }));
@@ -140,7 +145,9 @@ describe('<TopologyView />', () => {
     );
     renderWithI18n(
       <MemoryRouter>
+      <CompatRouter>
         <TopologyView />
+      </CompatRouter>
       </MemoryRouter>
     );
     await waitFor(() => screen.getByRole('heading', { level: 2 }));

--- a/awx/ui/src/screens/TopologyView/utils/helpers.js
+++ b/awx/ui/src/screens/TopologyView/utils/helpers.js
@@ -83,11 +83,11 @@ export function renderIconPosition(nodeState, bbox) {
   return false;
 }
 
-export function redirectToDetailsPage(selectedNode, history) {
-  if (selectedNode && history) {
+export function redirectToDetailsPage(selectedNode, navigate) {
+  if (selectedNode && navigate) {
     const { id: nodeId } = selectedNode;
     const constructedURL = `/instances/${nodeId}/details`;
-    history.push(constructedURL);
+    navigate(constructedURL);
   }
   return false;
 }

--- a/awx/ui/src/screens/User/UserAdd/UserAdd.js
+++ b/awx/ui/src/screens/User/UserAdd/UserAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import { OrganizationsAPI } from 'api';
@@ -7,7 +7,7 @@ import UserForm from '../shared/UserForm';
 
 function UserAdd() {
   const [formSubmitError, setFormSubmitError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     setFormSubmitError(null);
@@ -16,14 +16,14 @@ function UserAdd() {
       const {
         data: { id },
       } = await OrganizationsAPI.createUser(organization.id, userValues);
-      history.push(`/users/${id}/details`);
+      navigate(`/users/${id}/details`);
     } catch (error) {
       setFormSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/users`);
+    navigate(`/users`);
   };
 
   return (

--- a/awx/ui/src/screens/User/UserDetail/UserDetail.js
+++ b/awx/ui/src/screens/User/UserDetail/UserDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 
@@ -28,7 +29,7 @@ function UserDetail({ user }) {
     is_system_auditor,
     summary_fields,
   } = user;
-  const history = useHistory();
+  const navigate = useNavigate();
   const { t } = useLingui();
 
   const {
@@ -38,8 +39,8 @@ function UserDetail({ user }) {
   } = useRequest(
     useCallback(async () => {
       await UsersAPI.destroy(id);
-      history.push(`/users`);
-    }, [id, history])
+      navigate(`/users`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/User/UserEdit/UserEdit.js
+++ b/awx/ui/src/screens/User/UserEdit/UserEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { UsersAPI } from 'api';
@@ -10,7 +10,7 @@ import UserForm from '../shared/UserForm';
 function UserEdit({ user }) {
   const [formSubmitError, setFormSubmitError] = useState(null);
   const { me } = useConfig();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     setFormSubmitError(null);
@@ -28,14 +28,14 @@ function UserEdit({ user }) {
           await dynamicActivate(Object.keys(locales).includes(browserLang) ? browserLang : 'en');
         }
       }
-      history.push(`/users/${user.id}/details`);
+      navigate(`/users/${user.id}/details`);
     } catch (error) {
       setFormSubmitError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/users/${user.id}/details`);
+    navigate(`/users/${user.id}/details`);
   };
 
   return (

--- a/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.js
+++ b/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.js
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { TokensAPI, UsersAPI } from 'api';
@@ -7,7 +8,7 @@ import useRequest from 'hooks/useRequest';
 import UserTokenForm from '../shared/UserTokenForm';
 
 function UserTokenAdd({ onSuccessfulAdd }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id: userId } = useParams();
   const { error: submitError, request: handleSubmit } = useRequest(
     useCallback(
@@ -24,14 +25,14 @@ function UserTokenAdd({ onSuccessfulAdd }) {
 
         onSuccessfulAdd(response.data);
 
-        history.push(`/users/${userId}/tokens/${response.data.id}/details`);
+        navigate(`/users/${userId}/tokens/${response.data.id}/details`);
       },
-      [history, userId, onSuccessfulAdd]
+      [navigate, userId, onSuccessfulAdd]
     )
   );
 
   const handleCancel = () => {
-    history.push(`/users/${userId}/tokens`);
+    navigate(`/users/${userId}/tokens`);
   };
 
   return (

--- a/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.js
+++ b/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import AlertModal from 'components/AlertModal';
@@ -18,7 +19,7 @@ function UserTokenDetail({ token }) {
   const helptext = userHelpTextStrings();
   const { scope, description, created, modified, expires, summary_fields } =
     token;
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id, tokenId } = useParams();
   const {
     request: deleteToken,
@@ -27,8 +28,8 @@ function UserTokenDetail({ token }) {
   } = useRequest(
     useCallback(async () => {
       await TokensAPI.destroy(tokenId);
-      history.push(`/users/${id}/tokens`);
-    }, [tokenId, id, history])
+      navigate(`/users/${id}/tokens`);
+    }, [tokenId, id, navigate])
   );
   const { error, dismissError } = useDismissableError(deleteError);
 

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import styled from 'styled-components';
 import {
   Divider as PFDivider,
@@ -47,7 +48,7 @@ const WFDetailList = styled(DetailList)`
 function WorkflowApprovalDetail({ workflowApproval, fetchWorkflowApproval }) {
   const { t } = useLingui();
   const { id: workflowApprovalId } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { addToast, Toast, toastProps } = useToast();
 
   const {
@@ -57,8 +58,8 @@ function WorkflowApprovalDetail({ workflowApproval, fetchWorkflowApproval }) {
   } = useRequest(
     useCallback(async () => {
       await WorkflowApprovalsAPI.destroy(workflowApprovalId);
-      history.push(`/workflow_approvals`);
-    }, [workflowApprovalId, history])
+      navigate(`/workflow_approvals`);
+    }, [workflowApprovalId, navigate])
   );
 
   const { error: deleteError, dismissError: dismissDeleteError } =

--- a/awx/ui/testUtils/enzymeHelpers.js
+++ b/awx/ui/testUtils/enzymeHelpers.js
@@ -5,7 +5,9 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
 import { mount, shallow } from 'enzyme';
-import { MemoryRouter, Router } from 'react-router-dom';
+import { Router, useLocation } from 'react-router-dom';
+import { Router as RouterV6 } from 'react-router-dom-v5-compat';
+import { createMemoryHistory } from 'history';
 import { I18nProvider } from '@lingui/react';
 import { i18n } from '@lingui/core';
 import { en } from 'make-plural/plurals';
@@ -64,29 +66,34 @@ const defaultContexts = {
   },
 };
 
+// The v5 Router above subscribes to history and drives re-renders; this
+// nested v6 Router is fully controlled (location comes from v5's context,
+// the navigator is the shared history object) so components migrated to
+// the react-router-dom-v5-compat APIs work without a second subscription.
+function CompatV6Layer({ history, children }) {
+  const location = useLocation();
+  return (
+    <RouterV6 location={location} navigator={history}>
+      {children}
+    </RouterV6>
+  );
+}
+
 function wrapContexts(node, context) {
   const { config, router, session } = context;
+  const history = router.history || createMemoryHistory();
   class Wrap extends React.Component {
     render() {
       // eslint-disable-next-line react/no-this-in-sfc
       const { children, ...props } = this.props;
       const component = React.cloneElement(children, props);
-      if (router.history) {
-        return (
-          <I18nProvider i18n={i18n}>
-            <SessionProvider value={session}>
-              <ConfigProvider value={config}>
-                <Router history={router.history}>{component}</Router>
-              </ConfigProvider>
-            </SessionProvider>
-          </I18nProvider>
-        );
-      }
       return (
         <I18nProvider i18n={i18n}>
           <SessionProvider value={session}>
             <ConfigProvider value={config}>
-              <MemoryRouter>{component}</MemoryRouter>
+              <Router history={history}>
+                <CompatV6Layer history={history}>{component}</CompatV6Layer>
+              </Router>
             </ConfigProvider>
           </SessionProvider>
         </I18nProvider>

--- a/licenses/ui/react-router-dom-v5-compat.txt
+++ b/licenses/ui/react-router-dom-v5-compat.txt
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) React Training LLC 2015-2019
+Copyright (c) Remix Software Inc. 2020-2021
+Copyright (c) Shopify Inc. 2022-2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 📋 Merge instructions — all 13 open PRs, any order, zero conflicts

Every pair of open PRs has been verified conflict-free with `git merge-tree` (0 conflicts across all 78 pairs), and the union of all 13 was integration-tested green (Python suite 3477 passed, Jest 2873 passed, lint, build, licenses). **Merge in any order you like.** Two recommendations, not requirements:

- Merge PR #388 first — it makes full parallel Python test runs deterministic for reviewing everything else.
- Merge PR #381 before #382/#383/#384 for clean attribution. (Not required: each batch contains the bridge commit, so merging a batch first simply brings the bridge along and #381 then shows as already merged.)

The full queue:

1. Merge PR #374 - Upgrade twisted, kubernetes, pyyaml, Cython and Django to latest allowed versions
2. Merge PR #376 - Upgrade django-oauth-toolkit 1.7.1 to 3.3.0
3. Merge PR #380 - Upgrade styled-components from 5 to 6
4. Merge PR #381 - Begin react-router 5 → 6 migration via react-router-dom-v5-compat
5. Merge PR #382 - react-router migration batch 1: shared components, contexts and hooks
6. **Merge PR #383 - react-router migration batch 2: screen directories (all except Inventory and Setting)** ⬅️ this PR
7. Merge PR #384 - react-router migration batch 3: Inventory and Setting screens
8. Merge PR #385 - Add React Testing Library migration infrastructure and first conversions
9. Merge PR #386 - Remove EOL msrestazure, msrest and adal dependencies
10. Merge PR #388 - Fix cross-test mock leak behind the flaky parallel test failures
11. Merge PR #389 - Build Activity Stream links for inventory source sync schedules
12. Merge PR #390 - Surface an error when the webhook credential type lookup returns nothing
13. Merge PR #391 - Modernize the frontend toolchain: Lingui 6, ESLint 9 and @dagrejs/dagre

---
## SUMMARY
Second batch of the incremental react-router 5 → 6 migration. Migrates **70 files** across 18 screen directories (Template, InstanceGroup, User, Job, Application, Credential, Host, Project, CredentialType, ExecutionEnvironment, NotificationTemplate, Organization, Team, Instances, WorkflowApproval, ManagementJob, ActivityStream, TopologyView) to the `react-router-dom-v5-compat` APIs, using the recipe from the bridge PR:

- `useHistory()` → `useNavigate()`; `history.push/replace/goBack` → `navigate(...)` (`replace: true` where applicable)
- `history.location` reads → `useLocation()`
- zero-argument `useRouteMatch()` used only for `.params` → `useParams()`
- conditional `<Redirect>` → `<Navigate>` (only in files with no `<Switch>`)
- dead `withRouter` wrappers dropped (`Templates`, `Organizations`, `Projects` take no props)
- TopologyView's `redirectToDetailsPage` helper takes `navigate` instead of a history object

**Deliberately left on v5** for the route-tree phase: `Switch`/`Route` definitions, `<Redirect from>` entries inside a `Switch`, `match.path`/`match.url` route building, and argument-form `useRouteMatch` prefix checks.

Test changes: only the two TopologyView RTL suites — they mount with a bare `MemoryRouter` and now need the v6 context, so their wrappers gain `CompatRouter`. (As in batch 1, this requirement is self-enforcing: missing context fails loudly with `useNavigate() may be used only in the context of a <Router>`.)

**Stacked on #381** (contains its commit; the bridge is a hard prerequisite). **Parallel to #382** — batches 1 and 2 touch disjoint files and can merge in either order once #381 lands. Remaining after this: Inventory + Setting (~82 files, batch 3), then the route-tree phase and the v6 flip.

## ISSUE TYPE
- New or Enhanced Feature

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev5+gcda0899.d20260610
```

## ADDITIONAL INFORMATION
All UI gates run against this branch state:
```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 544 suites passed (1 skipped), 2869 tests passed (5 skipped)
npm --prefix awx/ui run build    # production build succeeds
```



