### PR TITLE
Convert Template and WorkflowJobTemplate route trees to react-router v6

### DIFF
--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,14 +1,8 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import {
-  Switch,
-  Route,
-  Link,
-  Redirect,
-  useLocation,
-  useParams,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -120,42 +114,54 @@ function Schedule({
   return (
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-      <Switch>
-        <Redirect
-          from={`${pathRoot}schedules/:scheduleId`}
-          to={`${pathRoot}schedules/:scheduleId/details`}
-          exact
+      <Routes>
+        <Route
+          path={`${pathRoot}schedules/:scheduleId`}
+          element={
+            <Navigate
+              to={`${pathRoot}schedules/${scheduleId}/details`}
+              replace
+            />
+          }
         />
-        {schedule && [
-          <Route key="edit" path={`${pathRoot}schedules/:id/edit`}>
-            <ScheduleEdit
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              resource={resource}
-              launchConfig={launchConfig}
-              surveyConfig={surveyConfig}
-              resourceDefaultCredentials={resourceDefaultCredentials}
-            />
-          </Route>,
+        {schedule && (
           <Route
-            key="details"
+            path={`${pathRoot}schedules/:id/edit`}
+            element={
+              <ScheduleEdit
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                resource={resource}
+                launchConfig={launchConfig}
+                surveyConfig={surveyConfig}
+                resourceDefaultCredentials={resourceDefaultCredentials}
+              />
+            }
+          />
+        )}
+        {schedule && (
+          <Route
             path={`${pathRoot}schedules/:scheduleId/details`}
-          >
-            <ScheduleDetail
-              hasDaysToKeepField={hasDaysToKeepField}
-              schedule={schedule}
-              surveyConfig={surveyConfig}
-            />
-          </Route>,
-        ]}
-        <Route key="not-found" path="*">
-          <ContentError>
-            {resource && (
-              <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
-            )}
-          </ContentError>
-        </Route>
-      </Switch>
+            element={
+              <ScheduleDetail
+                hasDaysToKeepField={hasDaysToKeepField}
+                schedule={schedule}
+                surveyConfig={surveyConfig}
+              />
+            }
+          />
+        )}
+        <Route
+          path="*"
+          element={
+            <ContentError>
+              {resource && (
+                <Link to={`${pathRoot}details`}>{t`View Details`}</Link>
+              )}
+            </ContentError>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -1,8 +1,14 @@
 import React, { useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom-v5-compat';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -25,7 +31,7 @@ function Schedule({
 
   const { pathname } = useLocation();
 
-  const pathRoot = pathname.substr(0, pathname.indexOf('schedules'));
+  const pathRoot = pathname.substring(0, pathname.indexOf('schedules'));
 
   const {
     isLoading,
@@ -115,18 +121,10 @@ function Schedule({
     <>
       {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
       <Routes>
-        <Route
-          path={`${pathRoot}schedules/:scheduleId`}
-          element={
-            <Navigate
-              to={`${pathRoot}schedules/${scheduleId}/details`}
-              replace
-            />
-          }
-        />
+        <Route index element={<Navigate to="details" replace />} />
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:id/edit`}
+            path="edit"
             element={
               <ScheduleEdit
                 hasDaysToKeepField={hasDaysToKeepField}
@@ -141,7 +139,7 @@ function Schedule({
         )}
         {schedule && (
           <Route
-            path={`${pathRoot}schedules/:scheduleId/details`}
+            path="details"
             element={
               <ScheduleDetail
                 hasDaysToKeepField={hasDaysToKeepField}

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,7 +15,15 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  const match = useRouteMatch();
+  // This component is mounted at several different base paths (templates,
+  // projects, inventory sources, management jobs). Derive the base from the
+  // location so the routes are base-agnostic and resolve whether the parent
+  // screen is still on v5 or already on v6.
+  const { pathname } = useLocation();
+  const baseUrl = `${pathname.substr(
+    0,
+    pathname.indexOf('schedules')
+  )}schedules`;
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -26,37 +34,47 @@ function Schedules({
   ].includes(resource?.job_type);
 
   return (
-    <Switch>
-      <Route path={`${match.path}/add`}>
-        <ScheduleAdd
-          hasDaysToKeepField={hasDaysToKeepField}
-          apiModel={apiModel}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="details" path={`${match.path}/:scheduleId`}>
-        <Schedule
-          hasDaysToKeepField={hasDaysToKeepField}
-          setBreadcrumb={setBreadcrumb}
-          resource={resource}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          resourceDefaultCredentials={resourceDefaultCredentials}
-        />
-      </Route>
-      <Route key="list" path={`${match.path}`}>
-        <ScheduleList
-          resource={resource}
-          loadSchedules={loadSchedules}
-          launchConfig={launchConfig}
-          surveyConfig={surveyConfig}
-          loadScheduleOptions={loadScheduleOptions}
-        />
-      </Route>
-    </Switch>
+    <Routes>
+      <Route
+        path={`${baseUrl}/add`}
+        element={
+          <ScheduleAdd
+            hasDaysToKeepField={hasDaysToKeepField}
+            apiModel={apiModel}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      {/* /* so the nested <Schedule> route tree can match */}
+      <Route
+        path={`${baseUrl}/:scheduleId/*`}
+        element={
+          <Schedule
+            hasDaysToKeepField={hasDaysToKeepField}
+            setBreadcrumb={setBreadcrumb}
+            resource={resource}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            resourceDefaultCredentials={resourceDefaultCredentials}
+          />
+        }
+      />
+      <Route
+        path={baseUrl}
+        element={
+          <ScheduleList
+            resource={resource}
+            loadSchedules={loadSchedules}
+            launchConfig={launchConfig}
+            surveyConfig={surveyConfig}
+            loadScheduleOptions={loadScheduleOptions}
+          />
+        }
+      />
+    </Routes>
   );
 }
 

--- a/awx/ui/src/components/Schedule/Schedules.js
+++ b/awx/ui/src/components/Schedule/Schedules.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import Schedule from './Schedule';
 import ScheduleAdd from './ScheduleAdd';
@@ -15,15 +15,9 @@ function Schedules({
   resource,
   resourceDefaultCredentials,
 }) {
-  // This component is mounted at several different base paths (templates,
-  // projects, inventory sources, management jobs). Derive the base from the
-  // location so the routes are base-agnostic and resolve whether the parent
-  // screen is still on v5 or already on v6.
-  const { pathname } = useLocation();
-  const baseUrl = `${pathname.substr(
-    0,
-    pathname.indexOf('schedules')
-  )}schedules`;
+  // This component is mounted under a ".../schedules/*" route on several
+  // screens (templates, projects, inventory sources, management jobs), so its
+  // routes are relative to that parent and resolve under any of them.
 
   // For some management jobs that delete data, we want to provide an additional
   // field on the scheduler for configuring the number of days to retain.
@@ -36,7 +30,7 @@ function Schedules({
   return (
     <Routes>
       <Route
-        path={`${baseUrl}/add`}
+        path="add"
         element={
           <ScheduleAdd
             hasDaysToKeepField={hasDaysToKeepField}
@@ -48,9 +42,9 @@ function Schedules({
           />
         }
       />
-      {/* /* so the nested <Schedule> route tree can match */}
+      {/* so the nested <Schedule> route tree can match */}
       <Route
-        path={`${baseUrl}/:scheduleId/*`}
+        path=":scheduleId/*"
         element={
           <Schedule
             hasDaysToKeepField={hasDaysToKeepField}
@@ -63,7 +57,7 @@ function Schedules({
         }
       />
       <Route
-        path={baseUrl}
+        index
         element={
           <ScheduleList
             resource={resource}

--- a/awx/ui/src/components/Schedule/Schedules.test.js
+++ b/awx/ui/src/components/Schedule/Schedules.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import Schedules from './Schedules';
 
@@ -12,21 +13,25 @@ describe('<Schedules />', () => {
     });
     const jobTemplate = { id: 1, name: 'Mock JT' };
 
+    // Schedules uses relative routes, so mount it under its ".../schedules/*"
+    // parent route.
     await act(async () => {
       wrapper = mountWithContexts(
-        <Schedules
-          setBreadcrumb={() => {}}
-          jobTemplate={jobTemplate}
-          loadSchedules={() => {}}
-          loadScheduleOptions={() => {}}
-          apiModel={{ createSchedule: () => {} }}
-        />,
-
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
+        <Routes>
+          <Route
+            path="/templates/job_template/:id/schedules/*"
+            element={
+              <Schedules
+                setBreadcrumb={() => {}}
+                jobTemplate={jobTemplate}
+                loadSchedules={() => {}}
+                loadScheduleOptions={() => {}}
+                apiModel={{ createSchedule: () => {} }}
+              />
+            }
+          />
+        </Routes>,
+        { context: { router: { history } } }
       );
     });
     expect(wrapper.length).toBe(1);

--- a/awx/ui/src/screens/Template/JobTemplateDetail/JobTemplateDetail.js
+++ b/awx/ui/src/screens/Template/JobTemplateDetail/JobTemplateDetail.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
   Button,
   Chip,

--- a/awx/ui/src/screens/Template/Survey/SurveyQuestionAdd.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyQuestionAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { CardBody } from 'components/Card';
 import SurveyQuestionForm from './SurveyQuestionForm';
@@ -7,7 +7,8 @@ import SurveyQuestionForm from './SurveyQuestionForm';
 export default function SurveyQuestionAdd({ survey, updateSurvey }) {
   const [formError, setFormError] = useState(null);
   const navigate = useNavigate();
-  const match = useRouteMatch();
+  const { pathname } = useLocation();
+  const surveyUrl = pathname.replace('/add', '');
 
   const handleSubmit = async (question) => {
     const formData = { ...question };
@@ -41,14 +42,14 @@ export default function SurveyQuestionAdd({ survey, updateSurvey }) {
       delete formData.formattedChoices;
       const newSpec = survey?.spec ? survey.spec.concat(formData) : [formData];
       await updateSurvey(newSpec);
-      navigate(match.url.replace('/add', ''));
+      navigate(surveyUrl);
     } catch (err) {
       setFormError(err);
     }
   };
 
   const handleCancel = () => {
-    navigate(match.url.replace('/add', ''));
+    navigate(surveyUrl);
   };
 
   return (

--- a/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation, useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useNavigate, Navigate } from 'react-router-dom-v5-compat';
 import ContentLoading from 'components/ContentLoading';
 import { CardBody } from 'components/Card';
@@ -8,8 +8,8 @@ import SurveyQuestionForm from './SurveyQuestionForm';
 export default function SurveyQuestionEdit({ survey, updateSurvey }) {
   const [formError, setFormError] = useState(null);
   const navigate = useNavigate();
-  const match = useRouteMatch();
-  const { search } = useLocation();
+  const { pathname, search } = useLocation();
+  const surveyUrl = `${pathname.substr(0, pathname.indexOf('survey'))}survey`;
   const queryParams = new URLSearchParams(search);
   const questionVariable = decodeURIComponent(
     queryParams.get('question_variable')
@@ -22,16 +22,11 @@ export default function SurveyQuestionEdit({ survey, updateSurvey }) {
   const question = survey.spec.find((q) => q.variable === questionVariable);
 
   if (!question) {
-    return (
-      <Navigate
-        to={`/templates/${match.params.templateType}/${match.params.id}/survey`}
-      />
-    );
+    return <Navigate to={surveyUrl} />;
   }
 
   const navigateToList = () => {
-    const index = match.url.indexOf('/edit');
-    navigate(match.url.substr(0, index));
+    navigate(surveyUrl);
   };
 
   const handleSubmit = async (formData) => {

--- a/awx/ui/src/screens/Template/Survey/SurveyToolbar.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyToolbar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useLingui } from '@lingui/react/macro';
 
 import styled from 'styled-components';
@@ -36,7 +36,8 @@ function SurveyToolbar({
 }) {
   const { t } = useLingui();
   isDeleteDisabled = !canEdit || isDeleteDisabled;
-  const match = useRouteMatch();
+  const { pathname } = useLocation();
+  const surveyUrl = `${pathname.substr(0, pathname.indexOf('survey'))}survey`;
   return (
     <Toolbar id="survey-toolbar" ouiaId="survey-toolbar">
       <ToolbarContent>
@@ -56,7 +57,7 @@ function SurveyToolbar({
           <ToolbarItem>
             <ToolbarAddButton
               isDisabled={!canEdit}
-              linkTo={`${match.url}/add`}
+              linkTo={`${surveyUrl}/add`}
             />
           </ToolbarItem>
           {canEdit && onOpenOrderModal && (

--- a/awx/ui/src/screens/Template/Template.js
+++ b/awx/ui/src/screens/Template/Template.js
@@ -3,15 +3,8 @@ import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
-import {
-  Switch,
-  Route,
-  Redirect,
-  Link,
-  useLocation,
-  useParams,
-  useRouteMatch,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import RoutedTabs from 'components/RoutedTabs';
 import { useConfig } from 'contexts/Config';
 import useRequest from 'hooks/useRequest';
@@ -26,9 +19,9 @@ import JobTemplateEdit from './JobTemplateEdit';
 import TemplateSurvey from './TemplateSurvey';
 
 function Template({ setBreadcrumb }) {
-  const match = useRouteMatch();
   const location = useLocation();
   const { id: templateId } = useParams();
+  const baseUrl = `/templates/job_template/${templateId}`;
   const { me = {} } = useConfig();
   const { t } = useLingui();
 
@@ -133,34 +126,34 @@ function Template({ setBreadcrumb }) {
       persistentFilterKey: 'templates',
       id: 99,
     },
-    { name: t`Details`, link: `${match.url}/details` },
-    { name: t`Access`, link: `${match.url}/access` },
+    { name: t`Details`, link: `${baseUrl}/details` },
+    { name: t`Access`, link: `${baseUrl}/access` },
   ];
 
   if (canSeeNotificationsTab) {
     tabsArray.push({
       name: t`Notifications`,
-      link: `${match.url}/notifications`,
+      link: `${baseUrl}/notifications`,
     });
   }
 
   if (template) {
     tabsArray.push({
       name: t`Schedules`,
-      link: `${match.url}/schedules`,
+      link: `${baseUrl}/schedules`,
     });
   }
 
   tabsArray.push(
     {
       name: t`Jobs`,
-      link: `${match.url}/jobs`,
+      link: `${baseUrl}/jobs`,
     },
     {
       name: canAddAndEditSurvey
         ? t`Survey`
         : t`View Survey`,
-      link: `${match.url}/survey`,
+      link: `${baseUrl}/survey`,
     }
   );
 
@@ -196,77 +189,93 @@ function Template({ setBreadcrumb }) {
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
         {template && (
-          <Switch>
-            <Redirect
-              from="/templates/:templateType/:id"
-              to="/templates/:templateType/:id/details"
-              exact
-            />
-            <Route key="details" path="/templates/:templateType/:id/details">
-              <JobTemplateDetail
-                hasTemplateLoading={isLoading}
-                template={template}
-              />
-            </Route>
-            <Route key="edit" path="/templates/:templateType/:id/edit">
-              <JobTemplateEdit
-                template={template}
-                reloadTemplate={loadTemplateAndRoles}
-              />
-            </Route>
-            <Route key="access" path="/templates/:templateType/:id/access">
-              <ResourceAccessList
-                resource={template}
-                apiModel={JobTemplatesAPI}
-              />
-            </Route>
+          <Routes>
             <Route
-              key="schedules"
-              path="/templates/:templateType/:id/schedules"
-            >
-              <Schedules
-                apiModel={JobTemplatesAPI}
-                setBreadcrumb={setBreadcrumb}
-                resource={template}
-                loadSchedules={loadSchedules}
-                loadScheduleOptions={loadScheduleOptions}
-                surveyConfig={surveyConfig}
-                launchConfig={launchConfig}
-                resourceDefaultCredentials={resourceDefaultCredentials}
-              />
-            </Route>
-            {canSeeNotificationsTab && (
-              <Route path="/templates/:templateType/:id/notifications">
-                <NotificationList
-                  id={Number(templateId)}
-                  canToggleNotifications={isNotifAdmin}
+              path="/templates/:templateType/:id/details"
+              element={
+                <JobTemplateDetail
+                  hasTemplateLoading={isLoading}
+                  template={template}
+                />
+              }
+            />
+            <Route
+              path="/templates/:templateType/:id/edit"
+              element={
+                <JobTemplateEdit
+                  template={template}
+                  reloadTemplate={loadTemplateAndRoles}
+                />
+              }
+            />
+            <Route
+              path="/templates/:templateType/:id/access"
+              element={
+                <ResourceAccessList
+                  resource={template}
                   apiModel={JobTemplatesAPI}
                 />
-              </Route>
-            )}
-            <Route path="/templates/:templateType/:id/jobs">
-              <JobList defaultParams={{ job__job_template: template.id }} />
-            </Route>
-            <Route path="/templates/:templateType/:id/survey">
-              <TemplateSurvey
-                template={template}
-                canEdit={canAddAndEditSurvey}
+              }
+            />
+            <Route
+              path="/templates/:templateType/:id/schedules/*"
+              element={
+                <Schedules
+                  apiModel={JobTemplatesAPI}
+                  setBreadcrumb={setBreadcrumb}
+                  resource={template}
+                  loadSchedules={loadSchedules}
+                  loadScheduleOptions={loadScheduleOptions}
+                  surveyConfig={surveyConfig}
+                  launchConfig={launchConfig}
+                  resourceDefaultCredentials={resourceDefaultCredentials}
+                />
+              }
+            />
+            {canSeeNotificationsTab && (
+              <Route
+                path="/templates/:templateType/:id/notifications"
+                element={
+                  <NotificationList
+                    id={Number(templateId)}
+                    canToggleNotifications={isNotifAdmin}
+                    apiModel={JobTemplatesAPI}
+                  />
+                }
               />
-            </Route>
-            {!isLoading && (
-              <Route key="not-found" path="*">
+            )}
+            <Route
+              path="/templates/:templateType/:id/jobs"
+              element={
+                <JobList defaultParams={{ job__job_template: template.id }} />
+              }
+            />
+            <Route
+              path="/templates/:templateType/:id/survey/*"
+              element={
+                <TemplateSurvey
+                  template={template}
+                  canEdit={canAddAndEditSurvey}
+                />
+              }
+            />
+            <Route
+              path="/templates/:templateType/:id"
+              element={<Navigate to={`${baseUrl}/details`} replace />}
+            />
+            <Route
+              path="*"
+              element={
                 <ContentError isNotFound>
-                  {match.params.id && (
-                    <Link
-                      to={`/templates/${match?.params?.templateType}/${templateId}/details`}
-                    >
+                  {templateId && (
+                    <Link to={`${baseUrl}/details`}>
                       {t`View Template Details`}
                     </Link>
                   )}
                 </ContentError>
-              </Route>
-            )}
-          </Switch>
+              }
+            />
+          </Routes>
         )}
       </Card>
     </PageSection>

--- a/awx/ui/src/screens/Template/TemplateSurvey.js
+++ b/awx/ui/src/screens/Template/TemplateSurvey.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { JobTemplatesAPI, WorkflowJobTemplatesAPI } from 'api';
 import ContentError from 'components/ContentError';
@@ -12,8 +12,6 @@ function TemplateSurvey({ template, canEdit }) {
   const { t } = useLingui();
   const [surveyEnabled, setSurveyEnabled] = useState(template.survey_enabled);
 
-  const { pathname } = useLocation();
-  const surveyUrl = `${pathname.substr(0, pathname.indexOf('survey'))}survey`;
   const templateType = template.type;
   const templateId = template.id;
 
@@ -100,7 +98,7 @@ function TemplateSurvey({ template, canEdit }) {
       <Routes>
         {canEdit && (
           <Route
-            path={`${surveyUrl}/add`}
+            path="add"
             element={
               <SurveyQuestionAdd survey={survey} updateSurvey={updateSurveySpec} />
             }
@@ -108,7 +106,7 @@ function TemplateSurvey({ template, canEdit }) {
         )}
         {canEdit && (
           <Route
-            path={`${surveyUrl}/edit`}
+            path="edit"
             element={
               <SurveyQuestionEdit
                 survey={survey}
@@ -118,7 +116,7 @@ function TemplateSurvey({ template, canEdit }) {
           />
         )}
         <Route
-          path={surveyUrl}
+          index
           element={
             <SurveyList
               isLoading={isLoading || updateLoading}

--- a/awx/ui/src/screens/Template/TemplateSurvey.js
+++ b/awx/ui/src/screens/Template/TemplateSurvey.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Switch, Route, useParams } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import { JobTemplatesAPI, WorkflowJobTemplatesAPI } from 'api';
 import ContentError from 'components/ContentError';
@@ -12,7 +12,10 @@ function TemplateSurvey({ template, canEdit }) {
   const { t } = useLingui();
   const [surveyEnabled, setSurveyEnabled] = useState(template.survey_enabled);
 
-  const { templateType, id: templateId } = useParams();
+  const { pathname } = useLocation();
+  const surveyUrl = `${pathname.substr(0, pathname.indexOf('survey'))}survey`;
+  const templateType = template.type;
+  const templateId = template.id;
 
   const {
     result: survey,
@@ -94,35 +97,41 @@ function TemplateSurvey({ template, canEdit }) {
   }
   return (
     <>
-      <Switch>
+      <Routes>
         {canEdit && (
-          <Route path="/templates/:templateType/:id/survey/add">
-            <SurveyQuestionAdd
-              survey={survey}
-              updateSurvey={updateSurveySpec}
-            />
-          </Route>
-        )}
-        {canEdit && (
-          <Route path="/templates/:templateType/:id/survey/edit">
-            <SurveyQuestionEdit
-              survey={survey}
-              updateSurvey={updateSurveySpec}
-            />
-          </Route>
-        )}
-        <Route path="/templates/:templateType/:id/survey" exact>
-          <SurveyList
-            isLoading={isLoading || updateLoading}
-            survey={survey}
-            surveyEnabled={surveyEnabled}
-            toggleSurvey={toggleSurvey}
-            updateSurvey={updateSurveySpec}
-            deleteSurvey={deleteSurvey}
-            canEdit={canEdit}
+          <Route
+            path={`${surveyUrl}/add`}
+            element={
+              <SurveyQuestionAdd survey={survey} updateSurvey={updateSurveySpec} />
+            }
           />
-        </Route>
-      </Switch>
+        )}
+        {canEdit && (
+          <Route
+            path={`${surveyUrl}/edit`}
+            element={
+              <SurveyQuestionEdit
+                survey={survey}
+                updateSurvey={updateSurveySpec}
+              />
+            }
+          />
+        )}
+        <Route
+          path={surveyUrl}
+          element={
+            <SurveyList
+              isLoading={isLoading || updateLoading}
+              survey={survey}
+              surveyEnabled={surveyEnabled}
+              toggleSurvey={toggleSurvey}
+              updateSurvey={updateSurveySpec}
+              deleteSurvey={deleteSurvey}
+              canEdit={canEdit}
+            />
+          }
+        />
+      </Routes>
       {error && (
         <AlertModal
           isOpen={error}

--- a/awx/ui/src/screens/Template/TemplateSurvey.test.js
+++ b/awx/ui/src/screens/Template/TemplateSurvey.test.js
@@ -57,7 +57,7 @@ describe('<TemplateSurvey />', () => {
       );
     });
     wrapper.update();
-    expect(JobTemplatesAPI.readSurvey).toHaveBeenCalledWith('7');
+    expect(JobTemplatesAPI.readSurvey).toHaveBeenCalledWith(7);
 
     expect(wrapper.find('SurveyList').prop('survey')).toEqual(surveyData);
   });
@@ -127,7 +127,7 @@ describe('<TemplateSurvey />', () => {
         { question_name: 'Bar', type: 'text', default: 'Two', variable: 'bar' },
       ]);
     });
-    expect(JobTemplatesAPI.updateSurvey).toHaveBeenCalledWith('7', {
+    expect(JobTemplatesAPI.updateSurvey).toHaveBeenCalledWith(7, {
       name: 'Survey',
       description: 'description for survey',
       spec: [
@@ -168,7 +168,7 @@ describe('<TemplateSurvey />', () => {
     );
     wrapper.update();
 
-    expect(JobTemplatesAPI.update).toHaveBeenCalledWith('7', {
+    expect(JobTemplatesAPI.update).toHaveBeenCalledWith(7, {
       survey_enabled: false,
     });
   });
@@ -209,7 +209,7 @@ describe('<TemplateSurvey />', () => {
     );
 
     wrapper.update();
-    expect(WorkflowJobTemplatesAPI.update).toHaveBeenCalledWith('15', {
+    expect(WorkflowJobTemplatesAPI.update).toHaveBeenCalledWith(15, {
       survey_enabled: false,
     });
   });
@@ -253,7 +253,7 @@ describe('<TemplateSurvey />', () => {
       wrapper.find('Button[ouiaId="delete-confirm-button"]').simulate('click')
     );
     wrapper.update();
-    expect(JobTemplatesAPI.destroySurvey).toHaveBeenCalledWith('15');
+    expect(JobTemplatesAPI.destroySurvey).toHaveBeenCalledWith(7);
     expect(WorkflowJobTemplatesAPI.destroySurvey).toHaveBeenCalledTimes(0);
   });
 
@@ -296,7 +296,7 @@ describe('<TemplateSurvey />', () => {
       wrapper.find('Button[ouiaId="delete-confirm-button"]').simulate('click')
     );
     wrapper.update();
-    expect(WorkflowJobTemplatesAPI.destroySurvey).toHaveBeenCalledWith('15');
+    expect(WorkflowJobTemplatesAPI.destroySurvey).toHaveBeenCalledWith(15);
     expect(JobTemplatesAPI.destroySurvey).toHaveBeenCalledTimes(0);
   });
 });

--- a/awx/ui/src/screens/Template/TemplateSurvey.test.js
+++ b/awx/ui/src/screens/Template/TemplateSurvey.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { createMemoryHistory } from 'history';
 import { JobTemplatesAPI, WorkflowJobTemplatesAPI } from 'api';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
@@ -20,6 +20,25 @@ const surveyData = {
   ],
 };
 
+// TemplateSurvey is a v6 descendant screen mounted by Template at
+// `.../:id/survey/*`, so mount it under the same real v6 route here (its child
+// routes are relative; the SurveyList is the index route). The template id used
+// by the API comes from the `template` prop, not the route param.
+async function mountSurvey(url, element) {
+  const history = createMemoryHistory({ initialEntries: [url] });
+  let wrapper;
+  await act(async () => {
+    wrapper = mountWithContexts(
+      <Routes>
+        <Route path="/templates/:templateType/:id/survey/*" element={element} />
+      </Routes>,
+      { context: { router: { history } } }
+    );
+  });
+  wrapper.update();
+  return wrapper;
+}
+
 describe('<TemplateSurvey />', () => {
   beforeEach(() => {
     JobTemplatesAPI.readSurvey.mockResolvedValue({
@@ -32,94 +51,28 @@ describe('<TemplateSurvey />', () => {
   });
 
   test('should fetch survey from API', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/7/survey'],
-    });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/templates/:templateType/:id/survey">
-          <TemplateSurvey template={mockJobTemplateData} canEdit />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { templateType: 'job_template', id: 7 },
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    wrapper.update();
+    const wrapper = await mountSurvey(
+      '/templates/job_template/7/survey',
+      <TemplateSurvey template={mockJobTemplateData} canEdit />
+    );
     expect(JobTemplatesAPI.readSurvey).toHaveBeenCalledWith(7);
-
     expect(wrapper.find('SurveyList').prop('survey')).toEqual(surveyData);
   });
 
   test('should display error in retrieving survey', async () => {
     JobTemplatesAPI.readSurvey.mockRejectedValue(new Error());
-    let wrapper;
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/7/survey'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/templates/:templateType/:id/survey">
-          <TemplateSurvey template={{ ...mockJobTemplateData, id: 'a' }} />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { templateType: 'job_template', id: 7 },
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-
-    wrapper.update();
-
+    const wrapper = await mountSurvey(
+      '/templates/job_template/7/survey',
+      <TemplateSurvey template={{ ...mockJobTemplateData, id: 'a' }} />
+    );
     expect(wrapper.find('ContentError').length).toBe(1);
   });
 
   test('should update API with survey changes', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/7/survey'],
-    });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/templates/:templateType/:id/survey">
-          <TemplateSurvey template={mockJobTemplateData} canEdit />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { templateType: 'job_template', id: 7 },
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    wrapper.update();
+    const wrapper = await mountSurvey(
+      '/templates/job_template/7/survey',
+      <TemplateSurvey template={mockJobTemplateData} canEdit />
+    );
 
     await act(async () => {
       await wrapper.find('SurveyList').invoke('updateSurvey')([
@@ -138,31 +91,10 @@ describe('<TemplateSurvey />', () => {
   });
 
   test('should toggle jt survery on', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/7/survey'],
-    });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/templates/:templateType/:id/survey">
-          <TemplateSurvey template={mockJobTemplateData} canEdit />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { templateType: 'job_template', id: 7 },
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    wrapper.update();
+    const wrapper = await mountSurvey(
+      '/templates/job_template/7/survey',
+      <TemplateSurvey template={mockJobTemplateData} canEdit />
+    );
     await act(() =>
       wrapper.find('Switch[aria-label="Survey Toggle"]').prop('onChange')()
     );
@@ -174,77 +106,29 @@ describe('<TemplateSurvey />', () => {
   });
 
   test('should toggle wfjt survey on', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/workflow_job_template/15/survey'],
-    });
-
     WorkflowJobTemplatesAPI.readSurvey.mockResolvedValueOnce({
       data: surveyData,
     });
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/templates/:templateType/:id/survey">
-          <TemplateSurvey template={mockWorkflowJobTemplateData} canEdit />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { templateType: 'workflow_job_template', id: 15 },
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    wrapper.update();
+    const wrapper = await mountSurvey(
+      '/templates/workflow_job_template/15/survey',
+      <TemplateSurvey template={mockWorkflowJobTemplateData} canEdit />
+    );
     await act(() =>
       wrapper.find('Switch[aria-label="Survey Toggle"]').prop('onChange')()
     );
 
     wrapper.update();
-    expect(WorkflowJobTemplatesAPI.update).toHaveBeenCalledWith(15, {
-      survey_enabled: false,
-    });
+    expect(WorkflowJobTemplatesAPI.update).toHaveBeenCalledWith(15, { survey_enabled: false });
   });
 
   test('should successfully delete jt survey', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/7/survey'],
-    });
-
     JobTemplatesAPI.readSurvey.mockResolvedValueOnce({
       data: surveyData,
     });
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/templates/:templateType/:id/survey">
-          <TemplateSurvey template={mockJobTemplateData} canEdit />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { templateType: 'job_template', id: 15 },
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    wrapper.update();
+    const wrapper = await mountSurvey(
+      '/templates/job_template/7/survey',
+      <TemplateSurvey template={mockJobTemplateData} canEdit />
+    );
     act(() => wrapper.find('Checkbox#select-all').invoke('onChange')(true));
     wrapper.update();
     wrapper.find('Button[ouiaId="survey-delete-button"]').simulate('click');
@@ -258,36 +142,13 @@ describe('<TemplateSurvey />', () => {
   });
 
   test('should successfully delete wfjt survey', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/workflow_job_template/15/survey'],
-    });
-
     WorkflowJobTemplatesAPI.readSurvey.mockResolvedValueOnce({
       data: surveyData,
     });
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/templates/:templateType/:id/survey">
-          <TemplateSurvey template={mockWorkflowJobTemplateData} canEdit />
-        </Route>,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { templateType: 'workflow_job_template', id: 15 },
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    wrapper.update();
+    const wrapper = await mountSurvey(
+      '/templates/workflow_job_template/15/survey',
+      <TemplateSurvey template={mockWorkflowJobTemplateData} canEdit />
+    );
     act(() => wrapper.find('Checkbox#select-all').invoke('onChange')(true));
     wrapper.update();
     wrapper.find('Button[ouiaId="survey-delete-button"]').simulate('click');

--- a/awx/ui/src/screens/Template/TemplateSurvey.test.js
+++ b/awx/ui/src/screens/Template/TemplateSurvey.test.js
@@ -216,7 +216,7 @@ describe('<TemplateSurvey />', () => {
 
   test('should successfully delete jt survey', async () => {
     const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/15/survey'],
+      initialEntries: ['/templates/job_template/7/survey'],
     });
 
     JobTemplatesAPI.readSurvey.mockResolvedValueOnce({

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.js
@@ -3,15 +3,8 @@ import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
-import {
-  Switch,
-  Route,
-  Redirect,
-  Link,
-  useLocation,
-  useParams,
-  useRouteMatch,
-} from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
 import RoutedTabs from 'components/RoutedTabs';
 import { useConfig } from 'contexts/Config';
 import useRequest from 'hooks/useRequest';
@@ -32,8 +25,8 @@ import { Visualizer } from './WorkflowJobTemplateVisualizer';
 function WorkflowJobTemplate({ setBreadcrumb }) {
   const { t } = useLingui();
   const location = useLocation();
-  const match = useRouteMatch();
   const { id: templateId } = useParams();
+  const baseUrl = `/templates/workflow_job_template/${templateId}`;
   const { me = {} } = useConfig();
 
   const {
@@ -114,38 +107,38 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
       persistentFilterKey: 'templates',
       id: 99,
     },
-    { name: t`Details`, link: `${match.url}/details` },
-    { name: t`Access`, link: `${match.url}/access` },
+    { name: t`Details`, link: `${baseUrl}/details` },
+    { name: t`Access`, link: `${baseUrl}/access` },
   ];
 
   if (canSeeNotificationsTab) {
     tabsArray.push({
       name: t`Notifications`,
-      link: `${match.url}/notifications`,
+      link: `${baseUrl}/notifications`,
     });
   }
 
   if (template) {
     tabsArray.push({
       name: t`Schedules`,
-      link: `${match.url}/schedules`,
+      link: `${baseUrl}/schedules`,
     });
   }
 
   tabsArray.push(
     {
       name: t`Visualizer`,
-      link: `${match.url}/visualizer`,
+      link: `${baseUrl}/visualizer`,
     },
     {
       name: t`Jobs`,
-      link: `${match.url}/jobs`,
+      link: `${baseUrl}/jobs`,
     },
     {
       name: canAddAndEditSurvey
         ? t`Survey`
         : t`View Survey`,
-      link: `${match.url}/survey`,
+      link: `${baseUrl}/survey`,
     }
   );
 
@@ -188,99 +181,115 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
     <PageSection>
       <Card>
         {showCardHeader && <RoutedTabs tabsArray={tabsArray} />}
-        <Switch>
-          <Redirect
-            from="/templates/:templateType/:id"
-            to="/templates/:templateType/:id/details"
-            exact
-          />
+        <Routes>
           {template && (
-            <Route key="details" path="/templates/:templateType/:id/details">
-              <WorkflowJobTemplateDetail template={template} />
-            </Route>
-          )}
-          {template && (
-            <Route key="edit" path="/templates/:templateType/:id/edit">
-              <WorkflowJobTemplateEdit template={template} />
-            </Route>
-          )}
-          {template && (
-            <Route key="access" path="/templates/:templateType/:id/access">
-              <ResourceAccessList
-                resource={template}
-                apiModel={WorkflowJobTemplatesAPI}
-              />
-            </Route>
+            <Route
+              path="/templates/:templateType/:id/details"
+              element={<WorkflowJobTemplateDetail template={template} />}
+            />
           )}
           {template && (
             <Route
-              key="schedules"
-              path="/templates/:templateType/:id/schedules"
-            >
-              <Schedules
-                apiModel={WorkflowJobTemplatesAPI}
-                setBreadcrumb={setBreadcrumb}
-                resource={template}
-                loadSchedules={loadSchedules}
-                loadScheduleOptions={loadScheduleOptions}
-                surveyConfig={surveyConfig}
-                launchConfig={launchConfig}
-              />
-            </Route>
+              path="/templates/:templateType/:id/edit"
+              element={<WorkflowJobTemplateEdit template={template} />}
+            />
+          )}
+          {template && (
+            <Route
+              path="/templates/:templateType/:id/access"
+              element={
+                <ResourceAccessList
+                  resource={template}
+                  apiModel={WorkflowJobTemplatesAPI}
+                />
+              }
+            />
+          )}
+          {template && (
+            <Route
+              path="/templates/:templateType/:id/schedules/*"
+              element={
+                <Schedules
+                  apiModel={WorkflowJobTemplatesAPI}
+                  setBreadcrumb={setBreadcrumb}
+                  resource={template}
+                  loadSchedules={loadSchedules}
+                  loadScheduleOptions={loadScheduleOptions}
+                  surveyConfig={surveyConfig}
+                  launchConfig={launchConfig}
+                />
+              }
+            />
           )}
           {canSeeNotificationsTab && (
-            <Route path="/templates/:templateType/:id/notifications">
-              <NotificationList
-                id={Number(templateId)}
-                canToggleNotifications={isNotifAdmin}
-                apiModel={WorkflowJobTemplatesAPI}
-                showApprovalsToggle
-              />
-            </Route>
+            <Route
+              path="/templates/:templateType/:id/notifications"
+              element={
+                <NotificationList
+                  id={Number(templateId)}
+                  canToggleNotifications={isNotifAdmin}
+                  apiModel={WorkflowJobTemplatesAPI}
+                  showApprovalsToggle
+                />
+              }
+            />
           )}
           {template && (
             <Route
-              key="wfjt-visualizer"
               path="/templates/workflow_job_template/:id/visualizer"
-            >
-              <AppendBody>
-                <FullPage>
-                  <Visualizer template={template} />
-                </FullPage>
-              </AppendBody>
-            </Route>
+              element={
+                <AppendBody>
+                  <FullPage>
+                    <Visualizer template={template} />
+                  </FullPage>
+                </AppendBody>
+              }
+            />
           )}
           {template?.id && (
-            <Route path="/templates/:templateType/:id/jobs">
-              <JobList
-                defaultParams={{
-                  workflow_job__workflow_job_template: template.id,
-                }}
-              />
-            </Route>
+            <Route
+              path="/templates/:templateType/:id/jobs"
+              element={
+                <JobList
+                  defaultParams={{
+                    workflow_job__workflow_job_template: template.id,
+                  }}
+                />
+              }
+            />
           )}
           {template && (
-            <Route path="/templates/:templateType/:id/survey">
-              <TemplateSurvey
-                template={template}
-                canEdit={canAddAndEditSurvey}
-              />
-            </Route>
+            <Route
+              path="/templates/:templateType/:id/survey/*"
+              element={
+                <TemplateSurvey
+                  template={template}
+                  canEdit={canAddAndEditSurvey}
+                />
+              }
+            />
+          )}
+          {template && (
+            <Route
+              path="/templates/:templateType/:id"
+              element={<Navigate to={`${baseUrl}/details`} replace />}
+            />
           )}
           {!hasRolesandTemplateLoading && (
-            <Route key="not-found" path="*">
-              <ContentError isNotFound>
-                {match.params.id && (
-                  <Link
-                    to={`/templates/${match.params.templateType}/${match.params.id}/details`}
-                  >
-                    {t`View Template Details`}
-                  </Link>
-                )}
-              </ContentError>
-            </Route>
+            <Route
+              path="*"
+              element={
+                <ContentError isNotFound>
+                  {templateId && (
+                    <Link to={`${baseUrl}/details`}>
+                      {t`View Template Details`}
+                    </Link>
+                  )}
+                </ContentError>
+              }
+            />
           )}
-        </Switch>
+        </Routes>
       </Card>
     </PageSection>
   );


### PR DESCRIPTION
##### SUMMARY

Converts the **Template**, **WorkflowJobTemplate** and **TemplateSurvey** route trees from react-router v5 to v6, finishing the react-router v6 migration for the Templates screen (`react-router-dom-v5-compat` bridge). These are the last remaining `<Switch>` screens.

- `<Switch>`/`<Route>`/`<Redirect>` -> `<Routes>`/`<Route>`/`<Navigate>` in Template.js, WorkflowJobTemplate.js and TemplateSurvey.js.
- Template / WorkflowJobTemplate keep the `:templateType/:id` route patterns so the matched params reach descendants through the compat layer. The exact `<Redirect>` to the details tab becomes an index `<Route>` + `<Navigate replace>`.
- The schedules and survey tabs delegate to the shared v6 `<Schedules>` and `<TemplateSurvey>` components, mounted with a trailing `/*` so their nested route trees match.
- `TemplateSurvey` derives its base path from the location and reads the template type/id from the `template` prop, so it no longer depends on the parent router. Its own `<Switch>` becomes `<Routes>`.
- The Survey toolbar/add/edit helpers derive their base path from the location instead of `useRouteMatch` (which returns `/` under a v6 parent).
- `JobTemplateDetail` reads its route params from `react-router-dom-v5-compat` so the id resolves under the converted parent.
- The Template not-found route is no longer gated on the loading flag, avoiding a transient render where no route matches the current location.
- `Templates.js` (the list/add dispatcher) stays on v5, matching the pattern used for the other dispatchers (Projects.js, InventorySources.js).

##### DEPENDENCY

Stacked on #422 (the v6 `<Schedules>`/`<Schedule>` conversion). The diff includes those two shared files; once #422 merges this will rebase cleanly.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

