### PR TITLE
Convert User route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/User/User.js
+++ b/awx/ui/src/screens/User/User.js
@@ -1,14 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
+import { Link } from 'react-router-dom';
 import {
-  Switch,
+  Routes,
   Route,
-  Redirect,
-  Link,
-  useRouteMatch,
+  Navigate,
+  useParams,
   useLocation,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';
@@ -25,7 +25,7 @@ import UserRolesList from './UserRoles/UserRolesList';
 function User({ setBreadcrumb, me }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch('/users/:id');
+  const { id } = useParams();
   const userListUrl = `/users`;
   const {
     result: user,
@@ -34,9 +34,9 @@ function User({ setBreadcrumb, me }) {
     request: fetchUser,
   } = useRequest(
     useCallback(async () => {
-      const { data } = await UsersAPI.readDetail(match.params.id);
+      const { data } = await UsersAPI.readDetail(id);
       return data;
-    }, [match.params.id]),
+    }, [id]),
     null
   );
 
@@ -62,20 +62,20 @@ function User({ setBreadcrumb, me }) {
       id: 99,
       persistentFilterKey: 'users',
     },
-    { name: t`Details`, link: `${match.url}/details`, id: 0 },
+    { name: t`Details`, link: `/users/${id}/details`, id: 0 },
     {
       name: t`Organizations`,
-      link: `${match.url}/organizations`,
+      link: `/users/${id}/organizations`,
       id: 1,
     },
-    { name: t`Teams`, link: `${match.url}/teams`, id: 2 },
-    { name: t`Roles`, link: `${match.url}/roles`, id: 3 },
+    { name: t`Teams`, link: `/users/${id}/teams`, id: 2 },
+    { name: t`Roles`, link: `/users/${id}/roles`, id: 3 },
   ];
 
