### PR TITLE
Fix canceled-status typo in live websocket hooks

### DIFF
--- a/awx/ui/src/screens/Inventory/shared/useWsInventorySourcesDetails.js
+++ b/awx/ui/src/screens/Inventory/shared/useWsInventorySourcesDetails.js
@@ -24,7 +24,7 @@ export default function useWsInventorySourcesDetails(initialSource) {
       }
 
       if (
-        ['successful', 'failed', 'error', 'cancelled'].includes(
+        ['successful', 'failed', 'error', 'canceled'].includes(
           lastMessage.status
         )
       ) {

--- a/awx/ui/src/screens/Job/WorkflowOutput/useWsWorkflowOutput.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/useWsWorkflowOutput.js
@@ -53,7 +53,7 @@ export default function useWsWorkflowOutput(workflowJobId, initialNodes) {
 
       if (
         lastMessage?.unified_job_id === workflowJobId &&
-        ['successful', 'failed', 'error', 'cancelled'].includes(
+        ['successful', 'failed', 'error', 'canceled'].includes(
           lastMessage.status
         )
       ) {


### PR DESCRIPTION
##### SUMMARY

Two live-view websocket hooks gate their "job finished, re-fetch everything" path on the terminal status `'cancelled'` (British spelling), but Ascender/AWX emits `'canceled'` (one L). Because the spelling never matches, the full re-fetch is skipped specifically on cancel:

- `screens/Job/WorkflowOutput/useWsWorkflowOutput.js` — when a workflow is canceled while its Output graph is open, `refreshNodeObjects()` never runs. Per-node updates that arrived during the run still show, but nodes that were marked do-not-run by the cancellation (or whose final summary fields changed) keep showing stale state until the page is reloaded.
- `screens/Inventory/shared/useWsInventorySourcesDetails.js` — same pattern for the inventory-source detail view on cancel.

`'successful' / 'failed' / 'error'` are unaffected because those spellings match. The fix is a one-word change in each hook to the correct `'canceled'` spelling. The rest of the UI already uses `'canceled'` (one L) consistently (22 occurrences vs. these 2 typos).

This is backend-data-safe — it only affects whether the live view re-syncs to the already-correct backend state on cancel.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ASCENDER VERSION

```
awx: 25.4.1.dev51+g2c31d76.d20260613
```

##### ADDITIONAL INFORMATION

Reproduction:
1. Open a workflow job's Output tab (or an inventory source's detail) while it is running.
2. Cancel it.
3. Observe the graph/detail does not fully settle to its final canceled state; reloading the page shows the correct final state.

After the fix, the cancel case triggers the same full re-fetch as successful/failed/error, so the view settles without a manual reload.
