### PR TITLE
Convert InventorySource route tree to react-router v6

### DIFF
--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,14 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import {
-  Switch,
-  Route,
-  Link,
-  Redirect,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -120,42 +114,54 @@ function Schedule({
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from={`${pathRoot}schedules/:scheduleId`}
-          to={`${pathRoot}schedules/:scheduleId/details`}
-          exact
+      <Routes>
+        <Route
+          path={`${pathRoot}schedules/:scheduleId`}
+          element={
+            <Navigate
+              to={`${pathRoot}schedules/${scheduleId}/details`}
+              replace
+            />
+          }
         />
-        {schedule && [
-          <Route key="edit" path={`${pathRoot}schedules/:id/edit`}>
-            <ScheduleEdit
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              resource={resource}
-              launchConfig={launchConfig}
-              surveyConfig={surveyConfig}
-              resourceDefaultCredentials={resourceDefaultCredentials}
-            />
-          </Route>,
+        {schedule && (
           <Route
-            key="details"
+            path={`${pathRoot}schedules/:id/edit`}
+            element={
+              <ScheduleEdit
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                resource={resource}
+                launchConfig={launchConfig}
+                surveyConfig={surveyConfig}
+                resourceDefaultCredentials={resourceDefaultCredentials}
+              />
+            }
+          />
+        )}
+        {schedule && (
+          <Route
             path={`${pathRoot}schedules/:scheduleId/details`}
-          >
-            <ScheduleDetail
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              surveyConfig={surveyConfig}
-            />
-          </Route>,
-        ]}
-        <Route key="not-found" path="*">
-          <ContentError>
-            {resource && (
-              <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
-            )}
-          </ContentError>
-        </Route>
-      </Switch>
+            element={
+              <ScheduleDetail
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                surveyConfig={surveyConfig}
+              />
+            }
+          />
+        )}
+        <Route
+          path="*"
+          element={
+            <ContentError>
+              {resource && (
+                <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
+              )}
+            </ContentError>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -121,18 +121,10 @@ function Schedule({
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
       <Routes>
-        <Route
-          path={`${pathRoot}schedules/:scheduleId`}
-          element={
-            <Navigate
-              to={`${pathRoot}schedules/${scheduleId}/details`}
-              replace
-            />
-          }
-        />
+        <Route index element={<Navigate to="details" replace />} />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/edit`}
+            path="edit"
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}
@@ -147,7 +139,7 @@ function Schedule({
         )}
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/details`}
+            path="details"
             element={
               <ScheduleDetail
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,8 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -25,7 +31,7 @@ function Schedule({
 
   const { pathname } = useLocation();
 
-  const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
+  const pathRoot = pathname.substring(0, pathname.indexOf('schedules'));
 
   const {
     isLoading,
@@ -126,7 +132,7 @@ function Schedule({
         />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:id/edit`}
+            path={`${pathRoot}schedules/:scheduleId/edit`}
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,7 +15,15 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  const match = useRouteMatch();
+  // This component is mounted at several different base paths (templates,
+  // projects, inventory sources, management jobs). Derive the base from the
+  // location so the routes are base-agnostic and resolve whether the parent
+  // screen is still on v5 or already on v6.
+  const { pathname } = useLocation();
+  const baseUrl = `${pathname.substr(
+    0,
+    pathname.indexOf('schedules')
+  )}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -26,37 +34,47 @@ function Schedules({
   ].includes(resource?.job_type);
 
   return (
-    <Switch>
-      <Route path={`${match.path}/add`}>
-        <ScheduleAdd
-          hasDaysToKeepField={hasDaysToKeepField}
-          apiModel={apiModel}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule
-          hasDaysToKeepField={hasDaysToKeepField}
-          setBreadcrumb={setBreadcrumb}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="list" path={`${match.path}`}>
-        <ScheduleList
-          resource={resource}
-          loadSchedules={loadSchedules}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          loadScheduleOptions={loadScheduleOptions}
-        />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path={`${baseUrl}/add`}
+        element={
+          <ScheduleAdd
+            hasDaysToKeepField={hasDaysToKeepField}
+            apiModel={apiModel}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      {/* /* so the nested <Schedule> route tree can match */}
+      <Route
+        path={`${baseUrl}/:scheduleId/*`}
+        element={
+          <Schedule
+            hasDaysToKeepField={hasDaysToKeepField}
+            setBreadcrumb={setBreadcrumb}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      <Route
+        path={baseUrl}
+        element={
+          <ScheduleList
+            resource={resource}
+            loadSchedules={loadSchedules}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            loadScheduleOptions={loadScheduleOptions}
+          />
+        }
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -20,10 +20,14 @@ function Schedules({
   // location so the routes are base-agnostic and resolve whether the parent
   // screen is still on v5 or already on v6.
   const { pathname } = useLocation();
-  const baseUrl = `${pathname.substr(
-    0,
-    pathname.indexOf('schedules')
-  )}schedules`;
+  // Schedules is always mounted under a ".../schedules" path; if that segment
+  // is somehow absent, fall back to the full pathname so baseUrl stays an
+  // absolute path rather than collapsing to the relative "schedules".
+  const schedulesIndex = pathname.indexOf('schedules');
+  const baseUrl =
+    schedulesIndex === -1
+      ? pathname
+      : `${pathname.substring(0, schedulesIndex)}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -48,7 +52,7 @@ function Schedules({
           />
         }
       />
-      {/* /* so the nested <Schedule> route tree can match */}
+      {/* so the nested <Schedule> route tree can match */}
       <Route
         path={`${baseUrl}/:scheduleId/*`}
         element={

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,19 +15,9 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  // This component is mounted at several different base paths (templates,
-  // projects, inventory sources, management jobs). Derive the base from the
-  // location so the routes are base-agnostic and resolve whether the parent
-  // screen is still on v5 or already on v6.
-  const { pathname } = useLocation();
-  // Schedules is always mounted under a ".../schedules" path; if that segment
-  // is somehow absent, fall back to the full pathname so baseUrl stays an
-  // absolute path rather than collapsing to the relative "schedules".
-  const schedulesIndex = pathname.indexOf('schedules');
-  const baseUrl =
-    schedulesIndex === -1
-      ? pathname
-      : `${pathname.substring(0, schedulesIndex)}schedules`;
+  // This component is mounted under a ".../schedules/*" route on several
+  // screens (templates, projects, inventory sources, management jobs), so its
+  // routes are relative to that parent and resolve under any of them.
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -40,7 +30,7 @@ function Schedules({
   return (
     <Routes>
       <Route
-        path={`${baseUrl}/add`}
+        path="add"
         element={
           <ScheduleAdd
             hasDaysToKeepField={hasDaysToKeepField}
@@ -54,7 +44,7 @@ function Schedules({
       />
       {/* so the nested <Schedule> route tree can match */}
       <Route
-        path={`${baseUrl}/:scheduleId/*`}
+        path=":scheduleId/*"
         element={
           <Schedule
             hasDaysToKeepField={hasDaysToKeepField}
@@ -67,7 +57,7 @@ function Schedules({
         }
       />
       <Route
-        path={baseUrl}
+        index
         element={
           <ScheduleList
             resource={resource}

--- a/awx/ui/src/components/Schedule/Schedules.test.js
+++ b/awx/ui/src/components/Schedule/Schedules.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import Schedules from './Schedules';
 
@@ -12,21 +13,25 @@ describe('<Schedules />', () => {
     });
     const jobTemplate = { id: 1, name: 'Mock JT' };
 
+    // Schedules uses relative routes, so mount it under its ".../schedules/*"
+    // parent route.
     await act(async () => {
       wrapper = mountWithContexts(
-        <Schedules
-          setBreadcrumb={() => {}}
-          jobTemplate={jobTemplate}
-          loadSchedules={() => {}}
-          loadScheduleOptions={() => {}}
-          apiModel={{ createSchedule: () => {} }}
-        />,
-
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
+        <Routes>
+          <Route
+            path="/templates/job_template/:id/schedules/*"
+            element={
+              <Schedules
+                setBreadcrumb={() => {}}
+                jobTemplate={jobTemplate}
+                loadSchedules={() => {}}
+                loadScheduleOptions={() => {}}
+                apiModel={{ createSchedule: () => {} }}
+              />
+            }
+          />
+        </Routes>,
+        { context: { router: { history } } }
       );
     });
     expect(wrapper.length).toBe(1);

--- a/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
+++ b/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Link, Switch, Route, Redirect, useRouteMatch, useLocation } from 'react-router-dom';
+import { Link, useParams, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import useRequest from 'hooks/useRequest';
 
@@ -17,7 +18,8 @@ import InventorySourceEdit from '../InventorySourceEdit';
 function InventorySource({ inventory, setBreadcrumb, me }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch('/inventories/inventory/:id/sources/:sourceId');
+  const { id, sourceId } = useParams();
+  const baseUrl = `/inventories/inventory/${id}/sources/${sourceId}`;
   const sourceListUrl = `/inventories/inventory/${inventory.id}/sources`;
 
   const {
@@ -28,7 +30,7 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
   } = useRequest(
     useCallback(async () => {
       const [inventorySource, notifAdminRes] = await Promise.all([
-        InventoriesAPI.readSourceDetail(inventory.id, match.params.sourceId),
+        InventoriesAPI.readSourceDetail(inventory.id, sourceId),
         OrganizationsAPI.read({
           page_size: 1,
           role_level: 'notification_admin_role',
@@ -38,7 +40,7 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
         source: inventorySource,
         isNotifAdmin: notifAdminRes.data.results.length > 0,
       };
-    }, [inventory.id, match.params.sourceId]),
+    }, [inventory.id, sourceId]),
     { source: null, isNotifAdmin: false }
   );
 
@@ -75,12 +77,12 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
     },
     {
       name: t`Details`,
-      link: `${match.url}/details`,
+      link: `${baseUrl}/details`,
       id: 1,
     },
     {
       name: t`Schedules`,
-      link: `${match.url}/schedules`,
+      link: `${baseUrl}/schedules`,
       id: 2,
     },
   ];
@@ -91,7 +93,7 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
   if (canSeeNotificationsTab) {
     tabsArray.push({
       name: t`Notifications`,
-      link: `${match.url}/notifications`,
+      link: `${baseUrl}/notifications`,
       id: 3,
     });
   }
@@ -113,56 +115,56 @@ function InventorySource({ inventory, setBreadcrumb, me }) {
       {isLoading && <ContentLoading />}
 
       {!isLoading && source && (
-        <Switch>
-          <Redirect
-            from="/inventories/inventory/:id/sources/:sourceId"
-            to="/inventories/inventory/:id/sources/:sourceId/details"
-            exact
+        <Routes>
+          <Route
+            path={`${baseUrl}/details`}
+            element={<InventorySourceDetail inventorySource={source} />}
           />
           <Route
-            key="details"
-            path="/inventories/inventory/:id/sources/:sourceId/details"
-          >
-            <InventorySourceDetail inventorySource={source} />
-          </Route>
+            path={`${baseUrl}/edit`}
+            element={
+              <InventorySourceEdit source={source} inventory={inventory} />
+            }
+          />
           <Route
-            key="edit"
-            path="/inventories/inventory/:id/sources/:sourceId/edit"
-          >
-            <InventorySourceEdit source={source} inventory={inventory} />
-          </Route>
+            path={`${baseUrl}/notifications`}
+            element={
+              <NotificationList
+                id={Number(sourceId)}
+                canToggleNotifications={canToggleNotifications}
+                apiModel={InventorySourcesAPI}
+              />
+            }
+          />
           <Route
-            key="notifications"
-            path="/inventories/inventory/:id/sources/:sourceId/notifications"
-          >
-            <NotificationList
-              id={Number(match.params.sourceId)}
-              canToggleNotifications={canToggleNotifications}
-              apiModel={InventorySourcesAPI}
-            />
-          </Route>
+            path={`${baseUrl}/schedules/*`}
+            element={
+              <Schedules
+                apiModel={InventorySourcesAPI}
+                setBreadcrumb={(schedule) =>
+                  setBreadcrumb(inventory, source, schedule)
+                }
+                resource={source}
+                loadSchedules={loadSchedules}
+                loadScheduleOptions={loadScheduleOptions}
+              />
+            }
+          />
           <Route
-            key="schedules"
-            path="/inventories/inventory/:id/sources/:sourceId/schedules"
-          >
-            <Schedules
-              apiModel={InventorySourcesAPI}
-              setBreadcrumb={(schedule) =>
-                setBreadcrumb(inventory, source, schedule)
-              }
-              resource={source}
-              loadSchedules={loadSchedules}
-              loadScheduleOptions={loadScheduleOptions}
-            />
-          </Route>
-          <Route key="not-found" path="*">
-            <ContentError isNotFound>
-              <Link to={`${match.url}/details`}>
-                {t`View inventory source details`}
-              </Link>
-            </ContentError>
-          </Route>
-        </Switch>
+            path={baseUrl}
+            element={<Navigate to={`${baseUrl}/details`} replace />}
+          />
+          <Route
+            path="*"
+            element={
+              <ContentError isNotFound>
+                <Link to={`${baseUrl}/details`}>
+                  {t`View inventory source details`}
+                </Link>
+              </ContentError>
+            }
+          />
+        </Routes>
       )}
     </>
   );

--- a/awx/ui/src/screens/Inventory/InventorySource/InventorySource.test.js
+++ b/awx/ui/src/screens/Inventory/InventorySource/InventorySource.test.js
@@ -15,10 +15,7 @@ jest.mock('../../../api/models/InventorySources');
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useRouteMatch: () => ({
-    url: '/inventories/inventory/2/sources/123',
-    params: { id: 2, sourceId: 123 },
-  }),
+  useParams: () => ({ id: 2, sourceId: 123 }),
 }));
 
 const mockInventory = {


### PR DESCRIPTION
##### SUMMARY

Converts the **InventorySource** route tree from react-router v5 to v6, continuing the react-router v6 migration (`react-router-dom-v5-compat` bridge).

- `<Switch>`/`<Route>`/`<Redirect>` -> `<Routes>`/`<Route>`/`<Navigate>`.
- Replaces `useRouteMatch('/inventories/inventory/:id/sources/:sourceId')` with `useParams`, building the absolute base path from the route params.
- The exact `<Redirect>` to the details tab becomes an index `<Route>` + `<Navigate replace>`.
- The schedules tab delegates to the shared v6 `<Schedules>` component, mounted with a trailing `/*` so its nested route tree matches.
- The not-found case uses `path="*"`.
- Test updated to mock `useParams` instead of `useRouteMatch`.

This is the InventorySource screen that was deferred from the Inventory PR (#421) because it renders the shared `<Schedules>` component.

##### DEPENDENCY

Stacked on #422 (the v6 `<Schedules>`/`<Schedule>` conversion). The diff includes those two shared files; once #422 merges this will rebase cleanly to a single-file change.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

