### PR TITLE
Convert the Setting screen route trees to react-router v6 Routes

### DIFF
--- a/awx/ui/src/screens/Setting/AzureAD/AzureAD.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureAD.js
@@ -28,24 +28,24 @@ function AzureAD() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/default/details`} replace />}
           />
           <Route
-            path={`${baseURL}/:category`}
+            path=":category"
             element={<CategoryRedirect baseURL={baseURL} />}
           />
           <Route
-            path={`${baseURL}/:category/details`}
+            path=":category/details"
             element={<AzureADDetail />}
           />
-          <Route path={`${baseURL}/default/edit`} element={<AzureADEdit />} />
+          <Route path="default/edit" element={<AzureADEdit />} />
           <Route
-            path={`${baseURL}/tenant/edit`}
+            path="tenant/edit"
             element={<AzureADTenantEdit />}
           />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/default/details`}>

--- a/awx/ui/src/screens/Setting/AzureAD/AzureAD.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureAD.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -7,43 +13,48 @@ import AzureADDetail from './AzureADDetail';
 import AzureADEdit from './AzureADEdit';
 import AzureADTenantEdit from './AzureADTenantEdit';
 
+// /settings/azure/:category (no sub-view) redirects to that category's details
+function CategoryRedirect({ baseURL }) {
+  const { category } = useParams();
+  return <Navigate to={`${baseURL}/${category}/details`} replace />;
+}
+
 function AzureAD() {
   const { t } = useLingui();
   const baseURL = '/settings/azure';
-  const baseRoute = useRouteMatch({ path: '/settings/azure', exact: true });
-  const categoryRoute = useRouteMatch({
-    path: '/settings/azure/:category',
-    exact: true,
-  });
 
   return (
     <PageSection>
       <Card>
-        <Switch>
-          {baseRoute && <Redirect to={`${baseURL}/default/details`} exact />}
-          {categoryRoute && (
-            <Redirect
-              to={`${baseURL}/${categoryRoute.params.category}/details`}
-              exact
-            />
-          )}
-          <Route path={`${baseURL}/:category/details`}>
-            <AzureADDetail />
-          </Route>
-          <Route path={`${baseURL}/default/edit`}>
-            <AzureADEdit />
-          </Route>
-          <Route path={`${baseURL}/tenant/edit`}>
-            <AzureADTenantEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/default/details`}>
-                {t`View Azure AD settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/default/details`} replace />}
+          />
+          <Route
+            path={`${baseURL}/:category`}
+            element={<CategoryRedirect baseURL={baseURL} />}
+          />
+          <Route
+            path={`${baseURL}/:category/details`}
+            element={<AzureADDetail />}
+          />
+          <Route path={`${baseURL}/default/edit`} element={<AzureADEdit />} />
+          <Route
+            path={`${baseURL}/tenant/edit`}
+            element={<AzureADTenantEdit />}
+          />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/default/details`}>
+                  {t`View Azure AD settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/AzureAD/AzureAD.test.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureAD.test.js
@@ -6,6 +6,7 @@ import { SettingsAPI } from 'api';
 import {
   mountWithContexts,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import AzureAD from './AzureAD';
 
@@ -42,7 +43,7 @@ describe('<AzureAD />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <AzureAD />
+          <Routes><Route path="/settings/azure/*" element={<AzureAD />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -57,7 +58,7 @@ describe('<AzureAD />', () => {
       initialEntries: ['/settings/azure/default/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<AzureAD />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/azure/*" element={<AzureAD />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -71,7 +72,7 @@ describe('<AzureAD />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <AzureAD />
+          <Routes><Route path="/settings/azure/*" element={<AzureAD />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },

--- a/awx/ui/src/screens/Setting/GitHub/GitHub.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHub.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -11,55 +17,61 @@ import GitHubEnterpriseEdit from './GitHubEnterpriseEdit';
 import GitHubEnterpriseOrgEdit from './GitHubEnterpriseOrgEdit';
 import GitHubEnterpriseTeamEdit from './GitHubEnterpriseTeamEdit';
 
+// /settings/github/:category (no sub-view) redirects to that category's details
+function CategoryRedirect({ baseURL }) {
+  const { category } = useParams();
+  return <Navigate to={`${baseURL}/${category}/details`} replace />;
+}
+
 function GitHub() {
   const { t } = useLingui();
   const baseURL = '/settings/github';
-  const baseRoute = useRouteMatch({ path: '/settings/github', exact: true });
-  const categoryRoute = useRouteMatch({
-    path: '/settings/github/:category',
-    exact: true,
-  });
 
   return (
     <PageSection>
       <Card>
-        <Switch>
-          {baseRoute && <Redirect to={`${baseURL}/default/details`} exact />}
-          {categoryRoute && (
-            <Redirect
-              to={`${baseURL}/${categoryRoute.params.category}/details`}
-              exact
-            />
-          )}
-          <Route path={`${baseURL}/:category/details`}>
-            <GitHubDetail />
-          </Route>
-          <Route path={`${baseURL}/default/edit`}>
-            <GitHubEdit />
-          </Route>
-          <Route path={`${baseURL}/organization/edit`}>
-            <GitHubOrgEdit />
-          </Route>
-          <Route path={`${baseURL}/team/edit`}>
-            <GitHubTeamEdit />
-          </Route>
-          <Route path={`${baseURL}/enterprise/edit`}>
-            <GitHubEnterpriseEdit />
-          </Route>
-          <Route path={`${baseURL}/enterprise_organization/edit`}>
-            <GitHubEnterpriseOrgEdit />
-          </Route>
-          <Route path={`${baseURL}/enterprise_team/edit`}>
-            <GitHubEnterpriseTeamEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/default/details`}>
-                {t`View GitHub Settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/default/details`} replace />}
+          />
+          <Route
+            path={`${baseURL}/:category`}
+            element={<CategoryRedirect baseURL={baseURL} />}
+          />
+          <Route
+            path={`${baseURL}/:category/details`}
+            element={<GitHubDetail />}
+          />
+          <Route path={`${baseURL}/default/edit`} element={<GitHubEdit />} />
+          <Route
+            path={`${baseURL}/organization/edit`}
+            element={<GitHubOrgEdit />}
+          />
+          <Route path={`${baseURL}/team/edit`} element={<GitHubTeamEdit />} />
+          <Route
+            path={`${baseURL}/enterprise/edit`}
+            element={<GitHubEnterpriseEdit />}
+          />
+          <Route
+            path={`${baseURL}/enterprise_organization/edit`}
+            element={<GitHubEnterpriseOrgEdit />}
+          />
+          <Route
+            path={`${baseURL}/enterprise_team/edit`}
+            element={<GitHubEnterpriseTeamEdit />}
+          />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/default/details`}>
+                  {t`View GitHub Settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/GitHub/GitHub.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHub.js
@@ -32,37 +32,37 @@ function GitHub() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/default/details`} replace />}
           />
           <Route
-            path={`${baseURL}/:category`}
+            path=":category"
             element={<CategoryRedirect baseURL={baseURL} />}
           />
           <Route
-            path={`${baseURL}/:category/details`}
+            path=":category/details"
             element={<GitHubDetail />}
           />
-          <Route path={`${baseURL}/default/edit`} element={<GitHubEdit />} />
+          <Route path="default/edit" element={<GitHubEdit />} />
           <Route
-            path={`${baseURL}/organization/edit`}
+            path="organization/edit"
             element={<GitHubOrgEdit />}
           />
-          <Route path={`${baseURL}/team/edit`} element={<GitHubTeamEdit />} />
+          <Route path="team/edit" element={<GitHubTeamEdit />} />
           <Route
-            path={`${baseURL}/enterprise/edit`}
+            path="enterprise/edit"
             element={<GitHubEnterpriseEdit />}
           />
           <Route
-            path={`${baseURL}/enterprise_organization/edit`}
+            path="enterprise_organization/edit"
             element={<GitHubEnterpriseOrgEdit />}
           />
           <Route
-            path={`${baseURL}/enterprise_team/edit`}
+            path="enterprise_team/edit"
             element={<GitHubEnterpriseTeamEdit />}
           />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/default/details`}>

