### PR TITLE
Convert InstanceGroup route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
@@ -1,12 +1,12 @@
 import React, { useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import {
-  Link,
-  Redirect,
+  Routes,
   Route,
-  Switch,
+  Navigate,
   useLocation,
   useParams,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { CaretLeftIcon } from '@patternfly/react-icons';
@@ -106,29 +106,26 @@ function ContainerGroup({ setBreadcrumb }) {
         {cardHeader}
         {isLoading && <ContentLoading />}
         {!isLoading && instanceGroup && (
-          <Switch>
-            <Redirect
-              from="/instance_groups/container_group/:id"
-              to="/instance_groups/container_group/:id/details"
-              exact
+          <Routes>
+            <Route index element={<Navigate to="details" replace />} />
+            <Route
+              path="edit"
+              element={<ContainerGroupEdit instanceGroup={instanceGroup} />}
             />
-            {instanceGroup && (
-              <>
-                <Route path="/instance_groups/container_group/:id/edit">
-                  <ContainerGroupEdit instanceGroup={instanceGroup} />
-                </Route>
-                <Route path="/instance_groups/container_group/:id/details">
-                  <ContainerGroupDetails instanceGroup={instanceGroup} />
-                </Route>
-                <Route path="/instance_groups/container_group/:id/jobs">
-                  <JobList
-                    showTypeColumn
-                    defaultParams={{ instance_group: instanceGroup.id }}
-                  />
-                </Route>
-              </>
-            )}
-          </Switch>
+            <Route
+              path="details"
+              element={<ContainerGroupDetails instanceGroup={instanceGroup} />}
+            />
+            <Route
+              path="jobs"
+              element={
+                <JobList
+                  showTypeColumn
+                  defaultParams={{ instance_group: instanceGroup.id }}
+                />
+              }
+            />
+          </Routes>
         )}
       </Card>
     </PageSection>

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
@@ -125,6 +125,16 @@ function ContainerGroup({ setBreadcrumb }) {
                 />
               }
             />
+            <Route
+              path="*"
+              element={
+                <ContentError isNotFound>
+                  <Link to="/instance_groups">
+                    {t`View all instance groups`}
+                  </Link>
+                </ContentError>
+              }
+            />
           </Routes>
         )}
       </Card>

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroup.test.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroup.test.js
@@ -1,58 +1,107 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { InstanceGroupsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
-
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ContainerGroup from './ContainerGroup';
 
-jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    url: '/instance_groups/container_group',
-  }),
-  useParams: () => ({ id: 42 }),
-}));
+jest.mock('../../api/models/InstanceGroups');
 
