### PR TITLE
Convert ManagementJob route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,14 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import {
-  Switch,
-  Route,
-  Link,
-  Redirect,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -120,42 +114,54 @@ function Schedule({
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from={`${pathRoot}schedules/:scheduleId`}
-          to={`${pathRoot}schedules/:scheduleId/details`}
-          exact
+      <Routes>
+        <Route
+          path={`${pathRoot}schedules/:scheduleId`}
+          element={
+            <Navigate
+              to={`${pathRoot}schedules/${scheduleId}/details`}
+              replace
+            />
+          }
         />
-        {schedule && [
-          <Route key="edit" path={`${pathRoot}schedules/:id/edit`}>
-            <ScheduleEdit
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              resource={resource}
-              launchConfig={launchConfig}
-              surveyConfig={surveyConfig}
-              resourceDefaultCredentials={resourceDefaultCredentials}
-            />
-          </Route>,
+        {schedule && (
           <Route
-            key="details"
+            path={`${pathRoot}schedules/:id/edit`}
+            element={
+              <ScheduleEdit
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                resource={resource}
+                launchConfig={launchConfig}
+                surveyConfig={surveyConfig}
+                resourceDefaultCredentials={resourceDefaultCredentials}
+              />
+            }
+          />
+        )}
+        {schedule && (
+          <Route
             path={`${pathRoot}schedules/:scheduleId/details`}
-          >
-            <ScheduleDetail
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              surveyConfig={surveyConfig}
-            />
-          </Route>,
-        ]}
-        <Route key="not-found" path="*">
-          <ContentError>
-            {resource && (
-              <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
-            )}
-          </ContentError>
-        </Route>
-      </Switch>
+            element={
+              <ScheduleDetail
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                surveyConfig={surveyConfig}
+              />
+            }
+          />
+        )}
+        <Route
+          path="*"
+          element={
+            <ContentError>
+              {resource && (
+                <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
+              )}
+            </ContentError>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -121,18 +121,10 @@ function Schedule({
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
       <Routes>
-        <Route
-          path={`${pathRoot}schedules/:scheduleId`}
-          element={
-            <Navigate
-              to={`${pathRoot}schedules/${scheduleId}/details`}
-              replace
-            />
-          }
-        />
+        <Route index element={<Navigate to="details" replace />} />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/edit`}
+            path="edit"
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}
@@ -147,7 +139,7 @@ function Schedule({
         )}
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/details`}
+            path="details"
             element={
               <ScheduleDetail
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,8 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -25,7 +31,7 @@ function Schedule({
 
   const { pathname } = useLocation();
 
-  const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
+  const pathRoot = pathname.substring(0, pathname.indexOf('schedules'));
 
   const {
     isLoading,
@@ -126,7 +132,7 @@ function Schedule({
         />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:id/edit`}
+            path={`${pathRoot}schedules/:scheduleId/edit`}
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,7 +15,15 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  const match = useRouteMatch();
+  // This component is mounted at several different base paths (templates,
+  // projects, inventory sources, management jobs). Derive the base from the
+  // location so the routes are base-agnostic and resolve whether the parent
+  // screen is still on v5 or already on v6.
+  const { pathname } = useLocation();
+  const baseUrl = `${pathname.substr(
+    0,
+    pathname.indexOf('schedules')
+  )}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -26,37 +34,47 @@ function Schedules({
   ].includes(resource?.job_type);
 
   return (
-    <Switch>
-      <Route path={`${match.path}/add`}>
-        <ScheduleAdd
-          hasDaysToKeepField={hasDaysToKeepField}
-          apiModel={apiModel}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule
-          hasDaysToKeepField={hasDaysToKeepField}
-          setBreadcrumb={setBreadcrumb}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="list" path={`${match.path}`}>
-        <ScheduleList
-          resource={resource}
-          loadSchedules={loadSchedules}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          loadScheduleOptions={loadScheduleOptions}
-        />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path={`${baseUrl}/add`}
+        element={
+          <ScheduleAdd
+            hasDaysToKeepField={hasDaysToKeepField}
+            apiModel={apiModel}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      {/* /* so the nested <Schedule> route tree can match */}
+      <Route
+        path={`${baseUrl}/:scheduleId/*`}
+        element={
+          <Schedule
+            hasDaysToKeepField={hasDaysToKeepField}
+            setBreadcrumb={setBreadcrumb}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      <Route
+        path={baseUrl}
+        element={
+          <ScheduleList
+            resource={resource}
+            loadSchedules={loadSchedules}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            loadScheduleOptions={loadScheduleOptions}
+          />
+        }
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -20,10 +20,14 @@ function Schedules({
   // location so the routes are base-agnostic and resolve whether the parent
   // screen is still on v5 or already on v6.
   const { pathname } = useLocation();
-  const baseUrl = `${pathname.substr(
-    0,
-    pathname.indexOf('schedules')
-  )}schedules`;
+  // Schedules is always mounted under a ".../schedules" path; if that segment
+  // is somehow absent, fall back to the full pathname so baseUrl stays an
+  // absolute path rather than collapsing to the relative "schedules".
+  const schedulesIndex = pathname.indexOf('schedules');
+  const baseUrl =
+    schedulesIndex === -1
+      ? pathname
+      : `${pathname.substring(0, schedulesIndex)}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -48,7 +52,7 @@ function Schedules({
           />
         }
       />
-      {/* /* so the nested <Schedule> route tree can match */}
+      {/* so the nested <Schedule> route tree can match */}
       <Route
         path={`${baseUrl}/:scheduleId/*`}
         element={

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,19 +15,9 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  // This component is mounted at several different base paths (templates,
-  // projects, inventory sources, management jobs). Derive the base from the
-  // location so the routes are base-agnostic and resolve whether the parent
-  // screen is still on v5 or already on v6.
-  const { pathname } = useLocation();
-  // Schedules is always mounted under a ".../schedules" path; if that segment
-  // is somehow absent, fall back to the full pathname so baseUrl stays an
-  // absolute path rather than collapsing to the relative "schedules".
-  const schedulesIndex = pathname.indexOf('schedules');
-  const baseUrl =
-    schedulesIndex === -1
-      ? pathname
-      : `${pathname.substring(0, schedulesIndex)}schedules`;
+  // This component is mounted under a ".../schedules/*" route on several
+  // screens (templates, projects, inventory sources, management jobs), so its
+  // routes are relative to that parent and resolve under any of them.
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -40,7 +30,7 @@ function Schedules({
   return (
     <Routes>
       <Route
-        path={`${baseUrl}/add`}
+        path="add"
         element={
           <ScheduleAdd
             hasDaysToKeepField={hasDaysToKeepField}
@@ -54,7 +44,7 @@ function Schedules({
       />
       {/* so the nested <Schedule> route tree can match */}
       <Route
-        path={`${baseUrl}/:scheduleId/*`}
+        path=":scheduleId/*"
         element={
           <Schedule
             hasDaysToKeepField={hasDaysToKeepField}
@@ -67,7 +57,7 @@ function Schedules({
         }
       />
       <Route
-        path={baseUrl}
+        index
         element={
           <ScheduleList
             resource={resource}

--- a/awx/ui/src/components/Schedule/Schedules.test.js
+++ b/awx/ui/src/components/Schedule/Schedules.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import Schedules from './Schedules';
 
@@ -12,21 +13,25 @@ describe('<Schedules />', () => {
     });
     const jobTemplate = { id: 1, name: 'Mock JT' };
 
+    // Schedules uses relative routes, so mount it under its ".../schedules/*"
+    // parent route.
     await act(async () => {
       wrapper = mountWithContexts(
-        <Schedules
-          setBreadcrumb={() => {}}
-          jobTemplate={jobTemplate}
-          loadSchedules={() => {}}
-          loadScheduleOptions={() => {}}
-          apiModel={{ createSchedule: () => {} }}
-        />,
-
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
+        <Routes>
+          <Route
+            path="/templates/job_template/:id/schedules/*"
+            element={
+              <Schedules
+                setBreadcrumb={() => {}}
+                jobTemplate={jobTemplate}
+                loadSchedules={() => {}}
+                loadScheduleOptions={() => {}}
+                apiModel={{ createSchedule: () => {} }}
+              />
+            }
+          />
+        </Routes>,
+        { context: { router: { history } } }
       );
     });
     expect(wrapper.length).toBe(1);

--- a/awx/ui/src/screens/ManagementJob/ManagementJob.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJob.js
@@ -1,13 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import {
-  Link,
-  Redirect,
+  Routes,
   Route,
-  Switch,
+  Navigate,
   useLocation,
   useParams,
-  useRouteMatch,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 
 import { useLingui } from '@lingui/react/macro';
 import { CaretLeftIcon } from '@patternfly/react-icons';
@@ -26,9 +25,9 @@ function ManagementJob({ setBreadcrumb }) {
   const { t } = useLingui();
   const basePath = '/management_jobs';
 
-  const match = useRouteMatch();
   const { id } = useParams();
   const { pathname } = useLocation();
+  const detailUrl = `${basePath}/${id}`;
   const { me } = useConfig();
 
   const [isNotificationAdmin, setIsNotificationAdmin] = useState(false);
@@ -107,7 +106,7 @@ function ManagementJob({ setBreadcrumb }) {
     tabsArray.push({
       id: 0,
       name: t`Schedules`,
-      link: `${match.url}/schedules`,
+      link: `${detailUrl}/schedules`,
     });
   }
 
@@ -115,7 +114,7 @@ function ManagementJob({ setBreadcrumb }) {
     tabsArray.push({
       id: 1,
       name: t`Notifications`,
-      link: `${match.url}/notifications`,
+      link: `${detailUrl}/notifications`,
     });
   }
 
@@ -158,34 +157,40 @@ function ManagementJob({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {Tabs}
-        <Switch>
-          <Redirect
-            exact
-            from={`${basePath}/:id`}
-            to={`${basePath}/:id/schedules`}
+        <Routes>
+          <Route
+            path={`${basePath}/:id`}
+            element={<Navigate to={`${detailUrl}/schedules`} replace />}
           />
           {shouldShowNotifications ? (
-            <Route path={`${basePath}/:id/notifications`}>
-              <NotificationList
-                id={Number(result?.systemJobTemplate?.id)}
-                canToggleNotifications={isNotificationAdmin}
-                apiModel={SystemJobTemplatesAPI}
-              />
-            </Route>
+            <Route
+              path={`${basePath}/:id/notifications`}
+              element={
+                <NotificationList
+                  id={Number(result?.systemJobTemplate?.id)}
+                  canToggleNotifications={isNotificationAdmin}
+                  apiModel={SystemJobTemplatesAPI}
+                />
+              }
+            />
           ) : null}
+          {/* /* so the nested <Schedules> route tree can match */}
           {shouldShowSchedules ? (
-            <Route path={`${basePath}/:id/schedules`}>
-              <Schedules
-                apiModel={SystemJobTemplatesAPI}
-                resource={result.systemJobTemplate}
-                createSchedule={createSchedule}
-                loadSchedules={loadSchedules}
-                loadScheduleOptions={loadScheduleOptions}
-                setBreadcrumb={setBreadcrumb}
-              />
-            </Route>
+            <Route
+              path={`${basePath}/:id/schedules/*`}
+              element={
+                <Schedules
+                  apiModel={SystemJobTemplatesAPI}
+                  resource={result.systemJobTemplate}
+                  createSchedule={createSchedule}
+                  loadSchedules={loadSchedules}
+                  loadScheduleOptions={loadScheduleOptions}
+                  setBreadcrumb={setBreadcrumb}
+                />
+              }
+            />
           ) : null}
-        </Switch>
+        </Routes>
       </Card>
     </PageSection>
   );

--- a/awx/ui/src/screens/ManagementJob/ManagementJob.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJob.js
@@ -159,12 +159,12 @@ function ManagementJob({ setBreadcrumb }) {
         {Tabs}
         <Routes>
           <Route
-            path={`${basePath}/:id`}
+            index
             element={<Navigate to={`${detailUrl}/schedules`} replace />}
           />
           {shouldShowNotifications ? (
             <Route
-              path={`${basePath}/:id/notifications`}
+              path="notifications"
               element={
                 <NotificationList
                   id={Number(result?.systemJobTemplate?.id)}
@@ -177,7 +177,7 @@ function ManagementJob({ setBreadcrumb }) {
           {/* /* so the nested <Schedules> route tree can match */}
           {shouldShowSchedules ? (
             <Route
-              path={`${basePath}/:id/schedules/*`}
+              path="schedules/*"
               element={
                 <Schedules
                   apiModel={SystemJobTemplatesAPI}

--- a/awx/ui/src/screens/ManagementJob/ManagementJobs.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobs.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import ScreenHeader from 'components/ScreenHeader';
 import PersistentFilters from 'components/PersistentFilters';
 import ManagementJob from './ManagementJob';
@@ -34,16 +34,21 @@ function ManagementJobs() {
   return (
     <>
       <ScreenHeader streamType="none" breadcrumbConfig={breadcrumbConfig} />
-      <Switch>
-        <Route path={`${basePath}/:id`}>
-          <ManagementJob setBreadcrumb={buildBreadcrumbConfig} />
-        </Route>
-        <Route path={basePath}>
-          <PersistentFilters pageKey="managementJobs">
-            <ManagementJobList setBreadcrumb={buildBreadcrumbConfig} />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        {/* /* so the nested <ManagementJob> route tree can match */}
+        <Route
+          path={`${basePath}/:id/*`}
+          element={<ManagementJob setBreadcrumb={buildBreadcrumbConfig} />}
+        />
+        <Route
+          path={basePath}
+          element={
+            <PersistentFilters pageKey="managementJobs">
+              <ManagementJobList setBreadcrumb={buildBreadcrumbConfig} />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/ManagementJob/ManagementJobs.test.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobs.test.js
@@ -1,21 +1,34 @@
 import React from 'react';
+import { createMemoryHistory } from 'history';
 
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import ManagementJobs from './ManagementJobs';
 
+// stub the list so the /management_jobs route resolves without hitting the API
+jest.mock('./ManagementJobList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ManagementJobList'),
+  };
+});
+
 describe('<ManagementJobs />', () => {
   let pageWrapper;
-  let pageSections;
 
   beforeEach(() => {
-    pageWrapper = mountWithContexts(<ManagementJobs />);
-    pageSections = pageWrapper.find('PageSection');
+    const history = createMemoryHistory({
+      initialEntries: ['/management_jobs'],
+    });
+    pageWrapper = mountWithContexts(<ManagementJobs />, {
+      context: { router: { history } },
+    });
   });
 
-  test('renders ok', () => {
+  test('renders the list at /management_jobs', () => {
     expect(pageWrapper.length).toBe(1);
     expect(pageWrapper.find('ScreenHeader').length).toBe(1);
-    expect(pageSections.length).toBe(1);
+    expect(pageWrapper.text()).toContain('ManagementJobList');
   });
 });


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **ManagementJob** screen's route trees from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`.

UI (no behavior change - same URLs, same panels):

- `ManagementJobs.js` (list router): `<Switch>` → `<Routes>`; the detail route is `/management_jobs/:id/*` so the nested `<ManagementJob>` tree matches.
- `ManagementJob.js` (detail router): `<Switch>` → `<Routes>`; `useRouteMatch` is replaced with the `id` route param + an explicit `detailUrl`; the exact `<Redirect>` becomes a `<Route>` that `<Navigate>`s to `schedules` (the default tab); the schedules tab delegates with `schedules/*` to the shared `<Schedules>`; notifications uses the `element` prop.
- `ManagementJobs.test.js`: mount at `/management_jobs` with a stubbed list so the route resolves without an API call.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration. One of the screens that embeds the shared schedule subtree.
- **Depends on #422** (shared Schedule component conversion): converting this screen to v6 while `Schedules` is still v5 would reintroduce the `match.path` break, so #422's two component files are included in this branch until it merges (then this rebases onto main and they drop out).
- Tests: full `screens/ManagementJob` directory passes (3 suites / 7 tests). `npm --prefix awx/ui run lint` clean on the changed source.