--- a/awx/ui/src/screens/Setting/GitHub/GitHub.test.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHub.test.js
@@ -7,6 +7,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import GitHub from './GitHub';
 
@@ -99,7 +100,9 @@ describe('<GitHub />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GitHub />
+          <Routes>
+            <Route path="/settings/github/*" element={<GitHub />} />
+          </Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -118,7 +121,9 @@ describe('<GitHub />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GitHub />
+          <Routes>
+            <Route path="/settings/github/*" element={<GitHub />} />
+          </Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -139,7 +144,9 @@ describe('<GitHub />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GitHub />
+          <Routes>
+            <Route path="/settings/github/*" element={<GitHub />} />
+          </Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -157,7 +164,9 @@ describe('<GitHub />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GitHub />
+          <Routes>
+            <Route path="/settings/github/*" element={<GitHub />} />
+          </Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },

--- a/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.js
+++ b/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,24 @@ function GoogleOAuth2() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <GoogleOAuth2Detail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <GoogleOAuth2Edit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View Google OAuth 2.0 settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<GoogleOAuth2Detail />} />
+          <Route path={`${baseURL}/edit`} element={<GoogleOAuth2Edit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>
+                  {t`View Google OAuth 2.0 settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.js
+++ b/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.js
@@ -15,13 +15,13 @@ function GoogleOAuth2() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<GoogleOAuth2Detail />} />
-          <Route path={`${baseURL}/edit`} element={<GoogleOAuth2Edit />} />
+          <Route path="details" element={<GoogleOAuth2Detail />} />
+          <Route path="edit" element={<GoogleOAuth2Edit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>

--- a/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.test.js
+++ b/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.test.js
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import { SettingsProvider } from 'contexts/Settings';
 import { SettingsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import GoogleOAuth2 from './GoogleOAuth2';
 
@@ -43,7 +44,7 @@ describe('<GoogleOAuth2 />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GoogleOAuth2 />
+          <Routes><Route path="/settings/google_oauth2/*" element={<GoogleOAuth2 />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -60,7 +61,7 @@ describe('<GoogleOAuth2 />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <GoogleOAuth2 />
+          <Routes><Route path="/settings/google_oauth2/*" element={<GoogleOAuth2 />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -75,7 +76,7 @@ describe('<GoogleOAuth2 />', () => {
       initialEntries: ['/settings/google_oauth2/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<GoogleOAuth2 />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/google_oauth2/*" element={<GoogleOAuth2 />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/Jobs/Jobs.js
+++ b/awx/ui/src/screens/Setting/Jobs/Jobs.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,22 @@ function Jobs() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <JobsDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <JobsEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View Jobs settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<JobsDetail />} />
+          <Route path={`${baseURL}/edit`} element={<JobsEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>{t`View Jobs settings`}</Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/Jobs/Jobs.js
+++ b/awx/ui/src/screens/Setting/Jobs/Jobs.js
@@ -15,13 +15,13 @@ function Jobs() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<JobsDetail />} />
-          <Route path={`${baseURL}/edit`} element={<JobsEdit />} />
+          <Route path="details" element={<JobsDetail />} />
+          <Route path="edit" element={<JobsEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>{t`View Jobs settings`}</Link>

--- a/awx/ui/src/screens/Setting/Jobs/Jobs.test.js
+++ b/awx/ui/src/screens/Setting/Jobs/Jobs.test.js
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
 import { SettingsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockJobSettings from '../shared/data.jobSettings.json';
 import Jobs from './Jobs';
 
@@ -26,7 +27,7 @@ describe('<Jobs />', () => {
       initialEntries: ['/settings/jobs/details'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Jobs />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/jobs/*" element={<Jobs />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -38,7 +39,7 @@ describe('<Jobs />', () => {
       initialEntries: ['/settings/jobs/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Jobs />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/jobs/*" element={<Jobs />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -50,7 +51,7 @@ describe('<Jobs />', () => {
       initialEntries: ['/settings/jobs/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Jobs />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/jobs/*" element={<Jobs />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/LDAP/LDAP.js
+++ b/awx/ui/src/screens/Setting/LDAP/LDAP.js
@@ -27,20 +27,20 @@ function LDAP() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/default/details`} replace />}
           />
           <Route
-            path={`${baseURL}/:category`}
+            path=":category"
             element={<CategoryRedirect baseURL={baseURL} />}
           />
           <Route
-            path={`${baseURL}/:category/details`}
+            path=":category/details"
             element={<LDAPDetail />}
           />
-          <Route path={`${baseURL}/:category/edit`} element={<LDAPEdit />} />
+          <Route path=":category/edit" element={<LDAPEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/default/details`}>

--- a/awx/ui/src/screens/Setting/LDAP/LDAP.js
+++ b/awx/ui/src/screens/Setting/LDAP/LDAP.js
@@ -1,45 +1,55 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
 import LDAPDetail from './LDAPDetail';
 import LDAPEdit from './LDAPEdit';
 
+// /settings/ldap/:category (no sub-view) redirects to that category's details
+function CategoryRedirect({ baseURL }) {
+  const { category } = useParams();
+  return <Navigate to={`${baseURL}/${category}/details`} replace />;
+}
+
 function LDAP() {
   const { t } = useLingui();
   const baseURL = '/settings/ldap';
-  const baseRoute = useRouteMatch({ path: '/settings/ldap', exact: true });
-  const categoryRoute = useRouteMatch({
-    path: '/settings/ldap/:category',
-    exact: true,
-  });
 
   return (
     <PageSection>
       <Card>
-        <Switch>
-          {baseRoute && <Redirect to={`${baseURL}/default/details`} exact />}
-          {categoryRoute && (
-            <Redirect
-              to={`${baseURL}/${categoryRoute.params.category}/details`}
-              exact
-            />
-          )}
-          <Route path={`${baseURL}/:category/details`}>
-            <LDAPDetail />
-          </Route>
-          <Route path={`${baseURL}/:category/edit`}>
-            <LDAPEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/default/details`}>
-                {t`View LDAP Settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/default/details`} replace />}
+          />
+          <Route
+            path={`${baseURL}/:category`}
+            element={<CategoryRedirect baseURL={baseURL} />}
+          />
+          <Route
+            path={`${baseURL}/:category/details`}
+            element={<LDAPDetail />}
+          />
+          <Route path={`${baseURL}/:category/edit`} element={<LDAPEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/default/details`}>
+                  {t`View LDAP Settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/LDAP/LDAP.test.js
+++ b/awx/ui/src/screens/Setting/LDAP/LDAP.test.js
@@ -7,6 +7,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import mockLDAP from '../shared/data.ldapSettings.json';
 import LDAP from './LDAP';
@@ -26,7 +27,7 @@ describe('<LDAP />', () => {
       initialEntries: ['/settings/ldap/'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<LDAP />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/ldap/*" element={<LDAP />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -41,7 +42,7 @@ describe('<LDAP />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <LDAP />
+          <Routes><Route path="/settings/ldap/*" element={<LDAP />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -57,7 +58,7 @@ describe('<LDAP />', () => {
       initialEntries: ['/settings/ldap/foo/bar'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<LDAP />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/ldap/*" element={<LDAP />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/Logging/Logging.js
+++ b/awx/ui/src/screens/Setting/Logging/Logging.js
@@ -17,12 +17,12 @@ function Logging() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<LoggingDetail />} />
+          <Route path="details" element={<LoggingDetail />} />
           <Route
-            path={`${baseURL}/edit`}
+            path="edit"
             element={
               me?.is_superuser ? (
                 <LoggingEdit />
@@ -32,7 +32,7 @@ function Logging() {
             }
           />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>{t`View Logging settings`}</Link>

--- a/awx/ui/src/screens/Setting/Logging/Logging.js
+++ b/awx/ui/src/screens/Setting/Logging/Logging.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -14,26 +15,31 @@ function Logging() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <LoggingDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            {me?.is_superuser ? (
-              <LoggingEdit />
-            ) : (
-              <Redirect to={`${baseURL}/details`} />
-            )}
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View Logging settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<LoggingDetail />} />
+          <Route
+            path={`${baseURL}/edit`}
+            element={
+              me?.is_superuser ? (
+                <LoggingEdit />
+              ) : (
+                <Navigate to={`${baseURL}/details`} replace />
+              )
+            }
+          />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>{t`View Logging settings`}</Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/Logging/Logging.test.js
+++ b/awx/ui/src/screens/Setting/Logging/Logging.test.js
@@ -6,6 +6,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import Logging from './Logging';
 
 jest.mock('../../../api/models/Settings');
@@ -50,7 +51,7 @@ describe('<Logging />', () => {
       initialEntries: ['/settings/logging/details'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Logging />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/logging/*" element={<Logging />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -63,7 +64,7 @@ describe('<Logging />', () => {
       initialEntries: ['/settings/logging/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Logging />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/logging/*" element={<Logging />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -76,7 +77,7 @@ describe('<Logging />', () => {
       initialEntries: ['/settings/logging/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Logging />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/logging/*" element={<Logging />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -88,7 +89,7 @@ describe('<Logging />', () => {
       initialEntries: ['/settings/logging/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Logging />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/logging/*" element={<Logging />} /></Routes>, {
         context: {
           router: {
             history,

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.js
@@ -17,12 +17,12 @@ function MiscAuthentication() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<MiscAuthenticationDetail />} />
+          <Route path="details" element={<MiscAuthenticationDetail />} />
           <Route
-            path={`${baseURL}/edit`}
+            path="edit"
             element={
               me?.is_superuser ? (
                 <MiscAuthenticationEdit />
@@ -32,7 +32,7 @@ function MiscAuthentication() {
             }
           />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>{t`View Miscellaneous Authentication settings`}</Link>

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -14,26 +15,31 @@ function MiscAuthentication() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <MiscAuthenticationDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            {me?.is_superuser ? (
-              <MiscAuthenticationEdit />
-            ) : (
-              <Redirect to={`${baseURL}/details`} />
-            )}
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View Miscellaneous Authentication settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<MiscAuthenticationDetail />} />
+          <Route
+            path={`${baseURL}/edit`}
+            element={
+              me?.is_superuser ? (
+                <MiscAuthenticationEdit />
+              ) : (
+                <Navigate to={`${baseURL}/details`} replace />
+              )
+            }
+          />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>{t`View Miscellaneous Authentication settings`}</Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.test.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.test.js
@@ -6,6 +6,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import MiscAuthentication from './MiscAuthentication';
 
 jest.mock('../../../api');
@@ -28,7 +29,7 @@ describe('<MiscAuthentication />', () => {
       initialEntries: ['/settings/miscellaneous_authentication/details'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscAuthentication />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_authentication/*" element={<MiscAuthentication />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -41,7 +42,7 @@ describe('<MiscAuthentication />', () => {
       initialEntries: ['/settings/miscellaneous_authentication/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscAuthentication />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_authentication/*" element={<MiscAuthentication />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -54,7 +55,7 @@ describe('<MiscAuthentication />', () => {
       initialEntries: ['/settings/miscellaneous_authentication/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscAuthentication />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_authentication/*" element={<MiscAuthentication />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -66,7 +67,7 @@ describe('<MiscAuthentication />', () => {
       initialEntries: ['/settings/miscellaneous_authentication/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscAuthentication />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_authentication/*" element={<MiscAuthentication />} /></Routes>, {
         context: {
           router: {
             history,

--- a/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.js
+++ b/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.js
@@ -18,12 +18,12 @@ function MiscSystem() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<MiscSystemDetail />} />
+          <Route path="details" element={<MiscSystemDetail />} />
           <Route
-            path={`${baseURL}/edit`}
+            path="edit"
             element={
               me?.is_superuser ? (
                 <MiscSystemEdit />
@@ -33,7 +33,7 @@ function MiscSystem() {
             }
           />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>{t`View Miscellaneous System settings`}</Link>

--- a/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.js
+++ b/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -15,26 +16,31 @@ function MiscSystem() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <MiscSystemDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            {me?.is_superuser ? (
-              <MiscSystemEdit />
-            ) : (
-              <Redirect to={`${baseURL}/details`} />
-            )}
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View Miscellaneous System settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<MiscSystemDetail />} />
+          <Route
+            path={`${baseURL}/edit`}
+            element={
+              me?.is_superuser ? (
+                <MiscSystemEdit />
+              ) : (
+                <Navigate to={`${baseURL}/details`} replace />
+              )
+            }
+          />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>{t`View Miscellaneous System settings`}</Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.test.js
+++ b/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.test.js
@@ -6,6 +6,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import MiscSystem from './MiscSystem';
 
 jest.mock('../../../api');
@@ -28,7 +29,7 @@ describe('<MiscSystem />', () => {
       initialEntries: ['/settings/miscellaneous_system/details'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscSystem />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_system/*" element={<MiscSystem />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -41,7 +42,7 @@ describe('<MiscSystem />', () => {
       initialEntries: ['/settings/miscellaneous_system/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscSystem />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_system/*" element={<MiscSystem />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -54,7 +55,7 @@ describe('<MiscSystem />', () => {
       initialEntries: ['/settings/miscellaneous_system/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscSystem />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_system/*" element={<MiscSystem />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -66,7 +67,7 @@ describe('<MiscSystem />', () => {
       initialEntries: ['/settings/miscellaneous_system/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<MiscSystem />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/miscellaneous_system/*" element={<MiscSystem />} /></Routes>, {
         context: {
           router: {
             history,

--- a/awx/ui/src/screens/Setting/OIDC/OIDC.js
+++ b/awx/ui/src/screens/Setting/OIDC/OIDC.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,24 @@ function OIDC() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <OIDCDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <OIDCEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View OIDC settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<OIDCDetail />} />
+          <Route path={`${baseURL}/edit`} element={<OIDCEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>
+                  {t`View OIDC settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/OIDC/OIDC.js
+++ b/awx/ui/src/screens/Setting/OIDC/OIDC.js
@@ -15,13 +15,13 @@ function OIDC() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<OIDCDetail />} />
-          <Route path={`${baseURL}/edit`} element={<OIDCEdit />} />
+          <Route path="details" element={<OIDCDetail />} />
+          <Route path="edit" element={<OIDCEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>

--- a/awx/ui/src/screens/Setting/OIDC/OIDC.test.js
+++ b/awx/ui/src/screens/Setting/OIDC/OIDC.test.js
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import { SettingsProvider } from 'contexts/Settings';
 import { SettingsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import OIDC from './OIDC';
 
@@ -34,7 +35,7 @@ describe('<OIDC />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <OIDC />
+          <Routes><Route path="/settings/oidc/*" element={<OIDC />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -51,7 +52,7 @@ describe('<OIDC />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <OIDC />
+          <Routes><Route path="/settings/oidc/*" element={<OIDC />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -66,7 +67,7 @@ describe('<OIDC />', () => {
       initialEntries: ['/settings/oidc/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<OIDC />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/oidc/*" element={<OIDC />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/RADIUS/RADIUS.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUS.js
@@ -15,13 +15,13 @@ function RADIUS() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<RADIUSDetail />} />
-          <Route path={`${baseURL}/edit`} element={<RADIUSEdit />} />
+          <Route path="details" element={<RADIUSDetail />} />
+          <Route path="edit" element={<RADIUSEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>

--- a/awx/ui/src/screens/Setting/RADIUS/RADIUS.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUS.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,24 @@ function RADIUS() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <RADIUSDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <RADIUSEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View RADIUS settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<RADIUSDetail />} />
+          <Route path={`${baseURL}/edit`} element={<RADIUSEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>
+                  {t`View RADIUS settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/RADIUS/RADIUS.test.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUS.test.js
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import { SettingsProvider } from 'contexts/Settings';
 import { SettingsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import RADIUS from './RADIUS';
 
@@ -33,7 +34,7 @@ describe('<RADIUS />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <RADIUS />
+          <Routes><Route path="/settings/radius/*" element={<RADIUS />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -50,7 +51,7 @@ describe('<RADIUS />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <RADIUS />
+          <Routes><Route path="/settings/radius/*" element={<RADIUS />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -65,7 +66,7 @@ describe('<RADIUS />', () => {
       initialEntries: ['/settings/radius/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<RADIUS />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/radius/*" element={<RADIUS />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/SAML/SAML.js
+++ b/awx/ui/src/screens/Setting/SAML/SAML.js
@@ -15,13 +15,13 @@ function SAML() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<SAMLDetail />} />
-          <Route path={`${baseURL}/edit`} element={<SAMLEdit />} />
+          <Route path="details" element={<SAMLDetail />} />
+          <Route path="edit" element={<SAMLEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>

--- a/awx/ui/src/screens/Setting/SAML/SAML.js
+++ b/awx/ui/src/screens/Setting/SAML/SAML.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,24 @@ function SAML() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <SAMLDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <SAMLEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View SAML settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<SAMLDetail />} />
+          <Route path={`${baseURL}/edit`} element={<SAMLEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>
+                  {t`View SAML settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/SAML/SAML.test.js
+++ b/awx/ui/src/screens/Setting/SAML/SAML.test.js
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import { SettingsAPI } from 'api';
 import { SettingsProvider } from 'contexts/Settings';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import SAML from './SAML';
 
@@ -48,7 +49,7 @@ describe('<SAML />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <SAML />
+          <Routes><Route path="/settings/saml/*" element={<SAML />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -65,7 +66,7 @@ describe('<SAML />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <SAML />
+          <Routes><Route path="/settings/saml/*" element={<SAML />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -80,7 +81,7 @@ describe('<SAML />', () => {
       initialEntries: ['/settings/saml/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<SAML />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/saml/*" element={<SAML />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/Settings.js
+++ b/awx/ui/src/screens/Setting/Settings.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, Route, Switch, Redirect } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -150,75 +151,61 @@ function Settings() {
   }
 
   if (!me?.is_superuser && !me?.is_system_auditor) {
-    return <Redirect to="/" />;
+    return <Navigate to="/" replace />;
   }
 
   return (
     <SettingsProvider value={result}>
       <ScreenHeader streamType="setting" breadcrumbConfig={breadcrumbConfig} />
-      <Switch>
-        <Route path="/settings/azure">
-          <AzureAD />
-        </Route>
-        <Route path="/settings/github">
-          <GitHub />
-        </Route>
-        <Route path="/settings/google_oauth2">
-          <GoogleOAuth2 />
-        </Route>
-        <Route path="/settings/oidc">
-          <OIDC />
-        </Route>
-        <Route path="/settings/jobs">
-          <Jobs />
-        </Route>
-        <Route path="/settings/ldap">
-          <LDAP />
-        </Route>
-        <Route path="/settings/subscription">
-          {license_info?.license_type === 'open' ? (
-            <Redirect to="/settings" />
-          ) : (
-            <Subscription />
-          )}
-        </Route>
-        <Route path="/settings/logging">
-          <Logging />
-        </Route>
-        <Route path="/settings/miscellaneous_authentication">
-          <MiscAuthentication />
-        </Route>
-        <Route path="/settings/miscellaneous_system">
-          <MiscSystem />
-        </Route>
-        <Route path="/settings/radius">
-          <RADIUS />
-        </Route>
-        <Route path="/settings/saml">
-          <SAML />
-        </Route>
-        <Route path="/settings/tacacs">
-          <TACACS />
-        </Route>
-        <Route path="/settings/troubleshooting">
-          <Troubleshooting />
-        </Route>
-        <Route path="/settings/ui">
-          <UI />
-        </Route>
-        <Route path="/settings" exact>
-          <SettingList />
-        </Route>
-        <Route key="not-found" path="*">
-          <PageSection>
-            <Card>
-              <ContentError isNotFound>
-                <Link to="/settings">{t`View all settings`}</Link>
-              </ContentError>
-            </Card>
-          </PageSection>
-        </Route>
-      </Switch>
+      <Routes>
+        {/* /* on each sub-screen so its own nested <Routes> can match */}
+        <Route path="/settings/azure/*" element={<AzureAD />} />
+        <Route path="/settings/github/*" element={<GitHub />} />
+        <Route path="/settings/google_oauth2/*" element={<GoogleOAuth2 />} />
+        <Route path="/settings/oidc/*" element={<OIDC />} />
+        <Route path="/settings/jobs/*" element={<Jobs />} />
+        <Route path="/settings/ldap/*" element={<LDAP />} />
+        <Route
+          path="/settings/subscription/*"
+          element={
+            license_info?.license_type === 'open' ? (
+              <Navigate to="/settings" replace />
+            ) : (
+              <Subscription />
+            )
+          }
+        />
+        <Route path="/settings/logging/*" element={<Logging />} />
+        <Route
+          path="/settings/miscellaneous_authentication/*"
+          element={<MiscAuthentication />}
+        />
+        <Route
+          path="/settings/miscellaneous_system/*"
+          element={<MiscSystem />}
+        />
+        <Route path="/settings/radius/*" element={<RADIUS />} />
+        <Route path="/settings/saml/*" element={<SAML />} />
+        <Route path="/settings/tacacs/*" element={<TACACS />} />
+        <Route
+          path="/settings/troubleshooting/*"
+          element={<Troubleshooting />}
+        />
+        <Route path="/settings/ui/*" element={<UI />} />
+        <Route path="/settings" element={<SettingList />} />
+        <Route
+          path="*"
+          element={
+            <PageSection>
+              <Card>
+                <ContentError isNotFound>
+                  <Link to="/settings">{t`View all settings`}</Link>
+                </ContentError>
+              </Card>
+            </PageSection>
+          }
+        />
+      </Routes>
     </SettingsProvider>
   );
 }

--- a/awx/ui/src/screens/Setting/Settings.test.js
+++ b/awx/ui/src/screens/Setting/Settings.test.js
@@ -49,7 +49,7 @@ describe('<Settings />', () => {
       });
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find('Redirect').length).toBe(1);
+    expect(history.location.pathname).toBe('/');
     expect(wrapper.find('SettingList').length).toBe(0);
   });
 

