### PR TITLE
Upgrade awxkit websockets extra to websocket-client 1.x

### DIFF
--- a/awxkit/awxkit/ws.py
+++ b/awxkit/awxkit/ws.py
@@ -105,7 +105,7 @@ class WSClient(object):
         self._add_received_time = add_received_time
 
     def connect(self):
-        wst = threading.Thread(target=self._ws_run_forever, args=(self.ws, {"cert_reqs": ssl.CERT_NONE}))
+        wst = threading.Thread(target=self._ws_run_forever, args=({"cert_reqs": ssl.CERT_NONE},))
         wst.daemon = True
         wst.start()
         atexit.register(self.close)
@@ -205,7 +205,7 @@ class WSClient(object):
         else:
             self._send(json.dumps(dict(groups={}, xrftoken=self.csrftoken)))
 
-    def _on_message(self, message):
+    def _on_message(self, ws, message):
         message = json.loads(message)
         log.debug('received message: {}'.format(message))
         if self._add_received_time:
@@ -230,17 +230,17 @@ class WSClient(object):
         self.subscribe(**subscription)
         self._should_subscribe_to_pending_job = False
 
-    def _on_open(self):
+    def _on_open(self, ws):
         self._ws_connected_flag.set()
 
-    def _on_error(self, error):
+    def _on_error(self, ws, error):
         log.info('Error received: {}'.format(error))
 
-    def _on_close(self):
+    def _on_close(self, ws, close_status_code, close_msg):
         log.info('Successfully closed ws.')
         self._ws_closed = True
 
-    def _ws_run_forever(self, sockopt=None, sslopt=None):
+    def _ws_run_forever(self, sslopt=None):
         self.ws.run_forever(sslopt=sslopt)
         log.debug('ws.run_forever finished')
 

--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -93,7 +93,7 @@ setup(
         'setuptools',
     ],
     python_requires=">=3.11",
-    extras_require={'formatting': ['jq'], 'websockets': ['websocket-client==0.57.0'], 'crypto': ['cryptography']},
+    extras_require={'formatting': ['jq'], 'websockets': ['websocket-client>=1.0.0'], 'crypto': ['cryptography']},
     license='Apache 2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/awxkit/test/test_ws.py
+++ b/awxkit/test/test_ws.py
@@ -39,3 +39,33 @@ def test_urlparsing(url, result):
         assert client.port == result.port
         assert client.hostname == result.hostname
         assert client._use_ssl == result.secure
+
+
+def test_callbacks_follow_websocket_client_1x_convention(caplog):
+    """websocket-client 1.x always invokes WebSocketApp callbacks with the app
+    as the first argument; these calls mirror exactly how run_forever fires
+    them and fail if the signatures regress to the 0.x style."""
+    client = WSClient("token", "hostname", 566, False)
+    app = client.ws
+
+    client._on_open(app)
+    assert client._ws_connected_flag.is_set()
+
+    client._on_message(app, '{"group_name": "jobs", "status": "successful"}')
+    assert client._recv(wait=True, timeout=1) == {"group_name": "jobs", "status": "successful"}
+
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="awxkit.ws"):
+        client._on_error(app, Exception("boom"))
+    assert "boom" in caplog.text
+
+    client._on_close(app, 1000, "normal closure")
+    assert client._ws_closed
+
+
+def test_unsubscribe_ack_sets_event():
+    client = WSClient("token", "hostname", 566, False)
+    client._on_message(client.ws, '{"groups_current": {}}')
+    assert client._pending_unsubscribe.is_set()
+


### PR DESCRIPTION
## SUMMARY
The awxkit `websockets` extra was pinned to websocket-client 0.57.0, a release from 2019 that has been end of life for years.

Just bumping the pin would not have worked. Starting with websocket-client 1.0, the library calls the WebSocketApp callbacks with the app object as the first argument. Our WSClient callbacks were still written in the old style, so under 1.x every callback raises a TypeError. The thread dies, the connection flag never gets set, and connect() fails with a misleading "Failed to establish channel connection w/ AWX" error.

This is not a theoretical problem. The AWX virtualenv already contains websocket-client 1.7.0, pulled in by the kubernetes package. So anyone using WSClient inside that environment today is running broken code. The same was true of awxkit's own tox environment, which installs websocket-client unpinned: the tests have been running against 1.x for a long time and nothing failed, because no test ever exercised the callbacks.

What this PR does:
- updates the four callback signatures to the 1.x convention (on_close now also receives the close status code and message)
- sets the extra to `websocket-client>=1.0.0`, so a constrained environment cannot resolve an old 0.x release against the new signatures
- adds tests that call the callbacks exactly the way run_forever does, so a future change in the calling convention fails loudly instead of silently
- removes a leftover: connect() was passing self.ws into a thread argument that was never used

How it was verified: the awxkit test suite passes (211 tests, including the new ones), and I ran a live session against a running AWX with websocket-client 1.7.0: connect, subscribe, receive the unsubscribe acknowledgement through _on_message, close cleanly.

One thing I found along the way and left alone: the server only accepts session cookie auth for websockets, so WSClient's token cookie option gets a 403 against current AWX no matter which client version is installed. That predates this change.

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- CLI

## ASCENDER VERSION
```
awx: 25.4.1.dev11+g51188f0
```

## ADDITIONAL INFORMATION
```
py.test awxkit/test/  # 211 passed (cli/ modules skipped, pre-existing metadata issue in the dev env)
```
Independent of the other open PRs, verified with git merge-tree.
