### PR TITLE
Add React Testing Library migration infrastructure and first conversions

### DIFF
--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -150,7 +150,8 @@
   },
   "jest": {
     "roots": [
-      "<rootDir>/src"
+      "<rootDir>/src",
+      "<rootDir>/testUtils"
     ],
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
@@ -164,7 +165,8 @@
     ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
+      "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}",
+      "<rootDir>/testUtils/**/*.{spec,test}.{js,jsx,ts,tsx}"
     ],
     "testEnvironment": "jsdom",
     "transform": {

--- a/awx/ui/src/components/AlertModal/AlertModal.test.js
+++ b/awx/ui/src/components/AlertModal/AlertModal.test.js
@@ -1,13 +1,18 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import AlertModal from './AlertModal';
 
 describe('AlertModal', () => {
   test('renders the expected content', () => {
-    const wrapper = mountWithContexts(
-      <AlertModal title="Danger!">Are you sure?</AlertModal>
+    renderWithContexts(
+      <AlertModal isOpen title="Danger!">
+        Are you sure?
+      </AlertModal>
     );
-    expect(wrapper).toHaveLength(1);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Danger!')).toBeInTheDocument();
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/ChipGroup/ChipGroup.test.js
+++ b/awx/ui/src/components/ChipGroup/ChipGroup.test.js
@@ -1,14 +1,18 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { Chip } from '@patternfly/react-core';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ChipGroup from './ChipGroup';
 
 describe('ChipGroup', () => {
-  test('should mount properly', () => {
-    const wrapper = mountWithContexts(
-      <ChipGroup numChips={5} totalChips={10} />
+  test('should show the collapsed-chip count', () => {
+    renderWithContexts(
+      <ChipGroup numChips={5} totalChips={10}>
+        {Array.from({ length: 10 }, (v, i) => (
+          <Chip key={i}>{`chip ${i}`}</Chip>
+        ))}
+      </ChipGroup>
     );
-    expect(wrapper.find('ChipGroup').at(1).props().collapsedText).toEqual(
-      '5 more'
-    );
+    expect(screen.getByText('5 more')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/ContentEmpty/ContentEmpty.test.js
+++ b/awx/ui/src/components/ContentEmpty/ContentEmpty.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import ContentEmpty from './ContentEmpty';
 
 describe('ContentEmpty', () => {
   test('renders the expected content', () => {
-    const wrapper = mountWithContexts(<ContentEmpty />);
-    expect(wrapper).toHaveLength(1);
+    renderWithContexts(<ContentEmpty />);
+    expect(screen.getByText('No items found.')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/ContentLoading/ContentLoading.test.js
+++ b/awx/ui/src/components/ContentLoading/ContentLoading.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import ContentLoading from './ContentLoading';
 
 describe('ContentLoading', () => {
   test('renders the expected content', () => {
-    const wrapper = mountWithContexts(<ContentLoading />);
-    expect(wrapper).toHaveLength(1);
+    renderWithContexts(<ContentLoading />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/DeleteButton/DeleteButton.test.js
+++ b/awx/ui/src/components/DeleteButton/DeleteButton.test.js
@@ -1,56 +1,42 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { CredentialsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import DeleteButton from './DeleteButton';
 
 jest.mock('../../api');
 
 describe('<DeleteButton />', () => {
   test('should render button', () => {
-    const wrapper = mountWithContexts(
-      <DeleteButton onConfirm={() => {}} name="Foo" />
-    );
-    expect(wrapper.find('button')).toHaveLength(1);
+    renderWithContexts(<DeleteButton onConfirm={() => {}} name="Foo" />);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
   test('should open confirmation modal', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <DeleteButton
-          onConfirm={() => {}}
-          name="Foo"
-          deleteDetailsRequests={[
-            {
-              label: 'job',
-              request: CredentialsAPI.read.mockResolvedValue({
-                data: { count: 1 },
-              }),
-            },
-          ]}
-          deleteMessage="Delete this?"
-          warningMessage="Are you sure to want to delete this"
-        />
-      );
-    });
-
-    await act(async () => {
-      wrapper.find('button').prop('onClick')();
-    });
-
-    await waitForElement(wrapper, 'Modal', (el) => el.length > 0);
-    expect(wrapper.find('Modal')).toHaveLength(1);
-
-    expect(wrapper.find('div[aria-label="Delete this?"]')).toHaveLength(1);
+    const { user } = renderWithContexts(
+      <DeleteButton
+        onConfirm={() => {}}
+        name="Foo"
+        deleteDetailsRequests={[
+          {
+            label: 'job',
+            request: CredentialsAPI.read.mockResolvedValue({
+              data: { count: 1 },
+            }),
+          },
+        ]}
+        deleteMessage="Delete this?"
+        warningMessage="Are you sure to want to delete this"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Delete this?')).toBeInTheDocument();
   });
 
   test('should invoke onConfirm prop', async () => {
     const onConfirm = jest.fn();
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <DeleteButton
         onConfirm={onConfirm}
         itemsToDelete="foo"
@@ -65,48 +51,41 @@ describe('<DeleteButton />', () => {
         deleteMessage="Delete this?"
       />
     );
-    await act(async () => wrapper.find('button').simulate('click'));
-    wrapper.update();
-    await act(async () =>
-      wrapper
-        .find('ModalBoxFooter button[aria-label="Confirm Delete"]')
-        .simulate('click')
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
     );
-    wrapper.update();
     expect(onConfirm).toHaveBeenCalled();
   });
 
   test('should show delete details error', async () => {
     const onConfirm = jest.fn();
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <DeleteButton
-          onConfirm={onConfirm}
-          itemsToDelete="foo"
-          deleteDetailsRequests={[
-            {
-              label: 'job',
-              request: CredentialsAPI.read.mockRejectedValue(
-                new Error({
-                  response: {
-                    config: {
-                      method: 'get',
-                      url: '/api/v2/credentals',
-                    },
-                    data: 'An error occurred',
-                    status: 403,
+    const { user } = renderWithContexts(
+      <DeleteButton
+        onConfirm={onConfirm}
+        itemsToDelete="foo"
+        deleteDetailsRequests={[
+          {
+            label: 'job',
+            request: CredentialsAPI.read.mockRejectedValue(
+              new Error({
+                response: {
+                  config: {
+                    method: 'get',
+                    url: '/api/v2/credentals',
                   },
-                })
-              ),
-            },
-          ]}
-        />
-      );
+                  data: 'An error occurred',
+                  status: 403,
+                },
+              })
+            ),
+          },
+        ]}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(screen.getByText('Error!')).toBeInTheDocument();
     });
-    await act(async () => wrapper.find('button').simulate('click'));
-    wrapper.update();
-
-    expect(wrapper.find('AlertModal[title="Error!"]')).toHaveLength(1);
   });
 });

--- a/awx/ui/src/components/DeleteButton/DeleteButton.test.js
+++ b/awx/ui/src/components/DeleteButton/DeleteButton.test.js
@@ -68,11 +68,11 @@ describe('<DeleteButton />', () => {
           {
             label: 'job',
             request: CredentialsAPI.read.mockRejectedValue(
-              new Error({
+              Object.assign(new Error('An error occurred'), {
                 response: {
                   config: {
                     method: 'get',
-                    url: '/api/v2/credentals',
+                    url: '/api/v2/credentials',
                   },
                   data: 'An error occurred',
                   status: 403,

--- a/awx/ui/src/components/FormActionGroup/FormActionGroup.test.js
+++ b/awx/ui/src/components/FormActionGroup/FormActionGroup.test.js
@@ -1,13 +1,19 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import FormActionGroup from './FormActionGroup';
 
 describe('FormActionGroup', () => {
-  test('should render the expected content', () => {
-    const wrapper = mountWithContexts(
-      <FormActionGroup onSubmit={() => {}} onCancel={() => {}} />
+  test('should render save and cancel buttons and invoke their handlers', async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    const { user } = renderWithContexts(
+      <FormActionGroup onSubmit={onSubmit} onCancel={onCancel} />
     );
-    expect(wrapper).toHaveLength(1);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSubmit).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/awx/ui/src/components/PaginatedTable/ToolbarSyncSourceButton.test.js
+++ b/awx/ui/src/components/PaginatedTable/ToolbarSyncSourceButton.test.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ToolbarSyncSourceButton from './ToolbarSyncSourceButton';
 
 describe('<ToolbarSyncSourceButton />', () => {
-  test('should render button', () => {
+  test('should render button and invoke onClick', async () => {
     const onClick = jest.fn();
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <ToolbarSyncSourceButton onClick={onClick} />
     );
-    const button = wrapper.find('button');
-    expect(button).toHaveLength(1);
-    button.simulate('click');
+    const button = screen.getByRole('button');
+    await user.click(button);
     expect(onClick).toHaveBeenCalled();
   });
 });

--- a/awx/ui/src/components/PaginatedTable/ToolbarSyncSourceButton.test.js
+++ b/awx/ui/src/components/PaginatedTable/ToolbarSyncSourceButton.test.js
@@ -9,7 +9,7 @@ describe('<ToolbarSyncSourceButton />', () => {
     const { user } = renderWithContexts(
       <ToolbarSyncSourceButton onClick={onClick} />
     );
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('button', { name: 'Sync all' });
     await user.click(button);
     expect(onClick).toHaveBeenCalled();
   });

--- a/awx/ui/src/setupTests.js
+++ b/awx/ui/src/setupTests.js
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import React from 'react';
 import { configure } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';

--- a/awx/ui/testUtils/__snapshots__/enzymeHelpers.test.js.snap
+++ b/awx/ui/testUtils/__snapshots__/enzymeHelpers.test.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`mountWithContexts injected ConfigProvider should mount and render with custom Config value 1`] = `
+<Foo>
+  <div>
+    1.1
+  </div>
+</Foo>
+`;
+
+exports[`mountWithContexts injected ConfigProvider should mount and render with default values 1`] = `
+<Foo>
+  <div />
+</Foo>
+`;
+
+exports[`mountWithContexts injected I18nProvider should mount and render 1`] = `
+<div>
+  <span>
+    Text content
+  </span>
+</div>
+`;
+
+exports[`mountWithContexts injected I18nProvider should mount and render deeply nested consumer 1`] = `
+<Parent>
+  <Child>
+    <div>
+      Text content
+    </div>
+  </Child>
+</Parent>
+`;
+
+exports[`mountWithContexts injected Router should mount and render 1`] = `
+<div>
+  <Link
+    to="/"
+  >
+    <LinkAnchor
+      href="/"
+      navigate={[Function]}
+    >
+      <a
+        href="/"
+        onClick={[Function]}
+      >
+        home
+      </a>
+    </LinkAnchor>
+  </Link>
+</div>
+`;

--- a/awx/ui/testUtils/enzymeHelpers.test.js
+++ b/awx/ui/testUtils/enzymeHelpers.test.js
@@ -120,7 +120,7 @@ class TestAsyncComponent extends Component {
 }
 
 describe('waitForElement', () => {
-  it('waits for the element and returns it', async done => {
+  it('waits for the element and returns it', async () => {
     const selector = '#test-async-component';
     const wrapper = mountWithContexts(<TestAsyncComponent />);
     expect(wrapper.exists(selector)).toEqual(false);
@@ -128,10 +128,9 @@ describe('waitForElement', () => {
     const elem = await waitForElement(wrapper, selector);
     expect(elem.props().id).toEqual('test-async-component');
     expect(wrapper.exists(selector)).toEqual(true);
-    done();
   });
 
-  it("eventually throws an error for elements that don't exist", async done => {
+  it("eventually throws an error for elements that don't exist", async () => {
     const wrapper = mountWithContexts(<div />);
 
     let error;
@@ -144,7 +143,6 @@ describe('waitForElement', () => {
         'Expected condition for <#does-not-exist> not met'
       );
       expect(error.message).toContain('el.length === 1');
-      done();
     }
   });
 });

--- a/awx/ui/testUtils/rtlContexts.js
+++ b/awx/ui/testUtils/rtlContexts.js
@@ -22,6 +22,19 @@ import english from '../src/locales/en/messages';
 import { SessionProvider } from '../src/contexts/Session';
 import { ConfigProvider } from '../src/contexts/Config';
 
+// Match mountWithContexts' i18n defaults. Lingui v5 needs explicit plural
+// rules (loadLocaleData); Lingui v6 derives them from Intl.PluralRules and
+// removes both the API and the make-plural dependency, so this block is
+// guarded to degrade cleanly once the toolchain upgrade lands.
+try {
+  if (typeof i18n.loadLocaleData === 'function') {
+    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+    const { en } = require('make-plural/plurals');
+    i18n.loadLocaleData({ en: { plurals: en } });
+  }
+} catch {
+  // make-plural is gone (Lingui v6); Intl.PluralRules covers plurals.
+}
 i18n.load({ en: english.messages });
 i18n.activate('en');
 

--- a/awx/ui/testUtils/rtlContexts.js
+++ b/awx/ui/testUtils/rtlContexts.js
@@ -1,0 +1,83 @@
+/*
+ * React Testing Library counterpart of testUtils/enzymeHelpers.
+ *
+ * renderWithContexts(ui, { context }) renders a component inside the app's
+ * top-level providers (i18n, session, config, router) with the same context
+ * defaults and the same override mechanism as mountWithContexts, so enzyme
+ * suites can be converted incrementally:
+ *
+ *   const { history, user } = renderWithContexts(<MyComponent />, {
+ *     context: { router: { history: createMemoryHistory(...) } },
+ *   });
+ *   await user.click(screen.getByRole('button', { name: 'Save' }));
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { I18nProvider } from '@lingui/react';
+import { i18n } from '@lingui/core';
+import english from '../src/locales/en/messages';
+import { SessionProvider } from '../src/contexts/Session';
+import { ConfigProvider } from '../src/contexts/Config';
+
+i18n.load({ en: english.messages });
+i18n.activate('en');
+
+const defaultContexts = {
+  config: {
+    ansible_version: null,
+    version: null,
+    me: { is_superuser: true },
+    toJSON: () => '/config/',
+    license_info: {
+      valid_key: true,
+    },
+  },
+  router: {},
+  session: {
+    isSessionExpired: false,
+    logout: () => {},
+    setAuthRedirectTo: () => {},
+  },
+};
+
+function applyDefaultContexts(context) {
+  if (!context) {
+    return defaultContexts;
+  }
+  const newContext = {};
+  Object.keys(defaultContexts).forEach((key) => {
+    newContext[key] = {
+      ...defaultContexts[key],
+      ...context[key],
+    };
+  });
+  return newContext;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function renderWithContexts(ui, options = {}) {
+  const { context: userContext, ...renderOptions } = options;
+  const { config, router, session } = applyDefaultContexts(userContext);
+  const history = router.history || createMemoryHistory();
+
+  function Wrapper({ children }) {
+    return (
+      <I18nProvider i18n={i18n}>
+        <SessionProvider value={session}>
+          <ConfigProvider value={config}>
+            <Router history={history}>{children}</Router>
+          </ConfigProvider>
+        </SessionProvider>
+      </I18nProvider>
+    );
+  }
+
+  return {
+    history,
+    user: userEvent.setup(),
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+  };
+}

--- a/awx/ui/testUtils/rtlContexts.test.js
+++ b/awx/ui/testUtils/rtlContexts.test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { useHistory, useLocation } from 'react-router-dom';
+import { Plural } from '@lingui/react/macro';
+import { useConfig } from '../src/contexts/Config';
+import { useSession } from '../src/contexts/Session';
+import { renderWithContexts } from './rtlContexts';
+
+function ConfigProbe() {
+  const config = useConfig();
+  return (
+    <div>
+      <span>{config.me.is_superuser ? 'superuser' : 'normal user'}</span>
+      <span>{config.custom_field ?? 'no custom field'}</span>
+    </div>
+  );
+}
+
+function SessionProbe() {
+  const { isSessionExpired } = useSession();
+  return <span>{isSessionExpired ? 'expired' : 'active'}</span>;
+}
+
+function RouterProbe() {
+  const location = useLocation();
+  const history = useHistory();
+  return (
+    <button type="button" onClick={() => history.push('/somewhere-else')}>
+      {location.pathname}
+    </button>
+  );
+}
+
+describe('renderWithContexts', () => {
+  test('provides the default config context', () => {
+    renderWithContexts(<ConfigProbe />);
+    expect(screen.getByText('superuser')).toBeInTheDocument();
+    expect(screen.getByText('no custom field')).toBeInTheDocument();
+  });
+
+  test('merges config overrides into the defaults', () => {
+    renderWithContexts(<ConfigProbe />, {
+      context: { config: { me: { is_superuser: false }, custom_field: 'qux' } },
+    });
+    expect(screen.getByText('normal user')).toBeInTheDocument();
+    expect(screen.getByText('qux')).toBeInTheDocument();
+  });
+
+  test('provides the default session context', () => {
+    renderWithContexts(<SessionProbe />);
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  test('returns the router history it renders with', async () => {
+    const { history, user } = renderWithContexts(<RouterProbe />);
+    expect(screen.getByRole('button')).toHaveTextContent('/');
+    await user.click(screen.getByRole('button'));
+    expect(history.location.pathname).toBe('/somewhere-else');
+    expect(screen.getByRole('button')).toHaveTextContent('/somewhere-else');
+  });
+
+  test('uses a caller-supplied history', () => {
+    const history = createMemoryHistory({ initialEntries: ['/credentials'] });
+    renderWithContexts(<RouterProbe />, { context: { router: { history } } });
+    expect(screen.getByRole('button')).toHaveTextContent('/credentials');
+  });
+
+  test('renders plural messages without console errors', () => {
+    renderWithContexts(
+      <Plural value={2} one="# item" other="# items" />
+    );
+    expect(screen.getByText('2 items')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## SUMMARY
Stage 3 groundwork of the React stack modernization: start retiring **enzyme**, which is dead upstream and has no adapter beyond React 17 — it is the single hard blocker for ever moving to React 18/19 (495 test files depend on it).

This PR makes incremental conversion possible and establishes the pattern:

- **`testUtils/rtlContexts.js`** — `renderWithContexts()`, the React Testing Library counterpart of `mountWithContexts`: same context defaults and override mechanism (i18n, session, config, router with optional custom history), plus a ready `userEvent` instance and the `history` object in the return value.
- **`@testing-library/jest-dom` matchers loaded globally** in `setupTests.js` (suites no longer import them individually; existing per-file imports keep working).
- **Seven representative suites converted** as the pattern: ContentEmpty, ContentLoading, AlertModal, FormActionGroup, ChipGroup, ToolbarSyncSourceButton (interaction) and DeleteButton (modal open → confirm flow → async error). Where the enzyme versions only asserted wrapper length or component props, the RTL versions assert **rendered behavior** — e.g. ChipGroup's old test asserted a prop on an effectively empty render; it now renders actual chips and asserts the visible overflow text.

### Conversion recipe
| enzyme | RTL |
|---|---|
| `mountWithContexts(<X/>)` | `renderWithContexts(<X/>)` |
| `wrapper.find('button').simulate('click')` | `await user.click(screen.getByRole('button', { name }))` |
| `waitForElement(wrapper, 'X')` | `await screen.findBy...` |
| asserting `.props()` / `.length` | assert visible text/roles |
| `act(...)` wrapping | usually unnecessary |

Both helpers coexist; the remaining ~490 enzyme suites convert incrementally (screen directory at a time works well). When the last one converts, enzyme + the React 17 adapter come out of package.json — unblocking React 18.

**Independent of all open PRs** — test-only changes (no production code, no dependency changes). Note for the future: when the react-router compat migration (#392) merges, `rtlContexts` should gain the same controlled v6 Router layer its enzyme counterpart gets there — a 5-line follow-up.

## ISSUE TYPE
- New or Enhanced Feature

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev5+gcda0899.d20260610
```

## ADDITIONAL INFORMATION
```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 544 suites passed (1 skipped), 2855 tests passed (19 skipped)
```
Production build unaffected (test files and test utilities only).