-  if (me?.id === Number(match.params.id)) {
+  if (me?.id === Number(id)) {
     tabsArray.push({
       name: t`Tokens`,
-      link: `${match.url}/tokens`,
+      link: `/users/${id}/tokens`,
       id: 4,
     });
   }
@@ -108,44 +108,49 @@ function User({ setBreadcrumb, me }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-        <Switch>
-          <Redirect from="/users/:id" to="/users/:id/details" exact />
-          {user && [
-            <Route path="/users/:id/edit" key="edit">
-              <UserEdit user={user} />
-            </Route>,
-            <Route path="/users/:id/details" key="details">
-              <UserDetail user={user} />
-            </Route>,
-            <Route path="/users/:id/organizations" key="organizations">
-              <UserOrganizations id={Number(match.params.id)} />
-            </Route>,
-            <Route path="/users/:id/teams" key="teams">
-              <UserTeams />
-            </Route>,
-            <Route path="/users/:id/roles" key="roles">
-              <UserRolesList user={user} />
-            </Route>,
-            <Route path="/users/:id/tokens" key="tokens">
-              <UserTokens
-                user={user}
-                setBreadcrumb={setBreadcrumb}
-                id={Number(match.params.id)}
-              />
-            </Route>,
-          ]}
-          <Route key="not-found" path="*">
-            {!isLoading && (
-              <ContentError isNotFound>
-                {match.params.id && (
-                  <Link to={`/users/${match.params.id}/details`}>
-                    {t`View User Details`}
-                  </Link>
-                )}
-              </ContentError>
-            )}
-          </Route>
-        </Switch>
+        <Routes>
+          <Route index element={<Navigate to="details" replace />} />
+          {user && <Route path="edit" element={<UserEdit user={user} />} />}
+          {user && (
+            <Route path="details" element={<UserDetail user={user} />} />
+          )}
+          {user && (
+            <Route
+              path="organizations"
+              element={<UserOrganizations id={Number(id)} />}
+            />
+          )}
+          {user && <Route path="teams" element={<UserTeams />} />}
+          {user && (
+            <Route path="roles" element={<UserRolesList user={user} />} />
+          )}
+          {user && (
+            <Route
+              path="tokens/*"
+              element={
+                <UserTokens
+                  user={user}
+                  setBreadcrumb={setBreadcrumb}
+                  id={Number(id)}
+                />
+              }
+            />
+          )}
+          <Route
+            path="*"
+            element={
+              !isLoading ? (
+                <ContentError isNotFound>
+                  {id && (
+                    <Link to={`/users/${id}/details`}>
+                      {t`View User Details`}
+                    </Link>
+                  )}
+                </ContentError>
+              ) : null
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/User/User.js
+++ b/awx/ui/src/screens/User/User.js
@@ -128,11 +128,7 @@ function User({ setBreadcrumb, me }) {
             <Route
               path="tokens/*"
               element={
-                <UserTokens
-                  user={user}
-                  setBreadcrumb={setBreadcrumb}
-                  id={Number(id)}
-                />
+                <UserTokens user={user} setBreadcrumb={setBreadcrumb} />
               }
             />
           )}

--- a/awx/ui/src/screens/User/User.test.js
+++ b/awx/ui/src/screens/User/User.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { UsersAPI } from 'api';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import mockDetails from './data.user.json';
@@ -8,13 +9,23 @@ import User from './User';
 
 jest.mock('../../api');
 
+// Mount under the same /users/:id/* route that Users.js gives it, so the
+// nested v6 <Routes> resolve and useParams sees the id.
 function renderUser(initialEntry, props = {}) {
   const history = createMemoryHistory({
     initialEntries: [initialEntry],
   });
-  return renderWithContexts(<User setBreadcrumb={() => {}} {...props} />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/users/:id/*"
+        element={<User setBreadcrumb={() => {}} {...props} />}
+      />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<User />', () => {

--- a/awx/ui/src/screens/User/UserList/UserList.js
+++ b/awx/ui/src/screens/User/UserList/UserList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import { Card, PageSection } from '@patternfly/react-core';
 import { UsersAPI } from 'api';
@@ -27,7 +27,6 @@ const QS_CONFIG = getQSConfig('user', {
 
 function UserList() {
   const location = useLocation();
-  const match = useRouteMatch();
   const { t } = useLingui();
 
   const {
@@ -143,7 +142,7 @@ function UserList() {
                     ? [
                         <ToolbarAddButton
                           key="add"
-                          linkTo={`${match.url}/add`}
+                          linkTo="/users/add"
                         />,
                       ]
                     : []),
@@ -177,7 +176,7 @@ function UserList() {
               <UserListItem
                 key={user.id}
                 user={user}
-                detailUrl={`${match.url}/${user.id}/details`}
+                detailUrl={`/users/${user.id}/details`}
                 isSelected={selected.some((row) => row.id === user.id)}
                 onSelect={() => handleSelect(user)}
                 rowIndex={index}
@@ -185,7 +184,7 @@ function UserList() {
             )}
             emptyStateControls={
               canAdd ? (
-                <ToolbarAddButton key="add" linkTo={`${match.url}/add`} />
+                <ToolbarAddButton key="add" linkTo="/users/add" />
               ) : null
             }
           />

--- a/awx/ui/src/screens/User/UserOrganizations/UserOrganizationList.js
+++ b/awx/ui/src/screens/User/UserOrganizations/UserOrganizationList.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import PaginatedTable, {

--- a/awx/ui/src/screens/User/UserOrganizations/UserOrganizationList.test.js
+++ b/awx/ui/src/screens/User/UserOrganizations/UserOrganizationList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { UsersAPI } from 'api';
@@ -33,10 +33,12 @@ describe('<UserOrganizationlist />', () => {
       data: { actions: { GET: {} } },
     });
     renderWithContexts(
-      <Route
-        path="/users/:id/organizations"
-        component={() => <UserOrganizationList />}
-      />,
+      <Routes>
+        <Route
+          path="/users/:id/organizations"
+          element={<UserOrganizationList />}
+        />
+      </Routes>,
       {
         context: {
           router: {

--- a/awx/ui/src/screens/User/UserTeams/UserTeamList.js
+++ b/awx/ui/src/screens/User/UserTeams/UserTeamList.js
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import PaginatedTable, {
   HeaderRow,

--- a/awx/ui/src/screens/User/UserToken/UserToken.js
+++ b/awx/ui/src/screens/User/UserToken/UserToken.js
@@ -1,13 +1,13 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
+import { Link } from 'react-router-dom';
 import {
-  Link,
-  Redirect,
+  Routes,
   Route,
-  Switch,
+  Navigate,
   useLocation,
   useParams,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import RoutedTabs from 'components/RoutedTabs';
@@ -85,29 +85,27 @@ function UserToken({ setBreadcrumb, user }) {
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from="/users/:id/tokens/:tokenId"
-          to="/users/:id/tokens/:tokenId/details"
-          exact
-        />
+      <Routes>
+        <Route index element={<Navigate to="details" replace />} />
         {token && (
-          <Route path="/users/:id/tokens/:tokenId/details">
-            <UserTokenDetail token={token} />
-          </Route>
+          <Route
+            path="details"
+            element={<UserTokenDetail token={token} />}
+          />
         )}
-        <Route key="not-found" path="*">
-          {!isLoading && (
-            <ContentError isNotFound>
-              {id && (
-                <Link to={`/users/${id}/tokens`}>
-                  {t`View Tokens`}
-                </Link>
-              )}
-            </ContentError>
-          )}
-        </Route>
-      </Switch>
+        <Route
+          path="*"
+          element={
+            !isLoading ? (
+              <ContentError isNotFound>
+                {id && (
+                  <Link to={`/users/${id}/tokens`}>{t`View Tokens`}</Link>
+                )}
+              </ContentError>
+            ) : null
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/User/UserToken/UserToken.test.js
+++ b/awx/ui/src/screens/User/UserToken/UserToken.test.js
@@ -6,8 +6,8 @@ import UserToken from './UserToken';
 
 jest.mock('../../../api/models/Tokens');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({
     id: 1,
     tokenId: 2,

--- a/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.js
+++ b/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.js
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 
 import { CardBody } from 'components/Card';
 import { TokensAPI, UsersAPI } from 'api';

--- a/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.test.js
+++ b/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.test.js
@@ -6,8 +6,8 @@ import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import UserTokenAdd from './UserTokenAdd';
 
 jest.mock('../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({ id: 1 }),
 }));
 

--- a/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.js
+++ b/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.js
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import AlertModal from 'components/AlertModal';

--- a/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.test.js
+++ b/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.test.js
@@ -9,8 +9,8 @@ import UserTokenDetail from './UserTokenDetail';
 
 jest.mock('../../../api/models/Tokens');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({
     id: 1,
     tokenId: 2,

--- a/awx/ui/src/screens/User/UserTokenList/UserTokenList.js
+++ b/awx/ui/src/screens/User/UserTokenList/UserTokenList.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { getQSConfig, parseQueryString } from 'util/qs';
 import PaginatedTable, {

--- a/awx/ui/src/screens/User/UserTokenList/UserTokenList.test.js
+++ b/awx/ui/src/screens/User/UserTokenList/UserTokenList.test.js
@@ -15,6 +15,10 @@ jest.mock('react-router-dom', () => ({
   useLocation: () => ({
     search: '',
   }),
+}));
+// the component reads useParams from react-router-dom-v5-compat (v6 route tree)
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/User/UserTokenList/UserTokenListItem.js
+++ b/awx/ui/src/screens/User/UserTokenList/UserTokenListItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Tr, Td } from '@patternfly/react-table';
 import { toTitleCase } from 'util/strings';

--- a/awx/ui/src/screens/User/UserTokens/UserTokens.js
+++ b/awx/ui/src/screens/User/UserTokens/UserTokens.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
-import { Routes, Route, useParams } from 'react-router-dom-v5-compat';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import {
   Alert,
   ClipboardCopy,
@@ -21,7 +21,6 @@ const TokenAlert = styled(Alert)`
 function UserTokens({ setBreadcrumb, user }) {
   const { t } = useLingui();
   const [tokenModalSource, setTokenModalSource] = useState(null);
-  const { id } = useParams();
 
   const onSuccessfulAdd = useCallback(
     (token) => setTokenModalSource(token),
@@ -33,22 +32,14 @@ function UserTokens({ setBreadcrumb, user }) {
       <Routes>
         <Route
           path="add"
-          element={
-            <UserTokenAdd id={Number(id)} onSuccessfulAdd={onSuccessfulAdd} />
-          }
+          element={<UserTokenAdd onSuccessfulAdd={onSuccessfulAdd} />}
         />
-        {/* /* so the nested <UserToken> route tree can match the rest */}
+        {/* so the nested <UserToken> route tree can match the rest */}
         <Route
           path=":tokenId/*"
-          element={
-            <UserToken
-              user={user}
-              setBreadcrumb={setBreadcrumb}
-              id={Number(id)}
-            />
-          }
+          element={<UserToken user={user} setBreadcrumb={setBreadcrumb} />}
         />
-        <Route index element={<UserTokenList id={Number(id)} />} />
+        <Route index element={<UserTokenList />} />
       </Routes>
       {tokenModalSource && (
         <Modal

--- a/awx/ui/src/screens/User/UserTokens/UserTokens.js
+++ b/awx/ui/src/screens/User/UserTokens/UserTokens.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
-import { Switch, Route, useParams } from 'react-router-dom';
+import { Routes, Route, useParams } from 'react-router-dom-v5-compat';
 import {
   Alert,
   ClipboardCopy,
@@ -30,21 +30,26 @@ function UserTokens({ setBreadcrumb, user }) {
 
   return (
     <>
-      <Switch>
-        <Route key="add" path="/users/:id/tokens/add">
-          <UserTokenAdd id={Number(id)} onSuccessfulAdd={onSuccessfulAdd} />
-        </Route>
-        <Route key="token" path="/users/:id/tokens/:tokenId">
-          <UserToken
-            user={user}
-            setBreadcrumb={setBreadcrumb}
-            id={Number(id)}
-          />
-        </Route>
-        <Route key="list" path="/users/:id/tokens">
-          <UserTokenList id={Number(id)} />
-        </Route>
-      </Switch>
+      <Routes>
+        <Route
+          path="add"
+          element={
+            <UserTokenAdd id={Number(id)} onSuccessfulAdd={onSuccessfulAdd} />
+          }
+        />
+        {/* /* so the nested <UserToken> route tree can match the rest */}
+        <Route
+          path=":tokenId/*"
+          element={
+            <UserToken
+              user={user}
+              setBreadcrumb={setBreadcrumb}
+              id={Number(id)}
+            />
+          }
+        />
+        <Route index element={<UserTokenList id={Number(id)} />} />
+      </Routes>
       {tokenModalSource && (
         <Modal
           aria-label={t`Token information`}

--- a/awx/ui/src/screens/User/UserTokens/UserTokens.test.js
+++ b/awx/ui/src/screens/User/UserTokens/UserTokens.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import UserTokens from './UserTokens';
@@ -32,9 +33,14 @@ describe('<UserTokens />', () => {
     const history = createMemoryHistory({
       initialEntries: ['/users/1/tokens/add'],
     });
-    const { user } = renderWithContexts(<UserTokens />, {
-      context: { router: { history } },
-    });
+    const { user } = renderWithContexts(
+      <Routes>
+        <Route path="/users/:id/tokens/*" element={<UserTokens />} />
+      </Routes>,
+      {
+        context: { router: { history } },
+      }
+    );
     expect(
       screen.queryByRole('dialog', { name: /Token information/ })
     ).not.toBeInTheDocument();

--- a/awx/ui/src/screens/User/Users.js
+++ b/awx/ui/src/screens/User/Users.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Route, useRouteMatch, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
 import PersistentFilters from 'components/PersistentFilters';
@@ -15,7 +15,6 @@ function Users() {
     '/users': t`Users`,
     '/users/add': t`Create New User`,
   });
-  const match = useRouteMatch();
 
   const addUserBreadcrumb = useCallback(
     (user, token) => {
@@ -42,23 +41,28 @@ function Users() {
   return (
     <>
       <ScreenHeader streamType="user" breadcrumbConfig={breadcrumbConfig} />
-      <Switch>
-        <Route path={`${match.path}/add`}>
-          <UserAdd />
-        </Route>
-        <Route path={`${match.path}/:id`}>
-          <Config>
-            {({ me }) => (
-              <User setBreadcrumb={addUserBreadcrumb} me={me || {}} />
-            )}
-          </Config>
-        </Route>
-        <Route path={`${match.path}`}>
-          <PersistentFilters pageKey="users">
-            <UsersList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path="/users/add" element={<UserAdd />} />
+        {/* /* so the nested <User> route tree can match the rest */}
+        <Route
+          path="/users/:id/*"
+          element={
+            <Config>
+              {({ me }) => (
+                <User setBreadcrumb={addUserBreadcrumb} me={me || {}} />
+              )}
+            </Config>
+          }
+        />
+        <Route
+          path="/users"
+          element={
+            <PersistentFilters pageKey="users">
+              <UsersList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/User/Users.test.js
+++ b/awx/ui/src/screens/User/Users.test.js
@@ -1,13 +1,10 @@
 import React from 'react';
+import { screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Users from './Users';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    path: 'users',
-  }),
-}));
+jest.mock('../../api/models/Users');
 
 // resetMocks: true strips jest.fn implementations between tests, so capture
 // the props with a plain function instead of asserting on mock.calls.
@@ -20,19 +17,61 @@ jest.mock('components/ScreenHeader/ScreenHeader', () => ({
   },
 }));
 
+// Replace the routed children with markers so the assertions are purely about
+// which branch of the v6 <Routes> tree resolves for a given URL.
+jest.mock('./UserList/UserList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'UsersList'),
+  };
+});
+jest.mock('./UserAdd/UserAdd', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'UserAdd'),
+  };
+});
+jest.mock('./User', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'User detail'),
+  };
+});
+
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<Users />, {
+    context: { router: { history } },
+  });
+}
+
 describe('<Users />', () => {
   beforeEach(() => {
     mockScreenHeaderProps = undefined;
   });
 
-  test('should set breadcrumbs', () => {
-    renderWithContexts(<Users />);
-
-    const props = mockScreenHeaderProps;
-    expect(props.streamType).toBe('user');
-    expect(props.breadcrumbConfig).toEqual({
+  test('renders the list and sets the breadcrumb config at /users', async () => {
+    renderAt('/users');
+    expect(await screen.findByText('UsersList')).toBeInTheDocument();
+    expect(mockScreenHeaderProps.streamType).toBe('user');
+    expect(mockScreenHeaderProps.breadcrumbConfig).toEqual({
       '/users': 'Users',
       '/users/add': 'Create New User',
     });
+  });
+
+  test('renders the add form at /users/add', async () => {
+    renderAt('/users/add');
+    expect(await screen.findByText('UserAdd')).toBeInTheDocument();
+    expect(screen.queryByText('UsersList')).not.toBeInTheDocument();
+  });
+
+  test('renders the detail subtree at /users/:id', async () => {
+    renderAt('/users/1/details');
+    expect(await screen.findByText('User detail')).toBeInTheDocument();
+    expect(screen.queryByText('UsersList')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **User** screen's nested route trees - the Users list, the User detail, the UserTokens subtree, and the UserToken detail - from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`.

UI (no behavior change - same URLs, same panels):

- `Users.js` (list router): `<Switch>` -> `<Routes>` with explicit `/users` paths; the detail route is `/users/:id/*` so the nested `<User>` tree matches; the unused `useRouteMatch` `match.path` is dropped.
- `User.js` (detail router): `<Switch>` -> `<Routes>` with relative child paths (`details`, `edit`, `organizations`, `teams`, `roles`, `tokens/*`); the exact `<Redirect>` becomes an index route that `<Navigate>`s to `details`; the catch-all not-found route stays as `path="*"`; `match.url` / `match.params.id` are replaced with the `id` route param.
- `UserTokens.js` (nested subtree): `<Switch>` -> `<Routes>` with relative paths (`add`, `:tokenId/*`, index list).
- `UserToken.js` (token detail): `<Switch>` -> `<Routes>` with a relative `details` path and an index `<Navigate>` to `details`.
- Descendants that read params under the now-v6 tree are switched to read from `react-router-dom-v5-compat` (UserTeamList, UserOrganizationList, UserTokenList, UserTokenListItem, UserTokenAdd, UserTokenDetail); UserList builds its add/detail links from the literal `/users` base instead of `useRouteMatch` `match.url`.
- Tests: `useParams` mocks pointed at `react-router-dom-v5-compat`, and components mounted under their real v6 parent route so the nested `<Routes>` resolve.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch off `main`.
- This is the deepest nesting converted so far (Users -> User -> UserTokens -> UserToken), each level delegating with a trailing `/*` and using relative child paths.
- Includes the same descendant param-resolution fixes that the earlier converted screens needed (the v5 `useParams`/`useRouteMatch` would otherwise return empty under a v6 parent).
- Tests: full `screens/User` directory passes (22 suites / 94 tests). `npm --prefix awx/ui run lint` clean on the changed source.

