### PR TITLE
Convert CredentialType route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/CredentialType/CredentialType.js
+++ b/awx/ui/src/screens/CredentialType/CredentialType.js
@@ -1,12 +1,12 @@
 import React, { useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import {
-  Link,
-  Redirect,
+  Routes,
   Route,
-  Switch,
+  Navigate,
   useLocation,
   useParams,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
@@ -97,23 +97,19 @@ function CredentialType({ setBreadcrumb }) {
         {cardHeader}
         {isLoading && <ContentLoading />}
         {!isLoading && credentialType && (
-          <Switch>
-            <Redirect
-              from="/credential_types/:id"
-              to="/credential_types/:id/details"
-              exact
+          <Routes>
+            <Route index element={<Navigate to="details" replace />} />
+            <Route
+              path="edit"
+              element={<CredentialTypeEdit credentialType={credentialType} />}
             />
-            {credentialType && (
-              <>
-                <Route path="/credential_types/:id/edit">
-                  <CredentialTypeEdit credentialType={credentialType} />
-                </Route>
-                <Route path="/credential_types/:id/details">
-                  <CredentialTypeDetails credentialType={credentialType} />
-                </Route>
-              </>
-            )}
-          </Switch>
+            <Route
+              path="details"
+              element={
+                <CredentialTypeDetails credentialType={credentialType} />
+              }
+            />
+          </Routes>
         )}
       </Card>
     </PageSection>

--- a/awx/ui/src/screens/CredentialType/CredentialType.js
+++ b/awx/ui/src/screens/CredentialType/CredentialType.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
 import {
+  Link,
   Routes,
   Route,
   Navigate,

--- a/awx/ui/src/screens/CredentialType/CredentialType.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialType.test.js
@@ -1,58 +1,96 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { CredentialTypesAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
-
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import CredentialType from './CredentialType';
 
-jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    url: '/credential_types',
-  }),
-  useParams: () => ({ id: 42 }),
-}));
+jest.mock('../../api/models/CredentialTypes');
 
