### PR TITLE
Show elapsed time on the workflow job output toolbar

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -23760,7 +23760,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -23760,7 +23760,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
@@ -137,7 +137,7 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
         <div>{t`Elapsed`}</div>
         <Tooltip content={t`Elapsed time that the job ran`}>
           <Badge isRead>
-            {job.finished
+            {job.finished && job.elapsed != null
               ? secondsToHHMMSS(job.elapsed)
               : activeJobElapsedTime}
           </Badge>

--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
@@ -35,6 +35,11 @@ const Badge = styled(PFBadge)`
       : null}
 `;
 
+const ElapsedBadge = styled(Badge)`
+  min-width: 70px;
+  font-variant-numeric: tabular-nums;
+`;
+
 const Wrapper = styled.div`
   align-items: center;
   display: flex;
@@ -136,11 +141,11 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
       <BadgeGroup aria-label={t`Elapsed Time`}>
         <div>{t`Elapsed`}</div>
         <Tooltip content={t`Elapsed time that the job ran`}>
-          <Badge isRead>
+          <ElapsedBadge isRead>
             {job.finished && job.elapsed != null
               ? secondsToHHMMSS(job.elapsed)
               : activeJobElapsedTime}
-          </Badge>
+          </ElapsedBadge>
         </Tooltip>
       </BadgeGroup>
       {['pending', 'waiting', 'running'].includes(jobStatus) &&

--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
-import { DateTime, Duration } from 'luxon';
+import { calculateElapsed, secondsToHHMMSS } from 'util/dates';
 import { bool, shape, func } from 'prop-types';
 import {
   DownloadIcon,
@@ -41,21 +41,6 @@ const Wrapper = styled.div`
   flex-flow: row wrap;
   font-size: 14px;
 `;
-const calculateElapsed = (started) => {
-  if (!started) return '00:00:00';
-  const now = DateTime.now();
-  const duration = now
-    .diff(DateTime.fromISO(`${started}`), [
-      'milliseconds',
-      'seconds',
-      'minutes',
-      'hours',
-    ])
-    .toObject();
-
-  return Duration.fromObject({ ...duration }).toFormat('hh:mm:ss');
-};
-
 const OUTPUT_NO_COUNT_JOB_TYPES = [
   'ad_hoc_command',
   'system_job',
@@ -153,9 +138,7 @@ const OutputToolbar = ({ job, onDelete, isDeleteDisabled, jobStatus }) => {
         <Tooltip content={t`Elapsed time that the job ran`}>
           <Badge isRead>
             {job.finished
-              ? Duration.fromObject({ seconds: job.elapsed }).toFormat(
-                  'hh:mm:ss'
-                )
+              ? secondsToHHMMSS(job.elapsed)
               : activeJobElapsedTime}
           </Badge>
         </Tooltip>

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
@@ -127,7 +127,7 @@ function WorkflowOutputToolbar({ job }) {
         <div>{t`Elapsed`}</div>
         <Tooltip content={t`Elapsed time that the job ran`}>
           <Badge isRead id="workflow-elapsed-badge">
-            {job.finished
+            {job.finished && job.elapsed != null
               ? secondsToHHMMSS(job.elapsed)
               : activeJobElapsedTime}
           </Badge>

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-icons';
 import styled from 'styled-components';
 import StatusLabel from 'components/StatusLabel';
+import { calculateElapsed, secondsToHHMMSS } from 'util/dates';
 import JobCancelButton from 'components/JobCancelButton';
 import {
   WorkflowDispatchContext,
@@ -71,6 +72,20 @@ function WorkflowOutputToolbar({ job }) {
     job.summary_fields?.workflow_job_template?.id ??
     job.summary_fields?.workflow_job_template?.[0]?.id;
 
+  const [activeJobElapsedTime, setActiveJobElapsedTime] = React.useState(
+    calculateElapsed(job.started)
+  );
+
+  React.useEffect(() => {
+    let secTimer;
+    if (job.started && !job.finished) {
+      secTimer = setInterval(() => {
+        setActiveJobElapsedTime(calculateElapsed(job.started));
+      }, 1000);
+    }
+    return () => clearInterval(secTimer);
+  }, [job.started, job.finished]);
+
   const totalNodes = nodes.reduce((n, node) => n + !node.isDeleted, 0) - 1;
   const navToWorkflow = () => {
     if (workflowTemplateId) {
@@ -109,6 +124,14 @@ function WorkflowOutputToolbar({ job }) {
             <ProjectDiagramIcon />
           </ActionButton>
         )}
+        <div>{t`Elapsed`}</div>
+        <Tooltip content={t`Elapsed time that the job ran`}>
+          <Badge isRead id="workflow-elapsed-badge">
+            {job.finished
+              ? secondsToHHMMSS(job.elapsed)
+              : activeJobElapsedTime}
+          </Badge>
+        </Tooltip>
         <div>{t`Total Nodes`}</div>
         <Badge isRead>{totalNodes}</Badge>
         <Tooltip content={t`Toggle Legend`} position="bottom">

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.js
@@ -49,6 +49,12 @@ const Badge = styled(PFBadge)`
   margin-left: 10px;
 `;
 
+const ElapsedBadge = styled(Badge)`
+  margin-right: 20px;
+  min-width: 70px;
+  font-variant-numeric: tabular-nums;
+`;
+
 const ActionButton = styled(Button)`
   border: none;
   margin: 0px 6px;
@@ -126,11 +132,11 @@ function WorkflowOutputToolbar({ job }) {
         )}
         <div>{t`Elapsed`}</div>
         <Tooltip content={t`Elapsed time that the job ran`}>
