### PR TITLE
Wire up date filtering in the Search toolbar

### DIFF
--- a/awx/ui/src/components/JobList/JobList.js
+++ b/awx/ui/src/components/JobList/JobList.js
@@ -41,7 +41,8 @@ function JobList({
       not__launch_type: 'sync',
       ...defaultParams,
     },
-    ['id', 'page', 'page_size']
+    ['id', 'page', 'page_size'],
+    ['created', 'modified', 'finished']
   );
 
   const { me } = useConfig();
@@ -247,6 +248,14 @@ function JobList({
             {
               name: t`Limit`,
               key: 'job__limit',
+            },
+            {
+              name: t`Created`,
+              key: 'created',
+            },
+            {
+              name: t`Finished`,
+              key: 'finished',
             },
           ]}
           headerRow={

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -99,6 +99,11 @@ function Search({
     onShowAdvancedSearch(actualSearchKey === 'advanced');
     setIsFilterDropdownOpen(false);
     setSearchKey(actualSearchKey);
+    // a value typed for the previous key must not leak into the next one -
+    // a controlled date input renders a stale text value as an empty field
+    // while leaving the submit button enabled, allowing a non-date value
+    // through to the API
+    setSearchValue('');
   };
 
   const handleSearch = (e) => {

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -27,6 +27,18 @@ const SubmitButtonWrapper = styled.div`
 `;
 SubmitButtonWrapper.displayName = 'SubmitButtonWrapper';
 
+const DateInputGroup = styled(InputGroup)`
+  /* keep the operator select at its natural width so the date input
+     next to it stays visible */
+  & > .pf-c-select {
+    width: auto;
+    flex: 0 0 auto;
+  }
+  & > .pf-c-form-control {
+    flex: 1 1 auto;
+  }
+`;
+
 const NoOptionDropdown = styled.div`
   align-self: stretch;
   border: 1px solid var(--pf-global--BorderColor--300);
@@ -266,7 +278,7 @@ function Search({
               </Select>
             )) ||
             ((qsConfig.dateFields || []).includes(key) && (
-              <InputGroup>
+              <DateInputGroup>
                 <Select
                   variant={SelectVariant.single}
                   className="dateOperatorSelect"
@@ -314,7 +326,7 @@ function Search({
                     <SearchIcon />
                   </Button>
                 </SubmitButtonWrapper>
-              </InputGroup>
+              </DateInputGroup>
             )) || (
               <InputGroup>
                 <TextInput

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -110,6 +110,7 @@ function Search({
     );
     onShowAdvancedSearch(actualSearchKey === 'advanced');
     setIsFilterDropdownOpen(false);
+    setIsDateOperatorOpen(false);
     setSearchKey(actualSearchKey);
     // a value typed for the previous key must not leak into the next one -
     // a controlled date input renders a stale text value as an empty field

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -69,6 +69,8 @@ function Search({
   );
   const [searchValue, setSearchValue] = useState('');
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
+  const [dateOperator, setDateOperator] = useState('gte');
+  const [isDateOperatorOpen, setIsDateOperatorOpen] = useState(false);
 
   const params = parseQueryString(qsConfig, location.search);
   if (params?.host_filter) {
@@ -112,6 +114,26 @@ function Search({
   const handleTextKeyDown = (e) => {
     if (e.key && e.key === 'Enter') {
       handleSearch(e);
+    }
+  };
+
+  const dateOperators = [
+    ['gte', t`On or after`],
+    ['lt', t`Before`],
+  ];
+
+  const handleDateSearch = (e) => {
+    e.preventDefault();
+
+    if (searchValue) {
+      onSearch(`${searchKey}__${dateOperator}`, searchValue);
+      setSearchValue('');
+    }
+  };
+
+  const handleDateKeyDown = (e) => {
+    if (e.key && e.key === 'Enter') {
+      handleDateSearch(e);
     }
   };
 
@@ -237,10 +259,59 @@ function Search({
                   {booleanLabels.false || t`No`}
                 </SelectOption>
               </Select>
+            )) ||
+            ((qsConfig.dateFields || []).includes(key) && (
+              <InputGroup>
+                <Select
+                  variant={SelectVariant.single}
+                  className="dateOperatorSelect"
+                  aria-label={t`Date operator select`}
+                  typeAheadAriaLabel={t`Date operator select`}
+                  onToggle={setIsDateOperatorOpen}
+                  onSelect={(event, selection) => {
+                    const [op] = dateOperators.find(
+                      ([, label]) => label === selection
+                    );
+                    setDateOperator(op);
+                    setIsDateOperatorOpen(false);
+                  }}
+                  selections={
+                    dateOperators.find(([op]) => op === dateOperator)[1]
+                  }
+                  isOpen={isDateOperatorOpen}
+                  ouiaId={`date-operator-select-${key}`}
+                  isDisabled={isDisabled}
+                  noResultsFoundText={t`No results found`}
+                >
+                  {dateOperators.map(([op, label]) => (
+                    <SelectOption key={op} value={label}>
+                      {label}
+                    </SelectOption>
+                  ))}
+                </Select>
+                <TextInput
+                  data-cy="date-search-input"
+                  type="date"
+                  aria-label={t`Date search input`}
+                  value={searchValue}
+                  onChange={setSearchValue}
+                  onKeyDown={handleDateKeyDown}
+                  isDisabled={isDisabled}
+                />
+                <SubmitButtonWrapper $disabled={!searchValue}>
+                  <Button
+                    ouiaId="date-search-submit-button"
+                    variant={ButtonVariant.control}
+                    isDisabled={!searchValue || isDisabled}
+                    aria-label={t`Search submit button`}
+                    onClick={handleDateSearch}
+                  >
+                    <SearchIcon />
+                  </Button>
+                </SubmitButtonWrapper>
+              </InputGroup>
             )) || (
               <InputGroup>
-                {/* TODO: add support for dates:
-          qsConfig.dateFields.filter(field => field === key).length && "date" */}
                 <TextInput
                   data-cy="search-text-input"
                   type={

--- a/awx/ui/src/components/Search/Search.test.js
+++ b/awx/ui/src/components/Search/Search.test.js
@@ -446,6 +446,41 @@ describe('<Search />', () => {
       expect(onSearch).toHaveBeenCalledWith('created__lt', '2026-06-30');
     });
 
+    test('a value typed for a text column does not leak into a date search', () => {
+      const onSearch = jest.fn();
+      search = mountSearch(onSearch);
+      const textInput = 'input[aria-label="Search text input"]';
+      search.find(textInput).instance().value = 'foo';
+      search.find(textInput).simulate('change');
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Created' } }
+        );
+      });
+      search.update();
+      expect(search.find(dateInput).prop('value')).toBe('');
+      expect(
+        search.find('button[aria-label="Search submit button"]').prop(
+          'disabled'
+        )
+      ).toBe(true);
+    });
+
+    test('Enter in the date input submits the search', () => {
+      const onSearch = jest.fn();
+      search = mountSearch(onSearch);
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Created' } }
+        );
+      });
+      search.update();
+      search.find(dateInput).instance().value = '2026-06-15';
+      search.find(dateInput).simulate('change');
+      search.find(dateInput).simulate('keydown', { key: 'Enter' });
+      expect(onSearch).toHaveBeenCalledWith('created__gte', '2026-06-15');
+    });
+
     test('non-date columns keep the plain text input', () => {
       search = mountSearch(jest.fn());
       expect(search.find(dateInput)).toHaveLength(0);

--- a/awx/ui/src/components/Search/Search.test.js
+++ b/awx/ui/src/components/Search/Search.test.js
@@ -365,4 +365,93 @@ describe('<Search />', () => {
     const fooFilterWrapper = wrapper.find('ToolbarFilter[categoryName="foo"]');
     expect(fooFilterWrapper.prop('chips')[0].key).toEqual('foo:bar');
   });
+
+  describe('date fields', () => {
+    const dateColumns = [
+      { name: 'Name', key: 'name__icontains', isDefault: true },
+      { name: 'Created', key: 'created' },
+    ];
+    const dateInput = 'input[aria-label="Date search input"]';
+    const dateSubmitBtn = 'button[aria-label="Search submit button"]';
+
+    function mountSearch(onSearch) {
+      return mountWithContexts(
+        <Toolbar
+          id={`${QS_CONFIG.namespace}-list-toolbar`}
+          clearAllFilters={() => {}}
+          collapseListedFiltersBreakpoint="lg"
+        >
+          <ToolbarContent>
+            <Search
+              qsConfig={QS_CONFIG}
+              columns={dateColumns}
+              onSearch={onSearch}
+              onShowAdvancedSearch={jest.fn}
+            />
+          </ToolbarContent>
+        </Toolbar>
+      );
+    }
+
+    test('renders date input and operator select for a date column', () => {
+      search = mountSearch(jest.fn());
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Created' } }
+        );
+      });
+      search.update();
+      expect(search.find(dateInput)).toHaveLength(1);
+      expect(search.find(dateInput).prop('type')).toBe('date');
+      expect(
+        search.find('Select[aria-label="Date operator select"]')
+      ).toHaveLength(1);
+    });
+
+    test('searching submits the column key with the default operator', () => {
+      const onSearch = jest.fn();
+      search = mountSearch(onSearch);
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Created' } }
+        );
+      });
+      search.update();
+      search.find(dateInput).instance().value = '2026-06-01';
+      search.find(dateInput).simulate('change');
+      search.find(dateSubmitBtn).simulate('click');
+      expect(onSearch).toHaveBeenCalledTimes(1);
+      expect(onSearch).toHaveBeenCalledWith('created__gte', '2026-06-01');
+    });
+
+    test('switching the operator changes the submitted parameter', () => {
+      const onSearch = jest.fn();
+      search = mountSearch(onSearch);
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Created' } }
+        );
+      });
+      search.update();
+      act(() => {
+        search
+          .find('Select[aria-label="Date operator select"]')
+          .prop('onSelect')(null, 'Before');
+      });
+      search.update();
+      search.find(dateInput).instance().value = '2026-06-30';
+      search.find(dateInput).simulate('change');
+      search.find(dateSubmitBtn).simulate('click');
+      expect(onSearch).toHaveBeenCalledTimes(1);
+      expect(onSearch).toHaveBeenCalledWith('created__lt', '2026-06-30');
+    });
+
+    test('non-date columns keep the plain text input', () => {
+      search = mountSearch(jest.fn());
+      expect(search.find(dateInput)).toHaveLength(0);
+      expect(
+        search.find('input[aria-label="Search text input"]')
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/awx/ui/src/components/Search/Search.test.js
+++ b/awx/ui/src/components/Search/Search.test.js
@@ -481,6 +481,39 @@ describe('<Search />', () => {
       expect(onSearch).toHaveBeenCalledWith('created__gte', '2026-06-15');
     });
 
+    test('operator dropdown does not stay open across column switches', () => {
+      search = mountSearch(jest.fn());
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Created' } }
+        );
+      });
+      search.update();
+      act(() => {
+        search
+          .find('Select[aria-label="Date operator select"]')
+          .prop('onToggle')(true);
+      });
+      search.update();
+      expect(
+        search.find('Select[aria-label="Date operator select"]').prop('isOpen')
+      ).toBe(true);
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Name' } }
+        );
+      });
+      act(() => {
+        search.find('Select[aria-label="Simple key select"]').prop('onSelect')(
+          { target: { innerText: 'Created' } }
+        );
+      });
+      search.update();
+      expect(
+        search.find('Select[aria-label="Date operator select"]').prop('isOpen')
+      ).toBe(false);
+    });
+
     test('non-date columns keep the plain text input', () => {
       search = mountSearch(jest.fn());
       expect(search.find(dateInput)).toHaveLength(0);

--- a/awx/ui/src/components/Search/getChipsByKey.js
+++ b/awx/ui/src/components/Search/getChipsByKey.js
@@ -28,13 +28,22 @@ export default function getChipsByKey(queryParams, columns, qsConfig) {
 
   nonDefaultParams.forEach((key) => {
     const columnKey = key;
-    const label = columns.filter(
-      ({ key: keyToCheck }) => columnKey === keyToCheck
-    ).length
-      ? `${
-          columns.find(({ key: keyToCheck }) => columnKey === keyToCheck).name
-        } (${key})`
-      : columnKey;
+    let label = columnKey;
+    if (columns.some(({ key: keyToCheck }) => columnKey === keyToCheck)) {
+      label = `${
+        columns.find(({ key: keyToCheck }) => columnKey === keyToCheck).name
+      } (${key})`;
+    } else {
+      // date filters are submitted as <column>__gte / <column>__lt etc.;
+      // label them with the base column's name
+      const baseKey = columnKey.replace(/__(gte?|lte?)$/, '');
+      const baseColumn = columns.find(
+        ({ key: keyToCheck }) => baseKey === keyToCheck
+      );
+      if (baseColumn) {
+        label = `${baseColumn.name} (${key})`;
+      }
+    }
 
     queryParamsByKey[columnKey] = { key, label, chips: [] };
 

--- a/awx/ui/src/components/Search/getChipsByKey.test.js
+++ b/awx/ui/src/components/Search/getChipsByKey.test.js
@@ -95,4 +95,24 @@ describe('getChipsByKey', () => {
       },
     });
   });
+
+  test('should label date-operator params with the base column name', () => {
+    const columns = [
+      { name: 'Name', key: 'name__icontains', isDefault: true },
+      { name: 'Created', key: 'created' },
+    ];
+    const queryParams = { created__gte: '2026-06-01', created__lt: '2026-06-30' };
+    const config = {
+      namespace: 'item',
+      defaultParams: { page: 1, page_size: 5, order_by: 'name' },
+      integerFields: ['page', 'page_size'],
+      dateFields: ['modified', 'created'],
+    };
+    const chips = getChipsByKey(queryParams, columns, config);
+    expect(chips.created__gte.label).toBe('Created (created__gte)');
+    expect(chips.created__lt.label).toBe('Created (created__lt)');
+    expect(chips.created__gte.chips).toEqual([
+      { key: 'created__gte:2026-06-01', node: '2026-06-01' },
+    ]);
+  });
 });

--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -62,7 +62,8 @@ function ActivityStream() {
       page_size: 20,
       order_by: '-timestamp',
     },
-    ['id', 'page', 'page_size']
+    ['id', 'page', 'page_size'],
+    ['timestamp']
   );
 
   const {
@@ -245,6 +246,10 @@ function ActivityStream() {
               {
                 name: t`Initiated by (username)`,
                 key: 'actor__username__icontains',
+              },
+              {
+                name: t`Time`,
+                key: 'timestamp',
               },
             ]}
             toolbarSortColumns={[

--- a/awx/ui/src/util/qs.js
+++ b/awx/ui/src/util/qs.js
@@ -75,7 +75,10 @@ function parseValue(config, key, rawValue) {
   if (config.integerFields && config.integerFields.some((v) => v === key)) {
     return parseInt(rawValue, 10);
   }
-  // TODO: parse dateFields into date format?
+  // dateFields stay strings on purpose: filter values are submitted as
+  // ISO dates (e.g. created__gte=2026-06-01), which is exactly what the
+  // API expects - parsing into Date objects would only force formatting
+  // them back
   return decodeURIComponent(rawValue);
 }
 


### PR DESCRIPTION
## SUMMARY
`qsConfig` has accepted `dateFields` since the search system was built — every list's config defaults to `['modified', 'created']` — but the Search component never rendered date inputs (an explicit TODO at the fallback text input), so no list could offer date filtering.

**Search** now renders a date-specific control when the selected search column is one of the qsConfig `dateFields`:
- a native `type=date` input plus an operator select — **On or after** → `__gte`, **Before** → `__lt` (deliberately the two operators whose semantics are exact when a date-only value meets the API's datetime fields; `lte`/`gt` on a bare date are off-by-a-day traps)
- submit calls `onSearch` with the suffixed param (e.g. `created__gte=2026-06-01`); the existing leftover-chip handling displays and removes it, and `getChipsByKey` now labels such chips with the base column's name (`Created (created__gte)`) instead of the raw key

**First consumers:** the Jobs list gains **Created** and **Finished** search columns (`finished` added to its dateFields), and the Activity Stream gains a **Time** column on its `timestamp` field. Any other list opts in by adding a search column whose key is in its `dateFields`.

Closes the 'date filtering not wired up' entry from the UI known-gaps list.

## ISSUE TYPE
- New or Enhanced Feature

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev11+g51188f0
```

## ADDITIONAL INFORMATION
Tests: six new Search tests (date control renders for date columns only; default-operator submit; operator switch changes the param; stale-value leak regression; Enter-key submit; plain input preserved otherwise) and a getChipsByKey labeling test.
```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 545 suites, 2864 passed (incl. 7 new)
npm --prefix awx/ui run build    # succeeds
```
New UI strings follow the catalog convention (English fallback until the next routine extract). **Independent of all five open PRs — verified pairwise with `git merge-tree`.**
