### PR TITLE
Fix busy-poll when waiting on an in-progress project update

### DIFF
--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -192,8 +192,6 @@ EXAMPLES = '''
     state: present
 '''
 
-import time
-
 from ..module_utils.controller_api import ControllerAPIModule
 
 
@@ -208,16 +206,23 @@ def wait_for_project_update(module, last_request):
     scm_revision_original = last_request['scm_revision']
 
     if 'current_update' in last_request['summary_fields']:
-        running = True
-        while running:
-            result = module.get_endpoint('/project_updates/{0}/'.format(last_request['summary_fields']['current_update']['id']))['json']
+        # A project update is already in progress (e.g. the automatic update that
+        # fires when a project is first created). Wait on it through the same
+        # interval/timeout-aware helper used by the explicit-update path below,
+        # rather than polling in a tight loop with no delay (see ansible/awx#12850).
+        if wait:
+            result_final = module.wait_on_url(
+                url='/project_updates/{0}/'.format(last_request['summary_fields']['current_update']['id']),
+                object_name=module.get_item_name(last_request),
+                object_type='Project Update',
+                timeout=timeout,
+                interval=interval,
+            )
 
-            if module.is_job_done(result['status']):
-                time.sleep(1)
-                running = False
-
-        if result['status'] != 'successful':
-            module.fail_json(msg="Project update failed")
+            # Set Changed to correct value depending on if hash changed
+            module.json_output['changed'] = True
+            if result_final['json']['scm_revision'] == scm_revision_original:
+                module.json_output['changed'] = False
     elif update_project:
         result = module.post_endpoint(last_request['related']['update'])
 

--- a/awx_collection/test/awx/test_project.py
+++ b/awx_collection/test/awx/test_project.py
@@ -66,3 +66,67 @@ def test_create_project_copy_from(run_module, admin_user, organization, silence_
         admin_user,
     )
     silence_warning.assert_called_with("A project with the name {0} already exists.".format(proj_name))
+
+
+def test_existing_update_is_waited_on_with_interval(collection_import, mocker):
+    """A project that already has an update in progress (e.g. the automatic
+    update on create) must be waited on through wait_on_url so that interval and
+    timeout are honored, instead of polling the update endpoint in a tight loop
+    with no delay. Regression test for the busy-poll in ansible/awx#12850.
+    """
+    project = collection_import('plugins.modules.project')
+
+    module = mocker.Mock()
+    module.params = {'update_project': False, 'wait': True, 'timeout': 30, 'interval': 5}
+    module.json_output = {}
+    module.get_item_name.return_value = 'foo'
+    module.wait_on_url.return_value = {'json': {'scm_revision': 'newrev'}}
+
+    last_request = {'scm_revision': 'oldrev', 'summary_fields': {'current_update': {'id': 42}}}
+
+    project.wait_for_project_update(module, last_request)
+
+    module.wait_on_url.assert_called_once_with(
+        url='/project_updates/42/',
+        object_name='foo',
+        object_type='Project Update',
+        timeout=30,
+        interval=5,
+    )
+    # The fix must not fall back to busy-polling the update endpoint
+    module.get_endpoint.assert_not_called()
+    # The SCM revision moved, so the task is reported as changed
+    assert module.json_output['changed'] is True
+
+
+def test_existing_update_unchanged_revision_is_not_changed(collection_import, mocker):
+    """If the in-progress update does not move the SCM revision, report not changed."""
+    project = collection_import('plugins.modules.project')
+
+    module = mocker.Mock()
+    module.params = {'update_project': False, 'wait': True, 'timeout': 30, 'interval': 2}
+    module.json_output = {}
+    module.get_item_name.return_value = 'foo'
+    module.wait_on_url.return_value = {'json': {'scm_revision': 'samerev'}}
+
+    last_request = {'scm_revision': 'samerev', 'summary_fields': {'current_update': {'id': 7}}}
+
+    project.wait_for_project_update(module, last_request)
+
+    assert module.json_output['changed'] is False
+
+
+def test_existing_update_not_waited_on_when_wait_false(collection_import, mocker):
+    """With wait=False the module must not block on an in-progress update."""
+    project = collection_import('plugins.modules.project')
+
+    module = mocker.Mock()
+    module.params = {'update_project': False, 'wait': False, 'timeout': 30, 'interval': 2}
+    module.json_output = {}
+
+    last_request = {'scm_revision': 'oldrev', 'summary_fields': {'current_update': {'id': 1}}}
+
+    project.wait_for_project_update(module, last_request)
+
+    module.wait_on_url.assert_not_called()
+    module.get_endpoint.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

`wait_for_project_update()` in `awx.awx.project` busy-polled an in-progress project update.

When a project already has an update running — most commonly the automatic update that fires right after an SCM project is created — the `current_update` branch looped over `GET /project_updates/<id>/` with **no delay between requests** until the update finished. The `time.sleep(1)` was placed *inside* the `is_job_done()` check, so it only ever ran once the job was already done. The same branch also ignored the module's `wait`, `timeout`, and `interval` parameters entirely:

- **API spam** — the update endpoint was hit back-to-back with zero delay.
- **`interval` ignored** — the user's polling interval had no effect.
- **`timeout` ignored** — a stuck update would loop forever.
- **`wait: false` ignored** — the task blocked unconditionally.

This change routes the branch through the existing `wait_on_url()` helper (the same one the explicit `update_project` path already uses), so `interval`/`timeout` are honored, the API is no longer hammered, and `wait: false` no longer blocks. `changed` is now derived from whether the SCM revision actually moved, matching the other branch.

This is the behavior requested upstream in ansible/awx#12850 — the busy-poll is still present in current upstream `devel`, so this fix is equally applicable there.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- Collection

##### ASCENDER VERSION

```
awx: 25.4.1.dev22+ga49ad5bf92.d20260614
```

##### ADDITIONAL INFORMATION

Reproduction (before this change): create a new git-backed project with the default `wait: true`. The module fires the automatic post-create update and lands in the `current_update` branch, which polls `/api/v2/project_updates/<id>/` in a tight loop with no delay until the sync finishes.

Tests: added unit tests for `wait_for_project_update()` covering the in-progress-update wait path (asserts `wait_on_url` is called with the configured `timeout`/`interval` and that the endpoint is not busy-polled), the unchanged-SCM-revision `changed: false` case, and the `wait: false` non-blocking case.

```
awx_collection/test/awx/test_project.py::test_existing_update_is_waited_on_with_interval PASSED
awx_collection/test/awx/test_project.py::test_existing_update_unchanged_revision_is_not_changed PASSED
awx_collection/test/awx/test_project.py::test_existing_update_not_waited_on_when_wait_false PASSED
```

(The three pre-existing `run_module`-based tests in this file fail identically on unmodified `main` due to an unrelated ansible-core/test-harness incompatibility in `exit_json`; they are not affected by this change.)
