### PR TITLE
Upgrade pip to resolve CVE-2026-8643

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==26.1 setuptools==80.9.0 setuptools_scm[toml]==9.2.2 wheel==0.46.2
+VENV_BOOTSTRAP ?= pip==26.1.2 setuptools==80.9.0 setuptools_scm[toml]==9.2.2 wheel==0.46.2
 
 NAME ?= awx
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -66,7 +66,7 @@ uWSGI>=2.0.22 # CVE-2023-27522
 uwsgitop
 valkey[libvalkey]
 wheel>=0.46.2  # CVE-2026-24049
-pip==26.1  # see CVE-2026-3219
+pip==26.1.2  # see CVE-2026-8643
 setuptools==80.9.0  # CVE-2025-47273
 setuptools-scm[toml]  # see UPGRADE BLOCKERs, xmlsec build dep
 setuptools-rust>=0.11.4  # cryptography build dep

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -511,7 +511,7 @@ zope-interface==7.0.3
     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1
+pip==26.1.2
     # via -r /awx_devel/requirements/requirements.in
 setuptools==80.9.0
     # via

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -23,7 +23,7 @@ generate_requirements() {
   source "${venv}/bin/activate"
 
   # pip / setuptools version must match the version used in AWX venv (see README.md UPGRADE BLOCKERs)
-  "${venv}/bin/python3" -m pip install -U 'pip==26.1' 'setuptools==80.9.0' pip-tools
+  "${venv}/bin/python3" -m pip install -U 'pip==26.1.2' 'setuptools==80.9.0' pip-tools
 
   ${pip_compile} ${input_reqs} --output-file requirements.txt
   # consider the git requirements for purposes of resolving deps


### PR DESCRIPTION
## SUMMARY

`pip` is pinned at 26.1, which is affected by **CVE-2026-8643** (PYSEC-2026-196), fixed in **26.1.2**. The pin was originally added to resolve an earlier pip advisory (CVE-2026-3219); this bumps it to pick up the newer fix while keeping that one.

Changes, mirroring the existing pip-pin pattern (PR #321):
- `requirements/requirements.in`: `pip==26.1  # see CVE-2026-3219` → `pip==26.1.2  # see CVE-2026-8643`
- `requirements/updater.sh`: compile-venv bootstrap `pip==26.1` → `pip==26.1.2`
- `Makefile`: `VENV_BOOTSTRAP` `pip==26.1` → `pip==26.1.2`
- `requirements/requirements.txt`: regenerated with `requirements/updater.sh run` — **the only package-level change is `pip==26.1` → `pip==26.1.2`**

Found via `pip-audit` against `requirements.txt`; it was the only vulnerability reported in the Python production requirements (dev requirements and the shipped UI bundle audit clean).

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

- API

## ASCENDER VERSION

```
awx: 25.4.1.dev21+g761ea17.d20260613
```

## ADDITIONAL INFORMATION

`requirements.txt` regenerated inside the awx container per the documented process.

```
# inside tools_awx_1
py.test awx/main/tests/functional/test_licenses.py   # 1 passed
pip-audit -r requirements/requirements.txt           # pip 26.1 was the only finding; resolved by 26.1.2
```
