### PR TITLE
Convert WorkflowApproval route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApproval.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApproval.js
@@ -3,15 +3,14 @@ import { useLingui } from '@lingui/react/macro';
 
 import { Card, PageSection } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
 import {
-  Link,
-  Switch,
+  Routes,
   Route,
-  Redirect,
+  Navigate,
   useParams,
-  useRouteMatch,
   useLocation,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import useRequest from 'hooks/useRequest';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';
@@ -21,7 +20,6 @@ import WorkflowApprovalDetail from './WorkflowApprovalDetail';
 function WorkflowApproval({ setBreadcrumb }) {
   const { t } = useLingui();
   const { id: workflowApprovalId } = useParams();
-  const match = useRouteMatch();
   const location = useLocation();
   const {
     result: { workflowApproval },
@@ -76,7 +74,7 @@ function WorkflowApproval({ setBreadcrumb }) {
     },
     {
       name: t`Details`,
-      link: `${match.url}/details`,
+      link: `/workflow_approvals/${workflowApprovalId}/details`,
       id: 0,
     },
   ];
@@ -84,32 +82,36 @@ function WorkflowApproval({ setBreadcrumb }) {
     <PageSection>
       <Card>
         <RoutedTabs tabsArray={tabs} />
-        <Switch>
-          <Redirect
-            from="/workflow_approvals/:id"
-            to="/workflow_approvals/:id/details"
-            exact
-          />
+        <Routes>
+          <Route index element={<Navigate to="details" replace />} />
           {workflowApproval && (
-            <Route path="/workflow_approvals/:id/details">
-              <WorkflowApprovalDetail
-                fetchWorkflowApproval={fetchWorkflowApproval}
-                workflowApproval={workflowApproval}
-              />
-            </Route>
+            <Route
+              path="details"
+              element={
+                <WorkflowApprovalDetail
+                  fetchWorkflowApproval={fetchWorkflowApproval}
+                  workflowApproval={workflowApproval}
+                />
+              }
+            />
           )}
-          <Route key="not-found" path="*">
-            {!isLoading && (
-              <ContentError isNotFound>
-                {match.params.id && (
-                  <Link to={`/workflow_approvals/${match.params.id}/details`}>
-                    {t`View Workflow Approval Details`}
-                  </Link>
-                )}
-              </ContentError>
-            )}
-          </Route>
-        </Switch>
+          <Route
+            path="*"
+            element={
+              !isLoading ? (
+                <ContentError isNotFound>
+                  {workflowApprovalId && (
+                    <Link
+                      to={`/workflow_approvals/${workflowApprovalId}/details`}
+                    >
+                      {t`View Workflow Approval Details`}
+                    </Link>
+                  )}
+                </ContentError>
+              ) : null
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApproval.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApproval.test.js
@@ -1,20 +1,39 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { WorkflowApprovalsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import mockWorkflowApprovals from './data.workflowApprovals.json';
 import WorkflowApproval from './WorkflowApproval';
 
-jest.mock('../../api');
+jest.mock('../../api/models/WorkflowApprovals');
 
-const mockMe = {
-  is_super_user: true,
-  is_system_auditor: false,
-};
+// Marker for the routed detail panel, so assertions are about which branch of
+// the nested v6 <Routes> tree resolves.
+jest.mock('./WorkflowApprovalDetail', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactLib.createElement('div', null, 'WorkflowApprovalDetail'),
+  };
+});
+
+// WorkflowApproval uses paths relative to its parent route, so mount it under
+// the same /workflow_approvals/:id/* route that WorkflowApprovals.js gives it.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/workflow_approvals/:id/*"
+        element={<WorkflowApproval setBreadcrumb={() => {}} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
 
 describe('<WorkflowApproval />', () => {
   beforeEach(() => {
@@ -23,41 +42,49 @@ describe('<WorkflowApproval />', () => {
     });
   });
 
-  test('initially renders successfully', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApproval setBreadcrumb={() => {}} me={mockMe} />
-      );
-    });
-    expect(wrapper.find('WorkflowApproval').length).toBe(1);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/workflow_approvals/1/foobar'],
-    });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApproval setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/workflow_approvals/1/foobar',
-                  path: '/workflow_approvals/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+  test('fetches the workflow approval detail', async () => {
+    renderAt('/workflow_approvals/1/details');
+    expect(
+      await screen.findByText('WorkflowApprovalDetail')
+    ).toBeInTheDocument();
+    // real route params are strings (the old enzyme test mocked a number)
+    expect(WorkflowApprovalsAPI.readDetail).toHaveBeenCalledWith('1');
+  });
+
+  test('redirects the index path to details', async () => {
+    const { history } = renderAt('/workflow_approvals/1');
+    expect(
+      await screen.findByText('WorkflowApprovalDetail')
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/workflow_approvals/1/details')
+    );
+  });
+
+  test('shows a not-found error on an unknown sub-route', async () => {
+    renderAt('/workflow_approvals/1/foobar');
+    expect(
+      await screen.findByText('View Workflow Approval Details')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('WorkflowApprovalDetail')
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows a not-found error when the detail request 404s', async () => {
+    const err = new Error('not found');
+    err.response = { status: 404 };
+    WorkflowApprovalsAPI.readDetail.mockRejectedValue(err);
+    renderAt('/workflow_approvals/1/details');
+    expect(
+      await screen.findByText('Workflow Approval not found.')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('WorkflowApprovalDetail')
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
@@ -8,7 +8,6 @@ import WorkflowApprovalList from './WorkflowApprovalList';
 import WorkflowApproval from './WorkflowApproval';
 
 function WorkflowApprovals() {
-  const match = useRouteMatch();
   const { t } = useLingui();
   const [breadcrumbConfig, setBreadcrumbConfig] = useState({
     '/workflow_approvals': t`Workflow Approvals`,
@@ -35,16 +34,21 @@ function WorkflowApprovals() {
         streamType="workflow_approval"
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path={`${match.url}/:id`}>
-          <WorkflowApproval setBreadcrumb={updateBreadcrumbConfig} />
-        </Route>
-        <Route path={`${match.url}`}>
-          <PersistentFilters pageKey="workflowApprovals">
-            <WorkflowApprovalList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        {/* /* so the nested <WorkflowApproval> route tree can match the rest */}
+        <Route
+          path="/workflow_approvals/:id/*"
+          element={<WorkflowApproval setBreadcrumb={updateBreadcrumbConfig} />}
+        />
+        <Route
+          path="/workflow_approvals"
+          element={
+            <PersistentFilters pageKey="workflowApprovals">
+              <WorkflowApprovalList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
@@ -35,7 +35,7 @@ function WorkflowApprovals() {
         breadcrumbConfig={breadcrumbConfig}
       />
       <Routes>
-        {/* /* so the nested <WorkflowApproval> route tree can match the rest */}
+        {/* so the nested <WorkflowApproval> route tree can match the rest */}
         <Route
           path="/workflow_approvals/:id/*"
           element={<WorkflowApproval setBreadcrumb={updateBreadcrumbConfig} />}

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.test.js
@@ -1,70 +1,47 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { WorkflowApprovalsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowApprovals from './WorkflowApprovals';
-import mockWorkflowApprovals from './data.workflowApprovals.json';
 
-jest.mock('../../api');
+jest.mock('../../api/models/WorkflowApprovals');
+
+// Replace the routed children with markers so the assertions are purely about
+// which branch of the v6 <Routes> tree resolves for a given URL.
+jest.mock('./WorkflowApprovalList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'WorkflowApprovalList'),
+  };
+});
+jest.mock('./WorkflowApproval', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactLib.createElement('div', null, 'WorkflowApproval detail'),
+  };
+});
+
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<WorkflowApprovals />, {
+    context: { router: { history } },
+  });
+}
 
 describe('<WorkflowApprovals />', () => {
-  beforeEach(() => {
-    WorkflowApprovalsAPI.read.mockResolvedValue({
-      data: {
-        count: mockWorkflowApprovals.results.length,
-        results: mockWorkflowApprovals.results,
-      },
-    });
-
-    WorkflowApprovalsAPI.readOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
+  test('renders the list at /workflow_approvals', async () => {
+    renderAt('/workflow_approvals');
+    expect(await screen.findByText('WorkflowApprovalList')).toBeInTheDocument();
   });
 
-  test('initially renders successfully', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovals />);
-    });
-    expect(wrapper.find('WorkflowApprovals').length).toBe(1);
-  });
-
-  test('should display a breadcrumb heading', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/workflow_approvals'],
-    });
-    const match = {
-      path: '/workflow_approvals',
-      url: '/workflow_approvals',
-      isExact: true,
-    };
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovals />, {
-        context: {
-          router: {
-            history,
-            route: {
-              location: history.location,
-              match,
-            },
-          },
-        },
-      });
-    });
-
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find('Title').length).toBe(1);
+  test('renders the detail subtree at /workflow_approvals/:id', async () => {
+    renderAt('/workflow_approvals/1/details');
+    expect(
+      await screen.findByText('WorkflowApproval detail')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('WorkflowApprovalList')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **WorkflowApproval** screen's route trees from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`, following the pattern used for the earlier screen conversions.

UI (no behavior change - same URLs, same panels):

- `WorkflowApprovals.js` (list router): `<Switch>` -> `<Routes>`; child routes use the `element` prop; the detail route is `/workflow_approvals/:id/*` so the nested `<WorkflowApproval>` tree can match the rest of the path; the unused `useRouteMatch` `match.url` is replaced by explicit paths.
- `WorkflowApproval.js` (detail router): `<Switch>` -> `<Routes>` with a relative `details` child path; the `exact` `<Redirect>` becomes an index route that `<Navigate replace>`s to `details`; the catch-all not-found route stays as `path="*"`; `match.url` / `match.params.id` are replaced with the `workflowApprovalId` route param.
- Tests: both suites rewritten with `renderWithContexts` (RTL) to assert real v6 route resolution - the detail panel, the index redirect, the unknown-sub-route not-found error, and the 404 detail error.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch off `main`.
- Tests: 6 route-resolution tests across the two converted suites; full `screens/WorkflowApproval` directory passes (11 suites / 61 tests).
- `npm --prefix awx/ui run lint` clean on the changed source.