--- a/awx/ui/src/screens/Setting/Settings.test.js
+++ b/awx/ui/src/screens/Setting/Settings.test.js
@@ -29,7 +29,7 @@ describe('<Settings />', () => {
     jest.clearAllMocks();
   });
 
-  test('should render Redirect for users without system admin or auditor permissions', async () => {
+  test('should redirect users without system admin or auditor permissions', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/settings'],
     });

--- a/awx/ui/src/screens/Setting/Subscription/Subscription.js
+++ b/awx/ui/src/screens/Setting/Subscription/Subscription.js
@@ -16,16 +16,16 @@ function Subscription() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
           <Route
-            path={`${baseURL}/details`}
+            path="details"
             element={<SubscriptionDetail />}
           />
-          <Route path={`${baseURL}/edit`} element={<SubscriptionEdit />} />
+          <Route path="edit" element={<SubscriptionEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={baseURL}>{t`View Settings`}</Link>

--- a/awx/ui/src/screens/Setting/Subscription/Subscription.js
+++ b/awx/ui/src/screens/Setting/Subscription/Subscription.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -9,28 +10,29 @@ import SubscriptionEdit from './SubscriptionEdit';
 function Subscription() {
   const { t } = useLingui();
   const baseURL = '/settings/subscription';
-  const baseRoute = useRouteMatch({
-    path: '/settings/subscription',
-    exact: true,
-  });
 
   return (
     <PageSection>
       <Card>
-        {baseRoute && <Redirect to={`${baseURL}/details`} />}
-        <Switch>
-          <Route path={`${baseURL}/details`}>
-            <SubscriptionDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <SubscriptionEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={baseURL}>{t`View Settings`}</Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route
+            path={`${baseURL}/details`}
+            element={<SubscriptionDetail />}
+          />
+          <Route path={`${baseURL}/edit`} element={<SubscriptionEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={baseURL}>{t`View Settings`}</Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/Subscription/Subscription.test.js
+++ b/awx/ui/src/screens/Setting/Subscription/Subscription.test.js
@@ -6,6 +6,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllSettings from '../shared/data.allSettings.json';
 import Subscription from './Subscription';
 
@@ -32,7 +33,7 @@ describe('<Subscription />', () => {
       initialEntries: ['/settings/subscription'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Subscription />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/subscription/*" element={<Subscription />} /></Routes>, {
         context: {
           router: {
             history,

--- a/awx/ui/src/screens/Setting/TACACS/TACACS.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACS.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,24 @@ function TACACS() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <TACACSDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <TACACSEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View TACACS+ settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<TACACSDetail />} />
+          <Route path={`${baseURL}/edit`} element={<TACACSEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>
+                  {t`View TACACS+ settings`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/TACACS/TACACS.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACS.js
@@ -15,13 +15,13 @@ function TACACS() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<TACACSDetail />} />
-          <Route path={`${baseURL}/edit`} element={<TACACSEdit />} />
+          <Route path="details" element={<TACACSDetail />} />
+          <Route path="edit" element={<TACACSEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>

--- a/awx/ui/src/screens/Setting/TACACS/TACACS.test.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACS.test.js
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import { SettingsProvider } from 'contexts/Settings';
 import { SettingsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import TACACS from './TACACS';
 
@@ -33,7 +34,7 @@ describe('<TACACS />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <TACACS />
+          <Routes><Route path="/settings/tacacs/*" element={<TACACS />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -50,7 +51,7 @@ describe('<TACACS />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <TACACS />
+          <Routes><Route path="/settings/tacacs/*" element={<TACACS />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -65,7 +66,7 @@ describe('<TACACS />', () => {
       initialEntries: ['/settings/tacacs/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<TACACS />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/tacacs/*" element={<TACACS />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.js
+++ b/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,22 @@ function Troubleshooting() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <TroubleshootingDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <TroubleshootingEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View Troubleshooting settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<TroubleshootingDetail />} />
+          <Route path={`${baseURL}/edit`} element={<TroubleshootingEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>{t`View Troubleshooting settings`}</Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.js
+++ b/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.js
@@ -15,13 +15,13 @@ function Troubleshooting() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<TroubleshootingDetail />} />
-          <Route path={`${baseURL}/edit`} element={<TroubleshootingEdit />} />
+          <Route path="details" element={<TroubleshootingDetail />} />
+          <Route path="edit" element={<TroubleshootingEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>{t`View Troubleshooting settings`}</Link>

--- a/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.test.js
+++ b/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.test.js
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
 import { SettingsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockJobSettings from '../shared/data.jobSettings.json';
 import Jobs from './Troubleshooting';
 import Troubleshooting from './Troubleshooting';
@@ -27,7 +28,7 @@ describe('<Troubleshooting />', () => {
       initialEntries: ['/settings/troubleshooting/details'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Jobs />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/troubleshooting/*" element={<Jobs />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -39,7 +40,7 @@ describe('<Troubleshooting />', () => {
       initialEntries: ['/settings/troubleshooting/edit'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Jobs />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/troubleshooting/*" element={<Jobs />} /></Routes>, {
         context: { router: { history } },
       });
     });
@@ -51,7 +52,7 @@ describe('<Troubleshooting />', () => {
       initialEntries: ['/settings/troubleshooting/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Troubleshooting />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/troubleshooting/*" element={<Troubleshooting />} /></Routes>, {
         context: { router: { history } },
       });
     });

--- a/awx/ui/src/screens/Setting/UI/UI.js
+++ b/awx/ui/src/screens/Setting/UI/UI.js
@@ -15,13 +15,13 @@ function UI() {
       <Card>
         <Routes>
           <Route
-            path={baseURL}
+            index
             element={<Navigate to={`${baseURL}/details`} replace />}
           />
-          <Route path={`${baseURL}/details`} element={<UIDetail />} />
-          <Route path={`${baseURL}/edit`} element={<UIEdit />} />
+          <Route path="details" element={<UIDetail />} />
+          <Route path="edit" element={<UIEdit />} />
           <Route
-            path={`${baseURL}/*`}
+            path="*"
             element={
               <ContentError isNotFound>
                 <Link to={`${baseURL}/details`}>{t`View User Interface settings`}</Link>

--- a/awx/ui/src/screens/Setting/UI/UI.js
+++ b/awx/ui/src/screens/Setting/UI/UI.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, Redirect, Route, Switch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -12,22 +13,22 @@ function UI() {
   return (
     <PageSection>
       <Card>
-        <Switch>
-          <Redirect from={baseURL} to={`${baseURL}/details`} exact />
-          <Route path={`${baseURL}/details`}>
-            <UIDetail />
-          </Route>
-          <Route path={`${baseURL}/edit`}>
-            <UIEdit />
-          </Route>
-          <Route key="not-found" path={`${baseURL}/*`}>
-            <ContentError isNotFound>
-              <Link to={`${baseURL}/details`}>
-                {t`View User Interface settings`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+        <Routes>
+          <Route
+            path={baseURL}
+            element={<Navigate to={`${baseURL}/details`} replace />}
+          />
+          <Route path={`${baseURL}/details`} element={<UIDetail />} />
+          <Route path={`${baseURL}/edit`} element={<UIEdit />} />
+          <Route
+            path={`${baseURL}/*`}
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseURL}/details`}>{t`View User Interface settings`}</Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Setting/UI/UI.test.js
+++ b/awx/ui/src/screens/Setting/UI/UI.test.js
@@ -7,6 +7,7 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import mockAllOptions from '../shared/data.allSettingOptions.json';
 import UI from './UI';
 
@@ -33,7 +34,7 @@ describe('<UI />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <UI />
+          <Routes><Route path="/settings/ui/*" element={<UI />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -51,7 +52,7 @@ describe('<UI />', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <SettingsProvider value={mockAllOptions.actions}>
-          <UI />
+          <Routes><Route path="/settings/ui/*" element={<UI />} /></Routes>
         </SettingsProvider>,
         {
           context: { router: { history } },
@@ -67,7 +68,7 @@ describe('<UI />', () => {
       initialEntries: ['/settings/ui/foo'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<UI />, {
+      wrapper = mountWithContexts(<Routes><Route path="/settings/ui/*" element={<UI />} /></Routes>, {
         context: { router: { history } },
       });
     });


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **entire Setting screen** - all 16 route trees - from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`.

UI (no behavior change - same URLs, same panels):

- **Single-form sub-screens** (TACACS, RADIUS, OIDC, SAML, GoogleOAuth2, Jobs, UI, Troubleshooting, MiscSystem, MiscAuthentication, Logging, Subscription): `<Switch>` → `<Routes>`; details/edit use the `element` prop; the base `<Redirect>` becomes a `<Route path={baseURL}>` that `<Navigate>`s to details; not-found kept as `{baseURL}/*`. MiscSystem/MiscAuthentication/Logging keep their superuser-gated edit route (the fallback inner `<Redirect>` becomes `<Navigate>`); Subscription folds its `useRouteMatch` base-redirect into a `<Route path={baseURL}>`.
- **Category-based sub-screens** (LDAP, AzureAD, GitHub): the `useRouteMatch` base/category redirects become a `<Route path={baseURL}>` Navigate plus a small `CategoryRedirect` helper (`useParams`) on the `/:category` route; detail/edit routes use the `element` prop.
- **`Settings.js` dispatcher**: `<Switch>` → `<Routes>`; each sub-screen route gets a trailing `/*` so its own nested `<Routes>` resolves; the non-superuser `<Redirect to="/">` and the open-license subscription `<Redirect>` become `<Navigate>`.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; each screen's route tree is independent and converted on its own branch off `main`. This PR covers the whole Setting screen.
- The sub-screens keep their absolute `baseURL` paths. Under the now-v6 `Settings.js` dispatcher they nest as `/settings/<name>/*` → the sub-screen's own `<Routes>`; v6 permits those absolute child paths because they extend the parent `/settings/<name>` path.
- The existing enzyme tests mount sub-screens at absolute `/settings/<name>/...` URLs, which v6 `<Routes>` resolve unchanged - so the only test change is `Settings.test.js` asserting the non-superuser redirect via the history location instead of finding a `<Redirect>` component.
- Tests: full `screens/Setting` directory passes (61 suites / 344 tests). `npm --prefix awx/ui run lint` clean on the changed source.

