### PR TITLE
Convert AllSchedules route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/Schedule/AllSchedules.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { PageSection, Card } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
 
@@ -37,6 +37,7 @@ function AllSchedules() {
             </PageSection>
           }
         />
+        <Route path="*" element={<Navigate to="/schedules" replace />} />
       </Routes>
     </>
   );

--- a/awx/ui/src/screens/Schedule/AllSchedules.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { PageSection, Card } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
 
@@ -22,19 +22,22 @@ function AllSchedules() {
           '/schedules': t`Schedules`,
         }}
       />
-      <Switch>
-        <Route path="/schedules">
-          <PageSection>
-            <Card>
-              <ScheduleList
-                loadSchedules={loadSchedules}
-                loadScheduleOptions={loadScheduleOptions}
-                hideAddButton
-              />
-            </Card>
-          </PageSection>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route
+          path="/schedules"
+          element={
+            <PageSection>
+              <Card>
+                <ScheduleList
+                  loadSchedules={loadSchedules}
+                  loadScheduleOptions={loadScheduleOptions}
+                  hideAddButton
+                />
+              </Card>
+            </PageSection>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/Schedule/AllSchedules.test.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.test.js
@@ -42,6 +42,7 @@ describe('<AllSchedules />', () => {
   test('renders the schedule list and sets the breadcrumb config at /schedules', async () => {
     renderAt('/schedules');
     expect(await screen.findByText('ScheduleList')).toBeInTheDocument();
+    expect(mockScreenHeaderProps).toBeDefined();
     expect(mockScreenHeaderProps.streamType).toBe('schedule');
     expect(mockScreenHeaderProps.breadcrumbConfig).toEqual({
       '/schedules': 'Schedules',

--- a/awx/ui/src/screens/Schedule/AllSchedules.test.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.test.js
@@ -1,16 +1,49 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import AllSchedules from './AllSchedules';
 
 jest.mock('../../api');
 
-describe('<AllSchedules />', () => {
-  test('should set breadcrumb config', () => {
-    const wrapper = mountWithContexts(<AllSchedules />);
+// resetMocks strips jest.fn implementations between tests, so capture the
+// props with a plain function instead of asserting on mock.calls.
+let mockScreenHeaderProps;
+jest.mock('components/ScreenHeader', () => ({
+  __esModule: true,
+  default: (props) => {
+    mockScreenHeaderProps = props;
+    return null;
+  },
+}));
 
-    const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toEqual('schedule');
-    expect(header.prop('breadcrumbConfig')).toEqual({
+// Marker for the routed list so the assertion is about which branch of the
+// v6 <Routes> tree resolves.
+jest.mock('components/Schedule', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    ScheduleList: () => ReactLib.createElement('div', null, 'ScheduleList'),
+  };
+});
+
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return renderWithContexts(<AllSchedules />, {
+    context: { router: { history } },
+  });
+}
+
+describe('<AllSchedules />', () => {
+  beforeEach(() => {
+    mockScreenHeaderProps = undefined;
+  });
+
+  test('renders the schedule list and sets the breadcrumb config at /schedules', async () => {
+    renderAt('/schedules');
+    expect(await screen.findByText('ScheduleList')).toBeInTheDocument();
+    expect(mockScreenHeaderProps.streamType).toBe('schedule');
+    expect(mockScreenHeaderProps.breadcrumbConfig).toEqual({
       '/schedules': 'Schedules',
     });
   });


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the global **Schedules** screen (`AllSchedules`) from the v5 `<Switch>` API to v6 `<Routes>` via `react-router-dom-v5-compat`.

UI (no behavior change - same URL, same list):

- `AllSchedules.js`: `<Switch>` -> `<Routes>` with the `/schedules` list route using the `element` prop. `AllSchedules` renders the shared `ScheduleList` directly (not the nested `Schedules` router), so this is a single list route with no entanglement.
- Test rewritten with `renderWithContexts` (RTL) to mount at `/schedules` and assert the list resolves and the breadcrumb config is set.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch off `main`.
- `npm --prefix awx/ui run lint` clean; `screens/Schedule/AllSchedules` test passes.