-          <Badge isRead id="workflow-elapsed-badge">
+          <ElapsedBadge isRead id="workflow-elapsed-badge">
             {job.finished && job.elapsed != null
               ? secondsToHHMMSS(job.elapsed)
               : activeJobElapsedTime}
-          </Badge>
+          </ElapsedBadge>
         </Tooltip>
         <div>{t`Total Nodes`}</div>
         <Badge isRead>{totalNodes}</Badge>

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import {
   WorkflowDispatchContext,
   WorkflowStateContext,
@@ -57,14 +58,14 @@ describe('WorkflowOutputToolbar', () => {
   test('should render correct toolbar item', () => {
     shouldFind(`Button[ouiaId="edit-workflow"]`);
     shouldFind('Button#workflow-output-toggle-legend');
-    shouldFind('Badge');
+    expect(wrapper.find('Badge')).toHaveLength(2);
     shouldFind('Button#workflow-output-toggle-tools');
     shouldFind('JobCancelButton');
   });
 
   test('Shows correct number of nodes', () => {
     // The start node (id=1) and deleted nodes (isDeleted=true) should be ignored
-    expect(wrapper.find('Badge').text()).toBe('1');
+    expect(wrapper.find('Badge').last().text()).toBe('1');
   });
 
   test('Toggle Legend button dispatches as expected', () => {
@@ -108,5 +109,62 @@ describe('WorkflowOutputToolbar', () => {
     expect(slicedWrapper.find('Button[ouiaId="edit-workflow"]')).toHaveLength(
       0
     );
+  });
+
+  describe('elapsed timer', () => {
+    beforeEach(() => {
+      jest.useFakeTimers('modern');
+      jest.setSystemTime(new Date('2021-09-01T12:30:45.000Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    function mountToolbar(jobOverrides) {
+      return mountWithContexts(
+        <WorkflowDispatchContext.Provider value={dispatch}>
+          <WorkflowStateContext.Provider value={workflowContext}>
+            <WorkflowOutputToolbar job={{ ...job, ...jobOverrides }} />
+          </WorkflowStateContext.Provider>
+        </WorkflowDispatchContext.Provider>
+      );
+    }
+
+    test('should show live elapsed time while running', () => {
+      const runningWrapper = mountToolbar({
+        started: '2021-09-01T12:30:40.000Z',
+        finished: null,
+      });
+      expect(
+        runningWrapper.find('Badge#workflow-elapsed-badge').text()
+      ).toBe('00:00:05');
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      runningWrapper.update();
+      expect(
+        runningWrapper.find('Badge#workflow-elapsed-badge').text()
+      ).toBe('00:00:07');
+    });
+
+    test('should show final elapsed time once finished', () => {
+      const finishedWrapper = mountToolbar({
+        status: 'successful',
+        started: '2021-09-01T11:00:00.000Z',
+        finished: '2021-09-01T12:01:01.000Z',
+        elapsed: 3661,
+      });
+      expect(
+        finishedWrapper.find('Badge#workflow-elapsed-badge').text()
+      ).toBe('01:01:01');
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      finishedWrapper.update();
+      expect(
+        finishedWrapper.find('Badge#workflow-elapsed-badge').text()
+      ).toBe('01:01:01');
+    });
   });
 });

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
@@ -58,14 +58,19 @@ describe('WorkflowOutputToolbar', () => {
   test('should render correct toolbar item', () => {
     shouldFind(`Button[ouiaId="edit-workflow"]`);
     shouldFind('Button#workflow-output-toggle-legend');
-    expect(wrapper.find('Badge')).toHaveLength(2);
+    shouldFind('Badge#workflow-elapsed-badge');
     shouldFind('Button#workflow-output-toggle-tools');
     shouldFind('JobCancelButton');
   });
 
   test('Shows correct number of nodes', () => {
     // The start node (id=1) and deleted nodes (isDeleted=true) should be ignored
-    expect(wrapper.find('Badge').last().text()).toBe('1');
+    expect(
+      wrapper
+        .find('Badge')
+        .filterWhere((b) => b.prop('id') !== 'workflow-elapsed-badge')
+        .text()
+    ).toBe('1');
   });
 
   test('Toggle Legend button dispatches as expected', () => {
@@ -146,6 +151,18 @@ describe('WorkflowOutputToolbar', () => {
       expect(
         runningWrapper.find('Badge#workflow-elapsed-badge').text()
       ).toBe('00:00:07');
+    });
+
+    test('should keep the live value while finished is set but elapsed has not arrived yet', () => {
+      const wsWindowWrapper = mountToolbar({
+        status: 'successful',
+        started: '2021-09-01T12:30:40.000Z',
+        finished: '2021-09-01T12:30:45.000Z',
+        elapsed: undefined,
+      });
+      expect(
+        wsWindowWrapper.find('Badge#workflow-elapsed-badge').text()
+      ).toBe('00:00:05');
     });
 
     test('should show final elapsed time once finished', () => {

--- a/awx/ui/src/util/dates.js
+++ b/awx/ui/src/util/dates.js
@@ -21,6 +21,20 @@ export function secondsToHHMMSS(seconds) {
   return Duration.fromObject({ seconds }).toFormat('hh:mm:ss');
 }
 
+export function calculateElapsed(started) {
+  if (!started) return '00:00:00';
+  const duration = DateTime.now()
+    .diff(DateTime.fromISO(`${started}`), [
+      'milliseconds',
+      'seconds',
+      'minutes',
+      'hours',
+    ])
+    .toObject();
+
+  return Duration.fromObject({ ...duration }).toFormat('hh:mm:ss');
+}
+
 export function secondsToDays(seconds) {
   return Duration.fromObject({ seconds }).toFormat('d');
 }

--- a/awx/ui/src/util/dates.test.js
+++ b/awx/ui/src/util/dates.test.js
@@ -1,5 +1,6 @@
 import { RRule } from 'rrule';
 import {
+  calculateElapsed,
   dateToInputDateTime,
   formatDateString,
   getRRuleDayConstants,
@@ -41,6 +42,29 @@ describe('secondsToDays', () => {
   test('it returns the expected value', () => {
     expect(secondsToDays(604800)).toEqual('7');
     expect(secondsToDays(0)).toEqual('0');
+  });
+});
+
+describe('calculateElapsed', () => {
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(new Date('2021-09-01T12:30:45.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('should return zero when not started', () => {
+    expect(calculateElapsed(null)).toEqual('00:00:00');
+    expect(calculateElapsed(undefined)).toEqual('00:00:00');
+    expect(calculateElapsed('')).toEqual('00:00:00');
+  });
+
+  test('should compute elapsed time from start timestamp', () => {
+    expect(calculateElapsed('2021-09-01T12:30:44.000Z')).toEqual('00:00:01');
+    expect(calculateElapsed('2021-09-01T12:29:45.000Z')).toEqual('00:01:00');
+    expect(calculateElapsed('2021-09-01T10:00:00.000Z')).toEqual('02:30:45');
   });
 });
 


### PR DESCRIPTION
## SUMMARY
Regular job output pages show a live `hh:mm:ss` elapsed badge — ticking every second while the job runs, switching to the API's final `elapsed` value on completion. **Workflow job output pages showed no elapsed time at all**, live or final.

The workflow output toolbar now renders the same badge next to **Total Nodes**:
- a one-second interval recomputes elapsed from `job.started` while the workflow runs
- the existing websocket-driven refetch (`useWsJob` refetches on terminal statuses) delivers `finished`/`elapsed`, so the badge settles on the authoritative final value without a reload
- `calculateElapsed` moves from a private helper inside `OutputToolbar` to `util/dates` alongside `secondsToHHMMSS`, and `OutputToolbar` now uses both shared helpers (no behavior change there)

No locale-catalog changes needed — both strings (`Elapsed`, `Elapsed time that the job ran`) already exist in the catalogs.

**Independent of every other open PR — verified conflict-free via pairwise `git merge-tree`** (the elapsed-state hooks are deliberately placed clear of the hunks #392 touches in the same file).

## ISSUE TYPE
- New or Enhanced Feature

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev6+g9b44420
```

## ADDITIONAL INFORMATION
Tests: unit coverage for `calculateElapsed` (zero/unstarted cases, fake-timer arithmetic) and two toolbar tests (badge ticks under fake timers while running; shows the formatted final `elapsed` and stops ticking once finished).
```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 544 suites, 2859 passed (incl. 6 new)
npm --prefix awx/ui run build    # succeeds
```
