### PR TITLE
Make VisualizerNode styling props transient

### DIFF
--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
@@ -27,14 +27,14 @@ import getNodeType from './shared/WorkflowJobTemplateVisualizerUtils';
 
 const NodeG = styled.g`
   pointer-events: ${(props) => (props.$noPointerEvents ? 'none' : 'initial')};
-  cursor: ${(props) => (props.job ? 'pointer' : 'default')};
+  cursor: ${(props) => (props.$job ? 'pointer' : 'default')};
 `;
 
 const NodeContents = styled.div`
   font-size: 13px;
   padding: 0px 10px;
   background-color: ${(props) =>
-    props.isInvalidLinkTarget ? 'var(--pf-global--BackgroundColor--200)' : 'var(--pf-global--BackgroundColor--100)'};
+    props.$isInvalidLinkTarget ? 'var(--pf-global--BackgroundColor--200)' : 'var(--pf-global--BackgroundColor--100)'};
   height: 100%;
   display: flex;
   justify-content: center;
@@ -285,7 +285,7 @@ function VisualizerNode({
     <>
       <NodeG
         id={`node-${node.id}`}
-        job={node.job}
+        $job={node.job}
         $noPointerEvents={isAddLinkSourceNode}
         onMouseEnter={handleNodeMouseEnter}
         onMouseLeave={handleNodeMouseLeave}
@@ -357,7 +357,7 @@ function VisualizerNode({
           x="1"
           y="1"
         >
-          <NodeContents isInvalidLinkTarget={node.isInvalidLinkTarget}>
+          <NodeContents $isInvalidLinkTarget={node.isInvalidLinkTarget}>
             <NodeResourceName id={`node-${node.id}-name`}>
               {nodeName}
             </NodeResourceName>


### PR DESCRIPTION
## SUMMARY
Follow-up to #380, which merged just before its last review fix was pushed — this recovers that commit. `NodeG`'s cursor styling read a non-transient `job` prop and `NodeContents` read `isInvalidLinkTarget` directly; under styled-components 6 (now on main) both are forwarded to the underlying `<g>`/`<div>` DOM elements. Both props are now $-prefixed transient props, matching the rest of the migration, so nothing custom reaches the DOM.

Addresses the two Copilot review comments on #380 (made there after merge, recorded in the PR thread).

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev11+g51188f0
```

## ADDITIONAL INFORMATION
```
npx jest src/screens/Template/WorkflowJobTemplateVisualizer   # 119 passed
npm --prefix awx/ui run lint                                  # clean
npm --prefix awx/ui run build                                 # succeeds
```
Independent of the four open PRs (#385, #390, #392, #393) — verified via `git merge-tree`.