### PR TITLE
Convert the Inventory screen route trees to react-router v6 Routes

### DIFF
--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,14 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
+import { Link } from 'react-router-dom';
 import {
-  Switch,
+  Routes,
   Route,
-  Link,
-  Redirect,
+  Navigate,
   useLocation,
   useParams,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -31,7 +31,7 @@ function Schedule({
 
   const { pathname } = useLocation();
 
-  const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
+  const pathRoot = pathname.substring(0, pathname.indexOf('schedules'));
 
   const {
     isLoading,
@@ -120,42 +120,46 @@ function Schedule({
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from={`${pathRoot}schedules/:scheduleId`}
-          to={`${pathRoot}schedules/:scheduleId/details`}
-          exact
-        />
-        {schedule && [
-          <Route key="edit" path={`${pathRoot}schedules/:id/edit`}>
-            <ScheduleEdit
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              resource={resource}
-              launchConfig={launchConfig}
-              surveyConfig={surveyConfig}
-              resourceDefaultCredentials={resourceDefaultCredentials}
-            />
-          </Route>,
+      <Routes>
+        <Route index element={<Navigate to="details" replace />} />
+        {schedule && (
           <Route
-            key="details"
-            path={`${pathRoot}schedules/:scheduleId/details`}
-          >
-            <ScheduleDetail
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              surveyConfig={surveyConfig}
-            />
-          </Route>,
-        ]}
-        <Route key="not-found" path="*">
-          <ContentError>
-            {resource && (
-              <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
-            )}
-          </ContentError>
-        </Route>
-      </Switch>
+            path="edit"
+            element={
+              <ScheduleEdit
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                resource={resource}
+                launchConfig={launchConfig}
+                surveyConfig={surveyConfig}
+                resourceDefaultCredentials={resourceDefaultCredentials}
+              />
+            }
+          />
+        )}
+        {schedule && (
+          <Route
+            path="details"
+            element={
+              <ScheduleDetail
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                surveyConfig={surveyConfig}
+              />
+            }
+          />
+        )}
+        <Route
+          path="*"
+          element={
+            <ContentError>
+              {resource && (
+                <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
+              )}
+            </ContentError>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,7 +15,9 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  const match = useRouteMatch();
+  // This component is mounted under a ".../schedules/*" route on several
+  // screens (templates, projects, inventory sources, management jobs), so its
+  // routes are relative to that parent and resolve under any of them.
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -26,37 +28,47 @@ function Schedules({
   ].includes(resource?.job_type);
 
   return (
-    <Switch>
-      <Route path={`${match.path}/add`}>
-        <ScheduleAdd
-          hasDaysToKeepField={hasDaysToKeepField}
-          apiModel={apiModel}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule
-          hasDaysToKeepField={hasDaysToKeepField}
-          setBreadcrumb={setBreadcrumb}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="list" path={`${match.path}`}>
-        <ScheduleList
-          resource={resource}
-          loadSchedules={loadSchedules}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          loadScheduleOptions={loadScheduleOptions}
-        />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path="add"
+        element={
+          <ScheduleAdd
+            hasDaysToKeepField={hasDaysToKeepField}
+            apiModel={apiModel}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      {/* so the nested <Schedule> route tree can match */}
+      <Route
+        path=":scheduleId/*"
+        element={
+          <Schedule
+            hasDaysToKeepField={hasDaysToKeepField}
+            setBreadcrumb={setBreadcrumb}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      <Route
+        index
+        element={
+          <ScheduleList
+            resource={resource}
+            loadSchedules={loadSchedules}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            loadScheduleOptions={loadScheduleOptions}
+          />
+        }
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/components/Schedule/Schedules.test.js
+++ b/awx/ui/src/components/Schedule/Schedules.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import Schedules from './Schedules';
 
@@ -12,21 +13,25 @@ describe('<Schedules />', () => {
     });
     const jobTemplate = { id: 1, name: 'Mock JT' };
 
+    // Schedules uses relative routes, so mount it under its ".../schedules/*"
+    // parent route.
     await act(async () => {
       wrapper = mountWithContexts(
-        <Schedules
-          setBreadcrumb={() => {}}
-          jobTemplate={jobTemplate}
-          loadSchedules={() => {}}
-          loadScheduleOptions={() => {}}
-          apiModel={{ createSchedule: () => {} }}
-        />,
-
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
+        <Routes>
+          <Route
+            path="/templates/job_template/:id/schedules/*"
+            element={
+              <Schedules
+                setBreadcrumb={() => {}}
+                jobTemplate={jobTemplate}
+                loadSchedules={() => {}}
+                loadScheduleOptions={() => {}}
+                apiModel={{ createSchedule: () => {} }}
+              />
+            }
+          />
+        </Routes>,
+        { context: { router: { history } } }
       );
     });
     expect(wrapper.length).toBe(1);

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHost/AdvancedInventoryHost.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHost/AdvancedInventoryHost.js
@@ -77,11 +77,11 @@ function AdvancedInventoryHost({ inventory, setBreadcrumb }) {
       {!isLoading && host && (
         <Routes>
           <Route
-            path="/inventories/:inventoryType/:id/hosts/:hostId"
+            index
             element={<Navigate to={`${hostBaseUrl}/details`} replace />}
           />
           <Route
-            path="/inventories/:inventoryType/:id/hosts/:hostId/details"
+            path="details"
             element={<AdvancedInventoryHostDetail host={host} />}
           />
           <Route

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHost/AdvancedInventoryHost.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHost/AdvancedInventoryHost.js
@@ -1,7 +1,13 @@
 import React, { useEffect, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';
@@ -12,9 +18,8 @@ import AdvancedInventoryHostDetail from '../AdvancedInventoryHostDetail';
 
 function AdvancedInventoryHost({ inventory, setBreadcrumb }) {
   const { t } = useLingui();
-  const { params, path, url } = useRouteMatch(
-    '/inventories/:inventoryType/:id/hosts/:hostId'
-  );
+  const { inventoryType, hostId } = useParams();
+  const hostBaseUrl = `/inventories/${inventoryType}/${inventory.id}/hosts/${hostId}`;
 
   const {
     result: host,
@@ -25,10 +30,10 @@ function AdvancedInventoryHost({ inventory, setBreadcrumb }) {
     useCallback(async () => {
       const response = await InventoriesAPI.readHostDetail(
         inventory.id,
-        params.hostId
+        hostId
       );
       return response;
-    }, [inventory.id, params.hostId]),
+    }, [inventory.id, hostId]),
     { isLoading: true }
   );
 
@@ -53,12 +58,12 @@ function AdvancedInventoryHost({ inventory, setBreadcrumb }) {
           {t`Back to Hosts`}
         </>
       ),
-      link: `/inventories/${params.inventoryType}/${inventory.id}/hosts`,
+      link: `/inventories/${inventoryType}/${inventory.id}/hosts`,
       id: 0,
     },
     {
       name: t`Details`,
-      link: `${url}/details`,
+      link: `${hostBaseUrl}/details`,
       id: 1,
     },
   ];
@@ -70,25 +75,28 @@ function AdvancedInventoryHost({ inventory, setBreadcrumb }) {
       {isLoading && <ContentLoading />}
 
       {!isLoading && host && (
-        <Switch>
-          <Redirect
-            from="/inventories/:inventoryType/:id/hosts/:hostId"
-            to={`${path}/details`}
-            exact
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/hosts/:hostId"
+            element={<Navigate to={`${hostBaseUrl}/details`} replace />}
           />
-          <Route key="details" path={`${path}/details`}>
-            <AdvancedInventoryHostDetail host={host} />
-          </Route>
-          <Route key="not-found" path="*">
-            <ContentError isNotFound>
-              <Link to={`${url}/details`}>
-                {params.inventoryType === 'smart_inventory'
-                  ? t`View smart inventory host details`
-                  : t`View constructed inventory host details`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+          <Route
+            path="/inventories/:inventoryType/:id/hosts/:hostId/details"
+            element={<AdvancedInventoryHostDetail host={host} />}
+          />
+          <Route
+            path="*"
+            element={
+              <ContentError isNotFound>
+                <Link to={`${hostBaseUrl}/details`}>
+                  {inventoryType === 'smart_inventory'
+                    ? t`View smart inventory host details`
+                    : t`View constructed inventory host details`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       )}
     </>
   );

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHostDetail/AdvancedInventoryHostDetail.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHostDetail/AdvancedInventoryHostDetail.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Host } from 'types';
 import { CardBody } from 'components/Card';

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHosts.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHosts.js
@@ -1,22 +1,27 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { Inventory } from 'types';
 import AdvancedInventoryHostList from './AdvancedInventoryHostList';
 import AdvancedInventoryHost from '../AdvancedInventoryHost';
 
 function AdvancedInventoryHosts({ inventory, setBreadcrumb }) {
   return (
-    <Switch>
-      <Route key="host" path="/inventories/:inventoryType/:id/hosts/:hostId">
-        <AdvancedInventoryHost
-          setBreadcrumb={setBreadcrumb}
-          inventory={inventory}
-        />
-      </Route>
-      <Route key="host-list" path="/inventories/:inventoryType/:id/hosts">
-        <AdvancedInventoryHostList inventory={inventory} />
-      </Route>
-    </Switch>
+    <Routes>
+      {/* /* so the nested <AdvancedInventoryHost> route tree can match */}
+      <Route
+        path="/inventories/:inventoryType/:id/hosts/:hostId/*"
+        element={
+          <AdvancedInventoryHost
+            setBreadcrumb={setBreadcrumb}
+            inventory={inventory}
+          />
+        }
+      />
+      <Route
+        path="/inventories/:inventoryType/:id/hosts"
+        element={<AdvancedInventoryHostList inventory={inventory} />}
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHosts.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHosts.js
@@ -9,7 +9,7 @@ function AdvancedInventoryHosts({ inventory, setBreadcrumb }) {
     <Routes>
       {/* /* so the nested <AdvancedInventoryHost> route tree can match */}
       <Route
-        path="/inventories/:inventoryType/:id/hosts/:hostId/*"
+        path=":hostId/*"
         element={
           <AdvancedInventoryHost
             setBreadcrumb={setBreadcrumb}
@@ -18,7 +18,7 @@ function AdvancedInventoryHosts({ inventory, setBreadcrumb }) {
         }
       />
       <Route
-        path="/inventories/:inventoryType/:id/hosts"
+        index
         element={<AdvancedInventoryHostList inventory={inventory} />}
       />
     </Routes>

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHosts.test.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHosts.test.js
@@ -1,11 +1,26 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import {
   mountWithContexts,
   waitForElement,
 } from '../../../../testUtils/enzymeHelpers';
 import AdvancedInventoryHosts from './AdvancedInventoryHosts';
+
+// AdvancedInventoryHosts uses relative routes; mount it under its v6 parent.
+function renderUnder(initialEntry, props) {
+  const history = createMemoryHistory({ initialEntries: [initialEntry] });
+  return mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/:inventoryType/:id/hosts/*"
+        element={<AdvancedInventoryHosts {...props} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
 
 jest.mock('../../../api');
 jest.mock('./AdvancedInventoryHostList', () => {
@@ -18,20 +33,9 @@ jest.mock('./AdvancedInventoryHostList', () => {
 
 describe('<AdvancedInventoryHosts />', () => {
   test('should render smart inventory host list', () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/smart_inventory/1/hosts'],
+    const wrapper = renderUnder('/inventories/smart_inventory/1/hosts', {
+      inventory: { id: 1 },
     });
-    const match = {
-      path: '/inventories/:inventoryType/:id/hosts',
-      url: '/inventories/smart_inventory/1/hosts',
-      isExact: true,
-    };
-    const wrapper = mountWithContexts(
-      <AdvancedInventoryHosts inventory={{ id: 1 }} />,
-      {
-        context: { router: { history, route: { match } } },
-      }
-    );
     expect(wrapper.find('AdvancedInventoryHostList').length).toBe(1);
     expect(wrapper.find('AdvancedInventoryHostList').prop('inventory')).toEqual(
       {
@@ -43,24 +47,11 @@ describe('<AdvancedInventoryHosts />', () => {
 
   test('should render smart inventory host details', async () => {
     let wrapper;
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/smart_inventory/1/hosts/2'],
-    });
-    const match = {
-      path: '/inventories/:inventoryType/:id/hosts/:hostId',
-      url: '/inventories/smart_inventory/1/hosts/2',
-      isExact: true,
-    };
     await act(async () => {
-      wrapper = mountWithContexts(
-        <AdvancedInventoryHosts
-          inventory={{ id: 1 }}
-          setBreadcrumb={() => {}}
-        />,
-        {
-          context: { router: { history, route: { match } } },
-        }
-      );
+      wrapper = renderUnder('/inventories/smart_inventory/1/hosts/2', {
+        inventory: { id: 1 },
+        setBreadcrumb: () => {},
+      });
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('AdvancedInventoryHost').length).toBe(1);

--- a/awx/ui/src/screens/Inventory/ConstructedInventory.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventory.js
@@ -1,6 +1,13 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+  useLocation,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 
@@ -22,7 +29,8 @@ import { getInventoryPath } from './shared/utils';
 function ConstructedInventory({ setBreadcrumb }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch('/inventories/constructed_inventory/:id');
+  const { id } = useParams();
+  const constructedBaseUrl = `/inventories/constructed_inventory/${id}`;
 
   const {
     result: inventory,
@@ -31,11 +39,9 @@ function ConstructedInventory({ setBreadcrumb }) {
     isLoading,
   } = useRequest(
     useCallback(async () => {
-      const { data } = await ConstructedInventoriesAPI.readDetail(
-        match.params.id
-      );
+      const { data } = await ConstructedInventoriesAPI.readDetail(id);
       return data;
-    }, [match.params.id]),
+    }, [id]),
     { inventory: null, isLoading: true }
   );
 
@@ -60,18 +66,18 @@ function ConstructedInventory({ setBreadcrumb }) {
       link: `/inventories`,
       id: 99,
     },
-    { name: t`Details`, link: `${match.url}/details`, id: 0 },
-    { name: t`Access`, link: `${match.url}/access`, id: 1 },
-    { name: t`Hosts`, link: `${match.url}/hosts`, id: 2 },
-    { name: t`Groups`, link: `${match.url}/groups`, id: 3 },
+    { name: t`Details`, link: `${constructedBaseUrl}/details`, id: 0 },
+    { name: t`Access`, link: `${constructedBaseUrl}/access`, id: 1 },
+    { name: t`Hosts`, link: `${constructedBaseUrl}/hosts`, id: 2 },
+    { name: t`Groups`, link: `${constructedBaseUrl}/groups`, id: 3 },
     {
       name: t`Jobs`,
-      link: `${match.url}/jobs`,
+      link: `${constructedBaseUrl}/jobs`,
       id: 4,
     },
     {
       name: t`Job Templates`,
-      link: `${match.url}/job_templates`,
+      link: `${constructedBaseUrl}/job_templates`,
       id: 5,
     },
   ];
@@ -106,7 +112,7 @@ function ConstructedInventory({ setBreadcrumb }) {
   }
 
   if (inventory && inventory?.kind !== 'constructed') {
-    return <Redirect to={`${getInventoryPath(inventory)}/details`} />;
+    return <Navigate to={`${getInventoryPath(inventory)}/details`} replace />;
   }
 
   let showCardHeader = true;
@@ -122,87 +128,97 @@ function ConstructedInventory({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-        <Switch>
-          <Redirect
-            from="/inventories/constructed_inventory/:id"
-            to="/inventories/constructed_inventory/:id/details"
-            exact
+        <Routes>
+          <Route
+            path="/inventories/constructed_inventory/:id"
+            element={<Navigate to={`${constructedBaseUrl}/details`} replace />}
           />
-          {inventory && [
+          {inventory && (
             <Route
               path="/inventories/constructed_inventory/:id/details"
-              key="details"
-            >
-              <ConstructedInventoryDetail inventory={inventory} />
-            </Route>,
+              element={<ConstructedInventoryDetail inventory={inventory} />}
+            />
+          )}
+          {inventory && (
             <Route
-              key="edit"
               path="/inventories/constructed_inventory/:id/edit"
-            >
-              <ConstructedInventoryEdit inventory={inventory} />
-            </Route>,
+              element={<ConstructedInventoryEdit inventory={inventory} />}
+            />
+          )}
+          {inventory && (
             <Route
               path="/inventories/constructed_inventory/:id/access"
-              key="access"
-            >
-              <ResourceAccessList
-                resource={inventory}
-                apiModel={InventoriesAPI}
-              />
-            </Route>,
+              element={
+                <ResourceAccessList
+                  resource={inventory}
+                  apiModel={InventoriesAPI}
+                />
+              }
+            />
+          )}
+          {/* /* so the nested <AdvancedInventoryHosts> route tree can match */}
+          {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/hosts"
-              key="hosts"
-            >
-              <AdvancedInventoryHosts
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
+              path="/inventories/constructed_inventory/:id/hosts/*"
+              element={
+                <AdvancedInventoryHosts
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {/* /* so the nested <InventoryGroups> route tree can match */}
+          {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/groups"
-              key="constructed_inventory_groups"
-            >
-              <InventoryGroups
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
+              path="/inventories/constructed_inventory/:id/groups/*"
+              element={
+                <InventoryGroups
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {inventory && (
             <Route
-              key="jobs"
               path="/inventories/constructed_inventory/:id/jobs"
-            >
-              <JobList
-                defaultParams={{
-                  or__job__inventory: inventory.id,
-                  or__adhoccommand__inventory: inventory.id,
-                  or__inventoryupdate__inventory_source__inventory:
-                    inventory.id,
-                  or__workflowjob__inventory: inventory.id,
-                }}
-              />
-            </Route>,
+              element={
+                <JobList
+                  defaultParams={{
+                    or__job__inventory: inventory.id,
+                    or__adhoccommand__inventory: inventory.id,
+                    or__inventoryupdate__inventory_source__inventory:
+                      inventory.id,
+                    or__workflowjob__inventory: inventory.id,
+                  }}
+                />
+              }
+            />
+          )}
+          {inventory && (
             <Route
-              key="job_templates"
               path="/inventories/constructed_inventory/:id/job_templates"
-            >
-              <RelatedTemplateList
-                searchParams={{ inventory__id: inventory.id }}
-              />
-            </Route>,
-          ]}
-          <Route path="*" key="not-found">
-            <ContentError isNotFound>
-              {match.params.id && (
-                <Link
-                  to={`/inventories/constructed_inventory/${match.params.id}/details`}
-                >
-                  {t`View Constructed Inventory Details`}
-                </Link>
-              )}
-            </ContentError>
-          </Route>
-        </Switch>
+              element={
+                <RelatedTemplateList
+                  searchParams={{ inventory__id: inventory.id }}
+                />
+              }
+            />
+          )}
+          <Route
+            path="*"
+            element={
+              <ContentError isNotFound>
+                {id && (
+                  <Link to={`${constructedBaseUrl}/details`}>
+                    {t`View Constructed Inventory Details`}
+                  </Link>
+                )}
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Inventory/ConstructedInventory.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventory.js
@@ -130,24 +130,24 @@ function ConstructedInventory({ setBreadcrumb }) {
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
         <Routes>
           <Route
-            path="/inventories/constructed_inventory/:id"
+            index
             element={<Navigate to={`${constructedBaseUrl}/details`} replace />}
           />
           {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/details"
+              path="details"
               element={<ConstructedInventoryDetail inventory={inventory} />}
             />
           )}
           {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/edit"
+              path="edit"
               element={<ConstructedInventoryEdit inventory={inventory} />}
             />
           )}
           {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/access"
+              path="access"
               element={
                 <ResourceAccessList
                   resource={inventory}
@@ -159,7 +159,7 @@ function ConstructedInventory({ setBreadcrumb }) {
           {/* /* so the nested <AdvancedInventoryHosts> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/hosts/*"
+              path="hosts/*"
               element={
                 <AdvancedInventoryHosts
                   inventory={inventory}
@@ -171,7 +171,7 @@ function ConstructedInventory({ setBreadcrumb }) {
           {/* /* so the nested <InventoryGroups> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/groups/*"
+              path="groups/*"
               element={
                 <InventoryGroups
                   inventory={inventory}
@@ -182,7 +182,7 @@ function ConstructedInventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/jobs"
+              path="jobs"
               element={
                 <JobList
                   defaultParams={{
@@ -198,7 +198,7 @@ function ConstructedInventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/constructed_inventory/:id/job_templates"
+              path="job_templates"
               element={
                 <RelatedTemplateList
                   searchParams={{ inventory__id: inventory.id }}

--- a/awx/ui/src/screens/Inventory/FederatedInventory.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventory.js
@@ -120,24 +120,24 @@ function FederatedInventory({ setBreadcrumb }) {
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
         <Routes>
           <Route
-            path="/inventories/federated_inventory/:id"
+            index
             element={<Navigate to={`${federatedBaseUrl}/details`} replace />}
           />
           {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/details"
+              path="details"
               element={<FederatedInventoryDetail inventory={inventory} />}
             />
           )}
           {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/edit"
+              path="edit"
               element={<FederatedInventoryEdit inventory={inventory} />}
             />
           )}
           {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/access"
+              path="access"
               element={
                 <ResourceAccessList
                   resource={inventory}
@@ -149,7 +149,7 @@ function FederatedInventory({ setBreadcrumb }) {
           {/* /* so the nested <AdvancedInventoryHosts> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/hosts/*"
+              path="hosts/*"
               element={
                 <AdvancedInventoryHosts
                   inventory={inventory}
@@ -161,7 +161,7 @@ function FederatedInventory({ setBreadcrumb }) {
           {/* /* so the nested <InventoryGroups> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/groups/*"
+              path="groups/*"
               element={
                 <InventoryGroups
                   inventory={inventory}
@@ -172,7 +172,7 @@ function FederatedInventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/jobs"
+              path="jobs"
               element={
                 <JobList
                   defaultParams={{
@@ -186,7 +186,7 @@ function FederatedInventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/job_templates"
+              path="job_templates"
               element={
                 <RelatedTemplateList
                   searchParams={{ inventory__id: inventory.id }}

--- a/awx/ui/src/screens/Inventory/FederatedInventory.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventory.js
@@ -1,6 +1,13 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+  useLocation,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 
@@ -22,7 +29,8 @@ import { getInventoryPath } from './shared/utils';
 function FederatedInventory({ setBreadcrumb }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch('/inventories/federated_inventory/:id');
+  const { id } = useParams();
+  const federatedBaseUrl = `/inventories/federated_inventory/${id}`;
 
   const {
     result: inventory,
@@ -31,11 +39,9 @@ function FederatedInventory({ setBreadcrumb }) {
     isLoading,
   } = useRequest(
     useCallback(async () => {
-      const { data } = await FederatedInventoriesAPI.readDetail(
-        match.params.id
-      );
+      const { data } = await FederatedInventoriesAPI.readDetail(id);
       return data;
-    }, [match.params.id]),
+    }, [id]),
     { inventory: null, isLoading: true }
   );
 
@@ -60,12 +66,12 @@ function FederatedInventory({ setBreadcrumb }) {
       link: `/inventories`,
       id: 99,
     },
-    { name: t`Details`, link: `${match.url}/details`, id: 0 },
-    { name: t`Access`, link: `${match.url}/access`, id: 1 },
-    { name: t`Hosts`, link: `${match.url}/hosts`, id: 2 },
-    { name: t`Groups`, link: `${match.url}/groups`, id: 3 },
-    { name: t`Jobs`, link: `${match.url}/jobs`, id: 4 },
-    { name: t`Job Templates`, link: `${match.url}/job_templates`, id: 5 },
+    { name: t`Details`, link: `${federatedBaseUrl}/details`, id: 0 },
+    { name: t`Access`, link: `${federatedBaseUrl}/access`, id: 1 },
+    { name: t`Hosts`, link: `${federatedBaseUrl}/hosts`, id: 2 },
+    { name: t`Groups`, link: `${federatedBaseUrl}/groups`, id: 3 },
+    { name: t`Jobs`, link: `${federatedBaseUrl}/jobs`, id: 4 },
+    { name: t`Job Templates`, link: `${federatedBaseUrl}/job_templates`, id: 5 },
   ];
 
   if (isLoading) {
@@ -96,7 +102,7 @@ function FederatedInventory({ setBreadcrumb }) {
   }
 
   if (inventory && inventory?.kind !== 'federated') {
-    return <Redirect to={`${getInventoryPath(inventory)}/details`} />;
+    return <Navigate to={`${getInventoryPath(inventory)}/details`} replace />;
   }
 
   let showCardHeader = true;
@@ -112,85 +118,95 @@ function FederatedInventory({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-        <Switch>
-          <Redirect
-            from="/inventories/federated_inventory/:id"
-            to="/inventories/federated_inventory/:id/details"
-            exact
+        <Routes>
+          <Route
+            path="/inventories/federated_inventory/:id"
+            element={<Navigate to={`${federatedBaseUrl}/details`} replace />}
           />
-          {inventory && [
+          {inventory && (
             <Route
               path="/inventories/federated_inventory/:id/details"
-              key="details"
-            >
-              <FederatedInventoryDetail inventory={inventory} />
-            </Route>,
+              element={<FederatedInventoryDetail inventory={inventory} />}
+            />
+          )}
+          {inventory && (
             <Route
-              key="edit"
               path="/inventories/federated_inventory/:id/edit"
-            >
-              <FederatedInventoryEdit inventory={inventory} />
-            </Route>,
+              element={<FederatedInventoryEdit inventory={inventory} />}
+            />
+          )}
+          {inventory && (
             <Route
               path="/inventories/federated_inventory/:id/access"
-              key="access"
-            >
-              <ResourceAccessList
-                resource={inventory}
-                apiModel={InventoriesAPI}
-              />
-            </Route>,
+              element={
+                <ResourceAccessList
+                  resource={inventory}
+                  apiModel={InventoriesAPI}
+                />
+              }
+            />
+          )}
+          {/* /* so the nested <AdvancedInventoryHosts> route tree can match */}
+          {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/hosts"
-              key="hosts"
-            >
-              <AdvancedInventoryHosts
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
+              path="/inventories/federated_inventory/:id/hosts/*"
+              element={
+                <AdvancedInventoryHosts
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {/* /* so the nested <InventoryGroups> route tree can match */}
+          {inventory && (
             <Route
-              path="/inventories/federated_inventory/:id/groups"
-              key="federated_inventory_groups"
-            >
-              <InventoryGroups
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
+              path="/inventories/federated_inventory/:id/groups/*"
+              element={
+                <InventoryGroups
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {inventory && (
             <Route
-              key="jobs"
               path="/inventories/federated_inventory/:id/jobs"
-            >
-              <JobList
-                defaultParams={{
-                  or__job__inventory: inventory.id,
-                  or__adhoccommand__inventory: inventory.id,
-                  or__workflowjob__inventory: inventory.id,
-                }}
-              />
-            </Route>,
+              element={
+                <JobList
+                  defaultParams={{
+                    or__job__inventory: inventory.id,
+                    or__adhoccommand__inventory: inventory.id,
+                    or__workflowjob__inventory: inventory.id,
+                  }}
+                />
+              }
+            />
+          )}
+          {inventory && (
             <Route
-              key="job_templates"
               path="/inventories/federated_inventory/:id/job_templates"
-            >
-              <RelatedTemplateList
-                searchParams={{ inventory__id: inventory.id }}
-              />
-            </Route>,
-          ]}
-          <Route path="*" key="not-found">
-            <ContentError isNotFound>
-              {match.params.id && (
-                <Link
-                  to={`/inventories/federated_inventory/${match.params.id}/details`}
-                >
-                  {t`View Federated Inventory Details`}
-                </Link>
-              )}
-            </ContentError>
-          </Route>
-        </Switch>
+              element={
+                <RelatedTemplateList
+                  searchParams={{ inventory__id: inventory.id }}
+                />
+              }
+            />
+          )}
+          <Route
+            path="*"
+            element={
+              <ContentError isNotFound>
+                {id && (
+                  <Link to={`${federatedBaseUrl}/details`}>
+                    {t`View Federated Inventory Details`}
+                  </Link>
+                )}
+              </ContentError>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Inventory/Inventories.js
+++ b/awx/ui/src/screens/Inventory/Inventories.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import { Config } from 'contexts/Config';
 import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
@@ -109,41 +109,52 @@ function Inventories() {
         streamType="inventory"
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path="/inventories/inventory/add">
-          <InventoryAdd />
-        </Route>
-        <Route path="/inventories/smart_inventory/add">
-          <SmartInventoryAdd />
-        </Route>
-        <Route path="/inventories/constructed_inventory/add">
-          <ConstructedInventoryAdd />
-        </Route>
-        <Route path="/inventories/federated_inventory/add">
-          <FederatedInventoryAdd />
-        </Route>
-        <Route path="/inventories/inventory/:id">
-          <Config>
-            {({ me }) => (
-              <Inventory setBreadcrumb={setBreadcrumbConfig} me={me || {}} />
-            )}
-          </Config>
-        </Route>
-        <Route path="/inventories/smart_inventory/:id">
-          <SmartInventory setBreadcrumb={setBreadcrumbConfig} />
-        </Route>
-        <Route path="/inventories/constructed_inventory/:id">
-          <ConstructedInventory setBreadcrumb={setBreadcrumbConfig} />
-        </Route>
-        <Route path="/inventories/federated_inventory/:id">
-          <FederatedInventory setBreadcrumb={setBreadcrumbConfig} />
-        </Route>
-        <Route path="/inventories">
-          <PersistentFilters pageKey="inventories">
-            <InventoryList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path="/inventories/inventory/add" element={<InventoryAdd />} />
+        <Route
+          path="/inventories/smart_inventory/add"
+          element={<SmartInventoryAdd />}
+        />
+        <Route
+          path="/inventories/constructed_inventory/add"
+          element={<ConstructedInventoryAdd />}
+        />
+        <Route
+          path="/inventories/federated_inventory/add"
+          element={<FederatedInventoryAdd />}
+        />
+        {/* /* on each detail so its own nested <Routes> can match */}
+        <Route
+          path="/inventories/inventory/:id/*"
+          element={
+            <Config>
+              {({ me }) => (
+                <Inventory setBreadcrumb={setBreadcrumbConfig} me={me || {}} />
+              )}
+            </Config>
+          }
+        />
+        <Route
+          path="/inventories/smart_inventory/:id/*"
+          element={<SmartInventory setBreadcrumb={setBreadcrumbConfig} />}
+        />
+        <Route
+          path="/inventories/constructed_inventory/:id/*"
+          element={<ConstructedInventory setBreadcrumb={setBreadcrumbConfig} />}
+        />
+        <Route
+          path="/inventories/federated_inventory/:id/*"
+          element={<FederatedInventory setBreadcrumb={setBreadcrumbConfig} />}
+        />
+        <Route
+          path="/inventories"
+          element={
+            <PersistentFilters pageKey="inventories">
+              <InventoryList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/Inventory/Inventories.js
+++ b/awx/ui/src/screens/Inventory/Inventories.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Routes, Route } from 'react-router-dom-v5-compat';
+import { Routes, Route, useParams } from 'react-router-dom-v5-compat';
 
 import { Config } from 'contexts/Config';
 import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
@@ -16,6 +16,27 @@ import SmartInventoryAdd from './SmartInventoryAdd';
 import ConstructedInventoryAdd from './ConstructedInventoryAdd';
 import FederatedInventoryAdd from './FederatedInventoryAdd';
 import { getInventoryPath } from './shared/utils';
+
+// A single :inventoryType/:id route (instead of one literal route per kind) so
+// inventoryType is a real route param that the nested group/host screens read
+// via useParams; this picks the right detail screen for the kind.
+function InventoryTypeRouter({ setBreadcrumb }) {
+  const { inventoryType } = useParams();
+  if (inventoryType === 'smart_inventory') {
+    return <SmartInventory setBreadcrumb={setBreadcrumb} />;
+  }
+  if (inventoryType === 'constructed_inventory') {
+    return <ConstructedInventory setBreadcrumb={setBreadcrumb} />;
+  }
+  if (inventoryType === 'federated_inventory') {
+    return <FederatedInventory setBreadcrumb={setBreadcrumb} />;
+  }
+  return (
+    <Config>
+      {({ me }) => <Inventory setBreadcrumb={setBreadcrumb} me={me || {}} />}
+    </Config>
+  );
+}
 
 function Inventories() {
   const { t } = useLingui();
@@ -123,28 +144,10 @@ function Inventories() {
           path="/inventories/federated_inventory/add"
           element={<FederatedInventoryAdd />}
         />
-        {/* /* on each detail so its own nested <Routes> can match */}
+        {/* /* so each detail screen's own nested <Routes> can match */}
         <Route
-          path="/inventories/inventory/:id/*"
-          element={
-            <Config>
-              {({ me }) => (
-                <Inventory setBreadcrumb={setBreadcrumbConfig} me={me || {}} />
-              )}
-            </Config>
-          }
-        />
-        <Route
-          path="/inventories/smart_inventory/:id/*"
-          element={<SmartInventory setBreadcrumb={setBreadcrumbConfig} />}
-        />
-        <Route
-          path="/inventories/constructed_inventory/:id/*"
-          element={<ConstructedInventory setBreadcrumb={setBreadcrumbConfig} />}
-        />
-        <Route
-          path="/inventories/federated_inventory/:id/*"
-          element={<FederatedInventory setBreadcrumb={setBreadcrumbConfig} />}
+          path="/inventories/:inventoryType/:id/*"
+          element={<InventoryTypeRouter setBreadcrumb={setBreadcrumbConfig} />}
         />
         <Route
           path="/inventories"

--- a/awx/ui/src/screens/Inventory/Inventories.test.js
+++ b/awx/ui/src/screens/Inventory/Inventories.test.js
@@ -1,14 +1,24 @@
 import React from 'react';
+import { createMemoryHistory } from 'history';
 
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import Inventories from './Inventories';
 
+// stub the list so the /inventories route renders without hitting the API
+jest.mock('./InventoryList', () => ({
+  __esModule: true,
+  InventoryList: () => null,
+}));
+
 describe('<Inventories />', () => {
   let pageWrapper;
 
   beforeEach(() => {
-    pageWrapper = mountWithContexts(<Inventories />);
+    const history = createMemoryHistory({ initialEntries: ['/inventories'] });
+    pageWrapper = mountWithContexts(<Inventories />, {
+      context: { router: { history } },
+    });
   });
 
   test('initially renders without crashing', () => {

--- a/awx/ui/src/screens/Inventory/Inventories.test.js
+++ b/awx/ui/src/screens/Inventory/Inventories.test.js
@@ -1,27 +1,58 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { InventoriesAPI, OrganizationsAPI } from 'api';
 
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import Inventories from './Inventories';
 
+jest.mock('../../api');
 // stub the list so the /inventories route renders without hitting the API
 jest.mock('./InventoryList', () => ({
   __esModule: true,
   InventoryList: () => null,
 }));
+// stub the detail so this suite asserts route resolution, not detail rendering
+jest.mock('./InventoryDetail', () => {
+  const InventoryDetail = () => <div>InventoryDetail</div>;
+  return { __esModule: true, default: InventoryDetail };
+});
 
 describe('<Inventories />', () => {
-  let pageWrapper;
-
-  beforeEach(() => {
+  test('initially renders without crashing', () => {
     const history = createMemoryHistory({ initialEntries: ['/inventories'] });
-    pageWrapper = mountWithContexts(<Inventories />, {
+    const pageWrapper = mountWithContexts(<Inventories />, {
       context: { router: { history } },
     });
+    expect(pageWrapper.length).toBe(1);
   });
 
-  test('initially renders without crashing', () => {
-    expect(pageWrapper.length).toBe(1);
+  // Guards against the absolute-vs-relative regression: a detail tab URL must
+  // resolve to that tab through the dispatcher, not fall through to not-found.
+  test('resolves a detail tab through the dispatcher', async () => {
+    InventoriesAPI.readDetail.mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Foo',
+        kind: '',
+        summary_fields: { user_capabilities: {} },
+      },
+    });
+    OrganizationsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
+    });
+    const history = createMemoryHistory({
+      initialEntries: ['/inventories/inventory/1/details'],
+    });
+    let wrapper;
+    await act(async () => {
+      wrapper = mountWithContexts(<Inventories />, {
+        context: { router: { history } },
+      });
+    });
+    wrapper.update();
+    expect(wrapper.find('InventoryDetail').length).toBe(1);
+    expect(wrapper.find('ContentError').length).toBe(0);
   });
 });

--- a/awx/ui/src/screens/Inventory/Inventory.js
+++ b/awx/ui/src/screens/Inventory/Inventory.js
@@ -128,12 +128,12 @@ function Inventory({ setBreadcrumb }) {
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
         <Routes>
           <Route
-            path="/inventories/inventory/:id"
+            index
             element={<Navigate to={`${inventoryBaseUrl}/details`} replace />}
           />
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/details"
+              path="details"
               element={
                 <InventoryDetail
                   inventory={inventory}
@@ -144,14 +144,14 @@ function Inventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/edit"
+              path="edit"
               element={<InventoryEdit inventory={inventory} />}
             />
           )}
           {/* /* so the nested <InventoryHosts> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/hosts/*"
+              path="hosts/*"
               element={
                 <InventoryHosts
                   inventory={inventory}
@@ -162,7 +162,7 @@ function Inventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/access"
+              path="access"
               element={
                 <ResourceAccessList
                   resource={inventory}
@@ -174,7 +174,7 @@ function Inventory({ setBreadcrumb }) {
           {/* /* so the nested <InventoryGroups> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/groups/*"
+              path="groups/*"
               element={
                 <InventoryGroups
                   inventory={inventory}
@@ -186,7 +186,7 @@ function Inventory({ setBreadcrumb }) {
           {/* /* so the nested <InventorySources> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/sources/*"
+              path="sources/*"
               element={
                 <InventorySources
                   inventory={inventory}
@@ -197,7 +197,7 @@ function Inventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/jobs"
+              path="jobs"
               element={
                 <JobList
                   defaultParams={{
@@ -216,7 +216,7 @@ function Inventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/inventory/:id/job_templates"
+              path="job_templates"
               element={
                 <RelatedTemplateList
                   searchParams={{ inventory__id: inventory.id }}

--- a/awx/ui/src/screens/Inventory/Inventory.js
+++ b/awx/ui/src/screens/Inventory/Inventory.js
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Switch, Route, Redirect, Link, useLocation, useRouteMatch } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -24,14 +31,13 @@ function Inventory({ setBreadcrumb }) {
   const [hasContentLoading, setHasContentLoading] = useState(true);
   const [inventory, setInventory] = useState(null);
   const location = useLocation();
-  const match = useRouteMatch({
-    path: '/inventories/inventory/:id',
-  });
+  const { id } = useParams();
+  const inventoryBaseUrl = `/inventories/inventory/${id}`;
 
   useEffect(() => {
     async function fetchData() {
       try {
-        const { data } = await InventoriesAPI.readDetail(match.params.id);
+        const { data } = await InventoriesAPI.readDetail(id);
         setBreadcrumb(data);
         setInventory(data);
       } catch (error) {
@@ -42,7 +48,7 @@ function Inventory({ setBreadcrumb }) {
     }
 
     fetchData();
-  }, [match.params.id, location.pathname, setBreadcrumb]);
+  }, [id, location.pathname, setBreadcrumb]);
 
   const tabsArray = [
     {
@@ -56,19 +62,19 @@ function Inventory({ setBreadcrumb }) {
       id: 99,
       persistentFilterKey: 'inventories',
     },
-    { name: t`Details`, link: `${match.url}/details`, id: 0 },
-    { name: t`Access`, link: `${match.url}/access`, id: 1 },
-    { name: t`Groups`, link: `${match.url}/groups`, id: 2 },
-    { name: t`Hosts`, link: `${match.url}/hosts`, id: 3 },
-    { name: t`Sources`, link: `${match.url}/sources`, id: 4 },
+    { name: t`Details`, link: `${inventoryBaseUrl}/details`, id: 0 },
+    { name: t`Access`, link: `${inventoryBaseUrl}/access`, id: 1 },
+    { name: t`Groups`, link: `${inventoryBaseUrl}/groups`, id: 2 },
+    { name: t`Hosts`, link: `${inventoryBaseUrl}/hosts`, id: 3 },
+    { name: t`Sources`, link: `${inventoryBaseUrl}/sources`, id: 4 },
     {
       name: t`Jobs`,
-      link: `${match.url}/jobs`,
+      link: `${inventoryBaseUrl}/jobs`,
       id: 5,
     },
     {
       name: t`Job Templates`,
-      link: `${match.url}/job_templates`,
+      link: `${inventoryBaseUrl}/job_templates`,
       id: 6,
     },
   ];
@@ -113,89 +119,125 @@ function Inventory({ setBreadcrumb }) {
   }
 
   if (inventory && inventory?.kind !== '') {
-    return <Redirect to={`${getInventoryPath(inventory)}/details`} />;
+    return <Navigate to={`${getInventoryPath(inventory)}/details`} replace />;
   }
 
   return (
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-        <Switch>
-          <Redirect
-            from="/inventories/inventory/:id"
-            to="/inventories/inventory/:id/details"
-            exact
+        <Routes>
+          <Route
+            path="/inventories/inventory/:id"
+            element={<Navigate to={`${inventoryBaseUrl}/details`} replace />}
           />
-          {inventory && [
-            <Route path="/inventories/inventory/:id/details" key="details">
-              <InventoryDetail
-                inventory={inventory}
-                hasInventoryLoading={hasContentLoading}
-              />
-            </Route>,
-            <Route path="/inventories/inventory/:id/edit" key="edit">
-              <InventoryEdit inventory={inventory} />
-            </Route>,
-            <Route path="/inventories/inventory/:id/hosts" key="hosts">
-              <InventoryHosts
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
-            <Route path="/inventories/inventory/:id/access" key="access">
-              <ResourceAccessList
-                resource={inventory}
-                apiModel={InventoriesAPI}
-              />
-            </Route>,
-            <Route path="/inventories/inventory/:id/groups" key="groups">
-              <InventoryGroups
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
-            <Route path="/inventories/inventory/:id/sources" key="sources">
-              <InventorySources
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
-            <Route path="/inventories/inventory/:id/jobs" key="jobs">
-              <JobList
-                defaultParams={{
-                  or__job__inventory: inventory.id,
-                  or__adhoccommand__inventory: inventory.id,
-                  or__inventoryupdate__inventory_source__inventory:
-                    inventory.id,
-                  or__workflowjob__inventory: inventory.id,
-                }}
-                additionalRelatedSearchableKeys={[
-                  'inventoryupdate__inventory_source__inventory',
-                ]}
-              />
-            </Route>,
+          {inventory && (
+            <Route
+              path="/inventories/inventory/:id/details"
+              element={
+                <InventoryDetail
+                  inventory={inventory}
+                  hasInventoryLoading={hasContentLoading}
+                />
+              }
+            />
+          )}
+          {inventory && (
+            <Route
+              path="/inventories/inventory/:id/edit"
+              element={<InventoryEdit inventory={inventory} />}
+            />
+          )}
+          {/* /* so the nested <InventoryHosts> route tree can match */}
+          {inventory && (
+            <Route
+              path="/inventories/inventory/:id/hosts/*"
+              element={
+                <InventoryHosts
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {inventory && (
+            <Route
+              path="/inventories/inventory/:id/access"
+              element={
+                <ResourceAccessList
+                  resource={inventory}
+                  apiModel={InventoriesAPI}
+                />
+              }
+            />
+          )}
+          {/* /* so the nested <InventoryGroups> route tree can match */}
+          {inventory && (
+            <Route
+              path="/inventories/inventory/:id/groups/*"
+              element={
+                <InventoryGroups
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {/* /* so the nested <InventorySources> route tree can match */}
+          {inventory && (
+            <Route
+              path="/inventories/inventory/:id/sources/*"
+              element={
+                <InventorySources
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {inventory && (
+            <Route
+              path="/inventories/inventory/:id/jobs"
+              element={
+                <JobList
+                  defaultParams={{
+                    or__job__inventory: inventory.id,
+                    or__adhoccommand__inventory: inventory.id,
+                    or__inventoryupdate__inventory_source__inventory:
+                      inventory.id,
+                    or__workflowjob__inventory: inventory.id,
+                  }}
+                  additionalRelatedSearchableKeys={[
+                    'inventoryupdate__inventory_source__inventory',
+                  ]}
+                />
+              }
+            />
+          )}
+          {inventory && (
             <Route
               path="/inventories/inventory/:id/job_templates"
-              key="job_templates"
-            >
-              <RelatedTemplateList
-                searchParams={{ inventory__id: inventory.id }}
-                resourceName={inventory.name}
-              />
-            </Route>,
-            <Route path="*" key="not-found">
+              element={
+                <RelatedTemplateList
+                  searchParams={{ inventory__id: inventory.id }}
+                  resourceName={inventory.name}
+                />
+              }
+            />
+          )}
+          <Route
+            path="*"
+            element={
               <ContentError isNotFound>
-                {match.params.id && (
-                  <Link
-                    to={`/inventories/inventory/${match.params.id}/details`}
-                  >
+                {id && (
+                  <Link to={`${inventoryBaseUrl}/details`}>
                     {t`View Inventory Details`}
                   </Link>
                 )}
               </ContentError>
-            </Route>,
-          ]}
-        </Switch>
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
@@ -145,7 +145,7 @@ function InventoryGroup({ setBreadcrumb, inventory }) {
             <ContentError>
               {inventory && (
                 <Link
-                  to={`/inventories/:inventoryType/${inventory.id}/details`}
+                  to={`/inventories/${inventoryType}/${inventory.id}/details`}
                 >
                   {t`View Inventory Details`}
                 </Link>

--- a/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
@@ -1,6 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Switch, Route, Link, Redirect, useLocation, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';
@@ -96,48 +103,57 @@ function InventoryGroup({ setBreadcrumb, inventory }) {
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from="/inventories/:inventoryType/:id/groups/:groupId"
-          to="/inventories/:inventoryType/:id/groups/:groupId/details"
-          exact
+      <Routes>
+        <Route
+          path="/inventories/:inventoryType/:id/groups/:groupId"
+          element={
+            <Navigate
+              to={`/inventories/${inventoryType}/${inventoryId}/groups/${groupId}/details`}
+              replace
+            />
+          }
         />
-        {inventoryGroup && [
+        {inventoryGroup && (
           <Route
-            key="edit"
             path="/inventories/:inventoryType/:id/groups/:groupId/edit"
-          >
-            <InventoryGroupEdit inventoryGroup={inventoryGroup} />
-          </Route>,
+            element={<InventoryGroupEdit inventoryGroup={inventoryGroup} />}
+          />
+        )}
+        {inventoryGroup && (
           <Route
-            key="details"
             path="/inventories/:inventoryType/:id/groups/:groupId/details"
-          >
-            <InventoryGroupDetail inventoryGroup={inventoryGroup} />
-          </Route>,
+            element={<InventoryGroupDetail inventoryGroup={inventoryGroup} />}
+          />
+        )}
+        {/* /* so the nested <InventoryGroupHosts> route tree can match */}
+        {inventoryGroup && (
           <Route
-            key="hosts"
-            path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts"
-          >
-            <InventoryGroupHosts inventoryGroup={inventoryGroup} />
-          </Route>,
+            path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts/*"
+            element={<InventoryGroupHosts inventoryGroup={inventoryGroup} />}
+          />
+        )}
+        {/* /* so the nested <InventoryRelatedGroups> route tree can match */}
+        {inventoryGroup && (
           <Route
-            key="relatedGroups"
-            path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups"
-          >
-            <InventoryRelatedGroups />
-          </Route>,
-        ]}
-        <Route key="not-found" path="*">
-          <ContentError>
-            {inventory && (
-              <Link to={`/inventories/:inventoryType/${inventory.id}/details`}>
-                {t`View Inventory Details`}
-              </Link>
-            )}
-          </ContentError>
-        </Route>
-      </Switch>
+            path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/*"
+            element={<InventoryRelatedGroups />}
+          />
+        )}
+        <Route
+          path="*"
+          element={
+            <ContentError>
+              {inventory && (
+                <Link
+                  to={`/inventories/:inventoryType/${inventory.id}/details`}
+                >
+                  {t`View Inventory Details`}
+                </Link>
+              )}
+            </ContentError>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
@@ -105,7 +105,7 @@ function InventoryGroup({ setBreadcrumb, inventory }) {
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
       <Routes>
         <Route
-          path="/inventories/:inventoryType/:id/groups/:groupId"
+          index
           element={
             <Navigate
               to={`/inventories/${inventoryType}/${inventoryId}/groups/${groupId}/details`}
@@ -115,27 +115,27 @@ function InventoryGroup({ setBreadcrumb, inventory }) {
         />
         {inventoryGroup && (
           <Route
-            path="/inventories/:inventoryType/:id/groups/:groupId/edit"
+            path="edit"
             element={<InventoryGroupEdit inventoryGroup={inventoryGroup} />}
           />
         )}
         {inventoryGroup && (
           <Route
-            path="/inventories/:inventoryType/:id/groups/:groupId/details"
+            path="details"
             element={<InventoryGroupDetail inventoryGroup={inventoryGroup} />}
           />
         )}
         {/* /* so the nested <InventoryGroupHosts> route tree can match */}
         {inventoryGroup && (
           <Route
-            path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts/*"
+            path="nested_hosts/*"
             element={<InventoryGroupHosts inventoryGroup={inventoryGroup} />}
           />
         )}
         {/* /* so the nested <InventoryRelatedGroups> route tree can match */}
         {inventoryGroup && (
           <Route
-            path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/*"
+            path="nested_groups/*"
             element={<InventoryRelatedGroups />}
           />
         )}

--- a/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
 import { GroupsAPI } from 'api';
@@ -11,46 +11,49 @@ import {
 import InventoryGroup from './InventoryGroup';
 
 jest.mock('../../../api');
-describe('<InventoryGroup />', () => {
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 1,
-      inventoryType: 'inventory',
-    }),
-  }));
 
+const groupData = {
+  data: {
+    id: 1,
+    name: 'Foo',
+    description: 'Bar',
+    variables: 'bizz: buzz',
+    summary_fields: {
+      inventory: { id: 1 },
+      created_by: { id: 1, username: 'Athena' },
+      modified_by: { id: 1, username: 'Apollo' },
+    },
+    created: '2020-04-25T01:23:45.678901Z',
+    modified: '2020-04-25T01:23:45.678901Z',
+  },
+};
+
+const inventory = { id: 1, name: 'Foo' };
+
+// Mount under the same /inventories/:inventoryType/:id/groups/:groupId/* route
+// that InventoryGroups gives it, so useParams resolves from the URL.
+function renderAt(path) {
+  const history = createMemoryHistory({ initialEntries: [path] });
+  return mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/:inventoryType/:id/groups/:groupId/*"
+        element={
+          <InventoryGroup setBreadcrumb={() => {}} inventory={inventory} />
+        }
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
+describe('<InventoryGroup />', () => {
   let wrapper;
-  let history;
-  const inventory = { id: 1, name: 'Foo' };
 
   beforeEach(async () => {
-    GroupsAPI.readDetail.mockResolvedValue({
-      data: {
-        id: 1,
-        name: 'Foo',
-        description: 'Bar',
-        variables: 'bizz: buzz',
-        summary_fields: {
-          inventory: { id: 1 },
-          created_by: { id: 1, username: 'Athena' },
-          modified_by: { id: 1, username: 'Apollo' },
-        },
-        created: '2020-04-25T01:23:45.678901Z',
-        modified: '2020-04-25T01:23:45.678901Z',
-      },
-    });
-    history = createMemoryHistory({
-      initialEntries: [`/inventories/inventory/1/groups/1/details`],
-    });
+    GroupsAPI.readDetail.mockResolvedValue(groupData);
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/groups">
-          <InventoryGroup setBreadcrumb={() => {}} inventory={inventory} />
-        </Route>,
-        { context: { router: { history } } }
-      );
+      wrapper = renderAt('/inventories/inventory/1/groups/1/details');
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
@@ -71,14 +74,8 @@ describe('<InventoryGroup />', () => {
   });
 
   test('should show content error when user attempts to navigate to erroneous route', async () => {
-    history = createMemoryHistory({
-      initialEntries: [`/inventories/inventory/1/groups/1/foobar`],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <InventoryGroup setBreadcrumb={() => {}} inventory={inventory} />,
-        { context: { router: { history } } }
-      );
+      wrapper = renderAt('/inventories/inventory/1/groups/1/foobar');
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });
@@ -88,7 +85,7 @@ describe('<InventoryGroup />', () => {
       Promise.reject(new Error())
     );
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroup inventory={inventory} />);
+      wrapper = renderAt('/inventories/inventory/1/groups/1/details');
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });
@@ -96,44 +93,12 @@ describe('<InventoryGroup />', () => {
 
 describe('constructed inventory', () => {
   let wrapper;
-  let history;
-  const inventory = { id: 1, name: 'Foo' };
-
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-      inventoryType: 'constructed_inventory',
-    }),
-  }));
 
   beforeEach(async () => {
-    GroupsAPI.readDetail.mockResolvedValue({
-      data: {
-        id: 1,
-        name: 'Foo',
-        description: 'Bar',
-        variables: 'bizz: buzz',
-        summary_fields: {
-          inventory: { id: 1 },
-          created_by: { id: 1, username: 'Athena' },
-          modified_by: { id: 1, username: 'Apollo' },
-        },
-        created: '2020-04-25T01:23:45.678901Z',
-        modified: '2020-04-25T01:23:45.678901Z',
-      },
-    });
-    history = createMemoryHistory({
-      initialEntries: [`/inventories/constructed_inventory/1/groups/1/details`],
-    });
-
+    GroupsAPI.readDetail.mockResolvedValue(groupData);
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/groups">
-          <InventoryGroup setBreadcrumb={() => {}} inventory={inventory} />
-        </Route>,
-        { context: { router: { history } } }
+      wrapper = renderAt(
+        '/inventories/constructed_inventory/1/groups/1/details'
       );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);

--- a/awx/ui/src/screens/Inventory/InventoryGroupAdd/InventoryGroupAdd.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupAdd/InventoryGroupAdd.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { Card } from '@patternfly/react-core';
 import { GroupsAPI } from 'api';
 

--- a/awx/ui/src/screens/Inventory/InventoryGroupAdd/InventoryGroupAdd.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupAdd/InventoryGroupAdd.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import { createMemoryHistory } from 'history';
 import { act } from 'react-dom/test-utils';
@@ -19,9 +19,13 @@ describe('<InventoryGroupAdd />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Route path="/inventories/inventory/:id/groups/add">
-          <InventoryGroupAdd />
-        </Route>,
+        <Routes>
+          <Route
+            path="/inventories/inventory/:id/groups/add/*"
+            element={<InventoryGroupAdd />}
+          />
+          <Route path="*" element={null} />
+        </Routes>,
         {
           context: {
             router: { history, route: { location: history.location } },

--- a/awx/ui/src/screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { Button } from '@patternfly/react-core';
 
 import { VariablesDetail } from 'components/CodeEditor';

--- a/awx/ui/src/screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupDetail/InventoryGroupDetail.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { createMemoryHistory } from 'history';
 import { act } from 'react-dom/test-utils';
 import { GroupsAPI } from 'api';
@@ -39,23 +39,19 @@ describe('<InventoryGroupDetail />', () => {
   let history;
 
   describe('User has full permissions', () => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({
-        id: 1,
-        groupId: 3,
-        inventoryType: 'inventory',
-      }),
-    }));
     beforeEach(async () => {
       await act(async () => {
         history = createMemoryHistory({
           initialEntries: ['/inventories/inventory/1/groups/1/details'],
         });
         wrapper = mountWithContexts(
-          <Route path="/inventories/inventory/:id/groups/:groupId">
-            <InventoryGroupDetail inventoryGroup={inventoryGroup} />
-          </Route>,
+          <Routes>
+            <Route
+              path="/inventories/:inventoryType/:id/groups/:groupId/*"
+              element={<InventoryGroupDetail inventoryGroup={inventoryGroup} />}
+            />
+            <Route path="*" element={null} />
+          </Routes>,
           {
             context: {
               router: {
@@ -124,14 +120,6 @@ describe('<InventoryGroupDetail />', () => {
   });
 
   describe('User has read-only permissions', () => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({
-        id: 1,
-        groupId: 3,
-        inventoryType: 'inventory',
-      }),
-    }));
     test('should hide edit/delete buttons', async () => {
       const readOnlyGroup = {
         ...inventoryGroup,
@@ -149,9 +137,13 @@ describe('<InventoryGroupDetail />', () => {
           initialEntries: ['/inventories/inventory/1/groups/1/details'],
         });
         wrapper = mountWithContexts(
-          <Route path="/inventories/inventory/:id/groups/:groupId">
-            <InventoryGroupDetail inventoryGroup={readOnlyGroup} />
-          </Route>,
+          <Routes>
+            <Route
+              path="/inventories/:inventoryType/:id/groups/:groupId/*"
+              element={<InventoryGroupDetail inventoryGroup={readOnlyGroup} />}
+            />
+            <Route path="*" element={null} />
+          </Routes>,
           {
             context: {
               router: {
@@ -179,12 +171,18 @@ describe('<InventoryGroupDetail />', () => {
     beforeEach(async () => {
       await act(async () => {
         history = createMemoryHistory({
-          initialEntries: ['/inventories/inventory/1/groups/1/details'],
+          initialEntries: [
+            '/inventories/constructed_inventory/1/groups/1/details',
+          ],
         });
         wrapper = mountWithContexts(
-          <Route path="/inventories/inventory/:id/groups/:groupId">
-            <InventoryGroupDetail inventoryGroup={inventoryGroup} />
-          </Route>,
+          <Routes>
+            <Route
+              path="/inventories/:inventoryType/:id/groups/:groupId/*"
+              element={<InventoryGroupDetail inventoryGroup={inventoryGroup} />}
+            />
+            <Route path="*" element={null} />
+          </Routes>,
           {
             context: {
               router: {

--- a/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { GroupsAPI } from 'api';
 
 import InventoryGroupForm from '../shared/InventoryGroupForm';

--- a/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupEdit/InventoryGroupEdit.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { createMemoryHistory } from 'history';
 import { act } from 'react-dom/test-utils';
 import { GroupsAPI } from 'api';
@@ -25,9 +25,13 @@ describe('<InventoryGroupEdit />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Route path="/inventories/inventory/:id/groups/:groupId/edit">
-          <InventoryGroupEdit inventoryGroup={{ id: 2 }} />
-        </Route>,
+        <Routes>
+          <Route
+            path="/inventories/inventory/:id/groups/:groupId/edit/*"
+            element={<InventoryGroupEdit inventoryGroup={{ id: 2 }} />}
+          />
+          <Route path="*" element={null} />
+        </Routes>,
         {
           context: {
             router: {

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useCallback, useState } from 'react';
-import { useLocation, useParams, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { DropdownItem } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { GroupsAPI, InventoriesAPI } from 'api';
 import {
   mountWithContexts,
@@ -8,20 +9,27 @@ import {
 } from '../../../../testUtils/enzymeHelpers';
 import InventoryGroupHostList from './InventoryGroupHostList';
 import mockHosts from '../shared/data.hosts.json';
-import { Route } from 'react-router-dom';
 
 jest.mock('../../../api/models/Groups');
 jest.mock('../../../api/models/Inventories');
 jest.mock('../../../api/models/CredentialTypes');
 
+function renderUnder(url) {
+  const history = createMemoryHistory({ initialEntries: [url] });
+  const wrapper = mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts/*"
+        element={<InventoryGroupHostList />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+  return { wrapper, history };
+}
+
 describe('<InventoryGroupHostList />', () => {
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-    }),
-  }));
+  const url = '/inventories/inventory/1/groups/2/nested_hosts';
   let wrapper;
 
   beforeEach(async () => {
@@ -52,7 +60,7 @@ describe('<InventoryGroupHostList />', () => {
       },
     });
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupHostList />);
+      ({ wrapper } = renderUnder(url));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
@@ -122,7 +130,7 @@ describe('<InventoryGroupHostList />', () => {
       },
     });
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupHostList />);
+      ({ wrapper } = renderUnder(url));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('AddDropDownButton').length).toBe(0);
@@ -258,15 +266,9 @@ describe('<InventoryGroupHostList />', () => {
         },
       },
     });
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/1/groups/2/nested_hosts/add'],
-    });
+    let history;
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupHostList />, {
-        context: {
-          router: { history },
-        },
-      });
+      ({ wrapper, history } = renderUnder(`${url}/add`));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     await act(async () => {
@@ -287,7 +289,7 @@ describe('<InventoryGroupHostList />', () => {
       Promise.reject(new Error())
     );
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupHostList />);
+      ({ wrapper } = renderUnder(url));
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });
@@ -307,21 +309,13 @@ describe('<InventoryGroupHostList />', () => {
       },
     });
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupHostList />);
+      ({ wrapper } = renderUnder(url));
     });
     expect(wrapper.find('AdHocCommands')).toHaveLength(0);
   });
 });
 
 describe('<InventoryGroupHostList> for constructed inventories', () => {
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-      inventoryType: 'constructed_inventory',
-    }),
-  }));
   let wrapper;
 
   beforeEach(async () => {
@@ -351,16 +345,10 @@ describe('<InventoryGroupHostList> for constructed inventories', () => {
         },
       },
     });
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/constructed_inventory/1/groups/2/hosts'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/groups/:groupId/hosts">
-          <InventoryGroupHostList />
-        </Route>,
-        { context: { router: { history } } }
-      );
+      ({ wrapper } = renderUnder(
+        '/inventories/constructed_inventory/1/groups/2/nested_hosts'
+      ));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { string, bool, func, number } from 'prop-types';
 import { useLingui } from '@lingui/react/macro';
 import { Button, Tooltip } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHosts.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHosts.js
@@ -1,18 +1,20 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import InventoryGroupHostAdd from '../InventoryGroupHostAdd';
 import InventoryGroupHostList from './InventoryGroupHostList';
 
 function InventoryGroupHosts({ inventoryGroup }) {
   return (
-    <Switch>
-      <Route path="/inventories/inventory/:id/groups/:groupId/nested_hosts/add">
-        <InventoryGroupHostAdd inventoryGroup={inventoryGroup} />
-      </Route>
-      <Route path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts">
-        <InventoryGroupHostList />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path="/inventories/inventory/:id/groups/:groupId/nested_hosts/add"
+        element={<InventoryGroupHostAdd inventoryGroup={inventoryGroup} />}
+      />
+      <Route
+        path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts"
+        element={<InventoryGroupHostList />}
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHosts.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHosts.js
@@ -7,11 +7,11 @@ function InventoryGroupHosts({ inventoryGroup }) {
   return (
     <Routes>
       <Route
-        path="/inventories/inventory/:id/groups/:groupId/nested_hosts/add"
+        path="add"
         element={<InventoryGroupHostAdd inventoryGroup={inventoryGroup} />}
       />
       <Route
-        path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts"
+        index
         element={<InventoryGroupHostList />}
       />
     </Routes>

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHosts.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHosts.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventoryGroupHosts from './InventoryGroupHosts';
 
@@ -15,11 +16,15 @@ describe('<InventoryGroupHosts />', () => {
     });
 
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupHosts />, {
-        context: {
-          router: { history, route: { location: history.location } },
-        },
-      });
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/groups/:groupId/nested_hosts/*"
+            element={<InventoryGroupHosts />}
+          />
+        </Routes>,
+        { context: { router: { history } } }
+      );
     });
     expect(wrapper.length).toBe(1);
     expect(wrapper.find('InventoryGroupHostList').length).toBe(1);

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupItem.js
@@ -5,7 +5,8 @@ import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem } from 'components/PaginatedTable';
 import { Group } from 'types';

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroups.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroups.js
@@ -11,7 +11,7 @@ function InventoryGroups({ setBreadcrumb, inventory }) {
   return (
     <Routes>
       <Route
-        path="/inventories/inventory/:id/groups/add"
+        path="add"
         element={
           <InventoryGroupAdd
             setBreadcrumb={setBreadcrumb}
@@ -21,13 +21,13 @@ function InventoryGroups({ setBreadcrumb, inventory }) {
       />
       {/* /* so the nested <InventoryGroup> route tree can match */}
       <Route
-        path="/inventories/:inventoryType/:id/groups/:groupId/*"
+        path=":groupId/*"
         element={
           <InventoryGroup inventory={inventory} setBreadcrumb={setBreadcrumb} />
         }
       />
       <Route
-        path="/inventories/:inventoryType/:id/groups"
+        index
         element={<InventoryGroupsList inventory={inventory} />}
       />
     </Routes>

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroups.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroups.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import InventoryGroupAdd from '../InventoryGroupAdd/InventoryGroupAdd';
 
@@ -9,23 +9,28 @@ import InventoryGroupsList from './InventoryGroupsList';
 
 function InventoryGroups({ setBreadcrumb, inventory }) {
   return (
-    <Switch>
-      <Route key="add" path="/inventories/inventory/:id/groups/add">
-        <InventoryGroupAdd
-          setBreadcrumb={setBreadcrumb}
-          inventory={inventory}
-        />
-      </Route>
+    <Routes>
       <Route
-        key="details"
-        path="/inventories/:inventoryType/:id/groups/:groupId/"
-      >
-        <InventoryGroup inventory={inventory} setBreadcrumb={setBreadcrumb} />
-      </Route>
-      <Route key="list" path="/inventories/:inventoryType/:id/groups">
-        <InventoryGroupsList inventory={inventory} />
-      </Route>
-    </Switch>
+        path="/inventories/inventory/:id/groups/add"
+        element={
+          <InventoryGroupAdd
+            setBreadcrumb={setBreadcrumb}
+            inventory={inventory}
+          />
+        }
+      />
+      {/* /* so the nested <InventoryGroup> route tree can match */}
+      <Route
+        path="/inventories/:inventoryType/:id/groups/:groupId/*"
+        element={
+          <InventoryGroup inventory={inventory} setBreadcrumb={setBreadcrumb} />
+        }
+      />
+      <Route
+        path="/inventories/:inventoryType/:id/groups"
+        element={<InventoryGroupsList inventory={inventory} />}
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroups.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroups.test.js
@@ -1,48 +1,47 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventoryGroups from './InventoryGroups';
 
 jest.mock('../../../api');
 
+// InventoryGroups uses relative routes, so mount it under its v6 parent route.
+function renderUnder(initialEntry, inventory) {
+  const history = createMemoryHistory({ initialEntries: [initialEntry] });
+  return mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/:inventoryType/:id/groups/*"
+        element={
+          <InventoryGroups setBreadcrumb={() => {}} inventory={inventory} />
+        }
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
 describe('<InventoryGroups />', () => {
   test('initially renders successfully', async () => {
     let wrapper;
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/1/groups'],
-    });
-    const inventory = { id: 1, name: 'Foo' };
-
     await act(async () => {
-      wrapper = mountWithContexts(
-        <InventoryGroups setBreadcrumb={() => {}} inventory={inventory} />,
-
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
-      );
+      wrapper = renderUnder('/inventories/inventory/1/groups', {
+        id: 1,
+        name: 'Foo',
+      });
     });
     expect(wrapper.length).toBe(1);
     expect(wrapper.find('InventoryGroupsList').length).toBe(1);
   });
   test('test that InventoryGroupsAdd renders', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/1/groups/add'],
-    });
-    const inventory = { id: 1, name: 'Foo' };
     let wrapper;
     await act(async () => {
-      wrapper = mountWithContexts(
-        <InventoryGroups setBreadcrumb={() => {}} inventory={inventory} />,
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
-      );
+      wrapper = renderUnder('/inventories/inventory/1/groups/add', {
+        id: 1,
+        name: 'Foo',
+      });
     });
     expect(wrapper.find('InventoryGroupsAdd').length).toBe(1);
   });

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupsList.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupsList.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { Tooltip } from '@patternfly/react-core';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupsList.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { createMemoryHistory } from 'history';
 import { InventoriesAPI, GroupsAPI } from 'api';
 import {
@@ -10,6 +10,20 @@ import {
 import InventoryGroupsList from './InventoryGroupsList';
 
 jest.mock('../../../api');
+
+function renderUnder(url) {
+  const history = createMemoryHistory({ initialEntries: [url] });
+  const wrapper = mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/:inventoryType/:id/groups/*"
+        element={<InventoryGroupsList />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+  return { wrapper, history };
+}
 const mockGroups = [
   {
     id: 1,
@@ -54,14 +68,6 @@ const mockGroups = [
 
 describe('<InventoryGroupsList />', () => {
   let wrapper;
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-      inventoryType: 'inventory',
-    }),
-  }));
   beforeEach(async () => {
     InventoriesAPI.readGroups.mockResolvedValue({
       data: {
@@ -92,25 +98,8 @@ describe('<InventoryGroupsList />', () => {
         },
       },
     });
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/3/groups'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/groups">
-          <InventoryGroupsList />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-              },
-            },
-          },
-        }
-      );
+      ({ wrapper } = renderUnder('/inventories/inventory/3/groups'));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
@@ -195,7 +184,7 @@ describe('<InventoryGroupsList />', () => {
       },
     });
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupsList />);
+      ({ wrapper } = renderUnder('/inventories/inventory/3/groups'));
     });
     expect(wrapper.find('AdHocCommands')).toHaveLength(0);
   });
@@ -256,7 +245,7 @@ describe('<InventoryGroupsList/> error handling', () => {
       Promise.reject(new Error())
     );
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupsList />);
+      ({ wrapper } = renderUnder('/inventories/inventory/3/groups'));
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length > 0);
   });
@@ -266,14 +255,14 @@ describe('<InventoryGroupsList/> error handling', () => {
       Promise.reject(new Error())
     );
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupsList />);
+      ({ wrapper } = renderUnder('/inventories/inventory/3/groups'));
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length > 0);
   });
 
   test('should show error modal when group is not successfully deleted from api', async () => {
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryGroupsList />);
+      ({ wrapper } = renderUnder('/inventories/inventory/3/groups'));
     });
     waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
 
@@ -320,14 +309,6 @@ describe('<InventoryGroupsList/> error handling', () => {
 
 describe('Constructed Inventory group', () => {
   let wrapper;
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-      inventoryType: 'constructed_inventory',
-    }),
-  }));
 
   beforeEach(async () => {
     InventoriesAPI.readGroups.mockResolvedValue({
@@ -359,25 +340,8 @@ describe('Constructed Inventory group', () => {
         },
       },
     });
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/constructed_inventory/3/groups'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/groups">
-          <InventoryGroupsList />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-              },
-            },
-          },
-        }
-      );
+      ({ wrapper } = renderUnder('/inventories/constructed_inventory/3/groups'));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });

--- a/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
+++ b/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
@@ -123,28 +123,28 @@ function InventoryHost({ setBreadcrumb, inventory }) {
       {!isLoading && host && (
         <Routes>
           <Route
-            path="/inventories/inventory/:id/hosts/:hostId"
+            index
             element={<Navigate to={`${hostBaseUrl}/details`} replace />}
           />
           <Route
-            path="/inventories/inventory/:id/hosts/:hostId/details"
+            path="details"
             element={<InventoryHostDetail host={host} />}
           />
           <Route
-            path="/inventories/inventory/:id/hosts/:hostId/edit"
+            path="edit"
             element={<InventoryHostEdit host={host} inventory={inventory} />}
           />
           <Route
-            path="/inventories/inventory/:id/hosts/:hostId/facts"
+            path="facts"
             element={<InventoryHostFacts host={host} />}
           />
           {/* /* so the nested <InventoryHostGroups> route tree can match */}
           <Route
-            path="/inventories/inventory/:id/hosts/:hostId/groups/*"
+            path="groups/*"
             element={<InventoryHostGroups />}
           />
           <Route
-            path="/inventories/inventory/:id/hosts/:hostId/jobs"
+            path="jobs"
             element={<JobList defaultParams={{ job__hosts: host.id }} />}
           />
           <Route

--- a/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
+++ b/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
@@ -1,6 +1,13 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Switch, Route, Redirect, Link, useRouteMatch, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+  useLocation,
+} from 'react-router-dom-v5-compat';
 import { Card } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import useRequest from 'hooks/useRequest';
@@ -18,8 +25,9 @@ import InventoryHostGroups from '../InventoryHostGroups';
 function InventoryHost({ setBreadcrumb, inventory }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch('/inventories/inventory/:id/hosts/:hostId');
+  const { hostId } = useParams();
   const hostListUrl = `/inventories/inventory/${inventory.id}/hosts`;
+  const hostBaseUrl = `${hostListUrl}/${hostId}`;
 
   const {
     result: { host },
@@ -30,12 +38,12 @@ function InventoryHost({ setBreadcrumb, inventory }) {
     useCallback(async () => {
       const response = await InventoriesAPI.readHostDetail(
         inventory.id,
-        match.params.hostId
+        hostId
       );
       return {
         host: response,
       };
-    }, [inventory.id, match.params.hostId]),
+    }, [inventory.id, hostId]),
     {
       host: null,
     }
@@ -64,22 +72,22 @@ function InventoryHost({ setBreadcrumb, inventory }) {
     },
     {
       name: t`Details`,
-      link: `${match.url}/details`,
+      link: `${hostBaseUrl}/details`,
       id: 1,
     },
     {
       name: t`Facts`,
-      link: `${match.url}/facts`,
+      link: `${hostBaseUrl}/facts`,
       id: 2,
     },
     {
       name: t`Groups`,
-      link: `${match.url}/groups`,
+      link: `${hostBaseUrl}/groups`,
       id: 3,
     },
     {
       name: t`Jobs`,
-      link: `${match.url}/jobs`,
+      link: `${hostBaseUrl}/jobs`,
       id: 4,
     },
   ];
@@ -113,50 +121,43 @@ function InventoryHost({ setBreadcrumb, inventory }) {
       {isLoading && <ContentLoading />}
 
       {!isLoading && host && (
-        <Switch>
-          <Redirect
-            from="/inventories/inventory/:id/hosts/:hostId"
-            to="/inventories/inventory/:id/hosts/:hostId/details"
-            exact
+        <Routes>
+          <Route
+            path="/inventories/inventory/:id/hosts/:hostId"
+            element={<Navigate to={`${hostBaseUrl}/details`} replace />}
           />
           <Route
-            key="details"
             path="/inventories/inventory/:id/hosts/:hostId/details"
-          >
-            <InventoryHostDetail host={host} />
-          </Route>
+            element={<InventoryHostDetail host={host} />}
+          />
           <Route
-            key="edit"
             path="/inventories/inventory/:id/hosts/:hostId/edit"
-          >
-            <InventoryHostEdit host={host} inventory={inventory} />
-          </Route>
+            element={<InventoryHostEdit host={host} inventory={inventory} />}
+          />
           <Route
-            key="facts"
             path="/inventories/inventory/:id/hosts/:hostId/facts"
-          >
-            <InventoryHostFacts host={host} />
-          </Route>
+            element={<InventoryHostFacts host={host} />}
+          />
+          {/* /* so the nested <InventoryHostGroups> route tree can match */}
           <Route
-            key="groups"
-            path="/inventories/inventory/:id/hosts/:hostId/groups"
-          >
-            <InventoryHostGroups />
-          </Route>
+            path="/inventories/inventory/:id/hosts/:hostId/groups/*"
+            element={<InventoryHostGroups />}
+          />
           <Route
-            key="jobs"
             path="/inventories/inventory/:id/hosts/:hostId/jobs"
-          >
-            <JobList defaultParams={{ job__hosts: host.id }} />
-          </Route>
-          <Route key="not-found" path="*">
-            <ContentError isNotFound>
-              <Link to={`${match.url}/details`}>
-                {t`View Inventory Host Details`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+            element={<JobList defaultParams={{ job__hosts: host.id }} />}
+          />
+          <Route
+            path="*"
+            element={
+              <ContentError isNotFound>
+                <Link to={`${hostBaseUrl}/details`}>
+                  {t`View Inventory Host Details`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       )}
     </>
   );

--- a/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroups.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroups.js
@@ -1,16 +1,17 @@
 import React from 'react';
 
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import InventoryHostGroupsList from './InventoryHostGroupsList';
 
 function InventoryHostGroups() {
   return (
-    <Switch>
-      <Route key="list" path="/inventories/inventory/:id/hosts/:hostId/groups">
-        <InventoryHostGroupsList />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path="/inventories/inventory/:id/hosts/:hostId/groups"
+        element={<InventoryHostGroupsList />}
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroups.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroups.js
@@ -8,7 +8,7 @@ function InventoryHostGroups() {
   return (
     <Routes>
       <Route
-        path="/inventories/inventory/:id/hosts/:hostId/groups"
+        index
         element={<InventoryHostGroupsList />}
       />
     </Routes>

--- a/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroups.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroups.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { HostsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventoryHostGroups from './InventoryHostGroups';
@@ -32,11 +33,15 @@ describe('<InventoryHostGroups />', () => {
     });
 
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryHostGroups />, {
-        context: {
-          router: { history, route: { location: history.location } },
-        },
-      });
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route
+            path="/inventories/inventory/:id/hosts/:hostId/groups/*"
+            element={<InventoryHostGroups />}
+          />
+        </Routes>,
+        { context: { router: { history } } }
+      );
     });
     expect(wrapper.length).toBe(1);
     expect(wrapper.find('InventoryHostGroupsList').length).toBe(1);

--- a/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 
 import { getQSConfig, parseQueryString, mergeParams } from 'util/qs';

--- a/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHostList.js
+++ b/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHostList.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { getQSConfig, parseQueryString } from 'util/qs';
 import { InventoriesAPI, HostsAPI } from 'api';

--- a/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHosts.js
+++ b/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHosts.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import InventoryHost from '../InventoryHost';
 import InventoryHostAdd from '../InventoryHostAdd';
@@ -7,17 +7,23 @@ import InventoryHostList from './InventoryHostList';
 
 function InventoryHosts({ setBreadcrumb, inventory }) {
   return (
-    <Switch>
-      <Route key="host-add" path="/inventories/inventory/:id/hosts/add">
-        <InventoryHostAdd inventory={inventory} />
-      </Route>
-      <Route key="host" path="/inventories/inventory/:id/hosts/:hostId">
-        <InventoryHost setBreadcrumb={setBreadcrumb} inventory={inventory} />
-      </Route>
-      <Route key="host-list" path="/inventories/inventory/:id/hosts">
-        <InventoryHostList />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path="/inventories/inventory/:id/hosts/add"
+        element={<InventoryHostAdd inventory={inventory} />}
+      />
+      {/* /* so the nested <InventoryHost> route tree can match */}
+      <Route
+        path="/inventories/inventory/:id/hosts/:hostId/*"
+        element={
+          <InventoryHost setBreadcrumb={setBreadcrumb} inventory={inventory} />
+        }
+      />
+      <Route
+        path="/inventories/inventory/:id/hosts"
+        element={<InventoryHostList />}
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHosts.js
+++ b/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHosts.js
@@ -9,18 +9,18 @@ function InventoryHosts({ setBreadcrumb, inventory }) {
   return (
     <Routes>
       <Route
-        path="/inventories/inventory/:id/hosts/add"
+        path="add"
         element={<InventoryHostAdd inventory={inventory} />}
       />
       {/* /* so the nested <InventoryHost> route tree can match */}
       <Route
-        path="/inventories/inventory/:id/hosts/:hostId/*"
+        path=":hostId/*"
         element={
           <InventoryHost setBreadcrumb={setBreadcrumb} inventory={inventory} />
         }
       />
       <Route
-        path="/inventories/inventory/:id/hosts"
+        index
         element={<InventoryHostList />}
       />
     </Routes>

--- a/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHosts.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHosts.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventoryHosts from './InventoryHosts';
 
@@ -17,15 +18,15 @@ describe('<InventoryHosts />', () => {
       initialEntries: ['/inventories/inventory/1/hosts'],
     });
 
-    const match = {
-      path: '/inventories/inventory/:id/hosts',
-      url: '/inventories/inventory/1/hosts',
-      isExact: true,
-    };
-
-    const wrapper = mountWithContexts(<InventoryHosts />, {
-      context: { router: { history, route: { match } } },
-    });
+    const wrapper = mountWithContexts(
+      <Routes>
+        <Route
+          path="/inventories/inventory/:id/hosts/*"
+          element={<InventoryHosts />}
+        />
+      </Routes>,
+      { context: { router: { history } } }
+    );
 
     expect(wrapper.find('InventoryHostList').length).toBe(1);
   });

--- a/awx/ui/src/screens/Inventory/InventoryList/InventoryList.js
+++ b/awx/ui/src/screens/Inventory/InventoryList/InventoryList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation, useRouteMatch, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection, DropdownItem } from '@patternfly/react-core';
 import { InventoriesAPI } from 'api';
@@ -29,7 +29,6 @@ const QS_CONFIG = getQSConfig('inventory', {
 
 function InventoryList() {
   const location = useLocation();
-  const match = useRouteMatch();
   const { addToast, Toast, toastProps } = useToast();
   const { t } = useLingui();
 
@@ -145,7 +144,7 @@ function InventoryList() {
       dropdownItems={[
         <DropdownItem
           ouiaId="add-inventory-item"
-          to={`${match.url}/inventory/add/`}
+          to="/inventories/inventory/add/"
           component={Link}
           key={addInventory}
           aria-label={addInventory}
@@ -154,7 +153,7 @@ function InventoryList() {
         </DropdownItem>,
         <DropdownItem
           ouiaId="add-smart-inventory-item"
-          to={`${match.url}/smart_inventory/add/`}
+          to="/inventories/smart_inventory/add/"
           component={Link}
           key={addSmartInventory}
           aria-label={addSmartInventory}
@@ -163,7 +162,7 @@ function InventoryList() {
         </DropdownItem>,
         <DropdownItem
           ouiaId="add-constructed-inventory-item"
-          to={`${match.url}/constructed_inventory/add/`}
+          to="/inventories/constructed_inventory/add/"
           component={Link}
           key={addConstructedInventory}
           aria-label={addConstructedInventory}
@@ -172,7 +171,7 @@ function InventoryList() {
         </DropdownItem>,
         <DropdownItem
           ouiaId="add-federated-inventory-item"
-          to={`${match.url}/federated_inventory/add/`}
+          to="/inventories/federated_inventory/add/"
           component={Link}
           key={addFederatedInventory}
           aria-label={addFederatedInventory}

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroupAdd/InventoryRelatedGroupAdd.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroupAdd/InventoryRelatedGroupAdd.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import { GroupsAPI } from 'api';
 import InventoryGroupForm from '../shared/InventoryGroupForm';
 

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroupAdd/InventoryRelatedGroupAdd.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroupAdd/InventoryRelatedGroupAdd.test.js
@@ -1,28 +1,31 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { GroupsAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventoryRelatedGroupAdd from './InventoryRelatedGroupAdd';
 
 jest.mock('../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({
-    id: 1,
-    groupId: 2,
-  }),
-  useHistory: () => ({ push: jest.fn() }),
-}));
 
 describe('<InventoryRelatedGroupAdd/>', () => {
   let wrapper;
-  const history = createMemoryHistory({
-    initialEntries: ['/inventories/inventory/1/groups/2/nested_groups'],
-  });
+  let history;
 
   beforeEach(() => {
-    wrapper = mountWithContexts(<InventoryRelatedGroupAdd />);
+    history = createMemoryHistory({
+      initialEntries: ['/inventories/inventory/1/groups/2/nested_groups/add'],
+    });
+    wrapper = mountWithContexts(
+      <Routes>
+        <Route
+          path="/inventories/inventory/:id/groups/:groupId/nested_groups/add/*"
+          element={<InventoryRelatedGroupAdd />}
+        />
+        <Route path="*" element={null} />
+      </Routes>,
+      { context: { router: { history } } }
+    );
   });
 
   test('should render properly', () => {
@@ -38,11 +41,11 @@ describe('<InventoryRelatedGroupAdd/>', () => {
       })
     );
     expect(GroupsAPI.create).toHaveBeenCalledWith({
-      inventory: 1,
+      inventory: '1',
       name: 'foo',
       description: 'bar',
     });
-    expect(GroupsAPI.associateChildGroup).toHaveBeenCalledWith(2, 3);
+    expect(GroupsAPI.associateChildGroup).toHaveBeenCalledWith('2', 3);
   });
 
   test('cancel should navigate user to Inventory Groups List', async () => {
@@ -90,7 +93,7 @@ describe('<InventoryRelatedGroupAdd/>', () => {
       })
     );
     expect(GroupsAPI.create).toHaveBeenCalledWith({
-      inventory: 1,
+      inventory: '1',
       name: 'foo',
       description: 'bar',
     });

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { useParams, useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import { DropdownItem } from '@patternfly/react-core';
 import { GroupsAPI, InventoriesAPI } from 'api';

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { GroupsAPI, InventoriesAPI } from 'api';
 import {
   mountWithContexts,
@@ -13,6 +13,20 @@ import mockRelatedGroups from '../shared/data.relatedGroups.json';
 jest.mock('../../../api/models/Groups');
 jest.mock('../../../api/models/Inventories');
 jest.mock('../../../api/models/CredentialTypes');
+
+function renderUnder(url) {
+  const history = createMemoryHistory({ initialEntries: [url] });
+  const wrapper = mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/*"
+        element={<InventoryRelatedGroupList />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+  return { wrapper, history };
+}
 
 const mockGroups = [
   {
@@ -57,15 +71,8 @@ const mockGroups = [
 ];
 
 describe('<InventoryRelatedGroupList />', () => {
+  const url = '/inventories/inventory/2/groups/2/nested_groups';
   let wrapper;
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 2,
-      groupId: 2,
-      inventoryType: 'inventory',
-    }),
-  }));
 
   beforeEach(async () => {
     GroupsAPI.readChildren.mockResolvedValue({
@@ -104,7 +111,7 @@ describe('<InventoryRelatedGroupList />', () => {
       },
     });
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+      ({ wrapper } = renderUnder(url));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
@@ -175,7 +182,7 @@ describe('<InventoryRelatedGroupList />', () => {
       Promise.reject(new Error())
     );
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+      ({ wrapper } = renderUnder(url));
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });
@@ -201,7 +208,7 @@ describe('<InventoryRelatedGroupList />', () => {
       },
     });
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+      ({ wrapper } = renderUnder(url));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('AddDropdown').length).toBe(0);
@@ -211,16 +218,8 @@ describe('<InventoryRelatedGroupList />', () => {
     GroupsAPI.readPotentialGroups.mockResolvedValue({
       data: { count: mockGroups.length, results: mockGroups },
     });
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/2/groups/2/nested_groups'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups">
-          <InventoryRelatedGroupList />
-        </Route>,
-        { context: { router: { history } } }
-      );
+      ({ wrapper } = renderUnder(url));
     });
     await waitForElement(
       wrapper,
@@ -273,21 +272,13 @@ describe('<InventoryRelatedGroupList />', () => {
       },
     });
     await act(async () => {
-      wrapper = mountWithContexts(<InventoryRelatedGroupList />);
+      ({ wrapper } = renderUnder(url));
     });
     expect(wrapper.find('AdHocCommands')).toHaveLength(0);
   });
 });
 
 describe('<InventoryRelatedGroupList> for constructed inventories', () => {
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-      inventoryType: 'constructed_inventory',
-    }),
-  }));
   let wrapper;
 
   beforeEach(async () => {
@@ -326,18 +317,10 @@ describe('<InventoryRelatedGroupList> for constructed inventories', () => {
         },
       },
     });
-    const history = createMemoryHistory({
-      initialEntries: [
-        '/inventories/constructed_inventory/1/groups/2/nested_groups',
-      ],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups">
-          <InventoryRelatedGroupList />
-        </Route>,
-        { context: { router: { history } } }
-      );
+      ({ wrapper } = renderUnder(
+        '/inventories/constructed_inventory/1/groups/2/nested_groups'
+      ));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { string, bool, func, number } from 'prop-types';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.test.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import InventoryRelatedGroupListItem from './InventoryRelatedGroupListItem';
 import mockRelatedGroups from '../shared/data.relatedGroups.json';
-import { Route } from 'react-router-dom';
 
 jest.mock('../../../api');
 
@@ -13,30 +13,27 @@ describe('<InventoryRelatedGroupListItem />', () => {
   const history = createMemoryHistory({
     initialEntries: ['/inventories/inventory/1/groups/2/nested_groups'],
   });
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-      inventoryType: 'inventory',
-    }),
-  }));
   beforeEach(() => {
     wrapper = mountWithContexts(
-      <Route path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups">
-        <table>
-          <tbody>
-            <InventoryRelatedGroupListItem
-              detailUrl="/group/1"
-              editUrl="/group/1"
-              group={mockGroup}
-              isSelected={false}
-              onSelect={() => {}}
-              rowIndex={0}
-            />
-          </tbody>
-        </table>
-      </Route>,
+      <Routes>
+        <Route
+          path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/*"
+          element={
+            <table>
+              <tbody>
+                <InventoryRelatedGroupListItem
+                  detailUrl="/group/1"
+                  editUrl="/group/1"
+                  group={mockGroup}
+                  isSelected={false}
+                  onSelect={() => {}}
+                  rowIndex={0}
+                />
+              </tbody>
+            </table>
+          }
+        />
+      </Routes>,
       { context: { router: { history } } }
     );
   });
@@ -51,20 +48,25 @@ describe('<InventoryRelatedGroupListItem />', () => {
 
   test('edit button hidden from users without edit capabilities', () => {
     wrapper = mountWithContexts(
-      <Route path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups">
-        <table>
-          <tbody>
-            <InventoryRelatedGroupListItem
-              detailUrl="/group/1"
-              editUrl="/group/1"
-              group={mockRelatedGroups.results[2]}
-              isSelected={false}
-              onSelect={() => {}}
-              rowIndex={0}
-            />
-          </tbody>
-        </table>
-      </Route>,
+      <Routes>
+        <Route
+          path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/*"
+          element={
+            <table>
+              <tbody>
+                <InventoryRelatedGroupListItem
+                  detailUrl="/group/1"
+                  editUrl="/group/1"
+                  group={mockRelatedGroups.results[2]}
+                  isSelected={false}
+                  onSelect={() => {}}
+                  rowIndex={0}
+                />
+              </tbody>
+            </table>
+          }
+        />
+      </Routes>,
       { context: { router: { history } } }
     );
     expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
@@ -72,15 +74,6 @@ describe('<InventoryRelatedGroupListItem />', () => {
 });
 
 describe('<InventoryRelatedGroupList> for constructed inventories', () => {
-  jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: () => ({
-      id: 1,
-      groupId: 2,
-      inventoryType: 'constructed_inventory',
-    }),
-  }));
-
   let wrapper;
 
   test('edit button hidden from users without edit capabilities', () => {
@@ -90,20 +83,25 @@ describe('<InventoryRelatedGroupList> for constructed inventories', () => {
       ],
     });
     wrapper = mountWithContexts(
-      <Route path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups">
-        <table>
-          <tbody>
-            <InventoryRelatedGroupListItem
-              detailUrl="/group/1"
-              editUrl="/group/1"
-              group={mockGroup}
-              isSelected={false}
-              onSelect={() => {}}
-              rowIndex={0}
-            />
-          </tbody>
-        </table>
-      </Route>,
+      <Routes>
+        <Route
+          path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/*"
+          element={
+            <table>
+              <tbody>
+                <InventoryRelatedGroupListItem
+                  detailUrl="/group/1"
+                  editUrl="/group/1"
+                  group={mockGroup}
+                  isSelected={false}
+                  onSelect={() => {}}
+                  rowIndex={0}
+                />
+              </tbody>
+            </table>
+          }
+        />
+      </Routes>,
       { context: { router: { history } } }
     );
     expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroups.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroups.js
@@ -7,11 +7,11 @@ function InventoryRelatedGroups() {
   return (
     <Routes>
       <Route
-        path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/add"
+        path="add"
         element={<InventoryRelatedGroupAdd />}
       />
       <Route
-        path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups"
+        index
         element={<InventoryRelatedGroupList />}
       />
     </Routes>

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroups.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroups.js
@@ -1,24 +1,20 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import InventoryRelatedGroupList from './InventoryRelatedGroupList';
 import InventoryRelatedGroupAdd from '../InventoryRelatedGroupAdd';
 
 function InventoryRelatedGroups() {
   return (
-    <Switch>
+    <Routes>
       <Route
-        key="addRelatedGroups"
         path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups/add"
-      >
-        <InventoryRelatedGroupAdd />
-      </Route>
+        element={<InventoryRelatedGroupAdd />}
+      />
       <Route
-        key="relatedGroups"
         path="/inventories/:inventoryType/:id/groups/:groupId/nested_groups"
-      >
-        <InventoryRelatedGroupList />
-      </Route>
-    </Switch>
+        element={<InventoryRelatedGroupList />}
+      />
+    </Routes>
   );
 }
 export default InventoryRelatedGroups;

--- a/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
+++ b/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
@@ -121,19 +121,19 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
           />
           <Route
             key="details"
-            path="/inventories/inventory/:id/sources/:sourceId/details"
+            path="details"
           >
             <InventorySourceDetail inventorySource={source} />
           </Route>
           <Route
             key="edit"
-            path="/inventories/inventory/:id/sources/:sourceId/edit"
+            path="edit"
           >
             <InventorySourceEdit source={source} inventory={inventory} />
           </Route>
           <Route
             key="notifications"
-            path="/inventories/inventory/:id/sources/:sourceId/notifications"
+            path="notifications"
           >
             <NotificationList
               id={Number(match.params.sourceId)}
@@ -143,7 +143,7 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
           </Route>
           <Route
             key="schedules"
-            path="/inventories/inventory/:id/sources/:sourceId/schedules"
+            path="schedules"
           >
             <Schedules
               apiModel={InventorySourcesAPI}

--- a/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
+++ b/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
@@ -1,7 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+  useLocation,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import useRequest from 'hooks/useRequest';
 
@@ -17,8 +24,9 @@ import InventorySourceEdit from '../InventorySourceEdit';
 function InventorySource({ inventory, setBreadcrumb, me }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch('/inventories/inventory/:id/sources/:sourceId');
+  const { sourceId } = useParams();
   const sourceListUrl = `/inventories/inventory/${inventory.id}/sources`;
+  const detailsBaseUrl = `${sourceListUrl}/${sourceId}`;
 
   const {
     result: { source, isNotifAdmin },
@@ -28,7 +36,7 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
   } = useRequest(
     useCallback(async () => {
       const [inventorySource, notifAdminRes] = await Promise.all([
-        InventoriesAPI.readSourceDetail(inventory.id, match.params.sourceId),
+        InventoriesAPI.readSourceDetail(inventory.id, sourceId),
         OrganizationsAPI.read({
           page_size: 1,
           role_level: 'notification_admin_role',
@@ -38,7 +46,7 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
         source: inventorySource,
         isNotifAdmin: notifAdminRes.data.results.length > 0,
       };
-    }, [inventory.id, match.params.sourceId]),
+    }, [inventory.id, sourceId]),
     { source: null, isNotifAdmin: false }
   );
 
@@ -75,12 +83,12 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
     },
     {
       name: t`Details`,
-      link: `${match.url}/details`,
+      link: `${detailsBaseUrl}/details`,
       id: 1,
     },
     {
       name: t`Schedules`,
-      link: `${match.url}/schedules`,
+      link: `${detailsBaseUrl}/schedules`,
       id: 2,
     },
   ];
@@ -91,7 +99,7 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
   if (canSeeNotificationsTab) {
     tabsArray.push({
       name: t`Notifications`,
-      link: `${match.url}/notifications`,
+      link: `${detailsBaseUrl}/notifications`,
       id: 3,
     });
   }
@@ -113,56 +121,54 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
       {isLoading && <ContentLoading />}
 
       {!isLoading && source && (
-        <Switch>
-          <Redirect
-            from="/inventories/inventory/:id/sources/:sourceId"
-            to="/inventories/inventory/:id/sources/:sourceId/details"
-            exact
+        <Routes>
+          <Route index element={<Navigate to="details" replace />} />
+          <Route
+            path="details"
+            element={<InventorySourceDetail inventorySource={source} />}
           />
           <Route
-            key="details"
-            path="details"
-          >
-            <InventorySourceDetail inventorySource={source} />
-          </Route>
-          <Route
-            key="edit"
             path="edit"
-          >
-            <InventorySourceEdit source={source} inventory={inventory} />
-          </Route>
+            element={
+              <InventorySourceEdit source={source} inventory={inventory} />
+            }
+          />
           <Route
-            key="notifications"
             path="notifications"
-          >
-            <NotificationList
-              id={Number(match.params.sourceId)}
-              canToggleNotifications={canToggleNotifications}
-              apiModel={InventorySourcesAPI}
-            />
-          </Route>
+            element={
+              <NotificationList
+                id={Number(sourceId)}
+                canToggleNotifications={canToggleNotifications}
+                apiModel={InventorySourcesAPI}
+              />
+            }
+          />
+          {/* /* so the nested <Schedules> route tree can match */}
           <Route
-            key="schedules"
-            path="schedules"
-          >
-            <Schedules
-              apiModel={InventorySourcesAPI}
-              setBreadcrumb={(schedule) =>
-                setBreadcrumb(inventory, source, schedule)
-              }
-              resource={source}
-              loadSchedules={loadSchedules}
-              loadScheduleOptions={loadScheduleOptions}
-            />
-          </Route>
-          <Route key="not-found" path="*">
-            <ContentError isNotFound>
-              <Link to={`${match.url}/details`}>
-                {t`View inventory source details`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+            path="schedules/*"
+            element={
+              <Schedules
+                apiModel={InventorySourcesAPI}
+                setBreadcrumb={(schedule) =>
+                  setBreadcrumb(inventory, source, schedule)
+                }
+                resource={source}
+                loadSchedules={loadSchedules}
+                loadScheduleOptions={loadScheduleOptions}
+              />
+            }
+          />
+          <Route
+            path="*"
+            element={
+              <ContentError isNotFound>
+                <Link to={`${detailsBaseUrl}/details`}>
+                  {t`View inventory source details`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       )}
     </>
   );

--- a/awx/ui/src/screens/Inventory/InventorySource/InventorySource.test.js
+++ b/awx/ui/src/screens/Inventory/InventorySource/InventorySource.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { InventoriesAPI, OrganizationsAPI } from 'api';
 import {
   mountWithContexts,
@@ -13,18 +14,33 @@ jest.mock('../../../api/models/Inventories');
 jest.mock('../../../api/models/Organizations');
 jest.mock('../../../api/models/InventorySources');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    url: '/inventories/inventory/2/sources/123',
-    params: { id: 2, sourceId: 123 },
-  }),
-}));
-
 const mockInventory = {
   id: 2,
   name: 'Mock Inventory',
 };
+
+// InventorySource reads :sourceId via useParams and uses relative routes, so
+// mount it under its ".../sources/:sourceId/*" parent route.
+function mountInventorySource(initialEntry, props = {}) {
+  const history = createMemoryHistory({ initialEntries: [initialEntry] });
+  const wrapper = mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/inventory/:id/sources/:sourceId/*"
+        element={
+          <InventorySource
+            inventory={mockInventory}
+            me={{ is_system_auditor: false }}
+            setBreadcrumb={() => {}}
+            {...props}
+          />
+        }
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+  return { wrapper, history };
+}
 
 describe('<InventorySource />', () => {
   let wrapper;
@@ -32,13 +48,9 @@ describe('<InventorySource />', () => {
 
   beforeEach(async () => {
     await act(async () => {
-      wrapper = mountWithContexts(
-        <InventorySource
-          inventory={mockInventory}
-          me={{ is_system_auditor: false }}
-          setBreadcrumb={() => {}}
-        />
-      );
+      ({ wrapper } = mountInventorySource(
+        '/inventories/inventory/2/sources/123/details'
+      ));
     });
   });
 
@@ -73,13 +85,9 @@ describe('<InventorySource />', () => {
     });
     InventoriesAPI.readSourceDetail.mockRejectedValueOnce(new Error());
     await act(async () => {
-      wrapper = mountWithContexts(
-        <InventorySource
-          inventory={mockInventory}
-          me={{ is_system_auditor: false }}
-          setBreadcrumb={() => {}}
-        />
-      );
+      ({ wrapper } = mountInventorySource(
+        '/inventories/inventory/2/sources/123/details'
+      ));
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
@@ -95,18 +103,10 @@ describe('<InventorySource />', () => {
     OrganizationsAPI.read.mockResolvedValue({
       data: { results: [{ id: 1, name: 'isNotifAdmin' }] },
     });
-    history = createMemoryHistory({
-      initialEntries: ['/inventories/inventory/2/sources/1/foobar'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <InventorySource
-          inventory={mockInventory}
-          setBreadcrumb={() => {}}
-          me={{ is_system_auditor: false }}
-        />,
-        { context: { router: { history } } }
-      );
+      ({ wrapper, history } = mountInventorySource(
+        '/inventories/inventory/2/sources/1/foobar'
+      ));
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
     expect(wrapper.find('ContentError Title').text()).toEqual('Not Found');
@@ -119,7 +119,7 @@ describe('<InventorySource />', () => {
     OrganizationsAPI.read.mockResolvedValue({
       data: { results: [{ id: 1, name: 'isNotifAdmin' }] },
     });
-    expect(InventoriesAPI.readSourceDetail).toHaveBeenCalledWith(2, 123);
+    expect(InventoriesAPI.readSourceDetail).toHaveBeenCalledWith(2, '123');
     expect(OrganizationsAPI.read).toHaveBeenCalled();
   });
 

--- a/awx/ui/src/screens/Inventory/InventorySources/InventorySourceList.js
+++ b/awx/ui/src/screens/Inventory/InventorySources/InventorySourceList.js
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { Plural, useLingui } from '@lingui/react/macro';
 
 import useRequest, {

--- a/awx/ui/src/screens/Inventory/InventorySources/InventorySourceList.test.js
+++ b/awx/ui/src/screens/Inventory/InventorySources/InventorySourceList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { createMemoryHistory } from 'history';
 import { act } from 'react-dom/test-utils';
 import {
@@ -60,7 +60,7 @@ describe('<InventorySourceList />', () => {
   let debug;
 
   beforeEach(async () => {
-    debug = global.console.debug; // eslint-disable-line prefer-destructuring
+    debug = global.console.debug;
     global.console.debug = () => {};
     InventoriesAPI.readSources.mockResolvedValue(sources);
     InventoriesAPI.updateSources.mockResolvedValue({
@@ -89,9 +89,12 @@ describe('<InventorySourceList />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/sources">
-          <InventorySourceList />
-        </Route>,
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/sources/*"
+            element={<InventorySourceList />}
+          />
+        </Routes>,
         {
           context: {
             router: {
@@ -232,8 +235,19 @@ describe('<InventorySourceList />', () => {
       })
     );
 
+    const errorHistory = createMemoryHistory({
+      initialEntries: ['/inventories/inventory/1/sources'],
+    });
     await act(async () => {
-      wrapper = mountWithContexts(<InventorySourceList />);
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/sources/*"
+            element={<InventorySourceList />}
+          />
+        </Routes>,
+        { context: { router: { history: errorHistory } } }
+      );
     });
     wrapper.update();
 
@@ -254,8 +268,19 @@ describe('<InventorySourceList />', () => {
       })
     );
 
+    const errorHistory = createMemoryHistory({
+      initialEntries: ['/inventories/inventory/1/sources'],
+    });
     await act(async () => {
-      wrapper = mountWithContexts(<InventorySourceList />);
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/sources/*"
+            element={<InventorySourceList />}
+          />
+        </Routes>,
+        { context: { router: { history: errorHistory } } }
+      );
     });
     wrapper.update();
 
@@ -321,9 +346,12 @@ describe('<InventorySourceList /> RBAC testing', () => {
     });
     await act(async () => {
       newWrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/sources">
-          <InventorySourceList />
-        </Route>,
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/sources/*"
+            element={<InventorySourceList />}
+          />
+        </Routes>,
         {
           context: {
             router: {
@@ -356,9 +384,12 @@ describe('<InventorySourceList /> RBAC testing', () => {
     });
     await act(async () => {
       newWrapper = mountWithContexts(
-        <Route path="/inventories/:inventoryType/:id/sources">
-          <InventorySourceList />
-        </Route>,
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/sources/*"
+            element={<InventorySourceList />}
+          />
+        </Routes>,
         {
           context: {
             router: {

--- a/awx/ui/src/screens/Inventory/InventorySources/InventorySources.js
+++ b/awx/ui/src/screens/Inventory/InventorySources/InventorySources.js
@@ -9,12 +9,12 @@ function InventorySources({ inventory, setBreadcrumb }) {
   return (
     <Routes>
       <Route
-        path="/inventories/inventory/:id/sources/add"
+        path="add"
         element={<InventorySourceAdd inventory={inventory} />}
       />
       {/* /* so the nested <InventorySource> route tree can match */}
       <Route
-        path="/inventories/inventory/:id/sources/:sourceId/*"
+        path=":sourceId/*"
         element={
           <Config>
             {({ me }) => (
@@ -28,7 +28,7 @@ function InventorySources({ inventory, setBreadcrumb }) {
         }
       />
       <Route
-        path="/inventories/:inventoryType/:id/sources"
+        index
         element={<InventorySourceList />}
       />
     </Routes>

--- a/awx/ui/src/screens/Inventory/InventorySources/InventorySources.js
+++ b/awx/ui/src/screens/Inventory/InventorySources/InventorySources.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { Config } from 'contexts/Config';
 import InventorySource from '../InventorySource';
 import InventorySourceAdd from '../InventorySourceAdd';
@@ -7,25 +7,31 @@ import InventorySourceList from './InventorySourceList';
 
 function InventorySources({ inventory, setBreadcrumb }) {
   return (
-    <Switch>
-      <Route key="add" path="/inventories/inventory/:id/sources/add">
-        <InventorySourceAdd inventory={inventory} />
-      </Route>
-      <Route path="/inventories/inventory/:id/sources/:sourceId">
-        <Config>
-          {({ me }) => (
-            <InventorySource
-              inventory={inventory}
-              setBreadcrumb={setBreadcrumb}
-              me={me || {}}
-            />
-          )}
-        </Config>
-      </Route>
-      <Route path="/inventories/:inventoryType/:id/sources">
-        <InventorySourceList />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path="/inventories/inventory/:id/sources/add"
+        element={<InventorySourceAdd inventory={inventory} />}
+      />
+      {/* /* so the nested <InventorySource> route tree can match */}
+      <Route
+        path="/inventories/inventory/:id/sources/:sourceId/*"
+        element={
+          <Config>
+            {({ me }) => (
+              <InventorySource
+                inventory={inventory}
+                setBreadcrumb={setBreadcrumb}
+                me={me || {}}
+              />
+            )}
+          </Config>
+        }
+      />
+      <Route
+        path="/inventories/:inventoryType/:id/sources"
+        element={<InventorySourceList />}
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/screens/Inventory/SmartInventory.js
+++ b/awx/ui/src/screens/Inventory/SmartInventory.js
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+  useLocation,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
@@ -21,7 +28,8 @@ import { getInventoryPath } from './shared/utils';
 function SmartInventory({ setBreadcrumb }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch('/inventories/smart_inventory/:id');
+  const { id } = useParams();
+  const smartBaseUrl = `/inventories/smart_inventory/${id}`;
 
   const {
     result: inventory,
@@ -30,9 +38,9 @@ function SmartInventory({ setBreadcrumb }) {
     request: fetchInventory,
   } = useRequest(
     useCallback(async () => {
-      const { data } = await InventoriesAPI.readDetail(match.params.id);
+      const { data } = await InventoriesAPI.readDetail(id);
       return data;
-    }, [match.params.id]),
+    }, [id]),
 
     null
   );
@@ -58,17 +66,17 @@ function SmartInventory({ setBreadcrumb }) {
       link: `/inventories`,
       id: 99,
     },
-    { name: t`Details`, link: `${match.url}/details`, id: 0 },
-    { name: t`Access`, link: `${match.url}/access`, id: 1 },
-    { name: t`Hosts`, link: `${match.url}/hosts`, id: 2 },
+    { name: t`Details`, link: `${smartBaseUrl}/details`, id: 0 },
+    { name: t`Access`, link: `${smartBaseUrl}/access`, id: 1 },
+    { name: t`Hosts`, link: `${smartBaseUrl}/hosts`, id: 2 },
     {
       name: t`Jobs`,
-      link: `${match.url}/jobs`,
+      link: `${smartBaseUrl}/jobs`,
       id: 3,
     },
     {
       name: t`Job Templates`,
-      link: `${match.url}/job_templates`,
+      link: `${smartBaseUrl}/job_templates`,
       id: 4,
     },
   ];
@@ -103,7 +111,7 @@ function SmartInventory({ setBreadcrumb }) {
   }
 
   if (inventory && inventory?.kind !== 'smart') {
-    return <Redirect to={`${getInventoryPath(inventory)}/details`} />;
+    return <Navigate to={`${getInventoryPath(inventory)}/details`} replace />;
   }
 
   let showCardHeader = true;
@@ -116,71 +124,92 @@ function SmartInventory({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-        <Switch>
-          <Redirect
-            from="/inventories/smart_inventory/:id"
-            to="/inventories/smart_inventory/:id/details"
-            exact
+        <Routes>
+          <Route
+            path="/inventories/smart_inventory/:id"
+            element={<Navigate to={`${smartBaseUrl}/details`} replace />}
           />
-          {inventory && [
+          {inventory && (
             <Route
-              key="details"
               path="/inventories/smart_inventory/:id/details"
-            >
-              <SmartInventoryDetail
-                isLoading={hasContentLoading}
-                inventory={inventory}
-              />
-            </Route>,
-            <Route key="edit" path="/inventories/smart_inventory/:id/edit">
-              <SmartInventoryEdit inventory={inventory} />
-            </Route>,
-            <Route key="access" path="/inventories/smart_inventory/:id/access">
-              <ResourceAccessList
-                resource={inventory}
-                apiModel={InventoriesAPI}
-              />
-            </Route>,
-            <Route key="hosts" path="/inventories/smart_inventory/:id/hosts">
-              <AdvancedInventoryHosts
-                inventory={inventory}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>,
-            <Route key="jobs" path="/inventories/smart_inventory/:id/jobs">
-              <JobList
-                defaultParams={{
-                  or__job__inventory: inventory.id,
-                  or__adhoccommand__inventory: inventory.id,
-                  or__inventoryupdate__inventory_source__inventory:
-                    inventory.id,
-                  or__workflowjob__inventory: inventory.id,
-                }}
-              />
-            </Route>,
+              element={
+                <SmartInventoryDetail
+                  isLoading={hasContentLoading}
+                  inventory={inventory}
+                />
+              }
+            />
+          )}
+          {inventory && (
             <Route
-              key="job_templates"
+              path="/inventories/smart_inventory/:id/edit"
+              element={<SmartInventoryEdit inventory={inventory} />}
+            />
+          )}
+          {inventory && (
+            <Route
+              path="/inventories/smart_inventory/:id/access"
+              element={
+                <ResourceAccessList
+                  resource={inventory}
+                  apiModel={InventoriesAPI}
+                />
+              }
+            />
+          )}
+          {/* /* so the nested <AdvancedInventoryHosts> route tree can match */}
+          {inventory && (
+            <Route
+              path="/inventories/smart_inventory/:id/hosts/*"
+              element={
+                <AdvancedInventoryHosts
+                  inventory={inventory}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
+          )}
+          {inventory && (
+            <Route
+              path="/inventories/smart_inventory/:id/jobs"
+              element={
+                <JobList
+                  defaultParams={{
+                    or__job__inventory: inventory.id,
+                    or__adhoccommand__inventory: inventory.id,
+                    or__inventoryupdate__inventory_source__inventory:
+                      inventory.id,
+                    or__workflowjob__inventory: inventory.id,
+                  }}
+                />
+              }
+            />
+          )}
+          {inventory && (
+            <Route
               path="/inventories/smart_inventory/:id/job_templates"
-            >
-              <RelatedTemplateList
-                searchParams={{ inventory__id: inventory.id }}
-              />
-            </Route>,
-            <Route key="not-found" path="*">
-              {!hasContentLoading && (
+              element={
+                <RelatedTemplateList
+                  searchParams={{ inventory__id: inventory.id }}
+                />
+              }
+            />
+          )}
+          <Route
+            path="*"
+            element={
+              !hasContentLoading ? (
                 <ContentError isNotFound>
-                  {match.params.id && (
-                    <Link
-                      to={`/inventories/smart_inventory/${match.params.id}/details`}
-                    >
+                  {id && (
+                    <Link to={`${smartBaseUrl}/details`}>
                       {t`View Inventory Details`}
                     </Link>
                   )}
                 </ContentError>
-              )}
-            </Route>,
-          ]}
-        </Switch>
+              ) : null
+            }
+          />
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/Inventory/SmartInventory.js
+++ b/awx/ui/src/screens/Inventory/SmartInventory.js
@@ -126,12 +126,12 @@ function SmartInventory({ setBreadcrumb }) {
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
         <Routes>
           <Route
-            path="/inventories/smart_inventory/:id"
+            index
             element={<Navigate to={`${smartBaseUrl}/details`} replace />}
           />
           {inventory && (
             <Route
-              path="/inventories/smart_inventory/:id/details"
+              path="details"
               element={
                 <SmartInventoryDetail
                   isLoading={hasContentLoading}
@@ -142,13 +142,13 @@ function SmartInventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/smart_inventory/:id/edit"
+              path="edit"
               element={<SmartInventoryEdit inventory={inventory} />}
             />
           )}
           {inventory && (
             <Route
-              path="/inventories/smart_inventory/:id/access"
+              path="access"
               element={
                 <ResourceAccessList
                   resource={inventory}
@@ -160,7 +160,7 @@ function SmartInventory({ setBreadcrumb }) {
           {/* /* so the nested <AdvancedInventoryHosts> route tree can match */}
           {inventory && (
             <Route
-              path="/inventories/smart_inventory/:id/hosts/*"
+              path="hosts/*"
               element={
                 <AdvancedInventoryHosts
                   inventory={inventory}
@@ -171,7 +171,7 @@ function SmartInventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/smart_inventory/:id/jobs"
+              path="jobs"
               element={
                 <JobList
                   defaultParams={{
@@ -187,7 +187,7 @@ function SmartInventory({ setBreadcrumb }) {
           )}
           {inventory && (
             <Route
-              path="/inventories/smart_inventory/:id/job_templates"
+              path="job_templates"
               element={
                 <RelatedTemplateList
                   searchParams={{ inventory__id: inventory.id }}

--- a/awx/ui/src/screens/Inventory/SmartInventory.test.js
+++ b/awx/ui/src/screens/Inventory/SmartInventory.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { InventoriesAPI } from 'api';
 import {
   mountWithContexts,
@@ -10,13 +11,21 @@ import mockSmartInventory from './shared/data.smart_inventory.json';
 import SmartInventory from './SmartInventory';
 
 jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    url: '/inventories/smart_inventory/1',
-    params: { id: 1 },
-  }),
-}));
+
+// SmartInventory uses relative routes and reads the id from useParams, so mount
+// it under its v6 parent route at a concrete URL.
+function renderAt(initialEntry) {
+  const history = createMemoryHistory({ initialEntries: [initialEntry] });
+  return mountWithContexts(
+    <Routes>
+      <Route
+        path="/inventories/smart_inventory/:id/*"
+        element={<SmartInventory setBreadcrumb={() => {}} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
 
 describe('<SmartInventory />', () => {
   let wrapper;
@@ -30,7 +39,7 @@ describe('<SmartInventory />', () => {
       data: mockSmartInventory,
     });
     await act(async () => {
-      wrapper = mountWithContexts(<SmartInventory setBreadcrumb={() => {}} />);
+      wrapper = renderAt('/inventories/smart_inventory/1/details');
     });
     wrapper.update();
     expect(wrapper.find('SmartInventory').length).toBe(1);
@@ -38,6 +47,9 @@ describe('<SmartInventory />', () => {
   });
 
   test('should render expected tabs', async () => {
+    InventoriesAPI.readDetail.mockResolvedValue({
+      data: mockSmartInventory,
+    });
     const expectedTabs = [
       'Back to Inventories',
       'Details',
@@ -47,8 +59,9 @@ describe('<SmartInventory />', () => {
       'Job Templates',
     ];
     await act(async () => {
-      wrapper = mountWithContexts(<SmartInventory setBreadcrumb={() => {}} />);
+      wrapper = renderAt('/inventories/smart_inventory/1/details');
     });
+    wrapper.update();
     wrapper.find('RoutedTabs li').forEach((tab, index) => {
       expect(tab.text()).toEqual(expectedTabs[index]);
     });
@@ -59,7 +72,7 @@ describe('<SmartInventory />', () => {
     error.response = { status: 404 };
     InventoriesAPI.readDetail.mockRejectedValueOnce(error);
     await act(async () => {
-      wrapper = mountWithContexts(<SmartInventory setBreadcrumb={() => {}} />);
+      wrapper = renderAt('/inventories/smart_inventory/1/details');
     });
     expect(InventoriesAPI.readDetail).toHaveBeenCalledTimes(1);
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
@@ -67,25 +80,11 @@ describe('<SmartInventory />', () => {
   });
 
   test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/inventories/smart_inventory/1/foobar'],
+    InventoriesAPI.readDetail.mockResolvedValue({
+      data: mockSmartInventory,
     });
     await act(async () => {
-      wrapper = mountWithContexts(<SmartInventory setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-            route: {
-              location: history.location,
-              match: {
-                params: { id: 1 },
-                url: '/inventories/smart_inventory/1/foobar',
-                path: '/inventories/smart_inventory/1/foobar',
-              },
-            },
-          },
-        },
-      });
+      wrapper = renderAt('/inventories/smart_inventory/1/foobar');
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });

--- a/awx/ui/src/screens/Inventory/shared/InventoryGroupsDeleteModal.js
+++ b/awx/ui/src/screens/Inventory/shared/InventoryGroupsDeleteModal.js
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom-v5-compat';
 import { func, bool, arrayOf } from 'prop-types';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Button, Radio, DropdownItem } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Inventory/shared/InventoryGroupsDeleteModal.test.js
+++ b/awx/ui/src/screens/Inventory/shared/InventoryGroupsDeleteModal.test.js
@@ -1,30 +1,37 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { InventoriesAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 
 import InventoryGroupsDeleteModal from './InventoryGroupsDeleteModal';
 
 jest.mock('../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({
-    id: 1,
-  }),
-}));
 describe('<InventoryGroupsDeleteModal />', () => {
   let wrapper;
   beforeEach(() => {
+    const history = createMemoryHistory({
+      initialEntries: ['/inventories/inventory/1/groups'],
+    });
     act(() => {
       wrapper = mountWithContexts(
-        <InventoryGroupsDeleteModal
-          onAfterDelete={() => {}}
-          isDisabled={false}
-          groups={[
-            { id: 1, name: 'Foo' },
-            { id: 2, name: 'Bar' },
-          ]}
-        />
+        <Routes>
+          <Route
+            path="/inventories/:inventoryType/:id/groups/*"
+            element={
+              <InventoryGroupsDeleteModal
+                onAfterDelete={() => {}}
+                isDisabled={false}
+                groups={[
+                  { id: 1, name: 'Foo' },
+                  { id: 2, name: 'Bar' },
+                ]}
+              />
+            }
+          />
+        </Routes>,
+        { context: { router: { history } } }
       );
     });
   });
@@ -61,7 +68,7 @@ describe('<InventoryGroupsDeleteModal />', () => {
     await act(() =>
       wrapper.find('Button[aria-label="Confirm Delete"]').prop('onClick')()
     );
-    expect(InventoriesAPI.promoteGroup).toHaveBeenCalledWith(1, 1);
+    expect(InventoriesAPI.promoteGroup).toHaveBeenCalledWith('1', 1);
   });
 
   test('should throw deletion error ', async () => {
@@ -91,7 +98,7 @@ describe('<InventoryGroupsDeleteModal />', () => {
     await act(() =>
       wrapper.find('Button[aria-label="Confirm Delete"]').prop('onClick')()
     );
-    expect(InventoriesAPI.promoteGroup).toHaveBeenCalledWith(1, 1);
+    expect(InventoriesAPI.promoteGroup).toHaveBeenCalledWith('1', 1);
     wrapper.update();
     expect(wrapper.find('ErrorDetail').length).toBe(1);
   });


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **Inventory screen** - the largest remaining screen family (16 nested route trees) - from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`. Done as a single PR with several commits.

UI (no behavior change - same URLs, same panels). Each route tree keeps its absolute `/inventories/...` paths, so it resolves correctly regardless of conversion order; every route that delegates to a nested screen gets a trailing `/*`; `useRouteMatch` is replaced with `useParams` + an explicit base url; exact `<Redirect>`s (and the inventory-kind mismatch redirects) become `<Navigate>`.

Converted (15 of the 16 trees):

- **Hosts**: AdvancedInventoryHost(s), InventoryHosts, InventoryHost, InventoryHostGroups
- **Groups**: InventoryGroups, InventoryGroup, InventoryGroupHosts, InventoryRelatedGroups
- **Sources**: InventorySources (the list)
- **Inventory-type details**: Inventory, SmartInventory, ConstructedInventory, FederatedInventory
- **Dispatcher**: Inventories.js (delegates each inventory-type detail with `/*`)

Deferred (1 tree):

- **InventorySource** (the source detail) renders the shared `Schedules` component, so it stays on v5 here and is handled with the shared-`Schedules` cluster. Its v5 `<Switch>` keeps working under the now-v6 `InventorySources` parent because it matches the absolute location.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration; converting the Inventory screen as one PR rather than many small PRs.
- Tests: full `screens/Inventory` directory passes (76 suites / 345 tests). A couple of tests needed updates (drop conflicting hoisted `useParams` module mocks and mount under the real v6 route; stub the inventory list / mount at `/inventories`); the rest pass unchanged because the routes keep absolute paths. `npm --prefix awx/ui run lint` clean on the changed source.

