### PR TITLE
Convert Project route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,14 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import {
-  Switch,
-  Route,
-  Link,
-  Redirect,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -120,42 +114,54 @@ function Schedule({
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from={`${pathRoot}schedules/:scheduleId`}
-          to={`${pathRoot}schedules/:scheduleId/details`}
-          exact
+      <Routes>
+        <Route
+          path={`${pathRoot}schedules/:scheduleId`}
+          element={
+            <Navigate
+              to={`${pathRoot}schedules/${scheduleId}/details`}
+              replace
+            />
+          }
         />
-        {schedule && [
-          <Route key="edit" path={`${pathRoot}schedules/:id/edit`}>
-            <ScheduleEdit
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              resource={resource}
-              launchConfig={launchConfig}
-              surveyConfig={surveyConfig}
-              resourceDefaultCredentials={resourceDefaultCredentials}
-            />
-          </Route>,
+        {schedule && (
           <Route
-            key="details"
+            path={`${pathRoot}schedules/:id/edit`}
+            element={
+              <ScheduleEdit
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                resource={resource}
+                launchConfig={launchConfig}
+                surveyConfig={surveyConfig}
+                resourceDefaultCredentials={resourceDefaultCredentials}
+              />
+            }
+          />
+        )}
+        {schedule && (
+          <Route
             path={`${pathRoot}schedules/:scheduleId/details`}
-          >
-            <ScheduleDetail
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              surveyConfig={surveyConfig}
-            />
-          </Route>,
-        ]}
-        <Route key="not-found" path="*">
-          <ContentError>
-            {resource && (
-              <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
-            )}
-          </ContentError>
-        </Route>
-      </Switch>
+            element={
+              <ScheduleDetail
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                surveyConfig={surveyConfig}
+              />
+            }
+          />
+        )}
+        <Route
+          path="*"
+          element={
+            <ContentError>
+              {resource && (
+                <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
+              )}
+            </ContentError>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -121,18 +121,10 @@ function Schedule({
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
       <Routes>
-        <Route
-          path={`${pathRoot}schedules/:scheduleId`}
-          element={
-            <Navigate
-              to={`${pathRoot}schedules/${scheduleId}/details`}
-              replace
-            />
-          }
-        />
+        <Route index element={<Navigate to="details" replace />} />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/edit`}
+            path="edit"
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}
@@ -147,7 +139,7 @@ function Schedule({
         )}
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/details`}
+            path="details"
             element={
               <ScheduleDetail
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,8 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -25,7 +31,7 @@ function Schedule({
 
   const { pathname } = useLocation();
 
-  const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
+  const pathRoot = pathname.substring(0, pathname.indexOf('schedules'));
 
   const {
     isLoading,
@@ -126,7 +132,7 @@ function Schedule({
         />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:id/edit`}
+            path={`${pathRoot}schedules/:scheduleId/edit`}
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,7 +15,15 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  const match = useRouteMatch();
+  // This component is mounted at several different base paths (templates,
+  // projects, inventory sources, management jobs). Derive the base from the
+  // location so the routes are base-agnostic and resolve whether the parent
+  // screen is still on v5 or already on v6.
+  const { pathname } = useLocation();
+  const baseUrl = `${pathname.substr(
+    0,
+    pathname.indexOf('schedules')
+  )}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -26,37 +34,47 @@ function Schedules({
   ].includes(resource?.job_type);
 
   return (
-    <Switch>
-      <Route path={`${match.path}/add`}>
-        <ScheduleAdd
-          hasDaysToKeepField={hasDaysToKeepField}
-          apiModel={apiModel}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule
-          hasDaysToKeepField={hasDaysToKeepField}
-          setBreadcrumb={setBreadcrumb}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="list" path={`${match.path}`}>
-        <ScheduleList
-          resource={resource}
-          loadSchedules={loadSchedules}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          loadScheduleOptions={loadScheduleOptions}
-        />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path={`${baseUrl}/add`}
+        element={
+          <ScheduleAdd
+            hasDaysToKeepField={hasDaysToKeepField}
+            apiModel={apiModel}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      {/* /* so the nested <Schedule> route tree can match */}
+      <Route
+        path={`${baseUrl}/:scheduleId/*`}
+        element={
+          <Schedule
+            hasDaysToKeepField={hasDaysToKeepField}
+            setBreadcrumb={setBreadcrumb}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      <Route
+        path={baseUrl}
+        element={
+          <ScheduleList
+            resource={resource}
+            loadSchedules={loadSchedules}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            loadScheduleOptions={loadScheduleOptions}
+          />
+        }
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -20,10 +20,14 @@ function Schedules({
   // location so the routes are base-agnostic and resolve whether the parent
   // screen is still on v5 or already on v6.
   const { pathname } = useLocation();
-  const baseUrl = `${pathname.substr(
-    0,
-    pathname.indexOf('schedules')
-  )}schedules`;
+  // Schedules is always mounted under a ".../schedules" path; if that segment
+  // is somehow absent, fall back to the full pathname so baseUrl stays an
+  // absolute path rather than collapsing to the relative "schedules".
+  const schedulesIndex = pathname.indexOf('schedules');
+  const baseUrl =
+    schedulesIndex === -1
+      ? pathname
+      : `${pathname.substring(0, schedulesIndex)}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -48,7 +52,7 @@ function Schedules({
           />
         }
       />
-      {/* /* so the nested <Schedule> route tree can match */}
+      {/* so the nested <Schedule> route tree can match */}
       <Route
         path={`${baseUrl}/:scheduleId/*`}
         element={

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,19 +15,9 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  // This component is mounted at several different base paths (templates,
-  // projects, inventory sources, management jobs). Derive the base from the
-  // location so the routes are base-agnostic and resolve whether the parent
-  // screen is still on v5 or already on v6.
-  const { pathname } = useLocation();
-  // Schedules is always mounted under a ".../schedules" path; if that segment
-  // is somehow absent, fall back to the full pathname so baseUrl stays an
-  // absolute path rather than collapsing to the relative "schedules".
-  const schedulesIndex = pathname.indexOf('schedules');
-  const baseUrl =
-    schedulesIndex === -1
-      ? pathname
-      : `${pathname.substring(0, schedulesIndex)}schedules`;
+  // This component is mounted under a ".../schedules/*" route on several
+  // screens (templates, projects, inventory sources, management jobs), so its
+  // routes are relative to that parent and resolve under any of them.
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -40,7 +30,7 @@ function Schedules({
   return (
     <Routes>
       <Route
-        path={`${baseUrl}/add`}
+        path="add"
         element={
           <ScheduleAdd
             hasDaysToKeepField={hasDaysToKeepField}
@@ -54,7 +44,7 @@ function Schedules({
       />
       {/* so the nested <Schedule> route tree can match */}
       <Route
-        path={`${baseUrl}/:scheduleId/*`}
+        path=":scheduleId/*"
         element={
           <Schedule
             hasDaysToKeepField={hasDaysToKeepField}
@@ -67,7 +57,7 @@ function Schedules({
         }
       />
       <Route
-        path={baseUrl}
+        index
         element={
           <ScheduleList
             resource={resource}

--- a/awx/ui/src/components/Schedule/Schedules.test.js
+++ b/awx/ui/src/components/Schedule/Schedules.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import Schedules from './Schedules';
 
@@ -12,21 +13,25 @@ describe('<Schedules />', () => {
     });
     const jobTemplate = { id: 1, name: 'Mock JT' };
 
+    // Schedules uses relative routes, so mount it under its ".../schedules/*"
+    // parent route.
     await act(async () => {
       wrapper = mountWithContexts(
-        <Schedules
-          setBreadcrumb={() => {}}
-          jobTemplate={jobTemplate}
-          loadSchedules={() => {}}
-          loadScheduleOptions={() => {}}
-          apiModel={{ createSchedule: () => {} }}
-        />,
-
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
+        <Routes>
+          <Route
+            path="/templates/job_template/:id/schedules/*"
+            element={
+              <Schedules
+                setBreadcrumb={() => {}}
+                jobTemplate={jobTemplate}
+                loadSchedules={() => {}}
+                loadScheduleOptions={() => {}}
+                apiModel={{ createSchedule: () => {} }}
+              />
+            }
+          />
+        </Routes>,
+        { context: { router: { history } } }
       );
     });
     expect(wrapper.length).toBe(1);

--- a/awx/ui/src/screens/Project/Project.js
+++ b/awx/ui/src/screens/Project/Project.js
@@ -1,13 +1,13 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
+import { Link } from 'react-router-dom';
 import {
-  Switch,
+  Routes,
   Route,
-  Redirect,
-  Link,
+  Navigate,
   useParams,
   useLocation,
-} from 'react-router-dom';
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import { useConfig } from 'contexts/Config';
@@ -154,55 +154,73 @@ function Project({ setBreadcrumb }) {
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
         {hasContentLoading && <ContentLoading />}
         {!hasContentLoading && project && (
-          <Switch>
-            <Redirect from="/projects/:id" to="/projects/:id/details" exact />
-            <Route path="/projects/:id/edit">
-              <ProjectEdit project={project} />
-            </Route>
-            <Route path="/projects/:id/details">
-              <ProjectDetail project={project} />
-            </Route>
-            <Route path="/projects/:id/access">
-              <ResourceAccessList resource={project} apiModel={ProjectsAPI} />
-            </Route>
+          <Routes>
+            <Route index element={<Navigate to="details" replace />} />
+            <Route
+              path="edit"
+              element={<ProjectEdit project={project} />}
+            />
+            <Route
+              path="details"
+              element={<ProjectDetail project={project} />}
+            />
+            <Route
+              path="access"
+              element={
+                <ResourceAccessList resource={project} apiModel={ProjectsAPI} />
+              }
+            />
             {canSeeNotificationsTab && (
-              <Route path="/projects/:id/notifications">
-                <NotificationList
-                  id={Number(id)}
-                  canToggleNotifications={canToggleNotifications}
-                  apiModel={ProjectsAPI}
-                />
-              </Route>
-            )}
-            <Route path="/projects/:id/job_templates">
-              <RelatedTemplateList
-                searchParams={{
-                  project__id: project.id,
-                }}
-                resourceName={project.name}
+              <Route
+                path="notifications"
+                element={
+                  <NotificationList
+                    id={Number(id)}
+                    canToggleNotifications={canToggleNotifications}
+                    apiModel={ProjectsAPI}
+                  />
+                }
               />
-            </Route>
-            {project?.scm_type && project.scm_type !== '' && (
-              <Route path="/projects/:id/schedules">
-                <Schedules
-                  setBreadcrumb={setBreadcrumb}
-                  resource={project}
-                  apiModel={ProjectsAPI}
-                  loadSchedules={loadSchedules}
-                  loadScheduleOptions={loadScheduleOptions}
-                />
-              </Route>
             )}
-            <Route key="not-found" path="*">
-              <ContentError isNotFound>
-                {id && (
-                  <Link to={`/projects/${id}/details`}>
-                    {t`View Project Details`}
-                  </Link>
-                )}
-              </ContentError>
-            </Route>
-          </Switch>
+            <Route
+              path="job_templates"
+              element={
+                <RelatedTemplateList
+                  searchParams={{
+                    project__id: project.id,
+                  }}
+                  resourceName={project.name}
+                />
+              }
+            />
+            {/* /* so the nested <Schedules> route tree can match */}
+            {project?.scm_type && project.scm_type !== '' && (
+              <Route
+                path="schedules/*"
+                element={
+                  <Schedules
+                    setBreadcrumb={setBreadcrumb}
+                    resource={project}
+                    apiModel={ProjectsAPI}
+                    loadSchedules={loadSchedules}
+                    loadScheduleOptions={loadScheduleOptions}
+                  />
+                }
+              />
+            )}
+            <Route
+              path="*"
+              element={
+                <ContentError isNotFound>
+                  {id && (
+                    <Link to={`/projects/${id}/details`}>
+                      {t`View Project Details`}
+                    </Link>
+                  )}
+                </ContentError>
+              }
+            />
+          </Routes>
         )}
       </Card>
     </PageSection>

--- a/awx/ui/src/screens/Project/Project.js
+++ b/awx/ui/src/screens/Project/Project.js
@@ -193,7 +193,7 @@ function Project({ setBreadcrumb }) {
                 />
               }
             />
-            {/* /* so the nested <Schedules> route tree can match */}
+            {/* so the nested <Schedules> route tree can match */}
             {project?.scm_type && project.scm_type !== '' && (
               <Route
                 path="schedules/*"

--- a/awx/ui/src/screens/Project/Project.test.js
+++ b/awx/ui/src/screens/Project/Project.test.js
@@ -140,4 +140,11 @@ describe('<Project />', () => {
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });
+
+  test('redirects the bare /projects/:id to the details tab', async () => {
+    await act(async () => {
+      wrapper = renderProject('/projects/1');
+    });
+    await waitForElement(wrapper, 'ProjectDetail', (el) => el.length === 1);
+  });
 });

--- a/awx/ui/src/screens/Project/Project.test.js
+++ b/awx/ui/src/screens/Project/Project.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
-import { OrganizationsAPI, ProjectsAPI } from 'api';
+import { Routes, Route } from 'react-router-dom-v5-compat';
+import { OrganizationsAPI, ProjectsAPI, RootAPI } from 'api';
 import mockOrganization from 'util/data.organization.json';
 import {
   mountWithContexts,
@@ -11,14 +12,6 @@ import mockDetails from './data.project.json';
 import Project from './Project';
 
 jest.mock('../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    pathname: '/projects/1/details',
-    url: '/projects/1',
-  }),
-  useParams: () => ({ id: 1 }),
-}));
 
 const mockMe = {
   is_super_user: true,
@@ -36,6 +29,21 @@ async function getOrganizations() {
   };
 }
 
+// Mount under the same /projects/:id/* route that Projects.js gives it, so the
+// nested v6 <Routes> resolve and useParams sees the id.
+function renderProject(initialEntry = '/projects/1/details') {
+  const history = createMemoryHistory({ initialEntries: [initialEntry] });
+  return mountWithContexts(
+    <Routes>
+      <Route
+        path="/projects/:id/*"
+        element={<Project setBreadcrumb={() => {}} me={mockMe} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
 describe('<Project />', () => {
   let wrapper;
 
@@ -44,19 +52,21 @@ describe('<Project />', () => {
     ProjectsAPI.readDetail = jest.fn();
     ProjectsAPI.readDetail.mockResolvedValue({ data: mockDetails });
     OrganizationsAPI.read.mockImplementation(getOrganizations);
+    // the resolved detail route mounts components that read the brand name
+    RootAPI.readAssetVariables = jest
+      .fn()
+      .mockResolvedValue({ data: { BRAND_NAME: 'AWX' } });
   });
 
   test('initially renders successfully', async () => {
     await act(async () => {
-      mountWithContexts(<Project setBreadcrumb={() => {}} me={mockMe} />);
+      renderProject();
     });
   });
 
   test('notifications tab shown for admins', async () => {
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderProject();
     });
     const tabs = await waitForElement(
       wrapper,
@@ -74,9 +84,7 @@ describe('<Project />', () => {
       data: { results: [] },
     });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderProject();
     });
     const tabs = await waitForElement(
       wrapper,
@@ -95,9 +103,7 @@ describe('<Project />', () => {
     });
 
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderProject();
     });
     const tabs = await waitForElement(
       wrapper,
@@ -118,9 +124,7 @@ describe('<Project />', () => {
     });
 
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderProject();
     });
     const tabs = await waitForElement(
       wrapper,
@@ -131,28 +135,8 @@ describe('<Project />', () => {
   });
 
   test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/projects/1/foobar'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/projects/1/foobar',
-                  path: '/project/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
+      wrapper = renderProject('/projects/1/foobar');
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });

--- a/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.test.js
+++ b/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.test.js
@@ -205,7 +205,14 @@ describe('<ProjectDetail />', () => {
   });
 
   test('should show edit and sync button for users with edit permission', async () => {
-    const wrapper = mountWithContexts(<ProjectDetail project={mockProject} />);
+    // the Sync button shows its "Sync" label only on the details view
+    const history = createMemoryHistory({
+      initialEntries: [`/projects/${mockProject.id}/details`],
+    });
+    const wrapper = mountWithContexts(
+      <ProjectDetail project={mockProject} />,
+      { context: { router: { history } } }
+    );
     const editButton = await waitForElement(
       wrapper,
       'ProjectDetail Button[aria-label="edit"]'

--- a/awx/ui/src/screens/Project/Projects.js
+++ b/awx/ui/src/screens/Project/Projects.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import ScreenHeader from 'components/ScreenHeader/ScreenHeader';
 import PersistentFilters from 'components/PersistentFilters';
@@ -42,19 +42,22 @@ function Projects() {
   return (
     <>
       <ScreenHeader streamType="project" breadcrumbConfig={breadcrumbConfig} />
-      <Switch>
-        <Route path="/projects/add">
-          <ProjectAdd />
-        </Route>
-        <Route path="/projects/:id">
-          <Project setBreadcrumb={buildBreadcrumbConfig} />
-        </Route>
-        <Route path="/projects">
-          <PersistentFilters pageKey="projects">
-            <ProjectsList />
-          </PersistentFilters>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path="/projects/add" element={<ProjectAdd />} />
+        {/* /* so the nested <Project> route tree can match */}
+        <Route
+          path="/projects/:id/*"
+          element={<Project setBreadcrumb={buildBreadcrumbConfig} />}
+        />
+        <Route
+          path="/projects"
+          element={
+            <PersistentFilters pageKey="projects">
+              <ProjectsList />
+            </PersistentFilters>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/Project/Projects.js
+++ b/awx/ui/src/screens/Project/Projects.js
@@ -44,7 +44,7 @@ function Projects() {
       <ScreenHeader streamType="project" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
         <Route path="/projects/add" element={<ProjectAdd />} />
-        {/* /* so the nested <Project> route tree can match */}
+        {/* so the nested <Project> route tree can match */}
         <Route
           path="/projects/:id/*"
           element={<Project setBreadcrumb={buildBreadcrumbConfig} />}

--- a/awx/ui/src/screens/Project/Projects.test.js
+++ b/awx/ui/src/screens/Project/Projects.test.js
@@ -1,10 +1,23 @@
 import React from 'react';
+import { createMemoryHistory } from 'history';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import { _Projects as Projects } from './Projects';
 
+// stub the list so the /projects route resolves without hitting the API
+jest.mock('./ProjectList/ProjectList', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: () => ReactLib.createElement('div', null, 'ProjectsList'),
+  };
+});
+
 describe('<Projects />', () => {
   test('should display a breadcrumb heading', () => {
-    const wrapper = mountWithContexts(<Projects />);
+    const history = createMemoryHistory({ initialEntries: ['/projects'] });
+    const wrapper = mountWithContexts(<Projects />, {
+      context: { router: { history } },
+    });
 
     const header = wrapper.find('ScreenHeader');
     expect(header.prop('streamType')).toBe('project');

--- a/awx/ui/src/screens/Project/shared/ProjectSyncButton.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSyncButton.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { SyncIcon } from '@patternfly/react-icons';
 
@@ -15,7 +15,7 @@ import getProjectHelpStrings from './Project.helptext';
 function ProjectSyncButton({ projectId, lastJobStatus = null }) {
   const { t } = useLingui();
   const projectHelpStrings = getProjectHelpStrings(t);
-  const match = useRouteMatch();
+  const { pathname } = useLocation();
 
   const { request: handleSync, error: syncError } = useRequest(
     useCallback(async () => {
@@ -24,7 +24,7 @@ function ProjectSyncButton({ projectId, lastJobStatus = null }) {
     null
   );
   const { error, dismissError } = useDismissableError(syncError);
-  const isDetailsView = match.url.endsWith('/details');
+  const isDetailsView = pathname.endsWith('/details');
   const isDisabled = ['pending', 'waiting', 'running'].includes(lastJobStatus);
 
   return (
@@ -38,7 +38,7 @@ function ProjectSyncButton({ projectId, lastJobStatus = null }) {
               variant={isDetailsView ? 'secondary' : 'plain'}
               isDisabled={isDisabled}
             >
-              {match.url.endsWith('/details') ? (
+              {pathname.endsWith('/details') ? (
                 t`Sync`
               ) : (
                 <SyncIcon />
@@ -54,7 +54,7 @@ function ProjectSyncButton({ projectId, lastJobStatus = null }) {
           isDisabled={isDisabled}
           onClick={handleSync}
         >
-          {match.url.endsWith('/details') ? t`Sync` : <SyncIcon />}
+          {pathname.endsWith('/details') ? t`Sync` : <SyncIcon />}
         </Button>
       )}
       {error && (


### PR DESCRIPTION
##### SUMMARY

Continues the react-router v5 → v6 route-tree migration. Converts the **Project** screen's route trees from the v5 `<Switch>`/`<Route>`/`<Redirect>` API to v6 `<Routes>`/`<Route>` via `react-router-dom-v5-compat`.

UI (no behavior change - same URLs, same panels):

- `Projects.js` (list router): `<Switch>` → `<Routes>`; the detail route is `/projects/:id/*` so the nested `<Project>` tree matches.
- `Project.js` (detail router): `<Switch>` → `<Routes>` with relative child paths (`details`, `edit`, `access`, `notifications`, `job_templates`, `schedules/*`); the exact `<Redirect>` becomes an index route that `<Navigate>`s to `details`; the schedules tab delegates with `schedules/*` to the shared `<Schedules>`; not-found stays `path="*"`.
- Tests: mount `Project` under the real `/projects/:id/*` route (dropping the `react-router-dom` `useRouteMatch`/`useParams` mocks), stub the list in `Projects.test.js`, and mock `RootAPI.readAssetVariables` for the brand-name hook the now-resolved detail route mounts.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- Part of the incremental react-router v6 migration. One of the screens that embeds the shared schedule subtree.
- **Depends on #422** (shared Schedule component conversion): its two component files are included in this branch until #422 merges (then this rebases onto main and they drop out).
- Tests: full `screens/Project` directory passes (11 suites / 66 tests). `npm --prefix awx/ui run lint` clean on the changed source.

