### PR TITLE
Convert the Application route tree from react-router v5 Switch to v6 Routes

### DIFF
--- a/awx/ui/src/screens/Application/Application/Application.js
+++ b/awx/ui/src/screens/Application/Application/Application.js
@@ -136,8 +136,10 @@ function Application({ setBreadcrumb }) {
                   />
                 }
               />
+              {/* /* so token detail URLs (tokens/:tokenId/details) still
+                  resolve to the list, matching the old non-exact v5 route */}
               <Route
-                path="tokens"
+                path="tokens/*"
                 element={<ApplicationTokens application={application} />}
               />
             </>

--- a/awx/ui/src/screens/Application/Application/Application.js
+++ b/awx/ui/src/screens/Application/Application/Application.js
@@ -112,7 +112,7 @@ function Application({ setBreadcrumb }) {
         <Routes>
           <Route
             index
-            element={<Navigate to={`/applications/${id}/details`} replace />}
+            element={<Navigate to="details" replace />}
           />
           {application && (
             <>

--- a/awx/ui/src/screens/Application/Application/Application.js
+++ b/awx/ui/src/screens/Application/Application/Application.js
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import {
+  Routes,
   Route,
-  Switch,
-  Redirect,
+  Navigate,
   useParams,
   useLocation,
-  Link,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
@@ -109,34 +109,40 @@ function Application({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {cardHeader}
-        <Switch>
-          <Redirect
-            from="/applications/:id"
-            to="/applications/:id/details"
-            exact
+        <Routes>
+          <Route
+            index
+            element={<Navigate to={`/applications/${id}/details`} replace />}
           />
           {application && (
             <>
-              <Route path="/applications/:id/edit">
-                <ApplicationEdit
-                  authorizationOptions={authorizationOptions}
-                  clientTypeOptions={clientTypeOptions}
-                  application={application}
-                />
-              </Route>
-              <Route path="/applications/:id/details">
-                <ApplicationDetails
-                  application={application}
-                  authorizationOptions={authorizationOptions}
-                  clientTypeOptions={clientTypeOptions}
-                />
-              </Route>
-              <Route path="/applications/:id/tokens">
-                <ApplicationTokens application={application} />
-              </Route>
+              <Route
+                path="edit"
+                element={
+                  <ApplicationEdit
+                    authorizationOptions={authorizationOptions}
+                    clientTypeOptions={clientTypeOptions}
+                    application={application}
+                  />
+                }
+              />
+              <Route
+                path="details"
+                element={
+                  <ApplicationDetails
+                    application={application}
+                    authorizationOptions={authorizationOptions}
+                    clientTypeOptions={clientTypeOptions}
+                  />
+                }
+              />
+              <Route
+                path="tokens"
+                element={<ApplicationTokens application={application} />}
+              />
             </>
           )}
-        </Switch>
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Application/Application/Application.test.js
+++ b/awx/ui/src/screens/Application/Application/Application.test.js
@@ -1,20 +1,36 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { ApplicationsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import Application from './Application';
 
 jest.mock('../../../api/models/Applications');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  history: () => ({
-    location: '/applications',
-  }),
-  useParams: () => ({ id: 1 }),
-}));
+
+// Markers for the routed tab panels, so assertions are about which branch of
+// the nested v6 <Routes> tree resolves.
+jest.mock('../ApplicationDetails', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ApplicationDetails'),
+  };
+});
+jest.mock('../ApplicationEdit', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ApplicationEdit'),
+  };
+});
+jest.mock('../ApplicationTokens', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ApplicationTokens'),
+  };
+});
 
 const options = {
   data: {
@@ -46,41 +62,66 @@ const application = {
   url: '',
   organization: 10,
 };
+
+// Application uses paths relative to its parent route, so mount it under the
+// same /applications/:id/* route that Applications.js gives it in the app.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/applications/:id/*"
+        element={<Application setBreadcrumb={() => {}} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
 describe('<Application />', () => {
-  let wrapper;
-  test('mounts properly', async () => {
+  beforeEach(() => {
     ApplicationsAPI.readOptions.mockResolvedValue(options);
-    ApplicationsAPI.readDetail.mockResolvedValue(application);
-    await act(async () => {
-      wrapper = mountWithContexts(<Application setBreadcrumb={() => {}} />);
-    });
-    expect(wrapper.find('Application').length).toBe(1);
-    expect(ApplicationsAPI.readOptions).toHaveBeenCalled();
-    expect(ApplicationsAPI.readDetail).toHaveBeenCalledWith(1);
+    ApplicationsAPI.readDetail.mockResolvedValue({ data: application });
   });
-  test('should throw error', async () => {
-    ApplicationsAPI.readOptions.mockResolvedValue(options);
-    ApplicationsAPI.readDetail.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'get',
-            url: '/api/v2/applications/1',
-          },
-          data: 'An error occurred',
-          status: 404,
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<Application setBreadcrumb={() => {}} />);
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length > 0);
-    expect(wrapper.find('ContentError').length).toBe(1);
-    expect(wrapper.find('ApplicationAdd').length).toBe(0);
-    expect(wrapper.find('ApplicationDetails').length).toBe(0);
-    expect(wrapper.find('Application').length).toBe(1);
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches the application detail and options', async () => {
+    renderAt('/applications/1/details');
+    expect(await screen.findByText('ApplicationDetails')).toBeInTheDocument();
     expect(ApplicationsAPI.readOptions).toHaveBeenCalled();
-    expect(ApplicationsAPI.readDetail).toHaveBeenCalledWith(1);
+    // real route params are strings (the old enzyme test mocked a number)
+    expect(ApplicationsAPI.readDetail).toHaveBeenCalledWith('1');
+  });
+
+  test('renders the edit panel at /edit', async () => {
+    renderAt('/applications/1/edit');
+    expect(await screen.findByText('ApplicationEdit')).toBeInTheDocument();
+  });
+
+  test('renders the tokens panel at /tokens', async () => {
+    renderAt('/applications/1/tokens');
+    expect(await screen.findByText('ApplicationTokens')).toBeInTheDocument();
+  });
+
+  test('redirects the index path to details', async () => {
+    const { history } = renderAt('/applications/1');
+    expect(await screen.findByText('ApplicationDetails')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/applications/1/details')
+    );
+  });
+
+  test('shows a not-found error when the detail request 404s', async () => {
+    const err = new Error('not found');
+    err.response = { status: 404 };
+    ApplicationsAPI.readDetail.mockRejectedValue(err);
+    renderAt('/applications/1/details');
+    expect(
+      await screen.findByText('Application not found.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('ApplicationDetails')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.js
+++ b/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 
 import { Card } from '@patternfly/react-core';
 import { ApplicationsAPI } from 'api';

--- a/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.test.js
+++ b/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.test.js
@@ -10,11 +10,11 @@ import ApplicationEdit from './ApplicationEdit';
 jest.mock('../../../api/models/Applications');
 jest.mock('../../../api/models/Organizations');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  history: () => ({
-    location: '/applications/1/edit',
-  }),
+// The component reads useParams from react-router-dom-v5-compat (the route
+// tree is v6); mock it there, keeping useNavigate real so the cancel/submit
+// navigation assertions still exercise history.
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({ id: 1 }),
 }));
 

--- a/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.js
+++ b/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom-v5-compat';
 import PaginatedTable, { getSearchableKeys } from 'components/PaginatedTable';
 import { getQSConfig, parseQueryString } from 'util/qs';
 import { TokensAPI, ApplicationsAPI } from 'api';

--- a/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.test.js
+++ b/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import { ApplicationsAPI, TokensAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
@@ -99,6 +101,31 @@ describe('<ApplicationTokenList/>', () => {
     });
     wrapper.update();
     expect(wrapper.find('ApplicationTokenList')).toHaveLength(1);
+  });
+
+  // Regression: the application id must come from the v6 route params. When the
+  // route tree moved to v6 <Routes>, reading useParams from plain react-router-dom
+  // returned {} and tokens were fetched for /applications/undefined/tokens.
+  test('fetches tokens for the application id from the v6 route params', async () => {
+    ApplicationsAPI.readTokens.mockResolvedValue(tokens);
+    const history = createMemoryHistory({
+      initialEntries: ['/applications/5/tokens'],
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route
+            path="/applications/:id/tokens/*"
+            element={<ApplicationTokenList />}
+          />
+        </Routes>,
+        { context: { router: { history } } }
+      );
+    });
+    expect(ApplicationsAPI.readTokens).toHaveBeenCalledWith(
+      '5',
+      expect.any(Object)
+    );
   });
 
   test('should have data fetched and render 2 rows', async () => {

--- a/awx/ui/src/screens/Application/Applications.js
+++ b/awx/ui/src/screens/Application/Applications.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import styled from 'styled-components';
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import {
   Alert,
@@ -50,21 +50,29 @@ function Applications() {
         streamType="o_auth2_application,o_auth2_access_token"
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path="/applications/add">
-          <ApplicationAdd
-            onSuccessfulAdd={(app) => setApplicationModalSource(app)}
-          />
-        </Route>
-        <Route path="/applications/:id">
-          <Application setBreadcrumb={buildBreadcrumbConfig} />
-        </Route>
-        <Route path="/applications">
-          <PersistentFilters pageKey="applications">
-            <ApplicationsList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route
+          path="/applications/add"
+          element={
+            <ApplicationAdd
+              onSuccessfulAdd={(app) => setApplicationModalSource(app)}
+            />
+          }
+        />
+        {/* /* so the nested <Application> route tree can match the rest */}
+        <Route
+          path="/applications/:id/*"
+          element={<Application setBreadcrumb={buildBreadcrumbConfig} />}
+        />
+        <Route
+          path="/applications"
+          element={
+            <PersistentFilters pageKey="applications">
+              <ApplicationsList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
       {applicationModalSource && (
         <Modal
           aria-label={t`Application information`}

--- a/awx/ui/src/screens/Application/Applications.test.js
+++ b/awx/ui/src/screens/Application/Applications.test.js
@@ -1,49 +1,92 @@
 import React from 'react';
+import { screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import Applications from './Applications';
 
 jest.mock('../../api/models/Applications');
 jest.mock('../../api/models/Organizations');
 
-describe('<Applications />', () => {
-  let wrapper;
+// Replace the routed children with markers so the assertions are purely about
+// which branch of the v6 <Routes> tree resolves for a given URL.
+jest.mock('./ApplicationsList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ApplicationsList'),
+  };
+});
+jest.mock('./ApplicationAdd', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: ({ onSuccessfulAdd }) =>
+      ReactLib.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () =>
+            onSuccessfulAdd({
+              name: 'test',
+              client_id: 'foobar',
+              client_secret: 'aaaaaaaaaaaaaaaaaaaaaaaaaa',
+            }),
+        },
+        'simulate successful add'
+      ),
+  };
+});
+jest.mock('./Application', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'Application detail'),
+  };
+});
 
-  test('renders successfully', () => {
-    wrapper = mountWithContexts(<Applications />);
-    const pageSections = wrapper.find('PageSection');
-    expect(wrapper.length).toBe(1);
-    expect(pageSections.length).toBe(1);
-    expect(pageSections.first().props().variant).toBe('light');
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<Applications />, {
+    context: { router: { history } },
+  });
+}
+
+describe('<Applications />', () => {
+  test('renders the list at /applications', async () => {
+    renderAt('/applications');
+    expect(await screen.findByText('ApplicationsList')).toBeInTheDocument();
   });
 
-  test('shows Application information modal after successful creation', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/applications/add'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<Applications />, {
-        context: { router: { history } },
-      });
-    });
-    
-    expect(wrapper.find('Modal[title="Application information"]').length).toBe(
-      0
+  test('renders the add form at /applications/add', async () => {
+    renderAt('/applications/add');
+    expect(
+      await screen.findByRole('button', { name: 'simulate successful add' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('ApplicationsList')).not.toBeInTheDocument();
+  });
+
+  test('renders the detail subtree at /applications/:id', async () => {
+    renderAt('/applications/5/details');
+    expect(await screen.findByText('Application detail')).toBeInTheDocument();
+    expect(screen.queryByText('ApplicationsList')).not.toBeInTheDocument();
+  });
+
+  test('shows the information modal after a successful creation', async () => {
+    const { user } = renderAt('/applications/add');
+    expect(
+      screen.queryByRole('dialog', { name: /Application information/ })
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'simulate successful add' })
     );
-    
-    await act(async () => {
-      wrapper.find('ApplicationAdd').props().onSuccessfulAdd({
-        name: 'test',
-        client_id: 'foobar',
-        client_secret: 'aaaaaaaaaaaaaaaaaaaaaaaaaa',
-      });
+
+    const dialog = await screen.findByRole('dialog', {
+      name: /Application information/,
     });
-    
-    wrapper.update();
-    expect(wrapper.find('Modal[title="Application information"]').length).toBe(
-      1
-    );
+    // the name renders as a plain Detail value (client_id/secret sit inside
+    // collapsed ClipboardCopy expansions, so they are not queried here)
+    expect(within(dialog).getByText('test')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationsList/ApplicationsList.js
+++ b/awx/ui/src/screens/Application/ApplicationsList/ApplicationsList.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Card, PageSection } from '@patternfly/react-core';
 import { getQSConfig, parseQueryString } from 'util/qs';
 import useRequest, { useDeleteItems } from 'hooks/useRequest';
@@ -26,7 +26,8 @@ const QS_CONFIG = getQSConfig('applications', {
 function ApplicationsList() {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch();
+  // this list always renders at /applications (see Applications.js routes)
+  const listUrl = '/applications';
 
   const {
     isLoading,
@@ -134,7 +135,7 @@ function ApplicationsList() {
                     ? [
                         <ToolbarAddButton
                           key="add"
-                          linkTo={`${match.url}/add`}
+                          linkTo={`${listUrl}/add`}
                         />,
                       ]
                     : []),
@@ -162,7 +163,7 @@ function ApplicationsList() {
                 key={application.id}
                 value={application.name}
                 application={application}
-                detailUrl={`${match.url}/${application.id}/details`}
+                detailUrl={`${listUrl}/${application.id}/details`}
                 onSelect={() => handleSelect(application)}
                 isSelected={selected.some((row) => row.id === application.id)}
                 rowIndex={index}
@@ -170,7 +171,7 @@ function ApplicationsList() {
             )}
             emptyStateControls={
               canAdd && (
-                <ToolbarAddButton key="add" linkTo={`${match.url}/add`} />
+                <ToolbarAddButton key="add" linkTo={`${listUrl}/add`} />
               )
             }
           />

--- a/awx/ui/src/screens/Application/shared/ApplicationForm.js
+++ b/awx/ui/src/screens/Application/shared/ApplicationForm.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { useLingui } from '@lingui/react/macro';
 import { Formik, useField, useFormikContext } from 'formik';
@@ -22,7 +22,7 @@ function ApplicationFormFields({
 }) {
   const { t } = useLingui();
   const applicationHelpTextStrings = getApplicationHelpTextStrings(t);
-  const match = useRouteMatch();
+  const { pathname } = useLocation();
   const { setFieldValue, setFieldTouched } = useFormikContext();
   const [organizationField, organizationMeta, organizationHelpers] =
     useField('organization');
@@ -95,7 +95,7 @@ function ApplicationFormFields({
           isValid={
             !authorizationTypeMeta.touched || !authorizationTypeMeta.error
           }
-          isDisabled={match.url.endsWith('edit')}
+          isDisabled={pathname.endsWith('edit')}
           id="authType"
           data={[{ label: '', key: 1, value: '' }, ...authorizationOptions]}
           onChange={(event, value) => {


### PR DESCRIPTION
## SUMMARY

First of the route-tree conversions, now that the v6-compat bridge has merged. Converts the **Application** screen's two route-tree files from v5 `<Switch>` to v6 `<Routes>`, establishing the pattern for the remaining route trees.

`Applications.js` (list / add / detail):
- `<Switch>` → `<Routes>`, `<Route path><Child/></Route>` → `<Route path element={<Child/>} />`.
- Uses **absolute** paths: this screen still mounts under App.js's v5 `ProtectedRoute`, so there is no v6 parent route to resolve relative paths against. The `/applications/:id` route gains a `/*` so the nested `Application` route tree can match the rest of the path.

`Application/Application.js` (detail tabs):
- `<Switch>` → `<Routes>`, `<Redirect from=":id" to=":id/details" exact />` → an `index` route rendering `<Navigate replace />`.
- Uses paths **relative** to the `/applications/:id/*` parent established above (`details`, `edit`, `tokens`).

Also clears the screen's remaining v5 `useRouteMatch` (the remaining "prefix-match" usage): `ApplicationsList` built links from `match.url` and `ApplicationForm` checked `match.url.endsWith('edit')`. The list always renders at `/applications` so it builds from that literal; the form reads `useLocation().pathname`. The Application screen now uses no v5 router APIs.

### Why this is safe and isolated

The compat package still exports v5 `Switch` for the remaining unconverted route trees, so v5 and v6 trees coexist under the single mounted compat router. Nothing outside the Application screen changes. The final `react-router-dom` → v6 flip and removal of `react-router-dom-v5-compat` stay for the **end** of the migration, once every `<Switch>` is gone.

### Verification

Both suites are rewritten from Enzyme to RTL and now assert **real route resolution** through the compat router (`renderWithContexts` mounts it, the same way the app does):

- `/applications` renders the list, `/applications/add` the add form, `/applications/:id/...` the nested detail subtree.
- The nested tabs resolve under a `/applications/:id/*` parent route (mounted in the test exactly as `Applications.js` wires it in the app): `details`, `edit`, `tokens`, and the bare `/applications/:id` index path redirecting to `details`.
- A 404 on the detail fetch surfaces the not-found error instead of a tab panel.

One assertion changed meaning for the better: route params are real strings now (`'1'`), where the old test mocked `useParams` to return the number `1`.

## ISSUE TYPE

- New or Enhanced Feature

## COMPONENT NAME

- UI

## ASCENDER VERSION

```
awx: 25.4.1.dev21+g761ea17.d20260613
```

## ADDITIONAL INFORMATION

```
npm --prefix awx/ui run lint     # clean
npm --prefix awx/ui run test     # full suite green
```