-describe('<ContainerGroup/>', () => {
-  let wrapper;
-  test('should render details properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<ContainerGroup setBreadcrumb={() => {}} />);
-    });
-    wrapper.update();
-    expect(wrapper.find('ContainerGroup').length).toBe(1);
-    expect(InstanceGroupsAPI.readDetail).toHaveBeenCalledWith(42);
+// Markers for the routed tab panels, so assertions are about which branch of
+// the nested v6 <Routes> tree resolves.
+jest.mock('./ContainerGroupDetails', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ContainerGroupDetails'),
+  };
+});
+jest.mock('./ContainerGroupEdit', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ContainerGroupEdit'),
+  };
+});
+jest.mock('components/JobList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'JobList'),
+  };
+});
+
+const instanceGroup = {
+  id: 42,
+  name: 'Foo',
+  is_container_group: true,
+  summary_fields: { user_capabilities: { edit: true, delete: true } },
+};
+
+// ContainerGroup uses paths relative to its parent route, so mount it under the
+// same /instance_groups/container_group/:id/* route that InstanceGroups.js
+// gives it in the app.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/instance_groups/container_group/:id/*"
+        element={<ContainerGroup setBreadcrumb={() => {}} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
+describe('<ContainerGroup />', () => {
+  beforeEach(() => {
+    InstanceGroupsAPI.readDetail.mockResolvedValue({ data: instanceGroup });
   });
 
-  test('should render expected tabs', async () => {
-    const expectedTabs = ['Back to instance groups', 'Details', 'Jobs'];
-    await act(async () => {
-      wrapper = mountWithContexts(<ContainerGroup setBreadcrumb={() => {}} />);
-    });
-    wrapper.find('RoutedTabs li').forEach((tab, index) => {
-      expect(tab.text()).toEqual(expectedTabs[index]);
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/instance_groups/container_group/42/foobar'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<ContainerGroup setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-          },
-        },
-      });
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+  test('fetches the container group detail', async () => {
+    renderAt('/instance_groups/container_group/42/details');
+    expect(
+      await screen.findByText('ContainerGroupDetails')
+    ).toBeInTheDocument();
+    expect(InstanceGroupsAPI.readDetail).toHaveBeenCalledWith('42');
+  });
+
+  test('renders the edit panel at /edit', async () => {
+    renderAt('/instance_groups/container_group/42/edit');
+    expect(await screen.findByText('ContainerGroupEdit')).toBeInTheDocument();
+  });
+
+  test('renders the jobs panel at /jobs', async () => {
+    renderAt('/instance_groups/container_group/42/jobs');
+    expect(await screen.findByText('JobList')).toBeInTheDocument();
+  });
+
+  test('redirects the index path to details', async () => {
+    const { history } = renderAt('/instance_groups/container_group/42');
+    expect(
+      await screen.findByText('ContainerGroupDetails')
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe(
+        '/instance_groups/container_group/42/details'
+      )
+    );
+  });
+
+  test('shows a not-found error when the detail request 404s', async () => {
+    const err = new Error('not found');
+    err.response = { status: 404 };
+    InstanceGroupsAPI.readDetail.mockRejectedValue(err);
+    renderAt('/instance_groups/container_group/42/details');
+    expect(
+      await screen.findByText('Container group not found.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('ContainerGroupDetails')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 import {

--- a/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.test.js
@@ -11,8 +11,10 @@ import InstanceDetails from './InstanceDetails';
 
 jest.mock('../../../api');
 jest.mock('../../../hooks/useDebounce');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// The component reads useParams from react-router-dom-v5-compat (the route
+// tree is v6); mock it there, keeping the rest of the module real.
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({
     id: 2,
     instanceId: 1,

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
@@ -1,12 +1,12 @@
 import React, { useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import {
-  Link,
-  Redirect,
+  Routes,
   Route,
-  Switch,
+  Navigate,
   useLocation,
   useParams,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { CaretLeftIcon } from '@patternfly/react-icons';
@@ -115,35 +115,36 @@ function InstanceGroup({ setBreadcrumb }) {
         {cardHeader}
         {isLoading && <ContentLoading />}
         {!isLoading && instanceGroup && (
-          <Switch>
-            <Redirect
-              from="/instance_groups/:id"
-              to="/instance_groups/:id/details"
-              exact
+          <Routes>
+            <Route index element={<Navigate to="details" replace />} />
+            <Route
+              path="edit"
+              element={<InstanceGroupEdit instanceGroup={instanceGroup} />}
             />
-            {instanceGroup && (
-              <>
-                <Route path="/instance_groups/:id/edit">
-                  <InstanceGroupEdit instanceGroup={instanceGroup} />
-                </Route>
-                <Route path="/instance_groups/:id/details">
-                  <InstanceGroupDetails instanceGroup={instanceGroup} />
-                </Route>
-                <Route path="/instance_groups/:id/instances">
-                  <Instances
-                    instanceGroup={instanceGroup}
-                    setBreadcrumb={setBreadcrumb}
-                  />
-                </Route>
-                <Route path="/instance_groups/:id/jobs">
-                  <JobList
-                    showTypeColumn
-                    defaultParams={{ instance_group: instanceGroup.id }}
-                  />
-                </Route>
-              </>
-            )}
-          </Switch>
+            <Route
+              path="details"
+              element={<InstanceGroupDetails instanceGroup={instanceGroup} />}
+            />
+            {/* /* so the nested <Instances> route tree can match the rest */}
+            <Route
+              path="instances/*"
+              element={
+                <Instances
+                  instanceGroup={instanceGroup}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+            <Route
+              path="jobs"
+              element={
+                <JobList
+                  showTypeColumn
+                  defaultParams={{ instance_group: instanceGroup.id }}
+                />
+              }
+            />
+          </Routes>
         )}
       </Card>
     </PageSection>

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
@@ -125,7 +125,7 @@ function InstanceGroup({ setBreadcrumb }) {
               path="details"
               element={<InstanceGroupDetails instanceGroup={instanceGroup} />}
             />
-            {/* /* so the nested <Instances> route tree can match the rest */}
+            {/* so the nested <Instances> route tree can match the rest */}
             <Route
               path="instances/*"
               element={
@@ -142,6 +142,16 @@ function InstanceGroup({ setBreadcrumb }) {
                   showTypeColumn
                   defaultParams={{ instance_group: instanceGroup.id }}
                 />
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <ContentError isNotFound>
+                  <Link to="/instance_groups">
+                    {t`View all instance groups`}
+                  </Link>
+                </ContentError>
               }
             />
           </Routes>

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.test.js
@@ -1,63 +1,112 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { InstanceGroupsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
-
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import InstanceGroup from './InstanceGroup';
 
-jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    url: '/instance_groups',
-  }),
-  useParams: () => ({ id: 42 }),
-}));
+jest.mock('../../api/models/InstanceGroups');
 
-describe('<InstanceGroup/>', () => {
-  let wrapper;
-  test('should render details properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroup setBreadcrumb={() => {}} />);
-    });
-    wrapper.update();
-    expect(wrapper.find('InstanceGroup').length).toBe(1);
-    expect(InstanceGroupsAPI.readDetail).toHaveBeenCalledWith(42);
+// Markers for the routed tab panels, so assertions are about which branch of
+// the nested v6 <Routes> tree resolves.
+jest.mock('./InstanceGroupDetails', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'InstanceGroupDetails'),
+  };
+});
+jest.mock('./InstanceGroupEdit', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'InstanceGroupEdit'),
+  };
+});
+jest.mock('./Instances/Instances', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'Instances subtree'),
+  };
+});
+jest.mock('components/JobList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'JobList'),
+  };
+});
+
+const instanceGroup = {
+  id: 42,
+  name: 'Foo',
+  summary_fields: { user_capabilities: { edit: true, delete: true } },
+};
+
+// InstanceGroup uses paths relative to its parent route, so mount it under the
+// same /instance_groups/:id/* route that InstanceGroups.js gives it in the app.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/instance_groups/:id/*"
+        element={<InstanceGroup setBreadcrumb={() => {}} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
+describe('<InstanceGroup />', () => {
+  beforeEach(() => {
+    InstanceGroupsAPI.readDetail.mockResolvedValue({ data: instanceGroup });
   });
 
-  test('should render expected tabs', async () => {
-    const expectedTabs = [
-      'Back to Instance Groups',
-      'Details',
-      'Instances',
-      'Jobs',
-    ];
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroup setBreadcrumb={() => {}} />);
-    });
-    wrapper.find('RoutedTabs li').forEach((tab, index) => {
-      expect(tab.text()).toEqual(expectedTabs[index]);
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/instance_groups/42/foobar'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroup setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-          },
-        },
-      });
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+  test('fetches the instance group detail', async () => {
+    renderAt('/instance_groups/42/details');
+    expect(await screen.findByText('InstanceGroupDetails')).toBeInTheDocument();
+    // real route params are strings (the old enzyme test mocked a number)
+    expect(InstanceGroupsAPI.readDetail).toHaveBeenCalledWith('42');
+  });
+
+  test('renders the edit panel at /edit', async () => {
+    renderAt('/instance_groups/42/edit');
+    expect(await screen.findByText('InstanceGroupEdit')).toBeInTheDocument();
+  });
+
+  test('renders the instances subtree at /instances', async () => {
+    renderAt('/instance_groups/42/instances');
+    expect(await screen.findByText('Instances subtree')).toBeInTheDocument();
+  });
+
+  test('renders the jobs panel at /jobs', async () => {
+    renderAt('/instance_groups/42/jobs');
+    expect(await screen.findByText('JobList')).toBeInTheDocument();
+  });
+
+  test('redirects the index path to details', async () => {
+    const { history } = renderAt('/instance_groups/42');
+    expect(await screen.findByText('InstanceGroupDetails')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/instance_groups/42/details')
+    );
+  });
+
+  test('shows a not-found error when the detail request 404s', async () => {
+    const err = new Error('not found');
+    err.response = { status: 404 };
+    InstanceGroupsAPI.readDetail.mockRejectedValue(err);
+    renderAt('/instance_groups/42/details');
+    expect(
+      await screen.findByText('Instance group not found.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('InstanceGroupDetails')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation, useRouteMatch, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 
 import { Plural, useLingui } from '@lingui/react/macro';
 
@@ -30,7 +30,6 @@ const QS_CONFIG = getQSConfig('instance-group', {
 function InstanceGroupList() {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch();
 
   const {
     error: contentError,
@@ -138,8 +137,8 @@ function InstanceGroupList() {
 
   const getDetailUrl = (item) =>
     item.is_container_group
-      ? `${match.url}/container_group/${item.id}/details`
-      : `${match.url}/${item.id}/details`;
+      ? `/instance_groups/container_group/${item.id}/details`
+      : `/instance_groups/${item.id}/details`;
   const deleteDetailsRequests = relatedResourceDeleteRequests(t).instanceGroup(
     selected[0]
   );

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
@@ -1,7 +1,8 @@
 import React, { useCallback, useState } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Route, Switch, useLocation } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 import ScreenHeader from 'components/ScreenHeader';
 import PersistentFilters from 'components/PersistentFilters';
 import InstanceGroupAdd from './InstanceGroupAdd';
@@ -58,25 +59,34 @@ function InstanceGroups() {
         streamType={streamType}
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path="/instance_groups/container_group/add">
-          <ContainerGroupAdd />
-        </Route>
-        <Route path="/instance_groups/container_group/:id">
-          <ContainerGroup setBreadcrumb={buildBreadcrumbConfig} />
-        </Route>
-        <Route path="/instance_groups/add">
-          <InstanceGroupAdd />
-        </Route>
-        <Route path="/instance_groups/:id">
-          <InstanceGroup setBreadcrumb={buildBreadcrumbConfig} />
-        </Route>
-        <Route path="/instance_groups">
-          <PersistentFilters pageKey="instanceGroups">
-            <InstanceGroupList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route
+          path="/instance_groups/container_group/add"
+          element={<ContainerGroupAdd />}
+        />
+        {/* /* so the nested <ContainerGroup> route tree can match the rest */}
+        <Route
+          path="/instance_groups/container_group/:id/*"
+          element={<ContainerGroup setBreadcrumb={buildBreadcrumbConfig} />}
+        />
+        <Route
+          path="/instance_groups/add"
+          element={<InstanceGroupAdd />}
+        />
+        {/* /* so the nested <InstanceGroup> route tree can match the rest */}
+        <Route
+          path="/instance_groups/:id/*"
+          element={<InstanceGroup setBreadcrumb={buildBreadcrumbConfig} />}
+        />
+        <Route
+          path="/instance_groups"
+          element={
+            <PersistentFilters pageKey="instanceGroups">
+              <InstanceGroupList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
@@ -1,56 +1,86 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import InstanceGroups from './InstanceGroups';
-import { useUserProfile } from 'contexts/Config';
 
-const mockUseLocationValue = {
-  pathname: '',
-};
-jest.mock('api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: () => mockUseLocationValue,
-}));
+jest.mock('../../api/models/InstanceGroups');
 
-beforeEach(() => {
-  useUserProfile.mockImplementation(() => {
-    return {
-      isSuperUser: true,
-      isSystemAuditor: false,
-      isOrgAdmin: false,
-      isNotificationAdmin: false,
-      isExecEnvAdmin: false,
-    };
-  });
+// Replace the routed children with markers so the assertions are purely about
+// which branch of the v6 <Routes> tree resolves for a given URL.
+jest.mock('./InstanceGroupList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'InstanceGroupList'),
+  };
+});
+jest.mock('./InstanceGroupAdd', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'InstanceGroupAdd'),
+  };
+});
+jest.mock('./ContainerGroupAdd', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ContainerGroupAdd'),
+  };
+});
+jest.mock('./InstanceGroup', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'InstanceGroup detail'),
+  };
+});
+jest.mock('./ContainerGroup', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ContainerGroup detail'),
+  };
 });
 
-describe('<InstanceGroups/>', () => {
-  test('should set breadcrumbs', () => {
-    mockUseLocationValue.pathname = '/instance_groups';
-
-    const wrapper = mountWithContexts(<InstanceGroups />);
-
-    const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toEqual('instance_group');
-    expect(header.prop('breadcrumbConfig')).toEqual({
-      '/instance_groups': 'Instance Groups',
-      '/instance_groups/add': 'Create new instance group',
-      '/instance_groups/container_group/add': 'Create new container group',
-    });
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<InstanceGroups />, {
+    context: { router: { history } },
   });
-  test('should set breadcrumbs', async () => {
-    mockUseLocationValue.pathname = '/instance_groups/1/instances';
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: { results: [{ hostname: 'EC2', id: 1 }] },
-    });
-    InstanceGroupsAPI.readInstanceOptions.mockResolvedValue({
-      data: { actions: {} },
-    });
+}
 
-    const wrapper = mountWithContexts(<InstanceGroups />);
+describe('<InstanceGroups />', () => {
+  test('renders the list at /instance_groups', async () => {
+    renderAt('/instance_groups');
+    expect(await screen.findByText('InstanceGroupList')).toBeInTheDocument();
+  });
 
-    expect(wrapper.find('ScreenHeader').prop('streamType')).toEqual('instance');
+  test('renders the instance group add form at /instance_groups/add', async () => {
+    renderAt('/instance_groups/add');
+    expect(await screen.findByText('InstanceGroupAdd')).toBeInTheDocument();
+    expect(screen.queryByText('InstanceGroupList')).not.toBeInTheDocument();
+  });
+
+  test('renders the container group add form at /instance_groups/container_group/add', async () => {
+    renderAt('/instance_groups/container_group/add');
+    expect(await screen.findByText('ContainerGroupAdd')).toBeInTheDocument();
+  });
+
+  test('renders the instance group detail subtree at /instance_groups/:id', async () => {
+    renderAt('/instance_groups/5/details');
+    expect(
+      await screen.findByText('InstanceGroup detail')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('InstanceGroupList')).not.toBeInTheDocument();
+  });
+
+  test('renders the container group detail subtree at /instance_groups/container_group/:id', async () => {
+    renderAt('/instance_groups/container_group/5/details');
+    expect(
+      await screen.findByText('ContainerGroup detail')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('InstanceGroup detail')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import useExpanded from 'hooks/useExpanded';
 import DataListToolbar from 'components/DataListToolbar';

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { bool, func } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
@@ -10,8 +10,10 @@ import InstanceListItem from './InstanceListItem';
 jest.mock('../../../api');
 jest.mock('../../../hooks/useDebounce');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// The component reads useParams from react-router-dom-v5-compat (the route
+// tree is v6); mock it there, keeping the rest of the module real.
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/InstanceGroup/Instances/Instances.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/Instances.js
@@ -1,29 +1,23 @@
 import React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import InstanceList from './InstanceList';
 import InstanceDetails from '../InstanceDetails';
 
 function Instances({ setBreadcrumb, instanceGroup }) {
   return (
-    <Switch>
-      <Redirect
-        from="/instance_groups/:id/instances/:instanceId"
-        to="/instance_groups/:id/instances/:instanceId/details"
-        exact
-      />
+    <Routes>
+      <Route index element={<InstanceList instanceGroup={instanceGroup} />} />
       <Route
-        key="details"
-        path="/instance_groups/:id/instances/:instanceId/details"
-      >
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={setBreadcrumb}
-        />
-      </Route>
-      <Route key="instanceList" path="/instance_groups/:id/instances">
-        <InstanceList instanceGroup={instanceGroup} />
-      </Route>
-    </Switch>
+        path=":instanceId/details"
+        element={
+          <InstanceDetails
+            instanceGroup={instanceGroup}
+            setBreadcrumb={setBreadcrumb}
+          />
+        }
+      />
+      <Route path=":instanceId" element={<Navigate to="details" replace />} />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/screens/InstanceGroup/Instances/Instances.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/Instances.test.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
+import Instances from './Instances';
+
+// Markers for the routed panels, so assertions are about which branch of the
+// nested v6 <Routes> tree resolves.
+jest.mock('./InstanceList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'InstanceList'),
+  };
+});
+jest.mock('../InstanceDetails', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'InstanceDetails'),
+  };
+});
+
+const instanceGroup = { id: 42, name: 'Foo' };
+
+// Instances uses paths relative to its parent route, so mount it under the same
+// /instance_groups/:id/instances/* route that InstanceGroup.js gives it.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/instance_groups/:id/instances/*"
+        element={
+          <Instances instanceGroup={instanceGroup} setBreadcrumb={() => {}} />
+        }
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
+describe('<Instances />', () => {
+  test('renders the instance list at the index path', async () => {
+    renderAt('/instance_groups/42/instances');
+    expect(await screen.findByText('InstanceList')).toBeInTheDocument();
+  });
+
+  test('renders the instance details at /:instanceId/details', async () => {
+    renderAt('/instance_groups/42/instances/7/details');
+    expect(await screen.findByText('InstanceDetails')).toBeInTheDocument();
+    expect(screen.queryByText('InstanceList')).not.toBeInTheDocument();
+  });
+
+  test('redirects /:instanceId to its details', async () => {
+    const { history } = renderAt('/instance_groups/42/instances/7');
+    expect(await screen.findByText('InstanceDetails')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe(
+        '/instance_groups/42/instances/7/details'
+      )
+    );
+  });
+});


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **InstanceGroup** screen's route trees — instance groups, container groups, and the nested per-group instances subtree — from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`, following the pattern used for the earlier screen conversions.

UI (no behavior change — same URLs, same panels):

- `InstanceGroups.js` (list router): `<Switch>` → `<Routes>`; child routes use the `element` prop; the container-group and instance-group detail routes use a trailing `/*` so their nested trees match the rest of the path. v6 route ranking keeps the static `container_group` / `add` segments ahead of the `:id` params.
- `InstanceGroup.js` / `ContainerGroup.js` (detail routers): `<Switch>` → `<Routes>` with **relative** child paths; the `exact` `<Redirect>` becomes an index route that `<Navigate replace>`s to `details`. InstanceGroup delegates its instances tab with `instances/*`.
- `Instances/Instances.js` (nested subtree): `<Switch>` → `<Routes>` with relative paths — the index renders the instance list, `:instanceId/details` renders the instance detail, and `:instanceId` redirects to details.
- Tests: the three detail/list suites are rewritten with `renderWithContexts` (RTL) and a new `Instances` route test is added, all asserting **real v6 route resolution** (each panel, the index redirects, and the 404 errors).

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch off `main`.
- This is the first conversion with a nested in-screen route subtree (`Instances`); it converts parent and child together so the nested routes resolve correctly under the v6 parent.
- Tests: 19 route-resolution tests across the four converted suites; full `screens/InstanceGroup` directory passes (17 suites / 86 tests).
- `npm --prefix awx/ui run lint` clean on the changed source.

