### PR TITLE
Convert the shared Schedule components to react-router v6 Routes

### DIFF
--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,14 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import {
-  Switch,
-  Route,
-  Link,
-  Redirect,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -120,42 +114,54 @@ function Schedule({
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from={`${pathRoot}schedules/:scheduleId`}
-          to={`${pathRoot}schedules/:scheduleId/details`}
-          exact
+      <Routes>
+        <Route
+          path={`${pathRoot}schedules/:scheduleId`}
+          element={
+            <Navigate
+              to={`${pathRoot}schedules/${scheduleId}/details`}
+              replace
+            />
+          }
         />
-        {schedule && [
-          <Route key="edit" path={`${pathRoot}schedules/:id/edit`}>
-            <ScheduleEdit
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              resource={resource}
-              launchConfig={launchConfig}
-              surveyConfig={surveyConfig}
-              resourceDefaultCredentials={resourceDefaultCredentials}
-            />
-          </Route>,
+        {schedule && (
           <Route
-            key="details"
+            path={`${pathRoot}schedules/:id/edit`}
+            element={
+              <ScheduleEdit
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                resource={resource}
+                launchConfig={launchConfig}
+                surveyConfig={surveyConfig}
+                resourceDefaultCredentials={resourceDefaultCredentials}
+              />
+            }
+          />
+        )}
+        {schedule && (
+          <Route
             path={`${pathRoot}schedules/:scheduleId/details`}
-          >
-            <ScheduleDetail
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              surveyConfig={surveyConfig}
-            />
-          </Route>,
-        ]}
-        <Route key="not-found" path="*">
-          <ContentError>
-            {resource && (
-              <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
-            )}
-          </ContentError>
-        </Route>
-      </Switch>
+            element={
+              <ScheduleDetail
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                surveyConfig={surveyConfig}
+              />
+            }
+          />
+        )}
+        <Route
+          path="*"
+          element={
+            <ContentError>
+              {resource && (
+                <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
+              )}
+            </ContentError>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -121,18 +121,10 @@ function Schedule({
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
       <Routes>
-        <Route
-          path={`${pathRoot}schedules/:scheduleId`}
-          element={
-            <Navigate
-              to={`${pathRoot}schedules/${scheduleId}/details`}
-              replace
-            />
-          }
-        />
+        <Route index element={<Navigate to="details" replace />} />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/edit`}
+            path="edit"
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}
@@ -147,7 +139,7 @@ function Schedule({
         )}
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/details`}
+            path="details"
             element={
               <ScheduleDetail
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,8 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -25,7 +31,7 @@ function Schedule({
 
   const { pathname } = useLocation();
 
-  const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
+  const pathRoot = pathname.substring(0, pathname.indexOf('schedules'));
 
   const {
     isLoading,
@@ -126,7 +132,7 @@ function Schedule({
         />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:id/edit`}
+            path={`${pathRoot}schedules/:scheduleId/edit`}
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,7 +15,15 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  const match = useRouteMatch();
+  // This component is mounted at several different base paths (templates,
+  // projects, inventory sources, management jobs). Derive the base from the
+  // location so the routes are base-agnostic and resolve whether the parent
+  // screen is still on v5 or already on v6.
+  const { pathname } = useLocation();
+  const baseUrl = `${pathname.substr(
+    0,
+    pathname.indexOf('schedules')
+  )}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -26,37 +34,47 @@ function Schedules({
   ].includes(resource?.job_type);
 
   return (
-    <Switch>
-      <Route path={`${match.path}/add`}>
-        <ScheduleAdd
-          hasDaysToKeepField={hasDaysToKeepField}
-          apiModel={apiModel}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule
-          hasDaysToKeepField={hasDaysToKeepField}
-          setBreadcrumb={setBreadcrumb}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="list" path={`${match.path}`}>
-        <ScheduleList
-          resource={resource}
-          loadSchedules={loadSchedules}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          loadScheduleOptions={loadScheduleOptions}
-        />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path={`${baseUrl}/add`}
+        element={
+          <ScheduleAdd
+            hasDaysToKeepField={hasDaysToKeepField}
+            apiModel={apiModel}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      {/* /* so the nested <Schedule> route tree can match */}
+      <Route
+        path={`${baseUrl}/:scheduleId/*`}
+        element={
+          <Schedule
+            hasDaysToKeepField={hasDaysToKeepField}
+            setBreadcrumb={setBreadcrumb}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      <Route
+        path={baseUrl}
+        element={
+          <ScheduleList
+            resource={resource}
+            loadSchedules={loadSchedules}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            loadScheduleOptions={loadScheduleOptions}
+          />
+        }
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -20,10 +20,14 @@ function Schedules({
   // location so the routes are base-agnostic and resolve whether the parent
   // screen is still on v5 or already on v6.
   const { pathname } = useLocation();
-  const baseUrl = `${pathname.substr(
-    0,
-    pathname.indexOf('schedules')
-  )}schedules`;
+  // Schedules is always mounted under a ".../schedules" path; if that segment
+  // is somehow absent, fall back to the full pathname so baseUrl stays an
+  // absolute path rather than collapsing to the relative "schedules".
+  const schedulesIndex = pathname.indexOf('schedules');
+  const baseUrl =
+    schedulesIndex === -1
+      ? pathname
+      : `${pathname.substring(0, schedulesIndex)}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -48,7 +52,7 @@ function Schedules({
           />
         }
       />
-      {/* /* so the nested <Schedule> route tree can match */}
+      {/* so the nested <Schedule> route tree can match */}
       <Route
         path={`${baseUrl}/:scheduleId/*`}
         element={

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,19 +15,9 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  // This component is mounted at several different base paths (templates,
-  // projects, inventory sources, management jobs). Derive the base from the
-  // location so the routes are base-agnostic and resolve whether the parent
-  // screen is still on v5 or already on v6.
-  const { pathname } = useLocation();
-  // Schedules is always mounted under a ".../schedules" path; if that segment
-  // is somehow absent, fall back to the full pathname so baseUrl stays an
-  // absolute path rather than collapsing to the relative "schedules".
-  const schedulesIndex = pathname.indexOf('schedules');
-  const baseUrl =
-    schedulesIndex === -1
-      ? pathname
-      : `${pathname.substring(0, schedulesIndex)}schedules`;
+  // This component is mounted under a ".../schedules/*" route on several
+  // screens (templates, projects, inventory sources, management jobs), so its
+  // routes are relative to that parent and resolve under any of them.
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -40,7 +30,7 @@ function Schedules({
   return (
     <Routes>
       <Route
-        path={`${baseUrl}/add`}
+        path="add"
         element={
           <ScheduleAdd
             hasDaysToKeepField={hasDaysToKeepField}
@@ -54,7 +44,7 @@ function Schedules({
       />
       {/* so the nested <Schedule> route tree can match */}
       <Route
-        path={`${baseUrl}/:scheduleId/*`}
+        path=":scheduleId/*"
         element={
           <Schedule
             hasDaysToKeepField={hasDaysToKeepField}
@@ -67,7 +57,7 @@ function Schedules({
         }
       />
       <Route
-        path={baseUrl}
+        index
         element={
           <ScheduleList
             resource={resource}

--- a/awx/ui/src/components/Schedule/Schedules.test.js
+++ b/awx/ui/src/components/Schedule/Schedules.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import Schedules from './Schedules';
 
@@ -12,21 +13,25 @@ describe('<Schedules />', () => {
     });
     const jobTemplate = { id: 1, name: 'Mock JT' };
 
+    // Schedules uses relative routes, so mount it under its ".../schedules/*"
+    // parent route.
     await act(async () => {
       wrapper = mountWithContexts(
-        <Schedules
-          setBreadcrumb={() => {}}
-          jobTemplate={jobTemplate}
-          loadSchedules={() => {}}
-          loadScheduleOptions={() => {}}
-          apiModel={{ createSchedule: () => {} }}
-        />,
-
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
+        <Routes>
+          <Route
+            path="/templates/job_template/:id/schedules/*"
+            element={
+              <Schedules
+                setBreadcrumb={() => {}}
+                jobTemplate={jobTemplate}
+                loadSchedules={() => {}}
+                loadScheduleOptions={() => {}}
+                apiModel={{ createSchedule: () => {} }}
+              />
+            }
+          />
+        </Routes>,
+        { context: { router: { history } } }
       );
     });
     expect(wrapper.length).toBe(1);


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **shared Schedule components** (`components/Schedule/Schedules.js` and `Schedule.js`) from the v5 `<Switch>`/`<Redirect>` API to v6 `<Routes>`/`<Navigate>` via `react-router-dom-v5-compat`.

These components are reused at several different base paths (templates, projects, inventory sources, management jobs), so they can't hardcode an absolute base. `Schedule.js` already derived its base from the location (`pathRoot` = the pathname up to `schedules`); this applies the same technique to `Schedules.js`.

- `Schedules.js`: drop `useRouteMatch`; compute the base from `useLocation` and use it for the list / add / `:scheduleId` routes (the schedule detail delegates with `/*`).
- `Schedule.js`: `<Switch>` → `<Routes>`; the exact `<Redirect>` becomes a `<Route>` that `<Navigate>`s to details; the edit/details routes keep their computed `pathRoot` paths; not-found stays `path="*"`.

Because the routes are computed-absolute, they resolve whether the parent screen is still on v5 `<Switch>` or already migrated to v6. This **decouples** the shared-component conversion from the screens that mount `<Schedules>` (Template, Project, ManagementJob, InventorySource, WorkflowJobTemplate), which can now be migrated independently afterward.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration. This unblocks the last cluster of screens (the five that embed the schedule subtree).
- Tests: `components/Schedule` passes (13 suites / 126 tests), and all five parent screens that mount `<Schedules>` pass unchanged. `npm --prefix awx/ui run lint` clean on the changed source.

