### PR TITLE
Convert NotificationTemplate route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
@@ -2,15 +2,14 @@ import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
 import {
-  Link,
-  Switch,
+  Routes,
   Route,
-  Redirect,
+  Navigate,
   useParams,
-  useRouteMatch,
   useLocation,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import useRequest from 'hooks/useRequest';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';
@@ -22,7 +21,6 @@ import NotificationTemplateEdit from './NotificationTemplateEdit';
 function NotificationTemplate({ setBreadcrumb }) {
   const { t } = useLingui();
   const { id: templateId } = useParams();
-  const match = useRouteMatch();
   const location = useLocation();
   const {
     result: { template, defaultMessages },
@@ -82,7 +80,7 @@ function NotificationTemplate({ setBreadcrumb }) {
     },
     {
       name: t`Details`,
-      link: `${match.url}/details`,
+      link: `/notification_templates/${templateId}/details`,
       id: 0,
     },
   ];
@@ -90,30 +88,30 @@ function NotificationTemplate({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabs} />}
-        <Switch>
-          <Redirect
-            from="/notification_templates/:id"
-            to="/notification_templates/:id/details"
-            exact
-          />
-          {isLoading && <ContentLoading />}
-          {template && (
-            <>
-              <Route path="/notification_templates/:id/edit">
+        {isLoading && <ContentLoading />}
+        {template && (
+          <Routes>
+            <Route index element={<Navigate to="details" replace />} />
+            <Route
+              path="edit"
+              element={
                 <NotificationTemplateEdit
                   template={template}
                   defaultMessages={defaultMessages}
                 />
-              </Route>
-              <Route path="/notification_templates/:id/details">
+              }
+            />
+            <Route
+              path="details"
+              element={
                 <NotificationTemplateDetail
                   template={template}
                   defaultMessages={defaultMessages}
                 />
-              </Route>
-            </>
-          )}
-        </Switch>
+              }
+            />
+          </Routes>
+        )}
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
@@ -22,6 +22,7 @@ function NotificationTemplate({ setBreadcrumb }) {
   const { t } = useLingui();
   const { id: templateId } = useParams();
   const location = useLocation();
+  const baseUrl = `/notification_templates/${templateId}`;
   const {
     result: { template, defaultMessages },
     isLoading,
@@ -43,8 +44,13 @@ function NotificationTemplate({ setBreadcrumb }) {
   );
 
   useEffect(() => {
+    // The bare /:id route immediately redirects to /:id/details, so skip the
+    // fetch there; otherwise we would fetch once on /:id and again after the
+    // redirect changes the pathname. Real navigation (e.g. edit -> details)
+    // still re-fetches so the detail reflects saved changes.
+    if (location.pathname === baseUrl) return;
     fetchTemplate();
-  }, [fetchTemplate, location.pathname]);
+  }, [fetchTemplate, location.pathname, baseUrl]);
 
   if (!isLoading && error) {
     return (
@@ -88,30 +94,35 @@ function NotificationTemplate({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabs} />}
-        {isLoading && <ContentLoading />}
-        {template && (
-          <Routes>
-            <Route index element={<Navigate to="details" replace />} />
-            <Route
-              path="edit"
-              element={
+        <Routes>
+          <Route index element={<Navigate to="details" replace />} />
+          <Route
+            path="edit"
+            element={
+              template ? (
                 <NotificationTemplateEdit
                   template={template}
                   defaultMessages={defaultMessages}
                 />
-              }
-            />
-            <Route
-              path="details"
-              element={
+              ) : (
+                <ContentLoading />
+              )
+            }
+          />
+          <Route
+            path="details"
+            element={
+              template ? (
                 <NotificationTemplateDetail
                   template={template}
                   defaultMessages={defaultMessages}
                 />
-              }
-            />
-          </Routes>
-        )}
+              ) : (
+                <ContentLoading />
+              )
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.test.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
+import { NotificationTemplatesAPI } from 'api';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
+import NotificationTemplate from './NotificationTemplate';
+
+jest.mock('../../api/models/NotificationTemplates');
+
+// Markers for the routed tab panels, so assertions are about which branch of
+// the nested v6 <Routes> tree resolves.
+jest.mock('./NotificationTemplateDetail', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactLib.createElement('div', null, 'NotificationTemplateDetail'),
+  };
+});
+jest.mock('./NotificationTemplateEdit', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactLib.createElement('div', null, 'NotificationTemplateEdit'),
+  };
+});
+
+const template = {
+  id: 42,
+  name: 'Foo',
+  summary_fields: { user_capabilities: { edit: true, delete: true } },
+};
+const options = { data: { actions: { POST: { messages: null } } } };
+
+// NotificationTemplate uses paths relative to its parent route, so mount it
+// under the same /notification_templates/:id/* route that
+// NotificationTemplates.js gives it.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/notification_templates/:id/*"
+        element={<NotificationTemplate setBreadcrumb={() => {}} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
+describe('<NotificationTemplate />', () => {
+  beforeEach(() => {
+    NotificationTemplatesAPI.readDetail.mockResolvedValue({ data: template });
+    NotificationTemplatesAPI.readOptions.mockResolvedValue(options);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches the template detail and options', async () => {
+    renderAt('/notification_templates/42/details');
+    expect(
+      await screen.findByText('NotificationTemplateDetail')
+    ).toBeInTheDocument();
+    expect(NotificationTemplatesAPI.readOptions).toHaveBeenCalled();
+    // real route params are strings
+    expect(NotificationTemplatesAPI.readDetail).toHaveBeenCalledWith('42');
+  });
+
+  test('renders the edit panel at /edit', async () => {
+    renderAt('/notification_templates/42/edit');
+    expect(
+      await screen.findByText('NotificationTemplateEdit')
+    ).toBeInTheDocument();
+  });
+
+  test('redirects the index path to details', async () => {
+    const { history } = renderAt('/notification_templates/42');
+    expect(
+      await screen.findByText('NotificationTemplateDetail')
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe(
+        '/notification_templates/42/details'
+      )
+    );
+  });
+
+  test('shows a not-found error when the detail request 404s', async () => {
+    const err = new Error('not found');
+    err.response = { status: 404 };
+    NotificationTemplatesAPI.readDetail.mockRejectedValue(err);
+    renderAt('/notification_templates/42/details');
+    expect(
+      await screen.findByText('Notification Template not found.')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('NotificationTemplateDetail')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
@@ -28,12 +28,11 @@ const QS_CONFIG = getQSConfig('notification-templates', {
 
 function NotificationTemplatesList() {
   const location = useLocation();
-  const match = useRouteMatch();
   const { t } = useLingui();
   // const [testToasts, setTestToasts] = useState([]);
   const { addToast, Toast, toastProps } = useToast();
 
-  const addUrl = `${match.url}/add`;
+  const addUrl = '/notification_templates/add';
 
   const {
     result: {
@@ -221,7 +220,7 @@ function NotificationTemplatesList() {
                 key={template.id}
                 fetchTemplates={fetchTemplates}
                 template={template}
-                detailUrl={`${match.url}/${template.id}`}
+                detailUrl={`/notification_templates/${template.id}`}
                 isSelected={selected.some((row) => row.id === template.id)}
                 onSelect={() => handleSelect(template)}
                 rowIndex={index}

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
@@ -37,7 +37,7 @@ function NotificationTemplates() {
           path="/notification_templates/add"
           element={<NotificationTemplateAdd />}
         />
-        {/* /* so the nested <NotificationTemplate> route tree can match the rest */}
+        {/* so the nested <NotificationTemplate> route tree can match the rest */}
         <Route
           path="/notification_templates/:id/*"
           element={

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
@@ -10,7 +10,6 @@ import NotificationTemplate from './NotificationTemplate';
 
 function NotificationTemplates() {
   const { t } = useLingui();
-  const match = useRouteMatch();
   const [breadcrumbConfig, setBreadcrumbConfig] = useState({
     '/notification_templates': t`Notification Templates`,
     '/notification_templates/add': t`Create New Notification Template`,
@@ -33,19 +32,27 @@ function NotificationTemplates() {
         streamType="notification_template"
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path={`${match.url}/add`}>
-          <NotificationTemplateAdd />
-        </Route>
-        <Route path={`${match.url}/:id`}>
-          <NotificationTemplate setBreadcrumb={updateBreadcrumbConfig} />
-        </Route>
-        <Route path={`${match.url}`}>
-          <PersistentFilters pageKey="notificationTemplates">
-            <NotificationTemplateList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route
+          path="/notification_templates/add"
+          element={<NotificationTemplateAdd />}
+        />
+        {/* /* so the nested <NotificationTemplate> route tree can match the rest */}
+        <Route
+          path="/notification_templates/:id/*"
+          element={
+            <NotificationTemplate setBreadcrumb={updateBreadcrumbConfig} />
+          }
+        />
+        <Route
+          path="/notification_templates"
+          element={
+            <PersistentFilters pageKey="notificationTemplates">
+              <NotificationTemplateList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.test.js
@@ -1,22 +1,70 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import NotificationTemplates from './NotificationTemplates';
 
+jest.mock('../../api/models/NotificationTemplates');
+
+// Replace the routed children with markers so the assertions are purely about
+// which branch of the v6 <Routes> tree resolves for a given URL.
 jest.mock('./NotificationTemplateList', () => {
-  const NotificationTemplateList = () => <div />;
+  const ReactLib = require('react');
   return {
     __esModule: true,
-    default: NotificationTemplateList,
+    default: () =>
+      ReactLib.createElement('div', null, 'NotificationTemplateList'),
+  };
+});
+jest.mock('./NotificationTemplateAdd', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactLib.createElement('div', null, 'NotificationTemplateAdd'),
+  };
+});
+jest.mock('./NotificationTemplate', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactLib.createElement('div', null, 'NotificationTemplate detail'),
   };
 });
 
-describe('<NotificationTemplates />', () => {
-  test('initially renders without crashing', () => {
-    const wrapper = mountWithContexts(<NotificationTemplates />);
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<NotificationTemplates />, {
+    context: { router: { history } },
+  });
+}
 
-    const pageSections = wrapper.find('PageSection');
-    expect(pageSections).toHaveLength(1);
-    expect(pageSections.first().props().variant).toBe('light');
-    expect(wrapper.find('NotificationTemplateList')).toHaveLength(1);
+describe('<NotificationTemplates />', () => {
+  test('renders the list at /notification_templates', async () => {
+    renderAt('/notification_templates');
+    expect(
+      await screen.findByText('NotificationTemplateList')
+    ).toBeInTheDocument();
+  });
+
+  test('renders the add form at /notification_templates/add', async () => {
+    renderAt('/notification_templates/add');
+    expect(
+      await screen.findByText('NotificationTemplateAdd')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('NotificationTemplateList')
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the detail subtree at /notification_templates/:id', async () => {
+    renderAt('/notification_templates/42/details');
+    expect(
+      await screen.findByText('NotificationTemplate detail')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('NotificationTemplateList')
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.test.js
@@ -4,7 +4,6 @@ import { createMemoryHistory } from 'history';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import NotificationTemplates from './NotificationTemplates';
 
-jest.mock('../../api/models/NotificationTemplates');
 
 // Replace the routed children with markers so the assertions are purely about
 // which branch of the v6 <Routes> tree resolves for a given URL.


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **NotificationTemplate** screen's route trees from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`, following the same pattern used for the Application and CredentialType route trees.

UI (no behavior change — same URLs, same panels):

- `NotificationTemplates.js` (list router): `<Switch>` → `<Routes>`; child routes use the `element` prop; the detail route is `/notification_templates/:id/*` so the nested `<NotificationTemplate>` tree can match the rest of the path; the unused `useRouteMatch` `match.url` is replaced by explicit paths.
- `NotificationTemplate.js` (detail router): `<Switch>` → `<Routes>` with **relative** child paths (`edit`, `details`); the `exact` `<Redirect>` becomes an index route that `<Navigate replace>`s to `details`; the Details tab link is built from the route id instead of `match.url`.
- Tests: the list test is converted to RTL and a new detail test is added, both using `renderWithContexts` to assert **real v6 route resolution** (which panel renders per URL, index redirect, 404 error).

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch off `main`.
- Tests: 7 route-resolution tests across the two suites; full `screens/NotificationTemplate` directory passes (6 suites / 31 tests).
- `npm --prefix awx/ui run lint` clean on the changed source.