-describe('<CredentialType/>', () => {
-  let wrapper;
-  test('should render details properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialType setBreadcrumb={() => {}} />);
-    });
-    wrapper.update();
-    expect(wrapper.find('CredentialType').length).toBe(1);
-    expect(CredentialTypesAPI.readDetail).toHaveBeenCalledWith(42);
+// Markers for the routed tab panels, so assertions are about which branch of
+// the nested v6 <Routes> tree resolves.
+jest.mock('./CredentialTypeDetails', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'CredentialTypeDetails'),
+  };
+});
+jest.mock('./CredentialTypeEdit', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'CredentialTypeEdit'),
+  };
+});
+
+const credentialType = {
+  id: 42,
+  name: 'Foo',
+  summary_fields: { user_capabilities: { edit: true, delete: true } },
+};
+
+// CredentialType uses paths relative to its parent route, so mount it under the
+// same /credential_types/:id/* route that CredentialTypes.js gives it.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/credential_types/:id/*"
+        element={<CredentialType setBreadcrumb={() => {}} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
+describe('<CredentialType />', () => {
+  beforeEach(() => {
+    CredentialTypesAPI.readDetail.mockResolvedValue({ data: credentialType });
   });
 
-  test('should render expected tabs', async () => {
-    const expectedTabs = ['Back to credential types', 'Details'];
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialType setBreadcrumb={() => {}} />);
-    });
-    wrapper.find('RoutedTabs li').forEach((tab, index) => {
-      expect(tab.text()).toEqual(expectedTabs[index]);
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/credential_types/42/foobar'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialType setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-          },
-        },
-      });
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+  test('fetches the credential type detail', async () => {
+    renderAt('/credential_types/42/details');
+    expect(await screen.findByText('CredentialTypeDetails')).toBeInTheDocument();
+    // real route params are strings (the old enzyme test mocked a number)
+    expect(CredentialTypesAPI.readDetail).toHaveBeenCalledWith('42');
+  });
+
+  test('renders the expected tabs', async () => {
+    renderAt('/credential_types/42/details');
+    expect(
+      await screen.findByText('Back to credential types')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Details')).toBeInTheDocument();
+  });
+
+  test('renders the edit panel at /edit', async () => {
+    renderAt('/credential_types/42/edit');
+    expect(await screen.findByText('CredentialTypeEdit')).toBeInTheDocument();
+  });
+
+  test('redirects the index path to details', async () => {
+    const { history } = renderAt('/credential_types/42');
+    expect(await screen.findByText('CredentialTypeDetails')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/credential_types/42/details')
+    );
+  });
+
+  test('shows a not-found error when the detail request 404s', async () => {
+    const err = new Error('not found');
+    err.response = { status: 404 };
+    CredentialTypesAPI.readDetail.mockRejectedValue(err);
+    renderAt('/credential_types/42/details');
+    expect(
+      await screen.findByText('Credential type not found.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('CredentialTypeDetails')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 
@@ -29,7 +29,6 @@ const QS_CONFIG = getQSConfig('credential-type', {
 function CredentialTypeList() {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch();
 
   const {
     error: contentError,
@@ -150,7 +149,7 @@ function CredentialTypeList() {
                     ? [
                         <ToolbarAddButton
                           key="add"
-                          linkTo={`${match.url}/add`}
+                          linkTo="/credential_types/add"
                         />,
                       ]
                     : []),
@@ -182,7 +181,7 @@ function CredentialTypeList() {
                 key={credentialType.id}
                 value={credentialType.name}
                 credentialType={credentialType}
-                detailUrl={`${match.url}/${credentialType.id}/details`}
+                detailUrl={`/credential_types/${credentialType.id}/details`}
                 onSelect={() => handleSelect(credentialType)}
                 isSelected={selected.some(
                   (row) => row.id === credentialType.id
@@ -192,7 +191,7 @@ function CredentialTypeList() {
             )}
             emptyStateControls={
               canAdd && (
-                <ToolbarAddButton key="add" linkTo={`${match.url}/add`} />
+                <ToolbarAddButton key="add" linkTo="/credential_types/add" />
               )
             }
           />

--- a/awx/ui/src/screens/CredentialType/CredentialTypes.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypes.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import PersistentFilters from 'components/PersistentFilters';
 import ScreenHeader from 'components/ScreenHeader';
 import CredentialTypeAdd from './CredentialTypeAdd';
@@ -36,19 +36,22 @@ function CredentialTypes() {
         streamType="credential_type"
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path="/credential_types/add">
-          <CredentialTypeAdd />
-        </Route>
-        <Route path="/credential_types/:id">
-          <CredentialType setBreadcrumb={buildBreadcrumbConfig} />
-        </Route>
-        <Route path="/credential_types">
-          <PersistentFilters pageKey="credentialTypes">
-            <CredentialTypeList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path="/credential_types/add" element={<CredentialTypeAdd />} />
+        {/* /* so the nested <CredentialType> route tree can match the rest */}
+        <Route
+          path="/credential_types/:id/*"
+          element={<CredentialType setBreadcrumb={buildBreadcrumbConfig} />}
+        />
+        <Route
+          path="/credential_types"
+          element={
+            <PersistentFilters pageKey="credentialTypes">
+              <CredentialTypeList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/CredentialType/CredentialTypes.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypes.js
@@ -38,7 +38,7 @@ function CredentialTypes() {
       />
       <Routes>
         <Route path="/credential_types/add" element={<CredentialTypeAdd />} />
-        {/* /* so the nested <CredentialType> route tree can match the rest */}
+        {/* so the nested <CredentialType> route tree can match the rest */}
         <Route
           path="/credential_types/:id/*"
           element={<CredentialType setBreadcrumb={buildBreadcrumbConfig} />}

--- a/awx/ui/src/screens/CredentialType/CredentialTypes.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypes.test.js
@@ -1,21 +1,60 @@
 import React from 'react';
-
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import CredentialTypes from './CredentialTypes';
 
-describe('<CredentialTypes/>', () => {
-  let pageWrapper;
-  let pageSections;
+jest.mock('../../api/models/CredentialTypes');
 
-  beforeEach(() => {
-    pageWrapper = mountWithContexts(<CredentialTypes />);
-    pageSections = pageWrapper.find('PageSection');
+// Replace the routed children with markers so the assertions are purely about
+// which branch of the v6 <Routes> tree resolves for a given URL.
+jest.mock('./CredentialTypeList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'CredentialTypeList'),
+  };
+});
+jest.mock('./CredentialTypeAdd', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'CredentialTypeAdd'),
+  };
+});
+jest.mock('./CredentialType', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'CredentialType detail'),
+  };
+});
+
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<CredentialTypes />, {
+    context: { router: { history } },
+  });
+}
+
+describe('<CredentialTypes />', () => {
+  test('renders the list at /credential_types', async () => {
+    renderAt('/credential_types');
+    expect(await screen.findByText('CredentialTypeList')).toBeInTheDocument();
   });
 
-  test('initially renders without crashing', () => {
-    expect(pageWrapper.length).toBe(1);
-    expect(pageSections.length).toBe(1);
-    expect(pageSections.first().props().variant).toBe('light');
+  test('renders the add form at /credential_types/add', async () => {
+    renderAt('/credential_types/add');
+    expect(await screen.findByText('CredentialTypeAdd')).toBeInTheDocument();
+    expect(screen.queryByText('CredentialTypeList')).not.toBeInTheDocument();
+  });
+
+  test('renders the detail subtree at /credential_types/:id', async () => {
+    renderAt('/credential_types/42/details');
+    expect(
+      await screen.findByText('CredentialType detail')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('CredentialTypeList')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/CredentialType/CredentialTypes.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypes.test.js
@@ -5,7 +5,6 @@ import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import CredentialTypes from './CredentialTypes';
 
-jest.mock('../../api/models/CredentialTypes');
 
 // Replace the routed children with markers so the assertions are purely about
 // which branch of the v6 <Routes> tree resolves for a given URL.


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **CredentialType** screen's route trees from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`, following the exact pattern established for the Application route tree.

UI (no behavior change — same URLs, same panels):

- `CredentialTypes.js` (list router): `<Switch>` → `<Routes>`; child routes use the `element` prop; the detail route is `/credential_types/:id/*` so the nested `<CredentialType>` tree can match the rest of the path.
- `CredentialType.js` (detail router): `<Switch>` → `<Routes>` with **relative** child paths (`edit`, `details`); the `exact` `<Redirect>` is replaced by an index route that `<Navigate replace>`s to `details`.
- Both test suites rewritten with `renderWithContexts` (RTL) to assert **real v6 route resolution** (which panel renders per URL, index redirect, 404 error) instead of enzyme structural checks.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch.
- Tests: 8 route-resolution tests across the two converted suites; full `screens/CredentialType` directory passes (8 suites / 37 tests).
- `npm --prefix awx/ui run lint` clean on the changed source.

