### PR TITLE
Remove old eslink-disable that is now not needed

### DIFF
--- a/awx/ui/src/components/StatusLabel/StatusLabel.js
+++ b/awx/ui/src/components/StatusLabel/StatusLabel.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-useless-fragment */
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { oneOf } from 'prop-types';


### PR DESCRIPTION
It now throws a warning with this being there since we upgraded eslint.