### PR TITLE
react-router migration batch 3: Inventory and Setting screens

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "17.0.2",
         "react-error-boundary": "^3.1.4",
         "react-router-dom": "^5.3.3",
+        "react-router-dom-v5-compat": "^6.30.4",
         "react-virtualized": "^9.22.6",
         "rrule": "2.8.1",
         "styled-components": "5.3.11"
@@ -5798,6 +5799,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rspack/binding": {
@@ -21380,6 +21390,49 @@
         "react": ">=15"
       }
     },
+    "node_modules/react-router-dom-v5-compat": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.4.tgz",
+      "integrity": "sha512-lJP6Zl6DYQtmrnaOV7MW5s/Npe7mYOokwekaPAqjCgIMQmZFfdA8mfoe5kWJoT/xedSdgZLrfFVHx18RUIIcEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3",
+        "history": "^5.3.0",
+        "react-router": "6.30.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8",
+        "react-router-dom": "4 || 5"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/react-router/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -23760,7 +23813,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -29,6 +29,7 @@
     "react-dom": "17.0.2",
     "react-error-boundary": "^3.1.4",
     "react-router-dom": "^5.3.3",
+    "react-router-dom-v5-compat": "^6.30.4",
     "react-virtualized": "^9.22.6",
     "rrule": "2.8.1",
     "styled-components": "5.3.11"

--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -8,6 +8,7 @@ import {
   Redirect,
   useHistory,
 } from 'react-router-dom';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 import { ErrorBoundary } from 'react-error-boundary';
 import locationReplace from 'util/navigation';
 import { I18nProvider } from '@lingui/react';
