### PR TITLE
Fix issue with project sync locks

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -411,11 +411,14 @@ class BaseTask(object):
             self.instance.refresh_from_db(fields=['cancel_flag'])
             if self.instance.cancel_flag or signal_callback():
                 logger.debug(f"Unified job {self.instance.id} was canceled while waiting for project file lock")
-                return
+                os.close(self.lock_fd)
+                self.lock_fd = None
+                return False
         waiting_time = time.time() - start_time
 
         if waiting_time > 1.0:
             logger.info(f'Job {unified_job_id} waited {waiting_time} to acquire lock for local source tree for path {lock_path}.')
+        return True
 
     def pre_run_hook(self, instance, private_data_dir):
         """
@@ -770,7 +773,12 @@ class SourceControlMixin(BaseTask):
             RunProjectUpdate.make_local_copy(project, private_data_dir)
 
     def sync_and_copy(self, project, private_data_dir, scm_branch=None):
-        self.acquire_lock(project, self.instance.id)
+        lock_acquired = self.acquire_lock(project, self.instance.id)
+        if not lock_acquired:
+            self.instance.refresh_from_db()
+            if self.instance.cancel_flag:
+                return
+            raise RuntimeError(f'Could not acquire lock for project {project.id}, job was interrupted')
         is_commit = False
         try:
             original_branch = None
@@ -1331,7 +1339,9 @@ class RunProjectUpdate(BaseTask):
         project_path = instance.project.get_project_path(check_if_exists=False)
 
         if instance.launch_type != 'sync':
-            self.acquire_lock(instance.project, instance.id)
+            lock_acquired = self.acquire_lock(instance.project, instance.id)
+            if not lock_acquired:
+                raise RuntimeError(f'Could not acquire lock for project {instance.project.id}, job was interrupted')
 
         if not os.path.exists(project_path):
             os.makedirs(project_path)  # used as container mount

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1428,7 +1428,7 @@ class RunProjectUpdate(BaseTask):
                     # copy project folder before resetting to default branch
                     self.make_local_copy(instance, self.job_private_data_dir)
         finally:
-            if instance.launch_type != 'sync':
+            if instance.launch_type != 'sync' and self.lock_fd is not None:
                 self.release_lock(instance.project)
 
         p = instance.project

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1904,6 +1904,132 @@ def test_acquire_lock_acquisition_fail_logged(fcntl_lockf, logger, os_close, os_
     logger.error.assert_called_with("I/O error({0}) while trying to acquire lock on file [{1}]: {2}".format(3, 'this_file_does_not_exist', 'dummy message'))
 
 
+@mock.patch('os.open')
+@mock.patch('os.close')
+@mock.patch('fcntl.lockf')
+def test_acquire_lock_returns_false_on_cancel(fcntl_lockf, os_close, os_open, mock_me):
+    """acquire_lock returns False and cleans up fd when cancel_flag is set while waiting."""
+    import errno
+
+    err = IOError()
+    err.errno = errno.EAGAIN
+    err.strerror = 'Resource temporarily unavailable'
+
+    os_open.return_value = 3
+    fcntl_lockf.side_effect = err
+
+    task = jobs.RunProjectUpdate()
+    instance = mock.Mock()
+    instance.get_lock_file.return_value = '/tmp/test.lock'
+    instance.cancel_flag = True
+    instance.id = 42
+    task.instance = instance
+
+    result = task.acquire_lock(instance)
+    assert result is False
+    assert task.lock_fd is None
+    os_close.assert_called_with(3)
+
+
+@mock.patch('os.open')
+@mock.patch('os.close')
+@mock.patch('fcntl.lockf')
+@mock.patch('awx.main.tasks.jobs.signal_callback', return_value=True)
+def test_acquire_lock_returns_false_on_signal(signal_cb, fcntl_lockf, os_close, os_open, mock_me):
+    """acquire_lock returns False and cleans up fd when signal_callback returns True."""
+    import errno
+
+    err = IOError()
+    err.errno = errno.EAGAIN
+    err.strerror = 'Resource temporarily unavailable'
+
+    os_open.return_value = 5
+    fcntl_lockf.side_effect = err
+
+    task = jobs.RunProjectUpdate()
+    instance = mock.Mock()
+    instance.get_lock_file.return_value = '/tmp/test.lock'
+    instance.cancel_flag = False
+    instance.id = 99
+    task.instance = instance
+
+    result = task.acquire_lock(instance)
+    assert result is False
+    assert task.lock_fd is None
+    os_close.assert_called_with(5)
+
+
+@mock.patch('os.open')
+@mock.patch('os.close')
+@mock.patch('fcntl.lockf')
+def test_acquire_lock_returns_true_on_success(fcntl_lockf, os_close, os_open, mock_me):
+    """acquire_lock returns True when lock is acquired successfully."""
+    os_open.return_value = 7
+    # lockf succeeds (no exception)
+    fcntl_lockf.return_value = None
+
+    task = jobs.RunProjectUpdate()
+    instance = mock.Mock()
+    instance.get_lock_file.return_value = '/tmp/test.lock'
+    task.instance = instance
+
+    result = task.acquire_lock(instance)
+    assert result is True
+    assert task.lock_fd == 7
+
+
+def test_sync_and_copy_returns_on_cancel(mock_me):
+    """sync_and_copy returns gracefully when acquire_lock fails due to cancel."""
+    task = jobs.RunJob()
+    task.instance = mock.Mock()
+    task.instance.id = 1
+    task.instance.cancel_flag = True
+
+    project = mock.Mock()
+    project.id = 10
+
+    with mock.patch.object(task, 'acquire_lock', return_value=False):
+        # Should return without raising
+        result = task.sync_and_copy(project, '/tmp/pdd')
+        assert result is None
+
+
+def test_sync_and_copy_raises_on_signal_interrupt(mock_me):
+    """sync_and_copy raises RuntimeError when acquire_lock fails due to signal (not cancel)."""
+    task = jobs.RunJob()
+    task.instance = mock.Mock()
+    task.instance.id = 1
+    task.instance.cancel_flag = False
+
+    project = mock.Mock()
+    project.id = 10
+
+    with mock.patch.object(task, 'acquire_lock', return_value=False):
+        with pytest.raises(RuntimeError, match='Could not acquire lock for project 10'):
+            task.sync_and_copy(project, '/tmp/pdd')
+
+
+def test_project_update_post_run_hook_skips_release_when_no_lock(mock_me):
+    """post_run_hook does not call release_lock when lock_fd is None (lock was never acquired)."""
+    task = jobs.RunProjectUpdate()
+    task.lock_fd = None
+    task.runner_callback = mock.Mock()
+    task.runner_callback.playbook_new_revision = None
+    task.job_private_data_dir = None
+
+    instance = mock.Mock()
+    instance.launch_type = 'manual'
+    instance.job_type = 'run'
+    instance.job_tags = ''
+    instance.get_cache_path.return_value = '/tmp/nonexistent_cache_path'
+
+    with mock.patch('os.path.exists', return_value=False):
+        task.post_run_hook(instance, 'failed')
+
+    # release_lock should never have been called
+    assert task.lock_fd is None
+
+
 @pytest.mark.parametrize('injector_cls', [cls for cls in ManagedCredentialType.registry.values() if cls.injectors])
 def test_managed_injector_redaction(injector_cls):
     """See awx.main.models.inventory.PluginFileInjector._get_shared_env


