### PR TITLE
Build Activity Stream links for inventory source sync schedules

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -6059,6 +6059,9 @@ class ActivityStreamSerializer(BaseSerializer):
         summary_dict = copy.copy(SUMMARIZABLE_FK_FIELDS)
         # Special requests
         summary_dict['group'] = summary_dict['group'] + ('inventory_id',)
+        # the UI builds inventory-source schedule urls from the activity
+        # stream and needs the parent inventory id to do so
+        summary_dict['inventory_source'] = summary_dict['inventory_source'] + ('inventory_id',)
         for key in summary_dict.keys():
             if 'id' not in summary_dict[key]:
                 summary_dict[key] = summary_dict[key] + ('id',)
@@ -6213,12 +6216,17 @@ class ActivityStreamSerializer(BaseSerializer):
         item = {}
         fields = SUMMARIZABLE_FK_FIELDS[summary_keys[fk]]
         if related_obj is not None:
-            summary_fields[get_type_for_model(related_obj)] = []
+            related_type = get_type_for_model(related_obj)
+            if related_type == 'inventory_source':
+                # the UI builds inventory-source schedule urls from the
+                # activity stream and needs the parent inventory id to do so
+                fields = fields + ('inventory_id',)
+            summary_fields[related_type] = []
             for field in fields:
                 fval = getattr(related_obj, field, None)
                 if fval is not None:
                     item[field] = fval
-            summary_fields[get_type_for_model(related_obj)].append(item)
+            summary_fields[related_type].append(item)
 
     def get_summary_fields(self, obj):
         summary_fields = OrderedDict()

--- a/awx/main/tests/functional/api/test_activity_streams.py
+++ b/awx/main/tests/functional/api/test_activity_streams.py
@@ -41,6 +41,26 @@ def test_basic_fields(monkeypatch, organization, get, user, settings):
 
 
 @pytest.mark.django_db
+def test_inventory_source_schedule_summary_fields(monkeypatch, inventory, get, user, settings):
+    settings.ACTIVITY_STREAM_ENABLED = True
+    from awx.main.models import InventorySource, Schedule
+
+    inv_src = InventorySource.objects.create(name='test-inv-src', inventory=inventory, source='ec2')
+    schedule = Schedule.objects.create(name='test-sched', unified_job_template=inv_src, rrule='DTSTART:20300112T210000Z RRULE:FREQ=DAILY;INTERVAL=1')
+
+    aspk = ActivityStream.objects.filter(schedule__pk=schedule.pk, operation='create').latest('pk').pk
+    url = reverse('api:activity_stream_detail', kwargs={'pk': aspk})
+    response = get(url, user('admin', True))
+
+    assert response.status_code == 200
+    summary = response.data['summary_fields']['inventory_source'][0]
+    assert summary['id'] == inv_src.id
+    # the UI builds /inventories/inventory/<inventory_id>/sources/<id>/schedules/<schedule_id>/
+    # links from the activity stream, so the parent inventory id must be serialized
+    assert summary['inventory_id'] == inventory.id
+
+
+@pytest.mark.django_db
 def test_ctint_activity_stream(monkeypatch, get, user, settings):
     Setting.objects.create(key="FOO", value="bar")
     settings.ACTIVITY_STREAM_ENABLED = True

--- a/awx/ui/src/screens/ActivityStream/ActivityStreamDescription.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStreamDescription.js
@@ -60,6 +60,11 @@ const buildAnchor = (obj, resource, activity) => {
           url = `/projects/${activity.summary_fields.project[0].id}/schedules/${obj.id}/`;
         } else if (activity.summary_fields.system_job_template) {
           url = null;
+        } else if (activity.summary_fields.inventory_source) {
+          const invSource = activity.summary_fields.inventory_source[0];
+          url = invSource.inventory_id
+            ? `/inventories/inventory/${invSource.inventory_id}/sources/${invSource.id}/schedules/${obj.id}/`
+            : null;
         } else {
           // urls for inventory sync schedules currently depend on having
           // an inventory id and group id

--- a/awx/ui/src/screens/ActivityStream/ActivityStreamDescription.test.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStreamDescription.test.js
@@ -9,4 +9,45 @@ describe('ActivityStreamDescription', () => {
     );
     expect(description.find('span').length).toBe(1);
   });
+
+  test('builds a link for an inventory source sync schedule', () => {
+    const activity = {
+      object_association: '',
+      object_type: 'schedule',
+      object1: 'schedule',
+      object2: '',
+      operation: 'create',
+      changes: { id: 5, name: 'Sync Schedule' },
+      summary_fields: {
+        schedule: [{ id: 5, name: 'Sync Schedule' }],
+        inventory_source: [{ id: 3, name: 'src', inventory_id: 7 }],
+      },
+    };
+    const description = mountWithContexts(
+      <ActivityStreamDescription activity={activity} />
+    );
+    const link = description.find('Link');
+    expect(link).toHaveLength(1);
+    expect(link.prop('to')).toBe('/inventories/inventory/7/sources/3/schedules/5/');
+    expect(link.text()).toBe('Sync Schedule');
+  });
+
+  test('falls back to plain text for a schedule with an unknown parent', () => {
+    const activity = {
+      object_association: '',
+      object_type: 'schedule',
+      object1: 'schedule',
+      object2: '',
+      operation: 'create',
+      changes: { id: 5, name: 'Mystery Schedule' },
+      summary_fields: {
+        schedule: [{ id: 5, name: 'Mystery Schedule' }],
+      },
+    };
+    const description = mountWithContexts(
+      <ActivityStreamDescription activity={activity} />
+    );
+    expect(description.find('Link')).toHaveLength(0);
+    expect(description.text()).toContain('Mystery Schedule');
+  });
 });


### PR DESCRIPTION
## SUMMARY
The Activity Stream description for a schedule belonging to an **inventory source sync** hit an explicit `throw new Error('activity.summary_fields to build this url not implemented yet')` and fell back to plain unlinked text — every other schedule parent (job template, workflow job template, project) gets a clickable link.

The blocker was that the inventory-source schedule route (`/inventories/inventory/<inventory_id>/sources/<id>/schedules/<schedule_id>/`) needs the **parent inventory id**, which the activity stream serializer didn't provide.

- **API**: `ActivityStreamSerializer._summarize_parent_ujt` now includes `inventory_id` when a schedule's parent unified job template is an `InventorySource` (the direct `inventory_source` summary gains it too, mirroring the existing `group`/`inventory_id` special case a few lines above).
- **UI**: `ActivityStreamDescription` builds the link from `summary_fields.inventory_source`, falling back to plain text when the id is unavailable rather than relying on a thrown exception for control flow.

Tests: a functional API test asserting `inventory_id` is serialized for an inventory-source schedule activity, and two UI tests (link built with the right href; graceful plain-text fallback for unknown parents).

**Independent of all open PRs** — no dependency or lockfile changes.

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- API
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev5+gcda0899.d20260610
```

## ADDITIONAL INFORMATION
Reproduce on main: create a schedule on an inventory source, then open the Activity Stream — the schedule entry renders as plain text instead of a link (the throw is caught upstream).
```
py.test --create-db -n auto --dist=loadfile awx/main/tests/...   # 3477 passed
npm --prefix awx/ui run lint                                      # clean
npm --prefix awx/ui run test                                      # 544 suites, 2857 passed
npm --prefix awx/ui run build                                     # succeeds
```