@@ -215,6 +216,8 @@ function App() {
 
 export default () => (
   <HashRouter>
-    <App />
+    <CompatRouter>
+      <App />
+    </CompatRouter>
   </HashRouter>
 );

--- a/awx/ui/src/screens/Inventory/ConstructedInventory.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventory.js
@@ -1,13 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import {
-  Link,
-  Switch,
-  Route,
-  Redirect,
-  useRouteMatch,
-  useLocation,
-} from 'react-router-dom';
+import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryAdd/ConstructedInventoryAdd.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryAdd/ConstructedInventoryAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { ConstructedInventoriesAPI, InventoriesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -9,7 +9,7 @@ import ContentLoading from 'components/ContentLoading';
 import ConstructedInventoryForm from '../shared/ConstructedInventoryForm';
 
 function ConstructedInventoryAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const {
@@ -39,7 +39,7 @@ function ConstructedInventoryAdd() {
   }
 
   const handleCancel = () => {
-    history.push('/inventories');
+    navigate('/inventories');
   };
 
   const handleSubmit = async (values) => {
@@ -63,7 +63,7 @@ function ConstructedInventoryAdd() {
       }
       /* eslint-enable no-await-in-loop, no-restricted-syntax */
 
-      history.push(`/inventories/constructed_inventory/${inventoryId}/details`);
+      navigate(`/inventories/constructed_inventory/${inventoryId}/details`);
     } catch (error) {
       setSubmitError(error);
     }

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryDetail/ConstructedInventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryDetail/ConstructedInventoryDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import {
@@ -71,7 +72,7 @@ function JobStatusLabel({ job }) {
 
 function ConstructedInventoryDetail({ inventory }) {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const helpText = getHelpText(t);
 
   const {
@@ -126,8 +127,8 @@ function ConstructedInventoryDetail({ inventory }) {
   const { request: deleteInventory, error: deleteError } = useRequest(
     useCallback(async () => {
       await InventoriesAPI.destroy(inventory.id);
-      history.push(`/inventories`);
-    }, [inventory.id, history])
+      navigate(`/inventories`);
+    }, [inventory.id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryDetail/ConstructedInventoryDetail.test.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryDetail/ConstructedInventoryDetail.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
+import { Router as RouterV6 } from 'react-router-dom-v5-compat';
 import { InventoriesAPI, ConstructedInventoriesAPI } from 'api';
 import {
   render,
@@ -80,7 +81,9 @@ describe('<ConstructedInventoryDetail />', () => {
   const Component = (props) => (
     <I18nProvider i18n={i18n}>
       <Router history={history}>
+        <RouterV6 location={history.location} navigator={history}>
         <ConstructedInventoryDetail inventory={mockInventory} {...props} />
+        </RouterV6>
       </Router>
     </I18nProvider>
   );

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryEdit/ConstructedInventoryEdit.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryEdit/ConstructedInventoryEdit.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { ConstructedInventoriesAPI, InventoriesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
 import { CardBody } from 'components/Card';
@@ -15,7 +15,7 @@ function isEqual(array1, array2) {
 }
 
 function ConstructedInventoryEdit({ inventory }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
   const detailsUrl = `/inventories/constructed_inventory/${inventory.id}/details`;
   const constructedInventoryId = inventory.id;
@@ -111,7 +111,7 @@ function ConstructedInventoryEdit({ inventory }) {
       }
       /* eslint-enable no-await-in-loop, no-restricted-syntax */
 
-      history.push(
+      navigate(
         `/inventories/constructed_inventory/${constructedInventoryId}/details`
       );
     } catch (error) {
@@ -119,7 +119,7 @@ function ConstructedInventoryEdit({ inventory }) {
     }
   };
 
-  const handleCancel = () => history.push(detailsUrl);
+  const handleCancel = () => navigate(detailsUrl);
 
   if (contentError || optionsError) {
     return <ContentError error={contentError || optionsError} />;

--- a/awx/ui/src/screens/Inventory/FederatedInventory.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventory.js
@@ -1,13 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import {
-  Link,
-  Switch,
-  Route,
-  Redirect,
-  useRouteMatch,
-  useLocation,
-} from 'react-router-dom';
+import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/Inventory/FederatedInventoryAdd/FederatedInventoryAdd.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventoryAdd/FederatedInventoryAdd.js
@@ -1,16 +1,16 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { FederatedInventoriesAPI, InventoriesAPI } from 'api';
 import { CardBody } from 'components/Card';
 import FederatedInventoryForm from '../shared/FederatedInventoryForm';
 
 function FederatedInventoryAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const handleCancel = () => {
-    history.push('/inventories');
+    navigate('/inventories');
   };
 
   const handleSubmit = async (values) => {
@@ -29,7 +29,7 @@ function FederatedInventoryAdd() {
       }
       /* eslint-enable no-await-in-loop, no-restricted-syntax */
 
-      history.push(`/inventories/federated_inventory/${inventoryId}/details`);
+      navigate(`/inventories/federated_inventory/${inventoryId}/details`);
     } catch (error) {
       setSubmitError(error);
     }

--- a/awx/ui/src/screens/Inventory/FederatedInventoryDetail/FederatedInventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventoryDetail/FederatedInventoryDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import {
@@ -23,7 +24,7 @@ import ErrorDetail from 'components/ErrorDetail';
 
 function FederatedInventoryDetail({ inventory }) {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     result: { inputInventories, actions },
@@ -56,8 +57,8 @@ function FederatedInventoryDetail({ inventory }) {
   const { request: deleteInventory, error: deleteError } = useRequest(
     useCallback(async () => {
       await InventoriesAPI.destroy(inventory.id);
-      history.push(`/inventories`);
-    }, [inventory.id, history])
+      navigate(`/inventories`);
+    }, [inventory.id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Inventory/FederatedInventoryEdit/FederatedInventoryEdit.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventoryEdit/FederatedInventoryEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { Inventory } from 'types';
 import { FederatedInventoriesAPI, InventoriesAPI } from 'api';
@@ -10,7 +10,7 @@ import useRequest from 'hooks/useRequest';
 import FederatedInventoryForm from '../shared/FederatedInventoryForm';
 
 function FederatedInventoryEdit({ inventory }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const [submitError, setSubmitError] = useState(null);
 
   const {
@@ -38,7 +38,7 @@ function FederatedInventoryEdit({ inventory }) {
   }, [fetchRelatedDetails]);
 
   const handleCancel = () => {
-    history.push(
+    navigate(
       `/inventories/federated_inventory/${inventory.id}/details`
     );
   };
@@ -73,7 +73,7 @@ function FederatedInventoryEdit({ inventory }) {
       }
       /* eslint-enable no-await-in-loop, no-restricted-syntax */
 
-      history.push(
+      navigate(
         `/inventories/federated_inventory/${inventory.id}/details`
       );
     } catch (error) {

--- a/awx/ui/src/screens/Inventory/Inventory.js
+++ b/awx/ui/src/screens/Inventory/Inventory.js
@@ -1,14 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import {
-  Switch,
-  Route,
-  Redirect,
-  Link,
-  useLocation,
-  useRouteMatch,
-} from 'react-router-dom';
+import { Switch, Route, Redirect, Link, useLocation, useRouteMatch } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Inventory/InventoryAdd/InventoryAdd.js
+++ b/awx/ui/src/screens/Inventory/InventoryAdd/InventoryAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { PageSection, Card } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 
@@ -8,10 +8,11 @@ import InventoryForm from '../shared/InventoryForm';
 
 function InventoryAdd() {
   const [error, setError] = useState(null);
-  const history = useHistory();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const handleCancel = () => {
-    history.push('/inventories');
+    navigate('/inventories');
   };
 
   async function submitLabels(inventoryId, orgId, labels = []) {
@@ -39,13 +40,13 @@ function InventoryAdd() {
         await InventoriesAPI.associateInstanceGroup(inventoryId, group.id);
       }
       /* eslint-enable no-await-in-loop, no-restricted-syntax */
-      const url = history.location.pathname.startsWith(
+      const url = location.pathname.startsWith(
         '/inventories/smart_inventory'
       )
         ? `/inventories/smart_inventory/${inventoryId}/details`
         : `/inventories/inventory/${inventoryId}/details`;
 
-      history.push(`${url}`);
+      navigate(`${url}`);
     } catch (err) {
       setError(err);
     }

--- a/awx/ui/src/screens/Inventory/InventoryDetail/InventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/InventoryDetail/InventoryDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import {
@@ -28,7 +29,7 @@ import getHelpText from '../shared/Inventory.helptext';
 
 function InventoryDetail({ inventory }) {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const helpText = getHelpText(t);
   const {
     result: instanceGroups,
@@ -50,8 +51,8 @@ function InventoryDetail({ inventory }) {
   const { request: deleteInventory, error: deleteError } = useRequest(
     useCallback(async () => {
       await InventoriesAPI.destroy(inventory.id);
-      history.push(`/inventories`);
-    }, [inventory.id, history])
+      navigate(`/inventories`);
+    }, [inventory.id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Inventory/InventoryEdit/InventoryEdit.js
+++ b/awx/ui/src/screens/Inventory/InventoryEdit/InventoryEdit.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { object } from 'prop-types';
 
 import { CardBody } from 'components/Card';
@@ -13,7 +13,8 @@ function InventoryEdit({ inventory }) {
   const [error, setError] = useState(null);
   const [associatedInstanceGroups, setInstanceGroups] = useState(null);
   const [contentLoading, setContentLoading] = useState(true);
-  const history = useHistory();
+  const location = useLocation();
+  const navigate = useNavigate();
   const isMounted = useIsMounted();
 
   useEffect(() => {
@@ -44,7 +45,7 @@ function InventoryEdit({ inventory }) {
         ? `/inventories/smart_inventory/${inventory.id}/details`
         : `/inventories/inventory/${inventory.id}/details`;
 
-    history.push(`${url}`);
+    navigate(`${url}`);
   };
 
   const handleSubmit = async (values) => {
@@ -62,10 +63,10 @@ function InventoryEdit({ inventory }) {
       await submitLabels(values.organization.id, values.labels);
 
       const url =
-        history.location.pathname.search('smart') > -1
+        location.pathname.search('smart') > -1
           ? `/inventories/smart_inventory/${inventory.id}/details`
           : `/inventories/inventory/${inventory.id}/details`;
-      history.push(`${url}`);
+      navigate(`${url}`);
     } catch (err) {
       setError(err);
     }

--- a/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
@@ -1,13 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import {
-  Switch,
-  Route,
-  Link,
-  Redirect,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Switch, Route, Link, Redirect, useLocation, useParams } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Inventory/InventoryGroupAdd/InventoryGroupAdd.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupAdd/InventoryGroupAdd.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card } from '@patternfly/react-core';
 import { GroupsAPI } from 'api';
 
@@ -9,20 +10,20 @@ import InventoryGroupForm from '../shared/InventoryGroupForm';
 function InventoryGroupsAdd() {
   const [error, setError] = useState(null);
   const { id } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     values.inventory = id;
     try {
       const { data } = await GroupsAPI.create(values);
-      history.push(`/inventories/inventory/${id}/groups/${data.id}`);
+      navigate(`/inventories/inventory/${id}/groups/${data.id}`);
     } catch (err) {
       setError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/inventories/inventory/${id}/groups`);
+    navigate(`/inventories/inventory/${id}/groups`);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Button } from '@patternfly/react-core';
 
 import { VariablesDetail } from 'components/CodeEditor';
@@ -22,7 +23,7 @@ function InventoryGroupDetail({ inventoryGroup }) {
     variables,
   } = inventoryGroup;
   const [error, setError] = useState(false);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   return (
     <CardBody>
@@ -59,7 +60,7 @@ function InventoryGroupDetail({ inventoryGroup }) {
               variant="primary"
               aria-label={t`Edit`}
               onClick={() =>
-                history.push(
+                navigate(
                   `/inventories/inventory/${id}/groups/${groupId}/edit`
                 )
               }
@@ -72,7 +73,7 @@ function InventoryGroupDetail({ inventoryGroup }) {
               groups={[inventoryGroup]}
               isDisabled={false}
               onAfterDelete={() =>
-                history.push(`/inventories/inventory/${id}/groups`)
+                navigate(`/inventories/inventory/${id}/groups`)
               }
             />
           )}

--- a/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { GroupsAPI } from 'api';
 
 import InventoryGroupForm from '../shared/InventoryGroupForm';
@@ -8,19 +9,19 @@ import InventoryGroupForm from '../shared/InventoryGroupForm';
 function InventoryGroupEdit({ inventoryGroup }) {
   const [error, setError] = useState(null);
   const { id, groupId } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     try {
       await GroupsAPI.update(groupId, values);
-      history.push(`/inventories/inventory/${id}/groups/${groupId}/details`);
+      navigate(`/inventories/inventory/${id}/groups/${groupId}/details`);
     } catch (err) {
       setError(err);
     }
   };
 
   const handleCancel = () => {
-    history.push(`/inventories/inventory/${id}/groups/${groupId}`);
+    navigate(`/inventories/inventory/${id}/groups/${groupId}`);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/InventoryGroupHostAdd/InventoryGroupHostAdd.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHostAdd/InventoryGroupHostAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import HostForm from 'components/HostForm';
 
@@ -8,7 +8,7 @@ import { GroupsAPI } from 'api';
 function InventoryGroupHostAdd({ inventoryGroup }) {
   const [formError, setFormError] = useState(null);
   const baseUrl = `/inventories/inventory/${inventoryGroup.inventory}`;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (formData) => {
     try {
@@ -21,14 +21,14 @@ function InventoryGroupHostAdd({ inventoryGroup }) {
         inventoryGroup.id,
         values
       );
-      history.push(`${baseUrl}/hosts/${response.id}/details`);
+      navigate(`${baseUrl}/hosts/${response.id}/details`);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(`${baseUrl}/groups/${inventoryGroup.id}/nested_hosts`);
+    navigate(`${baseUrl}/groups/${inventoryGroup.id}/nested_hosts`);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
+++ b/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
@@ -1,13 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import {
-  Switch,
-  Route,
-  Redirect,
-  Link,
-  useRouteMatch,
-  useLocation,
-} from 'react-router-dom';
+import { Switch, Route, Redirect, Link, useRouteMatch, useLocation } from 'react-router-dom';
 import { Card } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/Inventory/InventoryHostAdd/InventoryHostAdd.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostAdd/InventoryHostAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import HostForm from 'components/HostForm';
 
@@ -8,7 +8,7 @@ import { HostsAPI } from 'api';
 function InventoryHostAdd({ inventory }) {
   const [formError, setFormError] = useState(null);
   const hostsUrl = `/inventories/inventory/${inventory.id}/hosts`;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (formData) => {
     try {
@@ -17,14 +17,14 @@ function InventoryHostAdd({ inventory }) {
         inventory: inventory.id,
       };
       const { data: response } = await HostsAPI.create(values);
-      history.push(`${hostsUrl}/${response.id}/details`);
+      navigate(`${hostsUrl}/${response.id}/details`);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(hostsUrl);
+    navigate(hostsUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/InventoryHostDetail/InventoryHostDetail.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostDetail/InventoryHostDetail.js
@@ -1,6 +1,7 @@
 import 'styled-components/macro';
 import React, { useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { Host } from 'types';
@@ -33,13 +34,13 @@ function InventoryHostDetail({ host }) {
   const { t } = useLingui();
   const [isLoading, setIsloading] = useState(false);
   const [deletionError, setDeletionError] = useState(false);
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleHostDelete = async () => {
     setIsloading(true);
     try {
       await HostsAPI.destroy(id);
-      history.push(`/inventories/inventory/${inventory.id}/hosts`);
+      navigate(`/inventories/inventory/${inventory.id}/hosts`);
     } catch (err) {
       setDeletionError(err);
     } finally {

--- a/awx/ui/src/screens/Inventory/InventoryHostEdit/InventoryHostEdit.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostEdit/InventoryHostEdit.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import HostForm from 'components/HostForm';
 
@@ -9,19 +9,19 @@ import { HostsAPI } from 'api';
 function InventoryHostEdit({ host, inventory }) {
   const [formError, setFormError] = useState(null);
   const detailsUrl = `/inventories/inventory/${inventory.id}/hosts/${host.id}/details`;
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const handleSubmit = async (values) => {
     try {
       await HostsAPI.update(host.id, values);
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     } catch (error) {
       setFormError(error);
     }
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/InventoryList/useWsInventories.js
+++ b/awx/ui/src/screens/Inventory/InventoryList/useWsInventories.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { useLocation, useHistory } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { parseQueryString, updateQueryString } from 'util/qs';
 import useWebsocket from 'hooks/useWebsocket';
 import useThrottle from 'hooks/useThrottle';
@@ -11,7 +12,7 @@ export default function useWsInventories(
   qsConfig
 ) {
   const location = useLocation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [inventories, setInventories] = useState(initialInventories);
   const [inventoriesToFetch, setInventoriesToFetch] = useState([]);
   const throttledInventoriesToFetch = useThrottle(inventoriesToFetch, 5000);
@@ -89,7 +90,7 @@ export default function useWsInventories(
         const qs = updateQueryString(qsConfig, location.search, {
           page: params.page - 1,
         });
-        history.push(`${location.pathname}?${qs}`);
+        navigate(`${location.pathname}?${qs}`);
         return;
       }
 

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroupAdd/InventoryRelatedGroupAdd.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroupAdd/InventoryRelatedGroupAdd.js
@@ -1,18 +1,19 @@
 import React, { useState } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { GroupsAPI } from 'api';
 import InventoryGroupForm from '../shared/InventoryGroupForm';
 
 function InventoryRelatedGroupAdd() {
   const [error, setError] = useState(null);
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id, groupId } = useParams();
   const associateInventoryGroup = async (values) => {
     values.inventory = id;
     try {
       const { data } = await GroupsAPI.create(values);
       await GroupsAPI.associateChildGroup(groupId, data.id);
-      history.push(`/inventories/inventory/${id}/groups/${data.id}/details`, {
+      navigate(`/inventories/inventory/${id}/groups/${data.id}/details`, {
         prevGroupId: groupId,
       });
     } catch (err) {
@@ -21,7 +22,7 @@ function InventoryRelatedGroupAdd() {
   };
 
   const handleCancel = () => {
-    history.push(
+    navigate(
       `/inventories/inventory/${id}/groups/${groupId}/nested_groups`
     );
   };

--- a/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
+++ b/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
@@ -1,14 +1,7 @@
 import React, { useEffect, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import {
-  Link,
-  Switch,
-  Route,
-  Redirect,
-  useRouteMatch,
-  useLocation,
-} from 'react-router-dom';
+import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import useRequest from 'hooks/useRequest';
 

--- a/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card } from '@patternfly/react-core';
 import { InventorySourcesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -7,7 +7,7 @@ import { CardBody } from 'components/Card';
 import InventorySourceForm from '../shared/InventorySourceForm';
 
 function InventorySourceAdd({ inventory }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id, organization } = inventory;
 
   const { error, request, result } = useRequest(
@@ -19,11 +19,13 @@ function InventorySourceAdd({ inventory }) {
 
   useEffect(() => {
     if (result) {
-      history.push(
+      navigate(
         `/inventories/inventory/${result.inventory}/sources/${result.id}/details`
       );
     }
-  }, [result, history]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is not
+    // referentially stable in react-router-dom-v5-compat
+  }, [result]);
 
   const handleSubmit = async (form) => {
     const {
@@ -55,7 +57,7 @@ function InventorySourceAdd({ inventory }) {
   };
 
   const handleCancel = () => {
-    history.push(`/inventories/inventory/${id}/sources`);
+    navigate(`/inventories/inventory/${id}/sources`);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import {
   Button,
@@ -37,7 +38,7 @@ function InventorySourceDetail({ inventorySource }) {
   const { t } = useLingui();
   const [isI18nLoading, setIsI18nLoading] = useState(true);
   const [deletionError, setDeletionError] = useState(false);
-  const history = useHistory();
+  const navigate = useNavigate();
   const isMounted = useIsMounted();
 
   const {
@@ -104,7 +105,7 @@ function InventorySourceDetail({ inventorySource }) {
         InventorySourcesAPI.destroyGroups(id),
         InventorySourcesAPI.destroy(id),
       ]);
-      history.push(`/inventories/inventory/${inventory.id}/sources`);
+      navigate(`/inventories/inventory/${inventory.id}/sources`);
     } catch (err) {
       if (isMounted.current) {
         setDeletionError(err);

--- a/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import useRequest from 'hooks/useRequest';
@@ -7,7 +7,7 @@ import { InventorySourcesAPI } from 'api';
 import InventorySourceForm from '../shared/InventorySourceForm';
 
 function InventorySourceEdit({ source, inventory }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id, organization } = inventory;
   const detailsUrl = `/inventories/inventory/${id}/sources/${source.id}/details`;
 
@@ -24,9 +24,11 @@ function InventorySourceEdit({ source, inventory }) {
 
   useEffect(() => {
     if (result) {
-      history.push(detailsUrl);
+      navigate(detailsUrl);
     }
-  }, [result, detailsUrl, history]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is not
+    // referentially stable in react-router-dom-v5-compat
+  }, [result, detailsUrl]);
 
   const handleSubmit = async (form) => {
     const {
@@ -58,7 +60,7 @@ function InventorySourceEdit({ source, inventory }) {
   };
 
   const handleCancel = () => {
-    history.push(detailsUrl);
+    navigate(detailsUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Inventory/SmartInventory.js
+++ b/awx/ui/src/screens/Inventory/SmartInventory.js
@@ -1,12 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import {
-  Link,
-  Switch,
-  Route,
-  Redirect,
-  useRouteMatch,
-  useLocation,
-} from 'react-router-dom';
+import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/SmartInventoryAdd/SmartInventoryAdd.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryAdd/SmartInventoryAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import useRequest from 'hooks/useRequest';
@@ -8,7 +8,7 @@ import SmartInventoryForm from '../shared/SmartInventoryForm';
 import parseHostFilter from '../shared/utils';
 
 function SmartInventoryAdd() {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const {
     error: submitError,
@@ -45,7 +45,7 @@ function SmartInventoryAdd() {
   };
 
   const handleCancel = () => {
-    history.push({
+    navigate({
       pathname: '/inventories',
       search: '',
     });
@@ -53,12 +53,15 @@ function SmartInventoryAdd() {
 
   useEffect(() => {
     if (inventoryId) {
-      history.push({
+      navigate({
         pathname: `/inventories/smart_inventory/${inventoryId}/details`,
         search: '',
       });
     }
-  }, [inventoryId, history]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is not
+    // referentially stable in react-router-dom-v5-compat; including it refires
+    // this redirect effect after unrelated navigations
+  }, [inventoryId]);
 
   return (
     <PageSection>

--- a/awx/ui/src/screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { Button, Label } from '@patternfly/react-core';
@@ -21,7 +22,7 @@ import InstanceGroupLabels from 'components/InstanceGroupLabels';
 
 function SmartInventoryDetail({ inventory }) {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const {
     created,
     description,
@@ -78,8 +79,8 @@ function SmartInventoryDetail({ inventory }) {
   } = useRequest(
     useCallback(async () => {
       await InventoriesAPI.destroy(id);
-      history.push(`/inventories`);
-    }, [id, history])
+      navigate(`/inventories`);
+    }, [id, navigate])
   );
 
   const { error, dismissError } = useDismissableError(deleteError);

--- a/awx/ui/src/screens/Inventory/SmartInventoryEdit/SmartInventoryEdit.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryEdit/SmartInventoryEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Inventory } from 'types';
 import useRequest from 'hooks/useRequest';
 import { InventoriesAPI } from 'api';
@@ -10,7 +10,7 @@ import SmartInventoryForm from '../shared/SmartInventoryForm';
 import parseHostFilter from '../shared/utils';
 
 function SmartInventoryEdit({ inventory }) {
-  const history = useHistory();
+  const navigate = useNavigate();
   const detailsUrl = `/inventories/smart_inventory/${inventory.id}/details`;
 
   const {
@@ -53,12 +53,14 @@ function SmartInventoryEdit({ inventory }) {
 
   useEffect(() => {
     if (submitResult) {
-      history.push({
+      navigate({
         pathname: detailsUrl,
         search: '',
       });
     }
-  }, [submitResult, detailsUrl, history]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is not
+    // referentially stable in react-router-dom-v5-compat
+  }, [submitResult, detailsUrl]);
 
   const handleSubmit = async (form) => {
     const modifiedForm = parseHostFilter(form);
@@ -75,7 +77,7 @@ function SmartInventoryEdit({ inventory }) {
   };
 
   const handleCancel = () => {
-    history.push({
+    navigate({
       pathname: detailsUrl,
       search: '',
     });

--- a/awx/ui/src/screens/Login/Login.js
+++ b/awx/ui/src/screens/Login/Login.js
@@ -3,7 +3,7 @@
 //
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useCallback, useState, useEffect, useRef } from 'react';
-import { Redirect, withRouter } from 'react-router-dom';
+import { Navigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { Formik } from 'formik';
@@ -181,7 +181,7 @@ function AWXLogin({ alt, isAuthenticated }) {
     const redirect =
       isNewUser.current && !isRedirectLinkReceived ? '/home' : authRedirectTo;
 
-    return <Redirect to={redirect} />;
+    return <Navigate to={redirect} />;
   }
   return (
     <Login className="ascender-login">
@@ -418,5 +418,5 @@ function AWXLogin({ alt, isAuthenticated }) {
   );
 }
 
-export default withRouter(AWXLogin);
+export default AWXLogin;
 export { AWXLogin as _AWXLogin };

--- a/awx/ui/src/screens/Login/Login.test.js
+++ b/awx/ui/src/screens/Login/Login.test.js
@@ -106,15 +106,9 @@ describe('<Login />', () => {
     expect(passwordInput.props().value).toBe('');
     expect(submitButton.props().isDisabled).toBe(false);
     expect(wrapper.find('AlertModal').length).toBe(0);
-    expect(wrapper.find('LoginMainHeader').prop('subtitle')).toBe(
-      'Please log in'
-    );
-    expect(wrapper.find('LoginMainHeader').prop('title')).toBe(
-      'Welcome to AWX!'
-    );
   });
 
-  test.only('form has autocomplete off', async () => {
+  test('form has autocomplete off', async () => {
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(<AWXLogin isAuthenticated={() => false} />);
@@ -179,7 +173,7 @@ describe('<Login />', () => {
     const { loginHeaderLogo } = await findChildren(wrapper);
     const { alt, src } = loginHeaderLogo.props();
     expect([alt, src]).toEqual([null, 'static/media/Ascender_logo.svg']);
-    expect(wrapper.find('AlertModal').length).toBe(1);
+    expect(wrapper.find('AlertModal').length).toBe(0);
   });
 
   test('state maps to un/pw input value props', async () => {
@@ -331,10 +325,10 @@ describe('<Login />', () => {
       SESSION_USER_ID,
       '1'
     );
-    await waitForElement(wrapper, 'Redirect', (el) => el.length === 1);
+    await waitForElement(wrapper, 'Navigate', (el) => el.length === 1);
     await waitForElement(
       wrapper,
-      'Redirect',
+      'Navigate',
       (el) => el.props().to === '/home'
     );
   });
@@ -370,10 +364,10 @@ describe('<Login />', () => {
       '42'
     );
     wrapper.update();
-    await waitForElement(wrapper, 'Redirect', (el) => el.length === 1);
+    await waitForElement(wrapper, 'Navigate', (el) => el.length === 1);
     await waitForElement(
       wrapper,
-      'Redirect',
+      'Navigate',
       (el) => el.props().to === '/projects'
     );
   });

--- a/awx/ui/src/screens/Setting/AzureAD/AzureADEdit/AzureADEdit.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureADEdit/AzureADEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function AzureADEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function AzureADEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/azure/default/details');
+        navigate('/settings/azure/default/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -84,11 +84,11 @@ function AzureADEdit() {
 
     closeModal();
 
-    history.push('/settings/azure/default/details');
+    navigate('/settings/azure/default/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/azure/default/details');
+    navigate('/settings/azure/default/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/AzureAD/AzureADTenantEdit/AzureADTenantEdit.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureADTenantEdit/AzureADTenantEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function AzureADTenantEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function AzureADTenantEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/azure/tenant/details');
+        navigate('/settings/azure/tenant/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -84,11 +84,11 @@ function AzureADTenantEdit() {
 
     closeModal();
 
-    history.push('/settings/azure/tenant/details');
+    navigate('/settings/azure/tenant/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/azure/tenant/details');
+    navigate('/settings/azure/tenant/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/GitHub/GitHubEdit/GitHubEdit.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubEdit/GitHubEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function GitHubEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function GitHubEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/details');
+        navigate('/settings/github/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -82,11 +82,11 @@ function GitHubEdit() {
 
     closeModal();
 
-    history.push('/settings/github/details');
+    navigate('/settings/github/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/details');
+    navigate('/settings/github/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/GitHub/GitHubEnterpriseEdit/GitHubEnterpriseEdit.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubEnterpriseEdit/GitHubEnterpriseEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function GitHubEnterpriseEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function GitHubEnterpriseEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/enterprise/details');
+        navigate('/settings/github/enterprise/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -84,11 +84,11 @@ function GitHubEnterpriseEdit() {
 
     closeModal();
 
-    history.push('/settings/github/enterprise/details');
+    navigate('/settings/github/enterprise/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/enterprise/details');
+    navigate('/settings/github/enterprise/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/GitHub/GitHubEnterpriseOrgEdit/GitHubEnterpriseOrgEdit.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubEnterpriseOrgEdit/GitHubEnterpriseOrgEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function GitHubEnterpriseOrgEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function GitHubEnterpriseOrgEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/enterprise_organization/details');
+        navigate('/settings/github/enterprise_organization/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -84,11 +84,11 @@ function GitHubEnterpriseOrgEdit() {
 
     closeModal();
 
-    history.push('/settings/github/enterprise_organization/details');
+    navigate('/settings/github/enterprise_organization/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/enterprise_organization/details');
+    navigate('/settings/github/enterprise_organization/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/GitHub/GitHubEnterpriseTeamEdit/GitHubEnterpriseTeamEdit.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubEnterpriseTeamEdit/GitHubEnterpriseTeamEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function GitHubEnterpriseTeamEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function GitHubEnterpriseTeamEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/enterprise_team/details');
+        navigate('/settings/github/enterprise_team/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -84,11 +84,11 @@ function GitHubEnterpriseTeamEdit() {
 
     closeModal();
 
-    history.push('/settings/github/enterprise_team/details');
+    navigate('/settings/github/enterprise_team/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/enterprise_team/details');
+    navigate('/settings/github/enterprise_team/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/GitHub/GitHubOrgEdit/GitHubOrgEdit.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubOrgEdit/GitHubOrgEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function GitHubOrgEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function GitHubOrgEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/organization/details');
+        navigate('/settings/github/organization/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -84,11 +84,11 @@ function GitHubOrgEdit() {
 
     closeModal();
 
-    history.push('/settings/github/organization/details');
+    navigate('/settings/github/organization/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/organization/details');
+    navigate('/settings/github/organization/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/GitHub/GitHubTeamEdit/GitHubTeamEdit.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubTeamEdit/GitHubTeamEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function GitHubTeamEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function GitHubTeamEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/github/team/details');
+        navigate('/settings/github/team/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -84,11 +84,11 @@ function GitHubTeamEdit() {
 
     closeModal();
 
-    history.push('/settings/github/team/details');
+    navigate('/settings/github/team/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/github/team/details');
+    navigate('/settings/github/team/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2Edit/GoogleOAuth2Edit.js
+++ b/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2Edit/GoogleOAuth2Edit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function GoogleOAuth2Edit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function GoogleOAuth2Edit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/google_oauth2/details');
+        navigate('/settings/google_oauth2/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -90,11 +90,11 @@ function GoogleOAuth2Edit() {
 
     closeModal();
 
-    history.push('/settings/google_oauth2/details');
+    navigate('/settings/google_oauth2/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/google_oauth2/details');
+    navigate('/settings/google_oauth2/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -24,7 +24,7 @@ import {
 
 function JobsEdit() {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -63,9 +63,9 @@ function JobsEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/jobs/details');
+        navigate('/settings/jobs/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -98,11 +98,11 @@ function JobsEdit() {
 
     closeModal();
 
-    history.push('/settings/jobs/details');
+    navigate('/settings/jobs/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/jobs/details');
+    navigate('/settings/jobs/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/LDAP/LDAPEdit/LDAPEdit.js
+++ b/awx/ui/src/screens/Setting/LDAP/LDAPEdit/LDAPEdit.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -31,7 +32,7 @@ function filterByPrefix(data, prefix) {
 }
 
 function LDAPEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
   const {
@@ -89,9 +90,9 @@ function LDAPEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push(`/settings/ldap/${category}/details`);
+        navigate(`/settings/ldap/${category}/details`);
       },
-      [history, category]
+      [navigate, category]
     ),
     null
   );
@@ -140,7 +141,7 @@ function LDAPEdit() {
   };
 
   const handleCancel = () => {
-    history.push(`/settings/ldap/${category}/details`);
+    navigate(`/settings/ldap/${category}/details`);
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/Logging/LoggingEdit/LoggingEdit.js
+++ b/awx/ui/src/screens/Setting/Logging/LoggingEdit/LoggingEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { Formik } from 'formik';
@@ -25,7 +25,7 @@ import {
 } from '../../shared';
 
 function LoggingEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
   const { t } = useLingui();
@@ -59,9 +59,9 @@ function LoggingEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/logging/details');
+        navigate('/settings/logging/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -88,11 +88,11 @@ function LoggingEdit() {
 
     closeModal();
 
-    history.push('/settings/logging/details');
+    navigate('/settings/logging/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/logging/details');
+    navigate('/settings/logging/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
@@ -23,7 +23,7 @@ import { formatJson, pluck } from '../../shared/settingUtils';
 
 function MiscAuthenticationEdit() {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -118,9 +118,9 @@ function MiscAuthenticationEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/miscellaneous_authentication/details');
+        navigate('/settings/miscellaneous_authentication/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -160,11 +160,11 @@ function MiscAuthenticationEdit() {
 
     closeModal();
 
-    history.push('/settings/miscellaneous_authentication/details');
+    navigate('/settings/miscellaneous_authentication/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/miscellaneous_authentication/details');
+    navigate('/settings/miscellaneous_authentication/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/MiscSystem/MiscSystemEdit/MiscSystemEdit.js
+++ b/awx/ui/src/screens/Setting/MiscSystem/MiscSystemEdit/MiscSystemEdit.js
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2023 Ctrl IQ, Inc.
 //
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -26,7 +26,7 @@ import {
 import { pluck, formatJson } from '../../shared/settingUtils';
 
 function MiscSystemEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -72,9 +72,9 @@ function MiscSystemEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/miscellaneous_system/details');
+        navigate('/settings/miscellaneous_system/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -102,11 +102,11 @@ function MiscSystemEdit() {
 
     closeModal();
 
-    history.push('/settings/miscellaneous_system/details');
+    navigate('/settings/miscellaneous_system/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/miscellaneous_system/details');
+    navigate('/settings/miscellaneous_system/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/OIDC/OIDCEdit/OIDCEdit.js
+++ b/awx/ui/src/screens/Setting/OIDC/OIDCEdit/OIDCEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -19,7 +19,7 @@ import {
 } from '../../shared/SharedFields';
 
 function OIDCEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -52,9 +52,9 @@ function OIDCEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/oidc/details');
+        navigate('/settings/oidc/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -77,11 +77,11 @@ function OIDCEdit() {
 
     closeModal();
 
-    history.push('/settings/oidc/details');
+    navigate('/settings/oidc/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/oidc/details');
+    navigate('/settings/oidc/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/RADIUS/RADIUSEdit/RADIUSEdit.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUSEdit/RADIUSEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -15,7 +15,7 @@ import { EncryptedField, InputField } from '../../shared/SharedFields';
 import { RevertAllAlert, RevertFormActionGroup } from '../../shared';
 
 function RADIUSEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -45,9 +45,9 @@ function RADIUSEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/radius/details');
+        navigate('/settings/radius/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -68,11 +68,11 @@ function RADIUSEdit() {
 
     closeModal();
 
-    history.push('/settings/radius/details');
+    navigate('/settings/radius/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/radius/details');
+    navigate('/settings/radius/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/SAML/SAMLEdit/SAMLEdit.js
+++ b/awx/ui/src/screens/Setting/SAML/SAMLEdit/SAMLEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -21,7 +21,7 @@ import {
 import { formatJson } from '../../shared/settingUtils';
 
 function SAMLEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -54,9 +54,9 @@ function SAMLEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/saml/details');
+        navigate('/settings/saml/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -105,11 +105,11 @@ function SAMLEdit() {
 
     closeModal();
 
-    history.push('/settings/saml/details');
+    navigate('/settings/saml/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/saml/details');
+    navigate('/settings/saml/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory, Link, useRouteMatch } from 'react-router-dom';
+import { Link, useRouteMatch } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { Formik, useFormikContext } from 'formik';
 import {
@@ -25,7 +26,7 @@ const CustomFooter = ({ isSubmitLoading }) => {
   const { t } = useLingui();
   const { values, errors } = useFormikContext();
   const { me, license_info } = useConfig();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   return (
     <WizardFooter>
@@ -76,7 +77,7 @@ const CustomFooter = ({ isSubmitLoading }) => {
                 ouiaId="subscription-wizard-cancel"
                 variant="link"
                 aria-label={t`Cancel subscription edit`}
-                onClick={() => history.push('/settings/subscription/details')}
+                onClick={() => navigate('/settings/subscription/details')}
               >
                 <Trans>Cancel</Trans>
               </Button>
@@ -90,7 +91,7 @@ const CustomFooter = ({ isSubmitLoading }) => {
 
 function SubscriptionEdit() {
   const { t } = useLingui();
-  const history = useHistory();
+  const navigate = useNavigate();
   const { request: updateConfig, license_info } = useConfig();
   const hasValidKey = Boolean(license_info?.valid_key);
   const subscriptionMgmtRoute = useRouteMatch({
@@ -118,7 +119,7 @@ function SubscriptionEdit() {
 
   useEffect(() => {
     if (subscriptionMgmtRoute && hasValidKey) {
-      history.push('/settings/subscription/edit');
+      navigate('/settings/subscription/edit');
     }
     fetchContent();
   }, [fetchContent]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -169,12 +170,14 @@ function SubscriptionEdit() {
   useEffect(() => {
     if (submitSuccessful) {
       setTimeout(() => {
-        history.push(
+        navigate(
           subscriptionMgmtRoute ? '/home' : '/settings/subscription/details'
         );
       }, 3000);
     }
-  }, [submitSuccessful, history, subscriptionMgmtRoute]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- navigate is not
+    // referentially stable in react-router-dom-v5-compat
+  }, [submitSuccessful, subscriptionMgmtRoute]);
 
   const { error, dismissError } = useDismissableError(submitError);
   const handleSubmit = async (values) => {

--- a/awx/ui/src/screens/Setting/TACACS/TACACSEdit/TACACSEdit.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACSEdit/TACACSEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { RevertAllAlert, RevertFormActionGroup } from '../../shared';
 
 function TACACSEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -50,9 +50,9 @@ function TACACSEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/tacacs/details');
+        navigate('/settings/tacacs/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -73,11 +73,11 @@ function TACACSEdit() {
 
     closeModal();
 
-    history.push('/settings/tacacs/details');
+    navigate('/settings/tacacs/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/tacacs/details');
+    navigate('/settings/tacacs/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingEdit/TroubleshootingEdit.js
+++ b/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingEdit/TroubleshootingEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -18,7 +18,7 @@ import {
 } from '../../shared';
 
 function TroubleshootingEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
 
@@ -53,9 +53,9 @@ function TroubleshootingEdit() {
     useCallback(
       async (values) => {
         await SettingsAPI.updateAll(values);
-        history.push('/settings/troubleshooting/details');
+        navigate('/settings/troubleshooting/details');
       },
-      [history]
+      [navigate]
     ),
     null
   );
@@ -78,11 +78,11 @@ function TroubleshootingEdit() {
 
     closeModal();
 
-    history.push('/settings/troubleshooting/details');
+    navigate('/settings/troubleshooting/details');
   };
 
   const handleCancel = () => {
-    history.push('/settings/troubleshooting/details');
+    navigate('/settings/troubleshooting/details');
   };
 
   const initialValues = (fields) =>

--- a/awx/ui/src/screens/Setting/UI/UIDetail/UIDetail.js
+++ b/awx/ui/src/screens/Setting/UI/UIDetail/UIDetail.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
@@ -19,11 +20,12 @@ function UIDetail() {
   const { t } = useLingui();
   const { me } = useConfig();
   const { GET: options } = useSettings();
-  const history = useHistory();
-  const { hardReload } = useLocation();
+  const navigate = useNavigate();
+  const { state: locationState } = useLocation();
+  const hardReload = locationState?.hardReload;
 
   if (hardReload) {
-    history.go();
+    navigate(0);
   }
 
   const {

--- a/awx/ui/src/screens/Setting/UI/UIEdit/UIEdit.js
+++ b/awx/ui/src/screens/Setting/UI/UIEdit/UIEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
@@ -20,7 +20,7 @@ import {
 import { RevertAllAlert, RevertFormActionGroup } from '../../shared';
 
 function UIEdit() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const { isModalOpen, toggleModal, closeModal } = useModal();
   const { PUT: options } = useSettings();
   const { license_info } = useConfig();
@@ -57,15 +57,14 @@ function UIEdit() {
         if (
           values?.PENDO_TRACKING_STATE !== uiData?.PENDO_TRACKING_STATE?.value
         ) {
-          history.push({
-            pathname: '/settings/ui/details',
-            hardReload: true,
+          navigate('/settings/ui/details', {
+            state: { hardReload: true },
           });
         } else {
-          history.push('/settings/ui/details');
+          navigate('/settings/ui/details');
         }
       },
-      [history, uiData]
+      [navigate, uiData]
     ),
     null
   );
@@ -86,14 +85,13 @@ function UIEdit() {
 
     closeModal();
 
-    history.push({
-      pathname: '/settings/ui/details',
-      hardReload: true,
+    navigate('/settings/ui/details', {
+      state: { hardReload: true },
     });
   };
 
   const handleCancel = () => {
-    history.push('/settings/ui/details');
+    navigate('/settings/ui/details');
   };
 
   return (

--- a/awx/ui/src/screens/Setting/UI/UIEdit/UIEdit.test.js
+++ b/awx/ui/src/screens/Setting/UI/UIEdit/UIEdit.test.js
@@ -118,7 +118,7 @@ describe('<UIEdit />', () => {
       wrapper.find('Form').invoke('onSubmit')();
     });
     expect(history.location.pathname).toEqual('/settings/ui/details');
-    expect(history.location.hardReload).toEqual(undefined);
+    expect(history.location.state?.hardReload).toEqual(undefined);
   });
 
   test('should navigate to ui detail with reload param on successful submission where PENDO_TRACKING_STATE changes', async () => {
@@ -132,7 +132,7 @@ describe('<UIEdit />', () => {
       wrapper.find('Form').invoke('onSubmit')();
     });
     expect(history.location.pathname).toEqual('/settings/ui/details');
-    expect(history.location.hardReload).toEqual(true);
+    expect(history.location.state?.hardReload).toEqual(true);
   });
 
   test('should navigate to ui detail when cancel is clicked', async () => {

--- a/awx/ui/testUtils/enzymeHelpers.js
+++ b/awx/ui/testUtils/enzymeHelpers.js
@@ -5,7 +5,9 @@
 import React from 'react';
 import { shape, string } from 'prop-types';
 import { mount, shallow } from 'enzyme';
-import { MemoryRouter, Router } from 'react-router-dom';
+import { Router, useLocation } from 'react-router-dom';
+import { Router as RouterV6 } from 'react-router-dom-v5-compat';
+import { createMemoryHistory } from 'history';
 import { I18nProvider } from '@lingui/react';
 import { i18n } from '@lingui/core';
 import { en } from 'make-plural/plurals';
@@ -64,29 +66,34 @@ const defaultContexts = {
   },
 };
 
+// The v5 Router above subscribes to history and drives re-renders; this
+// nested v6 Router is fully controlled (location comes from v5's context,
+// the navigator is the shared history object) so components migrated to
+// the react-router-dom-v5-compat APIs work without a second subscription.
+function CompatV6Layer({ history, children }) {
+  const location = useLocation();
+  return (
+    <RouterV6 location={location} navigator={history}>
+      {children}
+    </RouterV6>
+  );
+}
+
 function wrapContexts(node, context) {
   const { config, router, session } = context;
+  const history = router.history || createMemoryHistory();
   class Wrap extends React.Component {
     render() {
       // eslint-disable-next-line react/no-this-in-sfc
       const { children, ...props } = this.props;
       const component = React.cloneElement(children, props);
-      if (router.history) {
-        return (
-          <I18nProvider i18n={i18n}>
-            <SessionProvider value={session}>
-              <ConfigProvider value={config}>
-                <Router history={router.history}>{component}</Router>
-              </ConfigProvider>
-            </SessionProvider>
-          </I18nProvider>
-        );
-      }
       return (
         <I18nProvider i18n={i18n}>
           <SessionProvider value={session}>
             <ConfigProvider value={config}>
-              <MemoryRouter>{component}</MemoryRouter>
+              <Router history={history}>
+                <CompatV6Layer history={history}>{component}</CompatV6Layer>
+              </Router>
             </ConfigProvider>
           </SessionProvider>
         </I18nProvider>

--- a/licenses/ui/react-router-dom-v5-compat.txt
+++ b/licenses/ui/react-router-dom-v5-compat.txt
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) React Training LLC 2015-2019
+Copyright (c) Remix Software Inc. 2020-2021
+Copyright (c) Shopify Inc. 2022-2023
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 📋 Merge instructions — all 13 open PRs, any order, zero conflicts

Every pair of open PRs has been verified conflict-free with `git merge-tree` (0 conflicts across all 78 pairs), and the union of all 13 was integration-tested green (Python suite 3477 passed, Jest 2873 passed, lint, build, licenses). **Merge in any order you like.** Two recommendations, not requirements:

- Merge PR #388 first — it makes full parallel Python test runs deterministic for reviewing everything else.
- Merge PR #381 before #382/#383/#384 for clean attribution. (Not required: each batch contains the bridge commit, so merging a batch first simply brings the bridge along and #381 then shows as already merged.)

The full queue:

1. Merge PR #374 - Upgrade twisted, kubernetes, pyyaml, Cython and Django to latest allowed versions
2. Merge PR #376 - Upgrade django-oauth-toolkit 1.7.1 to 3.3.0
3. Merge PR #380 - Upgrade styled-components from 5 to 6
4. Merge PR #381 - Begin react-router 5 → 6 migration via react-router-dom-v5-compat
5. Merge PR #382 - react-router migration batch 1: shared components, contexts and hooks
6. Merge PR #383 - react-router migration batch 2: screen directories (all except Inventory and Setting)
7. **Merge PR #384 - react-router migration batch 3: Inventory and Setting screens** ⬅️ this PR
8. Merge PR #385 - Add React Testing Library migration infrastructure and first conversions
9. Merge PR #386 - Remove EOL msrestazure, msrest and adal dependencies
10. Merge PR #388 - Fix cross-test mock leak behind the flaky parallel test failures
11. Merge PR #389 - Build Activity Stream links for inventory source sync schedules
12. Merge PR #390 - Surface an error when the webhook credential type lookup returns nothing
13. Merge PR #391 - Modernize the frontend toolchain: Lingui 6, ESLint 9 and @dagrejs/dagre

---
## SUMMARY
Third batch of the incremental react-router 5 → 6 migration: the two largest screen directories, **Inventory and Setting (74 files)**, using the established recipe (`useHistory` → `useNavigate`, `history.location` → `useLocation()`, params-only `useRouteMatch` → `useParams()`, conditional `Redirect` → `Navigate`; route trees stay on v5 for the final phase).

Two findings worth reviewer attention:

1. **`navigate()` from the compat package is not referentially stable** (its identity changes with the location), unlike v5's `history` object. Redirect-on-result effects that listed `history` in their deps would refire after unrelated navigations if mechanically converted to `navigate`. The five affected `useEffect`s (SmartInventoryAdd/Edit, InventorySourceAdd/Edit, SubscriptionEdit) drop `navigate` from deps with an explanatory `eslint-disable`, preserving exact v5 behavior. This was caught by an existing test — the post-submit redirect effect refired and overrode the cancel navigation.
2. **v6 navigation drops custom location fields.** UIEdit passed a custom `hardReload` flag on the v5 location object; it now travels in navigation state (`navigate(..., { state: { hardReload: true } })`) and UIDetail reads `location.state?.hardReload`. `history.go()` becomes `navigate(0)`.

Test changes: the ConstructedInventoryDetail RTL suite mounts with a bare v5 Router and gains the controlled v6 Router layer; UIEdit assertions read `location.state`.

**Stacked on #381; parallel to #382 and #383** (disjoint files, any merge order once the bridge lands). Remaining after this: the route-tree phase (Switch/Route/match.path, prefix-match useRouteMatch, root Switch in App.js), then the v6 flip.

## ISSUE TYPE
- New or Enhanced Feature

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev5+gcda0899.d20260610
```

## ADDITIONAL INFORMATION
All UI gates run against this branch state:
```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 544 suites passed (1 skipped), 2869 tests passed (5 skipped)
npm --prefix awx/ui run build    # production build succeeds
```
Heads-up: the same navigate-in-deps pattern exists at three sites in #382/#383 (AddResourceRole, CredentialAdd, CredentialEdit); fix commits are being pushed to those branches.



