### PR TITLE
Fix cross-test mock leak behind the flaky parallel test failures

### DIFF
--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -36,7 +36,7 @@ def private_data_dir():
 @mock.patch('awx.main.tasks.facts.finish_fact_cache')
 @mock.patch('awx.main.tasks.facts.settings')
 @mock.patch('awx.main.tasks.jobs.create_partition', return_value=True)
-def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, finish_fact_cache, private_data_dir, execution_environment):
+def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, finish_fact_cache, private_data_dir, execution_environment, mocker):
     # creates inventory_object with two hosts
     inventory = Inventory(pk=1)
     mock_inventory = mock.MagicMock(spec=Inventory, wraps=inventory)
@@ -65,7 +65,7 @@ def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, fin
     task = jobs.RunJob()
     task.instance = job
     task.update_model = mock.Mock(return_value=job)
-    task.model.objects.get = mock.Mock(return_value=job)
+    mocker.patch.object(task.model.objects, 'get', return_value=job)
 
     # run pre_run_hook
     task.facts_write_time = task.pre_run_hook(job, private_data_dir)
@@ -85,7 +85,7 @@ def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, fin
 @mock.patch('awx.main.tasks.facts.finish_fact_cache')
 @mock.patch('awx.main.tasks.facts.settings')
 @mock.patch('awx.main.tasks.jobs.create_partition', return_value=True)
-def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_facts_settings, finish_fact_cache, private_data_dir, execution_environment):
+def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_facts_settings, finish_fact_cache, private_data_dir, execution_environment, mocker):
     # creates inventory_object with two hosts
     inventory = Inventory(pk=1)
     mock_inventory = mock.MagicMock(spec=Inventory, wraps=inventory)
@@ -112,7 +112,7 @@ def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_fact
     task = jobs.RunJob()
     task.instance = job
     task.update_model = mock.Mock(return_value=job)
-    task.model.objects.get = mock.Mock(return_value=job)
+    mocker.patch.object(task.model.objects, 'get', return_value=job)
 
     # run pre_run_hook
     task.facts_write_time = task.pre_run_hook(job, private_data_dir)

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -461,7 +461,7 @@ class TestExtraVarSanitation(TestJobExecution):
 
 
 class TestGenericRun:
-    def test_generic_failure(self, patch_Job, execution_environment, mock_me, mock_create_partition):
+    def test_generic_failure(self, patch_Job, execution_environment, mock_me, mock_create_partition, mocker):
         job = Job(status='running', inventory=Inventory(), project=Project(local_path='/projects/_23_foo'))
         job.websocket_emit_status = mock.Mock()
         job.execution_environment = execution_environment
@@ -469,7 +469,7 @@ class TestGenericRun:
         task = jobs.RunJob()
         task.instance = job
         task.update_model = mock.Mock(return_value=job)
-        task.model.objects.get = mock.Mock(return_value=job)
+        mocker.patch.object(task.model.objects, 'get', return_value=job)
         task.build_private_data_files = mock.Mock(side_effect=OSError())
 
         with mock.patch('awx.main.tasks.jobs.shutil.copytree'):
@@ -481,7 +481,7 @@ class TestGenericRun:
         assert update_model_call['status'] == 'error'
         assert update_model_call['emitted_events'] == 0
 
-    def test_cancel_flag(self, job, update_model_wrapper, execution_environment, mock_me, mock_create_partition):
+    def test_cancel_flag(self, job, update_model_wrapper, execution_environment, mock_me, mock_create_partition, mocker):
         job.status = 'running'
         job.cancel_flag = True
         job.websocket_emit_status = mock.Mock()
@@ -491,7 +491,7 @@ class TestGenericRun:
         task = jobs.RunJob()
         task.instance = job
         task.update_model = mock.Mock(wraps=update_model_wrapper)
-        task.model.objects.get = mock.Mock(return_value=job)
+        mocker.patch.object(task.model.objects, 'get', return_value=job)
         task.build_private_data_files = mock.Mock()
 
         with mock.patch('awx.main.tasks.jobs.shutil.copytree'):
@@ -580,7 +580,7 @@ class TestGenericRun:
 
 @pytest.mark.django_db
 class TestAdhocRun(TestJobExecution):
