### PR TITLE
Search credentials by type over REST in CredentialLookup

### DIFF
--- a/awx/ui/src/components/Lookup/CredentialLookup.js
+++ b/awx/ui/src/components/Lookup/CredentialLookup.js
@@ -85,9 +85,13 @@ function CredentialLookup({
       }
 
       const searchKeys = getSearchableKeys(actionsResponse.data.actions?.GET);
-      const item = searchKeys.find((k) => k.key === 'type');
-      if (item) {
-        item.key = 'credential_type__kind';
+      // Expose the credential_type__kind filter (coarse enum: ssh, cloud, …)
+      // as a searchable key, mirroring CredentialList. Searching by the actual
+      // credential type name is handled by the credential_type__search column
+      // below, which queries the credential types over REST rather than the
+      // hardcoded kind enum.
+      if (actionsResponse.data.actions?.GET.type) {
+        searchKeys.push({ key: 'credential_type__kind', type: 'string' });
       }
 
       return {
@@ -152,8 +156,6 @@ function CredentialLookup({
     fetchCredentials();
   }, [fetchCredentials]);
 
-  // TODO: replace credential type search with REST-based grabbing of cred types
-
   return (
     <FormGroup
       fieldId="credential"
@@ -198,6 +200,10 @@ function CredentialLookup({
               {
                 name: t`Modified By (Username)`,
                 key: 'modified_by__username__icontains',
+              },
+              {
+                name: t`Credential Type`,
+                key: 'credential_type__search',
               },
             ]}
             sortColumns={[

--- a/awx/ui/src/components/Lookup/CredentialLookup.test.js
+++ b/awx/ui/src/components/Lookup/CredentialLookup.test.js
@@ -23,6 +23,17 @@ describe('CredentialLookup', () => {
         count: 5,
       },
     });
+    CredentialsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            name: { type: 'string', filterable: true },
+            type: { type: 'choice', filterable: true },
+          },
+        },
+        related_search_fields: ['credential_type__search'],
+      },
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## SUMMARY

The credential-type search inside `CredentialLookup` (the "pick a credential" modal used across job templates, the launch prompt, inventory sources, projects, notification templates, etc.) silently returned wrong results when filtering by credential type.

The lookup took the OPTIONS `type` searchable field and **remapped its key to `credential_type__kind`**:

```js
const item = searchKeys.find((k) => k.key === 'type');
if (item) {
  item.key = 'credential_type__kind';
}
```

`credential_type__kind` filters by the coarse, hardcoded kind enum (`ssh`, `cloud`, `scm`, `vault`, `net`, …) — not the actual credential type. So a user searching for a type by name (e.g. "Amazon Web Services", "GitHub Personal Access Token") got no/incorrect matches, and **custom credential types** — which mostly fall under `kind: cloud` — were unreachable by the filter. No error surfaced; the results were just wrong, and the failure got worse the more (custom) types an instance had.

## FIX

Mirror the proven pattern already used by `CredentialList`:

- Add a **"Credential Type"** search column keyed on **`credential_type__search`** — a REST related-field search that matches against the real credential type records (name/description), including custom types, instead of the kind enum.
- Keep the `credential_type__kind` enum filter available as a searchable key (pushed when the OPTIONS `type` action is present), rather than destructively remapping the `type` key.

This resolves the long-standing `// TODO: replace credential type search with REST-based grabbing of cred types`.

The `credentialTypeId` / `credentialTypeKind` / `credentialTypeNamespace` props (the programmatic pre-filters callers pass) are unchanged.

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

- UI

## ASCENDER VERSION

```
awx: 25.4.1.dev21+g761ea17.d20260613
```

## ADDITIONAL INFORMATION

```
npm --prefix awx/ui run lint    # clean
npm --prefix awx/ui run test    # full suite green
```
The CredentialLookup test now mocks `readOptions` so the search-key path is actually exercised (it previously threw and was swallowed by `useRequest`).
