### PR TITLE
Replace the ContentLoading spinner with skeleton placeholder lines

### DIFF
--- a/awx/ui/src/components/ContentLoading/ContentLoading.js
+++ b/awx/ui/src/components/ContentLoading/ContentLoading.js
@@ -1,23 +1,37 @@
 import React from 'react';
 
 import styled from 'styled-components';
-import {
-  EmptyState as PFEmptyState,
-  EmptyStateIcon,
-  Spinner,
-} from '@patternfly/react-core';
+import { useLingui } from '@lingui/react/macro';
+import { EmptyState as PFEmptyState, Skeleton } from '@patternfly/react-core';
 
 const EmptyState = styled(PFEmptyState)`
   --pf-c-empty-state--m-lg--MaxWidth: none;
   min-height: 250px;
 `;
 
-// TODO: Better loading state - skeleton lines / spinner, etc.
-const ContentLoading = ({ className }) => (
-  <EmptyState variant="full" className={className}>
-    <EmptyStateIcon variant="container" component={Spinner} />
-  </EmptyState>
-);
+const SkeletonStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-global--spacer--md);
+  text-align: left;
+  width: 100%;
+`;
+
+const ContentLoading = ({ className }) => {
+  const { t } = useLingui();
+  return (
+    <EmptyState variant="full" className={className}>
+      {/* role/aria match the indeterminate spinner this replaces, so screen
+          readers (and tests) still see a loading indicator */}
+      <SkeletonStack role="progressbar" aria-label={t`Loading`}>
+        <Skeleton width="80%" fontSize="md" />
+        <Skeleton width="100%" fontSize="md" />
+        <Skeleton width="60%" fontSize="md" />
+        <Skeleton width="90%" fontSize="md" />
+      </SkeletonStack>
+    </EmptyState>
+  );
+};
 
 export { ContentLoading as _ContentLoading };
 export default ContentLoading;

--- a/awx/ui/src/components/ContentLoading/ContentLoading.js
+++ b/awx/ui/src/components/ContentLoading/ContentLoading.js
@@ -21,8 +21,8 @@ const ContentLoading = ({ className }) => {
   const { t } = useLingui();
   return (
     <EmptyState variant="full" className={className}>
-      {/* role/aria match the indeterminate spinner this replaces, so screen
-          readers (and tests) still see a loading indicator */}
+      {/* indeterminate progressbar: the same accessible contract as the
+          spinner this replaces */}
       <SkeletonStack role="progressbar" aria-label={t`Loading`}>
         <Skeleton width="80%" fontSize="md" />
         <Skeleton width="100%" fontSize="md" />

--- a/awx/ui/src/components/ContentLoading/ContentLoading.test.js
+++ b/awx/ui/src/components/ContentLoading/ContentLoading.test.js
@@ -13,9 +13,8 @@ describe('ContentLoading', () => {
   });
 
   test('renders skeleton placeholder lines', () => {
-    const { container } = renderWithContexts(<ContentLoading />);
-    expect(
-      container.querySelectorAll('.pf-c-skeleton').length
-    ).toBeGreaterThan(0);
+    renderWithContexts(<ContentLoading />);
+    const indicator = screen.getByRole('progressbar', { name: 'Loading' });
+    expect(indicator.children).toHaveLength(4);
   });
 });

--- a/awx/ui/src/components/ContentLoading/ContentLoading.test.js
+++ b/awx/ui/src/components/ContentLoading/ContentLoading.test.js
@@ -5,8 +5,17 @@ import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ContentLoading from './ContentLoading';
 
 describe('ContentLoading', () => {
-  test('renders the expected content', () => {
+  test('renders an accessible loading indicator', () => {
     renderWithContexts(<ContentLoading />);
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(
+      screen.getByRole('progressbar', { name: 'Loading' })
+    ).toBeInTheDocument();
+  });
+
+  test('renders skeleton placeholder lines', () => {
+    const { container } = renderWithContexts(<ContentLoading />);
+    expect(
+      container.querySelectorAll('.pf-c-skeleton').length
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## SUMMARY

Resolves the long-standing `// TODO: Better loading state - skeleton lines / spinner, etc.` in `ContentLoading`: the centered spinner becomes PatternFly `Skeleton` lines, so the page layout appears immediately and content fills in instead of popping in after a blank box. `ContentLoading` is the loading state for **every list, detail and form screen** (175 importing files), which makes this a one-component change with an app-wide perceived-performance effect.

Deliberate choices to keep it a two-file diff:

- The skeleton stack keeps **`role="progressbar"` + `aria-label="Loading"`** — the same accessible contract as the indeterminate spinner it replaces. Screen readers still announce a loading indicator, and every existing test that waits on the loading state (e.g. the `waitForElementToBeRemoved(progressbar)` calls in the ConstructedInventoryDetail suite) keeps passing untouched.
- The aria-label reuses the **already-translated `Loading` msgid** present in all locale catalogs, so no `.po` extraction is needed — relevant while the catalog rework on the `language-updates` branch is in flight.
- Component API is unchanged (`className` passthrough, same `_ContentLoading` named export); none of the 175 consumers need edits.
- The test asserts the placeholder lines through the progressbar's children rather than PatternFly class names, so it survives the `pf-c-*` class renames in later PatternFly versions.

Fully independent of every open PR — neither touched file appears in any of their diffs.

## ISSUE TYPE

- New or Enhanced Feature

## COMPONENT NAME

- UI

## ASCENDER VERSION

```
awx: 25.4.1.dev17+g3946cc5.d20260613
```

## ADDITIONAL INFORMATION

```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # 546 suites passed (1 skipped), 2879 tests passed (19 skipped), run twice
```
Note: the run reports `1 snapshot file obsolete` — that's the orphaned `enzymeHelpers.test.jsx.snap` already present on main; the in-flight enzyme-to-RTL conversion work removes it.