### PR DESCRIPTION
I noticed this issue now that Federated jobs are launching multiple concurrent jobs at once.  Sometimes the project sync fails on one of the jobs and would throw this error.

```
Traceback (most recent call last):
  File "/awx_devel/awx/main/tasks/jobs.py", line 500, in run
    self.build_project_dir(self.instance, private_data_dir)
  File "/awx_devel/awx/main/tasks/jobs.py", line 1100, in build_project_dir
    self.sync_and_copy(job.project, private_data_dir, scm_branch=job.scm_branch)
  File "/awx_devel/awx/main/tasks/jobs.py", line 791, in sync_and_copy
    return self.sync_and_copy_without_lock(project, private_data_dir, scm_branch=scm_branch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/tasks/jobs.py", line 747, in sync_and_copy_without_lock
    sync_task.run(local_project_sync.id)
  File "/awx_devel/awx/main/tasks/jobs.py", line 95, in _wrapped
    return f(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/tasks/signals.py", line 80, in _wrapped
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/tasks/jobs.py", line 665, in run
    raise AwxTaskError.TaskError(self.instance, rc)
Exception: project_update 296 (error) encountered an error (rc=None), please see task stdout for details.
```

**The bug**: acquire_lock() in jobs.py:378 had a race condition where it would silently return (without the lock) when a job was canceled or received a signal while waiting for the file lock. The callers (sync_and_copy and RunProjectUpdate.pre_run_hook) never checked whether the lock was actually acquired, so they'd proceed to modify the shared project directory without mutual exclusion — causing the error you saw when 2 jobs ran simultaneously.

**The fix** (3 changes):

acquire_lock now returns a boolean — True if the lock was acquired, False if interrupted. It also properly closes the file descriptor when returning False to avoid leaking it.

sync_and_copy checks the return value — if the lock wasn't acquired and the job was canceled, it returns gracefully; otherwise it raises a RuntimeError to fail the job cleanly.

RunProjectUpdate.pre_run_hook checks the return value — raises RuntimeError if the lock wasn't acquired, preventing the project update from running without the lock.