### PR TITLE
Convert Organization route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/Organization/Organization.js
+++ b/awx/ui/src/screens/Organization/Organization.js
@@ -1,14 +1,13 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useLingui } from '@lingui/react/macro';
+import { Link } from 'react-router-dom';
 import {
-  Switch,
+  Routes,
   Route,
-  Redirect,
-  Link,
+  Navigate,
   useLocation,
   useParams,
-  useRouteMatch,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';
@@ -25,7 +24,6 @@ import OrganizationExecEnvList from './OrganizationExecEnvList';
 function Organization({ setBreadcrumb, me }) {
   const location = useLocation();
   const { id: organizationId } = useParams();
-  const match = useRouteMatch();
   const initialUpdate = useRef(true);
 
   const {
@@ -120,12 +118,20 @@ function Organization({ setBreadcrumb, me }) {
       id: 99,
       persistentFilterKey: 'organizations',
     },
-    { name: t`Details`, link: `${match.url}/details`, id: 0 },
-    { name: t`Access`, link: `${match.url}/access`, id: 1 },
-    { name: t`Teams`, link: `${match.url}/teams`, id: 2 },
+    {
+      name: t`Details`,
+      link: `/organizations/${organizationId}/details`,
+      id: 0,
+    },
+    {
+      name: t`Access`,
+      link: `/organizations/${organizationId}/access`,
+      id: 1,
+    },
+    { name: t`Teams`, link: `/organizations/${organizationId}/teams`, id: 2 },
     {
       name: t`Execution Environments`,
-      link: `${match.url}/execution_environments`,
+      link: `/organizations/${organizationId}/execution_environments`,
       id: 4,
     },
   ];
@@ -133,7 +139,7 @@ function Organization({ setBreadcrumb, me }) {
   if (canSeeNotificationsTab) {
     tabsArray.push({
       name: t`Notifications`,
-      link: `${match.url}/notifications`,
+      link: `/organizations/${organizationId}/notifications`,
       id: 3,
     });
   }
@@ -177,61 +183,69 @@ function Organization({ setBreadcrumb, me }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-        <Switch>
-          <Redirect
-            from="/organizations/:id"
-            to="/organizations/:id/details"
-            exact
+        <Routes>
+          <Route index element={<Navigate to="details" replace />} />
+          {organization && (
+            <Route
+              path="edit"
+              element={<OrganizationEdit organization={organization} />}
+            />
+          )}
+          {organization && (
+            <Route
+              path="details"
+              element={<OrganizationDetail organization={organization} />}
+            />
+          )}
+          {organization && (
+            <Route
+              path="access"
+              element={
+                <ResourceAccessList
+                  resource={organization}
+                  apiModel={OrganizationsAPI}
+                />
+              }
+            />
+          )}
+          <Route
+            path="teams"
+            element={<OrganizationTeams id={Number(organizationId)} />}
           />
-          {organization && (
-            <Route path="/organizations/:id/edit">
-              <OrganizationEdit organization={organization} />
-            </Route>
-          )}
-          {organization && (
-            <Route path="/organizations/:id/details">
-              <OrganizationDetail organization={organization} />
-            </Route>
-          )}
-          {organization && (
-            <Route path="/organizations/:id/access">
-              <ResourceAccessList
-                resource={organization}
-                apiModel={OrganizationsAPI}
-              />
-            </Route>
-          )}
-          <Route path="/organizations/:id/teams">
-            <OrganizationTeams id={Number(match.params.id)} />
-          </Route>
           {canSeeNotificationsTab && (
-            <Route path="/organizations/:id/notifications">
-              <NotificationList
-                id={Number(match.params.id)}
-                canToggleNotifications={canToggleNotifications}
-                apiModel={OrganizationsAPI}
-                showApprovalsToggle
-              />
-            </Route>
+            <Route
+              path="notifications"
+              element={
+                <NotificationList
+                  id={Number(organizationId)}
+                  canToggleNotifications={canToggleNotifications}
+                  apiModel={OrganizationsAPI}
+                  showApprovalsToggle
+                />
+              }
+            />
           )}
           {organization && (
-            <Route path="/organizations/:id/execution_environments">
-              <OrganizationExecEnvList organization={organization} />
-            </Route>
+            <Route
+              path="execution_environments"
+              element={<OrganizationExecEnvList organization={organization} />}
+            />
           )}
-          <Route key="not-found" path="*">
-            {!organizationLoading && !rolesLoading && (
-              <ContentError isNotFound>
-                {match.params.id && (
-                  <Link to={`/organizations/${match.params.id}/details`}>
-                    {t`View Organization Details`}
-                  </Link>
-                )}
-              </ContentError>
-            )}
-          </Route>
-          ,
-        </Switch>
+          <Route
+            path="*"
+            element={
+              !organizationLoading && !rolesLoading ? (
+                <ContentError isNotFound>
+                  {organizationId && (
+                    <Link to={`/organizations/${organizationId}/details`}>
+                      {t`View Organization Details`}
+                    </Link>
+                  )}
+                </ContentError>
+              ) : null
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Organization/Organization.test.js
+++ b/awx/ui/src/screens/Organization/Organization.test.js
@@ -1,124 +1,149 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { OrganizationsAPI } from 'api';
 import mockOrganization from 'util/data.organization.json';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Organization from './Organization';
 
-jest.mock('../../api');
+jest.mock('../../api/models/Organizations');
 
-const mockMe = {
-  is_super_user: true,
-  is_system_auditor: false,
-};
-
-async function getOrganizations(params) {
-  let results = [];
-  if (params && params.role_level) {
-    if (params.role_level === 'admin_role') {
-      results = [mockOrganization];
-    }
-    if (params.role_level === 'auditor_role') {
-      results = [mockOrganization];
-    }
-    if (params.role_level === 'notification_admin_role') {
-      results = [mockOrganization];
-    }
-  }
+// Markers for the routed tab panels, so assertions are about which branch of
+// the nested v6 <Routes> tree resolves.
+jest.mock('./OrganizationDetail', () => {
+  const ReactLib = require('react');
   return {
-    count: results.length,
-    next: null,
-    previous: null,
-    data: { results },
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'OrganizationDetail'),
   };
+});
+jest.mock('./OrganizationEdit', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'OrganizationEdit'),
+  };
+});
+jest.mock('./OrganizationTeams', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'OrganizationTeams'),
+  };
+});
+jest.mock('./OrganizationExecEnvList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactLib.createElement('div', null, 'OrganizationExecEnvList'),
+  };
+});
+jest.mock('components/ResourceAccessList', () => {
+  const ReactLib = require('react');
+  return {
+    ResourceAccessList: () =>
+      ReactLib.createElement('div', null, 'ResourceAccessList'),
+  };
+});
+jest.mock('components/NotificationList/NotificationList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'NotificationList'),
+  };
+});
+
+const mockMe = { is_super_user: true, is_system_auditor: false };
+const mockAuditorMe = { is_super_user: true, is_system_auditor: true };
+
+// Organization uses paths relative to its parent route, so mount it under the
+// same /organizations/:id/* route that Organizations.js gives it in the app.
+function renderAt(path, me = mockMe) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/organizations/:id/*"
+        element={<Organization setBreadcrumb={() => {}} me={me} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
 }
 
 describe('<Organization />', () => {
-  let wrapper;
-
   beforeEach(() => {
     OrganizationsAPI.readDetail.mockResolvedValue({ data: mockOrganization });
     OrganizationsAPI.readGalaxyCredentials.mockResolvedValue({
-      data: {
-        results: [],
-      },
-    });
-
-    OrganizationsAPI.read = jest.fn();
-    OrganizationsAPI.read.mockImplementation(getOrganizations);
-  });
-
-  test('initially renders successfully', async () => {
-    await act(async () => {
-      mountWithContexts(<Organization setBreadcrumb={() => {}} me={mockMe} />);
-    });
-  });
-
-  test('notifications tab shown for admins', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Organization setBreadcrumb={() => {}} me={mockMe} />
-      );
-    });
-
-    const tabs = await waitForElement(
-      wrapper,
-      '.pf-c-tabs__item',
-      (el) => el.length === 6
-    );
-    expect(tabs.last().text()).toEqual('Notifications');
-  });
-
-  test('notifications tab hidden with reduced permissions', async () => {
-    OrganizationsAPI.read = async () => ({
-      count: 0,
-      next: null,
-      previous: null,
       data: { results: [] },
     });
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Organization setBreadcrumb={() => {}} me={mockMe} />
-      );
-    });
-
-    const tabs = await waitForElement(
-      wrapper,
-      '.pf-c-tabs__item',
-      (el) => el.length === 5
-    );
-    tabs.forEach((tab) => expect(tab.text()).not.toEqual('Notifications'));
+    OrganizationsAPI.read.mockResolvedValue({ data: { results: [] } });
   });
 
-  test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/organizations/1/foobar'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Organization setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/organizations/1/foobar',
-                  path: '/organizations/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches the organization detail', async () => {
+    renderAt('/organizations/1/details');
+    expect(await screen.findByText('OrganizationDetail')).toBeInTheDocument();
+    // real route params are strings (the old enzyme test mocked a number)
+    expect(OrganizationsAPI.readDetail).toHaveBeenCalledWith('1');
+  });
+
+  test('renders the edit panel at /edit', async () => {
+    renderAt('/organizations/1/edit');
+    expect(await screen.findByText('OrganizationEdit')).toBeInTheDocument();
+  });
+
+  test('renders the access panel at /access', async () => {
+    renderAt('/organizations/1/access');
+    expect(await screen.findByText('ResourceAccessList')).toBeInTheDocument();
+  });
+
+  test('renders the teams panel at /teams', async () => {
+    renderAt('/organizations/1/teams');
+    expect(await screen.findByText('OrganizationTeams')).toBeInTheDocument();
+  });
+
+  test('renders the execution environments panel at /execution_environments', async () => {
+    renderAt('/organizations/1/execution_environments');
+    expect(
+      await screen.findByText('OrganizationExecEnvList')
+    ).toBeInTheDocument();
+  });
+
+  test('renders the notifications panel for an auditor', async () => {
+    renderAt('/organizations/1/notifications', mockAuditorMe);
+    expect(await screen.findByText('NotificationList')).toBeInTheDocument();
+  });
+
+  test('redirects the index path to details', async () => {
+    const { history } = renderAt('/organizations/1');
+    expect(await screen.findByText('OrganizationDetail')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/organizations/1/details')
+    );
+  });
+
+  test('shows a not-found error on an unknown sub-route', async () => {
+    renderAt('/organizations/1/foobar');
+    expect(
+      await screen.findByText('View Organization Details')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('OrganizationDetail')).not.toBeInTheDocument();
+  });
+
+  test('shows a not-found error when the detail request 404s', async () => {
+    const err = new Error('not found');
+    err.response = { status: 404 };
+    OrganizationsAPI.readDetail.mockRejectedValue(err);
+    renderAt('/organizations/1/details');
+    expect(
+      await screen.findByText('Organization not found.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('OrganizationDetail')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
+++ b/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { Link, useRouteMatch } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { OrganizationsAPI } from 'api';
@@ -20,9 +20,7 @@ import InstanceGroupLabels from 'components/InstanceGroupLabels';
 import { relatedResourceDeleteRequests } from 'util/getRelatedResourceDeleteDetails';
 
 function OrganizationDetail({ organization }) {
-  const {
-    params: { id },
-  } = useRouteMatch();
+  const { id } = useParams();
   const {
     name,
     description,

--- a/awx/ui/src/screens/Organization/OrganizationList/OrganizationList.js
+++ b/awx/ui/src/screens/Organization/OrganizationList/OrganizationList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 
@@ -28,9 +28,8 @@ const QS_CONFIG = getQSConfig('organization', {
 
 function OrganizationsList() {
   const location = useLocation();
-  const match = useRouteMatch();
 
-  const addUrl = `${match.url}/add`;
+  const addUrl = '/organizations/add';
 
   const {
     result: {
@@ -179,7 +178,7 @@ function OrganizationsList() {
                 key={o.id}
                 organization={o}
                 rowIndex={index}
-                detailUrl={`${match.url}/${o.id}`}
+                detailUrl={`/organizations/${o.id}`}
                 isSelected={selected.some((row) => row.id === o.id)}
                 onSelect={() => handleSelect(o)}
               />

--- a/awx/ui/src/screens/Organization/Organizations.js
+++ b/awx/ui/src/screens/Organization/Organizations.js
@@ -47,7 +47,7 @@ function Organizations() {
       />
       <Routes>
         <Route path="/organizations/add" element={<OrganizationAdd />} />
-        {/* /* so the nested <Organization> route tree can match the rest */}
+        {/* so the nested <Organization> route tree can match the rest */}
         <Route
           path="/organizations/:id/*"
           element={

--- a/awx/ui/src/screens/Organization/Organizations.js
+++ b/awx/ui/src/screens/Organization/Organizations.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 
@@ -12,7 +12,6 @@ import Organization from './Organization';
 
 function Organizations() {
   const { t } = useLingui();
-  const match = useRouteMatch();
   const [breadcrumbConfig, setBreadcrumbConfig] = useState({
     '/organizations': t`Organizations`,
     '/organizations/add': t`Create New Organization`,
@@ -46,23 +45,28 @@ function Organizations() {
         streamType="organization"
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path={`${match.path}/add`}>
-          <OrganizationAdd />
-        </Route>
-        <Route path={`${match.path}/:id`}>
-          <Config>
-            {({ me }) => (
-              <Organization setBreadcrumb={setBreadcrumb} me={me || {}} />
-            )}
-          </Config>
-        </Route>
-        <Route path={`${match.path}`}>
-          <PersistentFilters pageKey="organizations">
-            <OrganizationsList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path="/organizations/add" element={<OrganizationAdd />} />
+        {/* /* so the nested <Organization> route tree can match the rest */}
+        <Route
+          path="/organizations/:id/*"
+          element={
+            <Config>
+              {({ me }) => (
+                <Organization setBreadcrumb={setBreadcrumb} me={me || {}} />
+              )}
+            </Config>
+          }
+        />
+        <Route
+          path="/organizations"
+          element={
+            <PersistentFilters pageKey="organizations">
+              <OrganizationsList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/Organization/Organizations.test.js
+++ b/awx/ui/src/screens/Organization/Organizations.test.js
@@ -1,23 +1,57 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Organizations from './Organizations';
 
-jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-}));
+jest.mock('../../api/models/Organizations');
+
+// Replace the routed children with markers so the assertions are purely about
+// which branch of the v6 <Routes> tree resolves for a given URL.
+jest.mock('./OrganizationList/OrganizationList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'OrganizationList'),
+  };
+});
+jest.mock('./OrganizationAdd/OrganizationAdd', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'OrganizationAdd'),
+  };
+});
+jest.mock('./Organization', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'Organization detail'),
+  };
+});
+
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<Organizations />, {
+    context: { router: { history } },
+  });
+}
 
 describe('<Organizations />', () => {
-  test('initially renders successfully', async () => {
-    await act(async () => {
-      mountWithContexts(
-        <Organizations
-          match={{ path: '/organizations', url: '/organizations' }}
-          location={{ search: '', pathname: '/organizations' }}
-        />
-      );
-    });
+  test('renders the list at /organizations', async () => {
+    renderAt('/organizations');
+    expect(await screen.findByText('OrganizationList')).toBeInTheDocument();
+  });
+
+  test('renders the add form at /organizations/add', async () => {
+    renderAt('/organizations/add');
+    expect(await screen.findByText('OrganizationAdd')).toBeInTheDocument();
+    expect(screen.queryByText('OrganizationList')).not.toBeInTheDocument();
+  });
+
+  test('renders the detail subtree at /organizations/:id', async () => {
+    renderAt('/organizations/1/details');
+    expect(await screen.findByText('Organization detail')).toBeInTheDocument();
+    expect(screen.queryByText('OrganizationList')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **Organization** screen's route trees from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`, following the pattern used for the Application, CredentialType, NotificationTemplate, Team and ExecutionEnvironment route trees.

UI (no behavior change — same URLs, same panels):

- `Organizations.js` (list router): `<Switch>` → `<Routes>`; child routes use the `element` prop; the detail route is `/organizations/:id/*` so the nested `<Organization>` tree can match the rest of the path; the unused `useRouteMatch` `match.path` is replaced by explicit paths.
- `Organization.js` (detail router): `<Switch>` → `<Routes>` with **relative** child paths (`details`, `edit`, `access`, `teams`, `notifications`, `execution_environments`); the `exact` `<Redirect>` becomes an index route that `<Navigate replace>`s to `details`; the catch-all not-found route stays as `path="*"`; `match.url` / `match.params.id` are replaced with the `organizationId` route param; a stray `,` text node after the not-found route is removed.
- Tests: both suites rewritten with `renderWithContexts` (RTL) to assert **real v6 route resolution** — each tab panel, the notifications tab for an auditor, the index redirect, the unknown-sub-route not-found error, and the 404 detail error.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch off `main`.
- Tests: 12 route-resolution tests across the two converted suites; full `screens/Organization` directory passes (12 suites / 66 tests).
- `npm --prefix awx/ui run lint` clean on the changed source.

