### PR TITLE
Convert the App.js root route tree to react-router v6 Routes

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -196,7 +196,7 @@ function App() {
   const redirectURL = window.sessionStorage.getItem(SESSION_REDIRECT_URL);
   if (redirectURL) {
     window.sessionStorage.removeItem(SESSION_REDIRECT_URL);
-    if (redirectURL !== '/' || redirectURL !== '/home')
+    if (redirectURL !== '/' && redirectURL !== '/home')
       navigate(redirectURL, { replace: true });
   }
 

--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -1,14 +1,13 @@
 import React, { useEffect, useLayoutEffect, useState } from 'react';
+import { HashRouter } from 'react-router-dom';
 import {
-  useRouteMatch,
-  useLocation,
-  HashRouter,
+  CompatRouter,
+  Routes,
   Route,
-  Switch,
-  Redirect,
-  useHistory,
-} from 'react-router-dom';
-import { CompatRouter } from 'react-router-dom-v5-compat';
+  Navigate,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom-v5-compat';
 import { ErrorBoundary } from 'react-error-boundary';
 import locationReplace from 'util/navigation';
 import { I18nProvider } from '@lingui/react';
@@ -55,50 +54,71 @@ const RenderAppContainer = () => {
 
 const AuthorizedRoutes = ({ routeConfig }) => {
   const isAuthorized = useAuthorizedPath();
-  const match = useRouteMatch();
 
   if (!isAuthorized) {
     return (
-      <Switch>
-        <ProtectedRoute
-          key="/subscription_management"
+      <Routes>
+        <Route
           path="/subscription_management"
-        >
-          <PageSection>
-            <Card>
-              <SubscriptionEdit />
-            </Card>
-          </PageSection>
-        </ProtectedRoute>
-        <Route path="*">
-          <Redirect to="/subscription_management" />
-        </Route>
-      </Switch>
+          element={
+            <ProtectedRoute>
+              <PageSection>
+                <Card>
+                  <SubscriptionEdit />
+                </Card>
+              </PageSection>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="*"
+          element={<Navigate to="/subscription_management" replace />}
+        />
+      </Routes>
     );
   }
 
   return (
-    <Switch>
+    <Routes>
       {routeConfig
         .flatMap(({ routes }) => routes)
         .map(({ path, screen: Screen }) => (
-          <ProtectedRoute key={path} path={path}>
-            <Screen match={match} />
-          </ProtectedRoute>
+          // /* so each screen's own nested <Routes> can match the rest
+          <Route
+            key={path}
+            path={`${path}/*`}
+            element={
+              <ProtectedRoute>
+                <Screen />
+              </ProtectedRoute>
+            }
+          />
         ))
         .concat(
-          <ProtectedRoute key="metrics" path="/metrics">
-            <Metrics />
-          </ProtectedRoute>,
-          <ProtectedRoute key="not-found" path="*">
-            <NotFound />
-          </ProtectedRoute>
+          <Route
+            key="metrics"
+            path="/metrics/*"
+            element={
+              <ProtectedRoute>
+                <Metrics />
+              </ProtectedRoute>
+            }
+          />,
+          <Route
+            key="not-found"
+            path="*"
+            element={
+              <ProtectedRoute>
+                <NotFound />
+              </ProtectedRoute>
+            }
+          />
         )}
-    </Switch>
+    </Routes>
   );
 };
 
-export function ProtectedRoute({ children, ...rest }) {
+export function ProtectedRoute({ children }) {
   const {
     authRedirectTo,
     isUserBeingLoggedOut,
@@ -117,11 +137,9 @@ export function ProtectedRoute({ children, ...rest }) {
 
   if (isAuthenticated(document.cookie)) {
     return (
-      <Route {...rest}>
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
-          {children}
-        </ErrorBoundary>
-      </Route>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        {children}
+      </ErrorBoundary>
     );
   }
 
@@ -133,7 +151,7 @@ export function ProtectedRoute({ children, ...rest }) {
     locationReplace(loginRedirectOverride);
     return null;
   }
-  return <Redirect to="/login" />;
+  return <Navigate to="/login" replace />;
 }
 
 function App() {
@@ -152,8 +170,8 @@ function App() {
       import('./darkmode.css');
     }
   }, []);
-  const history = useHistory();
-  const { hash, search, pathname } = useLocation();
+  const navigate = useNavigate();
+  const { search } = useLocation();
   const searchParams = Object.fromEntries(new URLSearchParams(search));
   const pseudolocalization =
     searchParams.pseudolocalization === 'true' || false;
@@ -179,7 +197,7 @@ function App() {
   if (redirectURL) {
     window.sessionStorage.removeItem(SESSION_REDIRECT_URL);
     if (redirectURL !== '/' || redirectURL !== '/home')
-      history.replace(redirectURL);
+      navigate(redirectURL, { replace: true });
   }
 
   if (isLoading) {
@@ -193,22 +211,23 @@ function App() {
   return (
     <I18nProvider i18n={i18n}>
       <SessionProvider>
-        <Switch>
-          <Route exact strict path="/*/">
-            <Redirect to={`${pathname.slice(0, -1)}${search}${hash}`} />
-          </Route>
-          <Route path="/login">
-            <Login isAuthenticated={isAuthenticated} />
-          </Route>
-          <Route exact path="/">
-            <Redirect to="/home" />
-          </Route>
-          <ProtectedRoute>
-            <ConfigProvider>
-              <RenderAppContainer />
-            </ConfigProvider>
-          </ProtectedRoute>
-        </Switch>
+        <Routes>
+          <Route
+            path="/login"
+            element={<Login isAuthenticated={isAuthenticated} />}
+          />
+          <Route path="/" element={<Navigate to="/home" replace />} />
+          <Route
+            path="*"
+            element={
+              <ProtectedRoute>
+                <ConfigProvider>
+                  <RenderAppContainer />
+                </ConfigProvider>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
       </SessionProvider>
     </I18nProvider>
   );

--- a/awx/ui/src/App.test.js
+++ b/awx/ui/src/App.test.js
@@ -5,6 +5,7 @@ import * as SessionContext from 'contexts/Session';
 import { shallow } from 'enzyme';
 import { mountWithContexts } from '../testUtils/enzymeHelpers';
 import * as navigation from 'util/navigation';
+import * as auth from 'util/auth';
 import App, { ProtectedRoute } from './App';
 
 jest.mock('./api');
@@ -65,5 +66,26 @@ describe('<App />', () => {
 
     expect(replaceSpy).toHaveBeenCalled();
     replaceSpy.mockRestore();
+  });
+
+  test('renders children when authenticated', async () => {
+    jest.spyOn(SessionContext, 'useSession').mockImplementation(() => ({
+      setAuthRedirectTo: jest.fn(),
+      isSessionExpired: false,
+      isUserBeingLoggedOut: false,
+      loginRedirectOverride: null,
+    }));
+    jest.spyOn(auth, 'isAuthenticated').mockReturnValue(true);
+
+    let wrapper;
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <ProtectedRoute>
+          <div id="protected-child">foo</div>
+        </ProtectedRoute>
+      );
+    });
+    expect(wrapper.find('#protected-child').length).toBeGreaterThan(0);
+    jest.restoreAllMocks();
   });
 });

--- a/awx/ui/src/screens/Application/Applications.js
+++ b/awx/ui/src/screens/Application/Applications.js
@@ -52,7 +52,7 @@ function Applications() {
       />
       <Routes>
         <Route
-          path="/applications/add"
+          path="add"
           element={
             <ApplicationAdd
               onSuccessfulAdd={(app) => setApplicationModalSource(app)}
@@ -61,11 +61,11 @@ function Applications() {
         />
         {/* /* so the nested <Application> route tree can match the rest */}
         <Route
-          path="/applications/:id/*"
+          path=":id/*"
           element={<Application setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/applications"
+          index
           element={
             <PersistentFilters pageKey="applications">
               <ApplicationsList />

--- a/awx/ui/src/screens/Application/Applications.test.js
+++ b/awx/ui/src/screens/Application/Applications.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import Applications from './Applications';
@@ -47,9 +48,14 @@ jest.mock('./Application', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Applications />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/applications/*" element={<Applications />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<Applications />', () => {

--- a/awx/ui/src/screens/Credential/Credentials.js
+++ b/awx/ui/src/screens/Credential/Credentials.js
@@ -43,18 +43,18 @@ function Credentials() {
       />
       <Routes>
         <Route
-          path="/credentials/add"
+          path="add"
           element={
             <Config>{({ me }) => <CredentialAdd me={me || {}} />}</Config>
           }
         />
         {/* so the nested <Credential> route tree can match the rest */}
         <Route
-          path="/credentials/:id/*"
+          path=":id/*"
           element={<Credential setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/credentials"
+          index
           element={
             <PersistentFilters pageKey="credentials">
               <CredentialList />

--- a/awx/ui/src/screens/Credential/Credentials.test.js
+++ b/awx/ui/src/screens/Credential/Credentials.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Credentials from './Credentials';
 
@@ -43,9 +44,12 @@ jest.mock('./Credential', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Credentials />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/credentials/*" element={<Credentials />} />
+    </Routes>,
+    { context: { router: { history } } }
+  );
 }
 
 describe('<Credentials />', () => {

--- a/awx/ui/src/screens/CredentialType/CredentialTypes.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypes.js
@@ -37,14 +37,14 @@ function CredentialTypes() {
         breadcrumbConfig={breadcrumbConfig}
       />
       <Routes>
-        <Route path="/credential_types/add" element={<CredentialTypeAdd />} />
+        <Route path="add" element={<CredentialTypeAdd />} />
         {/* so the nested <CredentialType> route tree can match the rest */}
         <Route
-          path="/credential_types/:id/*"
+          path=":id/*"
           element={<CredentialType setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/credential_types"
+          index
           element={
             <PersistentFilters pageKey="credentialTypes">
               <CredentialTypeList />

--- a/awx/ui/src/screens/CredentialType/CredentialTypes.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypes.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import CredentialTypes from './CredentialTypes';
@@ -32,9 +33,14 @@ jest.mock('./CredentialType', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<CredentialTypes />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/credential_types/*" element={<CredentialTypes />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<CredentialTypes />', () => {

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironments.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironments.js
@@ -37,18 +37,18 @@ function ExecutionEnvironments() {
       />
       <Routes>
         <Route
-          path="/execution_environments/add"
+          path="add"
           element={<ExecutionEnvironmentAdd />}
         />
         {/* so the nested <ExecutionEnvironment> route tree can match the rest */}
         <Route
-          path="/execution_environments/:id/*"
+          path=":id/*"
           element={
             <ExecutionEnvironment setBreadcrumb={buildBreadcrumbConfig} />
           }
         />
         <Route
-          path="/execution_environments"
+          index
           element={
             <PersistentFilters pageKey="executionEnvironments">
               <ExecutionEnvironmentList />

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironments.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironments.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import ExecutionEnvironments from './ExecutionEnvironments';
@@ -36,9 +37,17 @@ jest.mock('./ExecutionEnvironment', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<ExecutionEnvironments />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/execution_environments/*"
+        element={<ExecutionEnvironments />}
+      />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<ExecutionEnvironments />', () => {

--- a/awx/ui/src/screens/Host/Hosts.js
+++ b/awx/ui/src/screens/Host/Hosts.js
@@ -40,10 +40,10 @@ function Hosts() {
     <>
       <ScreenHeader streamType="host" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
-        <Route path="/hosts/add" element={<HostAdd />} />
+        <Route path="add" element={<HostAdd />} />
         {/* /* so the nested <Host> route tree can match the rest */}
         <Route
-          path="/hosts/:id/*"
+          path=":id/*"
           element={
             <Config>
               {({ me }) => (
@@ -53,7 +53,7 @@ function Hosts() {
           }
         />
         <Route
-          path="/hosts"
+          index
           element={
             <PersistentFilters pageKey="hosts">
               <HostList />

--- a/awx/ui/src/screens/Host/Hosts.test.js
+++ b/awx/ui/src/screens/Host/Hosts.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Hosts from './Hosts';
 
@@ -32,9 +33,12 @@ jest.mock('./Host', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Hosts />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/hosts/*" element={<Hosts />} />
+    </Routes>,
+    { context: { router: { history } } }
+  );
 }
 
 describe('<Hosts />', () => {

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
@@ -61,25 +61,25 @@ function InstanceGroups() {
       />
       <Routes>
         <Route
-          path="/instance_groups/container_group/add"
+          path="container_group/add"
           element={<ContainerGroupAdd />}
         />
         {/* /* so the nested <ContainerGroup> route tree can match the rest */}
         <Route
-          path="/instance_groups/container_group/:id/*"
+          path="container_group/:id/*"
           element={<ContainerGroup setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/instance_groups/add"
+          path="add"
           element={<InstanceGroupAdd />}
         />
         {/* /* so the nested <InstanceGroup> route tree can match the rest */}
         <Route
-          path="/instance_groups/:id/*"
+          path=":id/*"
           element={<InstanceGroup setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/instance_groups"
+          index
           element={
             <PersistentFilters pageKey="instanceGroups">
               <InstanceGroupList />

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import InstanceGroups from './InstanceGroups';
 
@@ -46,9 +47,14 @@ jest.mock('./ContainerGroup', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<InstanceGroups />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/instance_groups/*" element={<InstanceGroups />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<InstanceGroups />', () => {

--- a/awx/ui/src/screens/Instances/Instances.js
+++ b/awx/ui/src/screens/Instances/Instances.js
@@ -39,20 +39,20 @@ function Instances() {
       <ScreenHeader streamType="instance" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
         <Route
-          path="/instances/add"
+          path="add"
           element={<InstanceAdd setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/instances/:id/edit"
+          path=":id/edit"
           element={<InstanceEdit setBreadcrumb={buildBreadcrumbConfig} />}
         />
         {/* so the nested <Instance> route tree can match the rest */}
         <Route
-          path="/instances/:id/*"
+          path=":id/*"
           element={<Instance setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/instances"
+          index
           element={
             <PersistentFilters pageKey="instances">
               <InstanceList />

--- a/awx/ui/src/screens/Instances/Instances.test.js
+++ b/awx/ui/src/screens/Instances/Instances.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Instances from './Instances';
 
@@ -39,9 +40,14 @@ jest.mock('./Instance', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Instances />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/instances/*" element={<Instances />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<Instances />', () => {

--- a/awx/ui/src/screens/Inventory/Inventories.js
+++ b/awx/ui/src/screens/Inventory/Inventories.js
@@ -131,26 +131,26 @@ function Inventories() {
         breadcrumbConfig={breadcrumbConfig}
       />
       <Routes>
-        <Route path="/inventories/inventory/add" element={<InventoryAdd />} />
+        <Route path="inventory/add" element={<InventoryAdd />} />
         <Route
-          path="/inventories/smart_inventory/add"
+          path="smart_inventory/add"
           element={<SmartInventoryAdd />}
         />
         <Route
-          path="/inventories/constructed_inventory/add"
+          path="constructed_inventory/add"
           element={<ConstructedInventoryAdd />}
         />
         <Route
-          path="/inventories/federated_inventory/add"
+          path="federated_inventory/add"
           element={<FederatedInventoryAdd />}
         />
         {/* /* so each detail screen's own nested <Routes> can match */}
         <Route
-          path="/inventories/:inventoryType/:id/*"
+          path=":inventoryType/:id/*"
           element={<InventoryTypeRouter setBreadcrumb={setBreadcrumbConfig} />}
         />
         <Route
-          path="/inventories"
+          index
           element={
             <PersistentFilters pageKey="inventories">
               <InventoryList />

--- a/awx/ui/src/screens/Inventory/Inventories.test.js
+++ b/awx/ui/src/screens/Inventory/Inventories.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { InventoriesAPI, OrganizationsAPI } from 'api';
 
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
@@ -22,9 +23,14 @@ jest.mock('./InventoryDetail', () => {
 describe('<Inventories />', () => {
   test('initially renders without crashing', () => {
     const history = createMemoryHistory({ initialEntries: ['/inventories'] });
-    const pageWrapper = mountWithContexts(<Inventories />, {
-      context: { router: { history } },
-    });
+    const pageWrapper = mountWithContexts(
+      <Routes>
+        <Route path="/inventories/*" element={<Inventories />} />
+      </Routes>,
+      {
+        context: { router: { history } },
+      }
+    );
     expect(pageWrapper.length).toBe(1);
   });
 
@@ -47,9 +53,14 @@ describe('<Inventories />', () => {
     });
     let wrapper;
     await act(async () => {
-      wrapper = mountWithContexts(<Inventories />, {
-        context: { router: { history } },
-      });
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route path="/inventories/*" element={<Inventories />} />
+        </Routes>,
+        {
+          context: { router: { history } },
+        }
+      );
     });
     wrapper.update();
     expect(wrapper.find('InventoryDetail').length).toBe(1);

--- a/awx/ui/src/screens/Job/Jobs.js
+++ b/awx/ui/src/screens/Job/Jobs.js
@@ -61,7 +61,7 @@ function Jobs() {
       <ScreenHeader streamType="job" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
         <Route
-          path="/jobs"
+          index
           element={
             <PageSection>
               <PersistentFilters pageKey="jobs">
@@ -70,21 +70,21 @@ function Jobs() {
             </PageSection>
           }
         />
-        <Route path="/jobs/system/:id/*" element={<SystemRedirect />} />
+        <Route path="system/:id/*" element={<SystemRedirect />} />
         <Route
-          path="/jobs/:id/details"
+          path=":id/details"
           element={<TypeRedirect view="details" />}
         />
         <Route
-          path="/jobs/:id/output"
+          path=":id/output"
           element={<TypeRedirect view="output" />}
         />
         {/* /* so the nested <Job> route tree can match details/output */}
         <Route
-          path="/jobs/:typeSegment/:id/*"
+          path=":typeSegment/:id/*"
           element={<Job setBreadcrumb={buildBreadcrumbConfig} />}
         />
-        <Route path="/jobs/:id" element={<TypeRedirect />} />
+        <Route path=":id" element={<TypeRedirect />} />
       </Routes>
     </>
   );

--- a/awx/ui/src/screens/Job/Jobs.test.js
+++ b/awx/ui/src/screens/Job/Jobs.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Jobs from './Jobs';
 
@@ -35,9 +36,12 @@ jest.mock('./JobTypeRedirect', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Jobs />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/jobs/*" element={<Jobs />} />
+    </Routes>,
+    { context: { router: { history } } }
+  );
 }
 
 describe('<Jobs />', () => {

--- a/awx/ui/src/screens/ManagementJob/ManagementJobs.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobs.js
@@ -37,11 +37,11 @@ function ManagementJobs() {
       <Routes>
         {/* /* so the nested <ManagementJob> route tree can match */}
         <Route
-          path={`${basePath}/:id/*`}
+          path=":id/*"
           element={<ManagementJob setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path={basePath}
+          index
           element={
             <PersistentFilters pageKey="managementJobs">
               <ManagementJobList setBreadcrumb={buildBreadcrumbConfig} />

--- a/awx/ui/src/screens/ManagementJob/ManagementJobs.test.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobs.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
@@ -21,9 +22,14 @@ describe('<ManagementJobs />', () => {
     const history = createMemoryHistory({
       initialEntries: ['/management_jobs'],
     });
-    pageWrapper = mountWithContexts(<ManagementJobs />, {
-      context: { router: { history } },
-    });
+    pageWrapper = mountWithContexts(
+      <Routes>
+        <Route path="/management_jobs/*" element={<ManagementJobs />} />
+      </Routes>,
+      {
+        context: { router: { history } },
+      }
+    );
   });
 
   test('renders the list at /management_jobs', () => {

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
@@ -34,18 +34,18 @@ function NotificationTemplates() {
       />
       <Routes>
         <Route
-          path="/notification_templates/add"
+          path="add"
           element={<NotificationTemplateAdd />}
         />
         {/* so the nested <NotificationTemplate> route tree can match the rest */}
         <Route
-          path="/notification_templates/:id/*"
+          path=":id/*"
           element={
             <NotificationTemplate setBreadcrumb={updateBreadcrumbConfig} />
           }
         />
         <Route
-          path="/notification_templates"
+          index
           element={
             <PersistentFilters pageKey="notificationTemplates">
               <NotificationTemplateList />

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import NotificationTemplates from './NotificationTemplates';
 
@@ -34,9 +35,17 @@ jest.mock('./NotificationTemplate', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<NotificationTemplates />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/notification_templates/*"
+        element={<NotificationTemplates />}
+      />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<NotificationTemplates />', () => {

--- a/awx/ui/src/screens/Organization/Organizations.js
+++ b/awx/ui/src/screens/Organization/Organizations.js
@@ -46,10 +46,10 @@ function Organizations() {
         breadcrumbConfig={breadcrumbConfig}
       />
       <Routes>
-        <Route path="/organizations/add" element={<OrganizationAdd />} />
+        <Route path="add" element={<OrganizationAdd />} />
         {/* so the nested <Organization> route tree can match the rest */}
         <Route
-          path="/organizations/:id/*"
+          path=":id/*"
           element={
             <Config>
               {({ me }) => (
@@ -59,7 +59,7 @@ function Organizations() {
           }
         />
         <Route
-          path="/organizations"
+          index
           element={
             <PersistentFilters pageKey="organizations">
               <OrganizationsList />

--- a/awx/ui/src/screens/Organization/Organizations.test.js
+++ b/awx/ui/src/screens/Organization/Organizations.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Organizations from './Organizations';
 
@@ -32,9 +33,14 @@ jest.mock('./Organization', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Organizations />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/organizations/*" element={<Organizations />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<Organizations />', () => {

--- a/awx/ui/src/screens/Project/Projects.js
+++ b/awx/ui/src/screens/Project/Projects.js
@@ -43,14 +43,14 @@ function Projects() {
     <>
       <ScreenHeader streamType="project" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
-        <Route path="/projects/add" element={<ProjectAdd />} />
+        <Route path="add" element={<ProjectAdd />} />
         {/* so the nested <Project> route tree can match */}
         <Route
-          path="/projects/:id/*"
+          path=":id/*"
           element={<Project setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/projects"
+          index
           element={
             <PersistentFilters pageKey="projects">
               <ProjectsList />

--- a/awx/ui/src/screens/Project/Projects.test.js
+++ b/awx/ui/src/screens/Project/Projects.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import { _Projects as Projects } from './Projects';
 
@@ -15,9 +16,12 @@ jest.mock('./ProjectList/ProjectList', () => {
 describe('<Projects />', () => {
   test('should display a breadcrumb heading', () => {
     const history = createMemoryHistory({ initialEntries: ['/projects'] });
-    const wrapper = mountWithContexts(<Projects />, {
-      context: { router: { history } },
-    });
+    const wrapper = mountWithContexts(
+      <Routes>
+        <Route path="/projects/*" element={<Projects />} />
+      </Routes>,
+      { context: { router: { history } } }
+    );
 
     const header = wrapper.find('ScreenHeader');
     expect(header.prop('streamType')).toBe('project');

--- a/awx/ui/src/screens/Schedule/AllSchedules.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.js
@@ -24,7 +24,7 @@ function AllSchedules() {
       />
       <Routes>
         <Route
-          path="/schedules"
+          index
           element={
             <PageSection>
               <Card>

--- a/awx/ui/src/screens/Schedule/AllSchedules.test.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import AllSchedules from './AllSchedules';
 
@@ -29,9 +30,14 @@ jest.mock('components/Schedule', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<AllSchedules />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/schedules/*" element={<AllSchedules />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<AllSchedules />', () => {

--- a/awx/ui/src/screens/Setting/Settings.js
+++ b/awx/ui/src/screens/Setting/Settings.js
@@ -159,14 +159,14 @@ function Settings() {
       <ScreenHeader streamType="setting" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
         {/* /* on each sub-screen so its own nested <Routes> can match */}
-        <Route path="/settings/azure/*" element={<AzureAD />} />
-        <Route path="/settings/github/*" element={<GitHub />} />
-        <Route path="/settings/google_oauth2/*" element={<GoogleOAuth2 />} />
-        <Route path="/settings/oidc/*" element={<OIDC />} />
-        <Route path="/settings/jobs/*" element={<Jobs />} />
-        <Route path="/settings/ldap/*" element={<LDAP />} />
+        <Route path="azure/*" element={<AzureAD />} />
+        <Route path="github/*" element={<GitHub />} />
+        <Route path="google_oauth2/*" element={<GoogleOAuth2 />} />
+        <Route path="oidc/*" element={<OIDC />} />
+        <Route path="jobs/*" element={<Jobs />} />
+        <Route path="ldap/*" element={<LDAP />} />
         <Route
-          path="/settings/subscription/*"
+          path="subscription/*"
           element={
             license_info?.license_type === 'open' ? (
               <Navigate to="/settings" replace />
@@ -175,24 +175,18 @@ function Settings() {
             )
           }
         />
-        <Route path="/settings/logging/*" element={<Logging />} />
+        <Route path="logging/*" element={<Logging />} />
         <Route
-          path="/settings/miscellaneous_authentication/*"
+          path="miscellaneous_authentication/*"
           element={<MiscAuthentication />}
         />
-        <Route
-          path="/settings/miscellaneous_system/*"
-          element={<MiscSystem />}
-        />
-        <Route path="/settings/radius/*" element={<RADIUS />} />
-        <Route path="/settings/saml/*" element={<SAML />} />
-        <Route path="/settings/tacacs/*" element={<TACACS />} />
-        <Route
-          path="/settings/troubleshooting/*"
-          element={<Troubleshooting />}
-        />
-        <Route path="/settings/ui/*" element={<UI />} />
-        <Route path="/settings" element={<SettingList />} />
+        <Route path="miscellaneous_system/*" element={<MiscSystem />} />
+        <Route path="radius/*" element={<RADIUS />} />
+        <Route path="saml/*" element={<SAML />} />
+        <Route path="tacacs/*" element={<TACACS />} />
+        <Route path="troubleshooting/*" element={<Troubleshooting />} />
+        <Route path="ui/*" element={<UI />} />
+        <Route index element={<SettingList />} />
         <Route
           path="*"
           element={

--- a/awx/ui/src/screens/Setting/Settings.test.js
+++ b/awx/ui/src/screens/Setting/Settings.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { SettingsAPI, RootAPI } from 'api';
 import {
   mountWithContexts,
@@ -34,19 +35,25 @@ describe('<Settings />', () => {
       initialEntries: ['/settings'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Settings />, {
-        context: {
-          router: {
-            history,
-          },
-          config: {
-            me: {
-              is_superuser: false,
-              is_system_auditor: false,
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route path="/settings/*" element={<Settings />} />
+          <Route path="*" element={null} />
+        </Routes>,
+        {
+          context: {
+            router: {
+              history,
+            },
+            config: {
+              me: {
+                is_superuser: false,
+                is_system_auditor: false,
+              },
             },
           },
-        },
-      });
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(history.location.pathname).toBe('/');
@@ -58,17 +65,22 @@ describe('<Settings />', () => {
       initialEntries: ['/settings'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Settings />, {
-        context: {
-          router: {
-            history,
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route path="/settings/*" element={<Settings />} />
+        </Routes>,
+        {
+          context: {
+            router: {
+              history,
+            },
+            config: {
+              is_superuser: true,
+              is_system_auditor: true,
+            },
           },
-          config: {
-            is_superuser: true,
-            is_system_auditor: true,
-          },
-        },
-      });
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('SettingList').length).toBe(1);
@@ -76,8 +88,23 @@ describe('<Settings />', () => {
 
   test('should render content error on throw', async () => {
     SettingsAPI.readAllOptions.mockRejectedValue(new Error());
+    const history = createMemoryHistory({
+      initialEntries: ['/settings'],
+    });
     await act(async () => {
-      wrapper = mountWithContexts(<Settings />);
+      wrapper = mountWithContexts(
+        <Routes>
+          <Route path="/settings/*" element={<Settings />} />
+          <Route path="*" element={null} />
+        </Routes>,
+        {
+          context: {
+            router: {
+              history,
+            },
+          },
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('ContentError').length).toBe(1);

--- a/awx/ui/src/screens/Team/Teams.js
+++ b/awx/ui/src/screens/Team/Teams.js
@@ -41,14 +41,14 @@ function Teams() {
     <>
       <ScreenHeader streamType="team" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
-        <Route path="/teams/add" element={<TeamAdd />} />
+        <Route path="add" element={<TeamAdd />} />
         {/* so the nested <Team> route tree can match the rest */}
         <Route
-          path="/teams/:id/*"
+          path=":id/*"
           element={<Team setBreadcrumb={buildBreadcrumbConfig} />}
         />
         <Route
-          path="/teams"
+          index
           element={
             <PersistentFilters pageKey="teams">
               <Config>

--- a/awx/ui/src/screens/Team/Teams.test.js
+++ b/awx/ui/src/screens/Team/Teams.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Teams from './Teams';
 
@@ -32,9 +33,14 @@ jest.mock('./Team', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Teams />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/teams/*" element={<Teams />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<Teams />', () => {

--- a/awx/ui/src/screens/Template/Template.js
+++ b/awx/ui/src/screens/Template/Template.js
@@ -191,7 +191,7 @@ function Template({ setBreadcrumb }) {
         {template && (
           <Routes>
             <Route
-              path="/templates/:templateType/:id/details"
+              path=":templateType/:id/details"
               element={
                 <JobTemplateDetail
                   hasTemplateLoading={isLoading}
@@ -200,7 +200,7 @@ function Template({ setBreadcrumb }) {
               }
             />
             <Route
-              path="/templates/:templateType/:id/edit"
+              path=":templateType/:id/edit"
               element={
                 <JobTemplateEdit
                   template={template}
@@ -209,7 +209,7 @@ function Template({ setBreadcrumb }) {
               }
             />
             <Route
-              path="/templates/:templateType/:id/access"
+              path=":templateType/:id/access"
               element={
                 <ResourceAccessList
                   resource={template}
@@ -218,7 +218,7 @@ function Template({ setBreadcrumb }) {
               }
             />
             <Route
-              path="/templates/:templateType/:id/schedules/*"
+              path=":templateType/:id/schedules/*"
               element={
                 <Schedules
                   apiModel={JobTemplatesAPI}
@@ -234,7 +234,7 @@ function Template({ setBreadcrumb }) {
             />
             {canSeeNotificationsTab && (
               <Route
-                path="/templates/:templateType/:id/notifications"
+                path=":templateType/:id/notifications"
                 element={
                   <NotificationList
                     id={Number(templateId)}
@@ -245,13 +245,13 @@ function Template({ setBreadcrumb }) {
               />
             )}
             <Route
-              path="/templates/:templateType/:id/jobs"
+              path=":templateType/:id/jobs"
               element={
                 <JobList defaultParams={{ job__job_template: template.id }} />
               }
             />
             <Route
-              path="/templates/:templateType/:id/survey/*"
+              path=":templateType/:id/survey/*"
               element={
                 <TemplateSurvey
                   template={template}
@@ -260,7 +260,7 @@ function Template({ setBreadcrumb }) {
               }
             />
             <Route
-              path="/templates/:templateType/:id"
+              path=":templateType/:id"
               element={<Navigate to={`${baseUrl}/details`} replace />}
             />
             <Route

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.js
@@ -184,19 +184,19 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
         <Routes>
           {template && (
             <Route
-              path="/templates/:templateType/:id/details"
+              path=":templateType/:id/details"
               element={<WorkflowJobTemplateDetail template={template} />}
             />
           )}
           {template && (
             <Route
-              path="/templates/:templateType/:id/edit"
+              path=":templateType/:id/edit"
               element={<WorkflowJobTemplateEdit template={template} />}
             />
           )}
           {template && (
             <Route
-              path="/templates/:templateType/:id/access"
+              path=":templateType/:id/access"
               element={
                 <ResourceAccessList
                   resource={template}
@@ -207,7 +207,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template && (
             <Route
-              path="/templates/:templateType/:id/schedules/*"
+              path=":templateType/:id/schedules/*"
               element={
                 <Schedules
                   apiModel={WorkflowJobTemplatesAPI}
@@ -223,7 +223,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {canSeeNotificationsTab && (
             <Route
-              path="/templates/:templateType/:id/notifications"
+              path=":templateType/:id/notifications"
               element={
                 <NotificationList
                   id={Number(templateId)}
@@ -236,7 +236,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template && (
             <Route
-              path="/templates/workflow_job_template/:id/visualizer"
+              path="workflow_job_template/:id/visualizer"
               element={
                 <AppendBody>
                   <FullPage>
@@ -248,7 +248,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template?.id && (
             <Route
-              path="/templates/:templateType/:id/jobs"
+              path=":templateType/:id/jobs"
               element={
                 <JobList
                   defaultParams={{
@@ -260,7 +260,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template && (
             <Route
-              path="/templates/:templateType/:id/survey/*"
+              path=":templateType/:id/survey/*"
               element={
                 <TemplateSurvey
                   template={template}
@@ -271,7 +271,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template && (
             <Route
-              path="/templates/:templateType/:id"
+              path=":templateType/:id"
               element={<Navigate to={`${baseUrl}/details`} replace />}
             />
           )}

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { act } from 'react-dom/test-utils';
 import {
   WorkflowJobTemplatesAPI,
@@ -244,12 +245,19 @@ describe('<WorkflowJobTemplate />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate
-          setBreadcrumb={() => {}}
-          me={{
-            is_system_auditor: true,
-          }}
-        />,
+        <Routes>
+          <Route
+            path="/templates/*"
+            element={
+              <WorkflowJobTemplate
+                setBreadcrumb={() => {}}
+                me={{
+                  is_system_auditor: true,
+                }}
+              />
+            }
+          />
+        </Routes>,
         {
           context: { router: { history } },
         }

--- a/awx/ui/src/screens/User/Users.js
+++ b/awx/ui/src/screens/User/Users.js
@@ -42,10 +42,10 @@ function Users() {
     <>
       <ScreenHeader streamType="user" breadcrumbConfig={breadcrumbConfig} />
       <Routes>
-        <Route path="/users/add" element={<UserAdd />} />
+        <Route path="add" element={<UserAdd />} />
         {/* /* so the nested <User> route tree can match the rest */}
         <Route
-          path="/users/:id/*"
+          path=":id/*"
           element={
             <Config>
               {({ me }) => (
@@ -55,7 +55,7 @@ function Users() {
           }
         />
         <Route
-          path="/users"
+          index
           element={
             <PersistentFilters pageKey="users">
               <UsersList />

--- a/awx/ui/src/screens/User/Users.test.js
+++ b/awx/ui/src/screens/User/Users.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Users from './Users';
 
@@ -43,9 +44,14 @@ jest.mock('./User', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<Users />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/users/*" element={<Users />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<Users />', () => {

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
@@ -37,11 +37,11 @@ function WorkflowApprovals() {
       <Routes>
         {/* so the nested <WorkflowApproval> route tree can match the rest */}
         <Route
-          path="/workflow_approvals/:id/*"
+          path=":id/*"
           element={<WorkflowApproval setBreadcrumb={updateBreadcrumbConfig} />}
         />
         <Route
-          path="/workflow_approvals"
+          index
           element={
             <PersistentFilters pageKey="workflowApprovals">
               <WorkflowApprovalList />

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowApprovals from './WorkflowApprovals';
 
@@ -26,9 +27,14 @@ jest.mock('./WorkflowApproval', () => {
 
 function renderAt(path) {
   const history = createMemoryHistory({ initialEntries: [path] });
-  return renderWithContexts(<WorkflowApprovals />, {
-    context: { router: { history } },
-  });
+  return renderWithContexts(
+    <Routes>
+      <Route path="/workflow_approvals/*" element={<WorkflowApprovals />} />
+    </Routes>,
+    {
+      context: { router: { history } },
+    }
+  );
 }
 
 describe('<WorkflowApprovals />', () => {


### PR DESCRIPTION
##### SUMMARY

Converts the **App.js root route tree** to react-router v6 `<Routes>`. This is the last piece of the v5 to v6 migration (#400 through #427). App.js now dispatches each `routeConfig` screen as a v6 descendant at `path="/<x>/*"`, and the outer login, `/` to `/home`, and `ProtectedRoute` tree is plain v6.

Once App.js is v6, every screen's own `<Routes>` becomes a descendant, which v6 matches relative to the parent. The merged route-tree PRs had written each list-entry screen with absolute child paths (`path="/credentials"`, `/credentials/add`, `/credentials/:id/*`), and those only matched while App.js was still v5 and the screens were effectively top-level. As descendants they stop matching, so most pages went blank or not-found after rebasing onto current `main`. This PR switches those screens to relative paths so they resolve under the v6 root:

- List-entry screens use `add`, `:id/*`, and `<Route index>`: Credentials, Jobs, Projects, Inventories, Hosts, Organizations, Users, Teams, CredentialTypes, WorkflowApprovals, NotificationTemplates, Applications, ExecutionEnvironments, AllSchedules, InstanceGroups, Instances, Settings, ManagementJobs.
- Template and WorkflowJobTemplate detail `<Routes>` use relative `:templateType/:id/...` (Templates.js itself stays a v5-compat `<Switch>`, which already prefix-matches the full path).
- Each screen's tests now mount the screen as a descendant under a real `<Routes><Route path="/<x>/*" element={<Screen/>}/></Routes>`. The old top-level mounts only resolved with absolute paths.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

I browser-smoke-tested this against the dev server (hash routing) after the change. Every top-level route and a representative set of detail tabs render, with no `/api/v2/.../undefined/...` calls:

- Lists: home, jobs, schedules, activity_stream, workflow_approvals, labels, templates, credentials, projects, inventories, hosts, organizations, users, teams, credential_types, notification_templates, management_jobs, applications, execution_environments, instances, topology_view, settings. All OK.
- Details: credentials/:id, jobs/:id/output, projects/:id, inventories/inventory/:id, hosts/:id, organizations/:id, instance_groups/:id, management_jobs/:id (notifications and schedules), settings/<category>, and templates/{job_template,workflow_job_template}/:id (details/edit/survey/visualizer). All OK.
- `host_metrics` and `subscription_usage` are license-gated out of `routeConfig` (`SUBSCRIPTION_USAGE_MODEL`), so they 404 by design. That's unchanged from `main`.

All 20 affected screen test suites pass (69 tests), and the changed screens lint clean.
