### PR TITLE
Fix relaunching a sliced job at the Workflow level

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3223,7 +3223,9 @@ class WorkflowJobRelaunch(GenericAPIView):
             jt = obj.job_template
             if not jt:
                 raise ParseError(_('Cannot relaunch slice workflow job orphaned from job template.'))
-            elif not obj.inventory or min(obj.inventory.hosts.count(), jt.job_slice_count) != obj.workflow_nodes.count():
+            elif getattr(obj.inventory, 'kind', None) != 'federated' and (
+                not obj.inventory or min(obj.inventory.hosts.count(), jt.job_slice_count) != obj.workflow_nodes.count()
+            ):
                 raise ParseError(_('Cannot relaunch sliced workflow job after slice count has changed.'))
         if from_failed:
             if not obj.workflow_nodes.filter(job__status__in=['failed', 'error', 'canceled']).exists():

--- a/awx/main/tests/functional/api/test_workflow_job.py
+++ b/awx/main/tests/functional/api/test_workflow_job.py
@@ -1,6 +1,6 @@
 import pytest
 
-
+from awx.main.models import Inventory, WorkflowJobNode
 from awx.api.versioning import reverse
 
 
@@ -36,6 +36,33 @@ def test_workflow_job_relaunch_not_inventory_failure(workflow_job, post, admin_u
     workflow_job.save()
     url = reverse("api:workflow_job_relaunch", kwargs={'pk': workflow_job.pk})
     post(url, user=admin_user, expect=400)
+
+
+@pytest.mark.django_db
+def test_workflow_job_relaunch_federated_inventory(organization, job_template, post, admin_user):
+    """Relaunching a sliced workflow spawned from a federated inventory must not
+    be blocked by the stale-slice-count check (federated inventories have no
+    direct hosts, so hosts.count() is always 0)."""
+    fed_inv = Inventory.objects.create(name='fed-inv', kind='federated', organization=organization)
+    inv_a = Inventory.objects.create(name='inv-a', organization=organization)
+    inv_b = Inventory.objects.create(name='inv-b', organization=organization)
+    inv_a.hosts.create(name='host-a')
+    inv_b.hosts.create(name='host-b')
+    fed_inv.input_inventories.add(inv_a)
+    fed_inv.input_inventories.add(inv_b)
+
+    job_template.inventory = fed_inv
+    job_template.organization = organization
+    job_template.save()
+
+    wfj = job_template.create_unified_job()
+    wfj.status = 'successful'
+    wfj.save()
+    assert wfj.is_sliced_job
+    assert wfj.workflow_nodes.count() == 2
+
+    url = reverse("api:workflow_job_relaunch", kwargs={'pk': wfj.pk})
+    post(url, user=admin_user, expect=201)
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/api/test_workflow_job.py
+++ b/awx/main/tests/functional/api/test_workflow_job.py
@@ -1,6 +1,6 @@
 import pytest
 
-from awx.main.models import Inventory, WorkflowJobNode
+from awx.main.models import Inventory
 from awx.api.versioning import reverse
 
 


### PR DESCRIPTION
This was working before, but recent changes seemed to have broken it