-    def test_options_jinja_usage(self, adhoc_job, adhoc_update_model_wrapper, mock_me, mock_create_partition):
+    def test_options_jinja_usage(self, adhoc_job, adhoc_update_model_wrapper, mock_me, mock_create_partition, mocker):
         ExecutionEnvironment.objects.create(name='Control Plane EE', managed=True)
         ExecutionEnvironment.objects.create(name='Default Job EE', managed=False)
 
@@ -590,7 +590,7 @@ class TestAdhocRun(TestJobExecution):
 
         task = jobs.RunAdHocCommand()
         task.update_model = mock.Mock(wraps=adhoc_update_model_wrapper)
-        task.model.objects.get = mock.Mock(return_value=adhoc_job)
+        mocker.patch.object(task.model.objects, 'get', return_value=adhoc_job)
         task.build_inventory = mock.Mock()
 
         with pytest.raises(Exception):
@@ -1926,7 +1926,7 @@ def test_managed_injector_redaction(injector_cls):
     assert 'very_secret_value' not in str(build_safe_env(env))
 
 
-def test_job_run_no_ee(mock_me, mock_create_partition):
+def test_job_run_no_ee(mock_me, mock_create_partition, mocker):
     org = Organization(pk=1)
     proj = Project(pk=1, organization=org)
     job = Job(project=proj, organization=org, inventory=Inventory(pk=1))
@@ -1934,7 +1934,7 @@ def test_job_run_no_ee(mock_me, mock_create_partition):
     task = jobs.RunJob()
     task.instance = job
     task.update_model = mock.Mock(return_value=job)
-    task.model.objects.get = mock.Mock(return_value=job)
+    mocker.patch.object(task.model.objects, 'get', return_value=job)
 
     with mock.patch('awx.main.tasks.jobs.shutil.copytree'):
         with pytest.raises(RuntimeError) as e:


### PR DESCRIPTION
Merge PR #388 first — it makes full parallel Python test runs deterministic for reviewing everything else.

## SUMMARY
Fixes #379 — and the root cause turned out to be none of the suspects in the issue. Six unit tests assigned a Mock **directly onto the model manager**, with no patch machinery:

```python
task.model.objects.get = mock.Mock(return_value=job)   # task.model is the Job / AdHocCommand class
```

That permanently replaces `Manager.get` for the remainder of the pytest-xdist **worker process**. Whichever functional test files later shared that worker became the 'flaky' victims, and the leaked mock explains every observed failure family:

- **`api/test_survey_spec.py`**: `Job.objects.get(...)` returned a MagicMock → `json.loads(job.extra_vars)` failed with *'must be str … not MagicMock'* (up to 13 parametrized failures per run).
- **`utils/test_update_model.py`**: `update_model()` returned the unit test's leftover **in-memory Job built with `Project(pk=1)`**; the test saved it, inserting a row whose `project_id=1` references nothing — which Django's whole-DB `check_constraints()` at teardown reported as the mysterious *'main_job … invalid foreign key'* IntegrityError.
- **`commands/test_secret_key_regeneration.py`**: same frankenjob → garbage decrypted `start_args`.

The xdist scheduling lottery decided which files shared a worker with the leakers each run — hence the random victim set, why every victim passed in isolation, and why pairwise reproductions failed.

## How it was found
A temporary pytest plugin scanned **every model manager for Mock instance attributes after each test** and logged transitions per worker. Both leak sources (`unit/test_tasks.py`, `unit/tasks/test_jobs.py`) were caught within two full parallel runs, attributed to the exact tests.

## The fix
All six sites become `mocker.patch.object(task.model.objects, 'get', return_value=...)` — same behavior inside the test, automatically unwound by pytest-mock at teardown.

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- API

## ASCENDER VERSION
```
awx: 25.4.1.dev5+gcda0899.d20260610
```

## ADDITIONAL INFORMATION
Validation: **five consecutive** full parallel runs (`py.test --create-db -n auto --dist=loadfile awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests`) all returned **3476 passed, 0 failed**, with the leak detector confirming no manager is ever left mocked. Before the fix, roughly two of every three such runs failed.

Note: the `TransactionTestCase` classes called out in the original issue text are innocent — their teardown flush verifiably leaves all tables empty. Test-only change; production code untouched. Independent of all open PRs.





