### PR TITLE
Surface an error when the webhook credential type lookup returns nothing

### DIFF
--- a/awx/ui/src/screens/Template/shared/WebhookSubForm.js
+++ b/awx/ui/src/screens/Template/shared/WebhookSubForm.js
@@ -56,8 +56,6 @@ function WebhookSubForm({ templateType }) {
         results = await CredentialTypesAPI.read({
           namespace: `${webhookServiceField.value}_token`,
         });
-        // TODO: Consider how to handle the situation where the results returns
-        // and empty array, or any of the other values is undefined or null (data, results, id)
       }
       return results?.data?.results[0]?.id;
     }, [webhookServiceField.value])

--- a/awx/ui/src/screens/Template/shared/WebhookSubForm.js
+++ b/awx/ui/src/screens/Template/shared/WebhookSubForm.js
@@ -4,6 +4,7 @@ import { useParams, useLocation } from 'react-router-dom';
 import { useLingui } from '@lingui/react/macro';
 
 import {
+  Alert,
   FormGroup,
   TextInput,
   InputGroup,
@@ -122,7 +123,7 @@ function WebhookSubForm({ templateType }) {
   ];
 
   if (error || webhookKeyError) {
-    return <ContentError error={error} />;
+    return <ContentError error={error || webhookKeyError} />;
   }
   if (isLoading) {
     return <ContentLoading />;
@@ -211,6 +212,14 @@ function WebhookSubForm({ templateType }) {
           helperTextInvalid={webhookCredentialMeta.error}
           value={webhookCredentialField.value}
           fieldName="webhook_credential"
+        />
+      )}
+      {!credTypeId && !isLoading && webhookServiceField.value && (
+        <Alert
+          variant="warning"
+          isInline
+          ouiaId="webhook-credential-type-missing"
+          title={t`Unable to look up the credential type for this webhook service, so the webhook credential field is unavailable.`}
         />
       )}
     </FormColumnLayout>

--- a/awx/ui/src/screens/Template/shared/WebhookSubForm.test.js
+++ b/awx/ui/src/screens/Template/shared/WebhookSubForm.test.js
@@ -164,6 +164,15 @@ describe('<WebhookSubForm />', () => {
     CredentialTypesAPI.read.mockResolvedValue({
       data: { results: [{ id: 9, name: 'GitHub Personal Access Token' }] },
     });
+    CredentialsAPI.read.mockResolvedValue({
+      data: { results: [{ id: 12, name: 'Github credential' }], count: 1 },
+    });
+    CredentialsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: { GET: {}, POST: {} },
+        related_search_fields: [],
+      },
+    });
     let newWrapper;
     await act(async () => {
       newWrapper = mountWithContexts(
@@ -185,7 +194,7 @@ describe('<WebhookSubForm />', () => {
         }
       );
     });
-    newWrapper.update();
+    await waitForElement(newWrapper, 'ContentLoading', (el) => el.length === 0);
     expect(newWrapper.find('CredentialLookup')).toHaveLength(1);
     expect(
       newWrapper.find('Alert[ouiaId="webhook-credential-type-missing"]')
@@ -215,7 +224,7 @@ describe('<WebhookSubForm />', () => {
         }
       );
     });
-    newWrapper.update();
+    await waitForElement(newWrapper, 'ContentLoading', (el) => el.length === 0);
     expect(newWrapper.find('CredentialLookup')).toHaveLength(0);
     expect(
       newWrapper.find('Alert[ouiaId="webhook-credential-type-missing"]')

--- a/awx/ui/src/screens/Template/shared/WebhookSubForm.test.js
+++ b/awx/ui/src/screens/Template/shared/WebhookSubForm.test.js
@@ -4,7 +4,7 @@ import { Route } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 
 import { Formik } from 'formik';
-import { CredentialsAPI } from 'api';
+import { CredentialsAPI, CredentialTypesAPI } from 'api';
 import {
   mountWithContexts,
   waitForElement,
@@ -158,5 +158,67 @@ describe('<WebhookSubForm />', () => {
     expect(
       newWrapper.find('TextInputBase[aria-label="Webhook URL"]').prop('value')
     ).toContain(webhook_url);
+  });
+
+  test('should render credential lookup when the credential type resolves', async () => {
+    CredentialTypesAPI.read.mockResolvedValue({
+      data: { results: [{ id: 9, name: 'GitHub Personal Access Token' }] },
+    });
+    let newWrapper;
+    await act(async () => {
+      newWrapper = mountWithContexts(
+        <Route path="templates/:templateType/:id/edit">
+          <Formik initialValues={initialValues}>
+            <WebhookSubForm templateType="job_template" />
+          </Formik>
+        </Route>,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: { pathname: 'templates/job_template/51/edit' },
+                match: { params: { id: 51, templateType: 'job_template' } },
+              },
+            },
+          },
+        }
+      );
+    });
+    newWrapper.update();
+    expect(newWrapper.find('CredentialLookup')).toHaveLength(1);
+    expect(
+      newWrapper.find('Alert[ouiaId="webhook-credential-type-missing"]')
+    ).toHaveLength(0);
+  });
+
+  test('should warn instead of failing silently when no credential type is found', async () => {
+    CredentialTypesAPI.read.mockResolvedValue({ data: { results: [] } });
+    let newWrapper;
+    await act(async () => {
+      newWrapper = mountWithContexts(
+        <Route path="templates/:templateType/:id/edit">
+          <Formik initialValues={initialValues}>
+            <WebhookSubForm templateType="job_template" />
+          </Formik>
+        </Route>,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: { pathname: 'templates/job_template/51/edit' },
+                match: { params: { id: 51, templateType: 'job_template' } },
+              },
+            },
+          },
+        }
+      );
+    });
+    newWrapper.update();
+    expect(newWrapper.find('CredentialLookup')).toHaveLength(0);
+    expect(
+      newWrapper.find('Alert[ouiaId="webhook-credential-type-missing"]')
+    ).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## SUMMARY
Fixes the second documented known-bug from the UI gaps list. `WebhookSubForm` looks up the `<service>_token` credential type to drive the **Webhook Credential** field, but when the API responds successfully with **no results**, the field silently never rendered (there's an explicit TODO at the lookup acknowledging this) — users selecting a webhook service got no credential field and no explanation.

- The form now renders an **inline warning Alert** when a webhook service is selected but no matching credential type could be resolved, instead of failing silently.
- Also fixes a secondary bug on the same screen: webhook-key failures rendered `<ContentError error={error} />` with the wrong (undefined) error object when only `webhookKeyError` was set.
- The new string is not yet in the locale catalogs (deliberately, to keep this PR free of whole-catalog churn); it falls back to its English source text at runtime and will be picked up by the next routine `extract-strings` run.

Worth noting: the pre-existing test suite ran **entirely in the silent-failure regime** — the auto-mocked `CredentialTypesAPI` returned no credential type and nothing asserted the lookup's presence. The new tests cover both sides: the lookup renders when a type resolves, and the warning appears (lookup absent) on empty results.

**No dependency, lockfile or locale-catalog changes.** Independent of every other open PR — verified conflict-free via pairwise `git merge-tree`.

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev5+gcda0899.d20260610
```

## ADDITIONAL INFORMATION
```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 544 suites, 2857 passed (incl. 2 new)
npm --prefix awx/ui run build    # succeeds
```








