### PR TITLE
enzyme -> RTL: convert the CredentialType screen suites

### DIFF
--- a/awx/ui/src/screens/CredentialType/CredentialType.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialType.test.js
@@ -58,7 +58,7 @@ describe('<CredentialType />', () => {
   test('fetches the credential type detail', async () => {
     renderAt('/credential_types/42/details');
     expect(await screen.findByText('CredentialTypeDetails')).toBeInTheDocument();
-    // real route params are strings (the old enzyme test mocked a number)
+    // real route params are strings (the previous test mocked a number)
     expect(CredentialTypesAPI.readDetail).toHaveBeenCalledWith('42');
   });
 

--- a/awx/ui/src/screens/CredentialType/CredentialTypeAdd/CredentialTypeAdd.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeAdd/CredentialTypeAdd.test.js
@@ -1,30 +1,21 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor } from '@testing-library/react';
 
 import { CredentialTypesAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import CredentialTypeAdd from './CredentialTypeAdd';
 
 jest.mock('../../../api');
 
-const credentialTypeData = {
+const mockCredentialTypeData = {
   name: 'Foo',
   description: 'Bar',
   kind: 'cloud',
   inputs: JSON.stringify({
     fields: [
-      {
-        id: 'username',
-        type: 'string',
-        label: 'Jenkins username',
-      },
-      {
-        id: 'password',
-        type: 'string',
-        label: 'Jenkins password',
-        secret: true,
-      },
+      { id: 'username', type: 'string', label: 'Jenkins username' },
+      { id: 'password', type: 'string', label: 'Jenkins password', secret: true },
     ],
     required: ['username', 'password'],
   }),
@@ -36,61 +27,66 @@ const credentialTypeData = {
   }),
 };
 
+// The form is exercised on its own in CredentialTypeForm.test.js; here we only
+// care about the container's submit/cancel/error handling, so stub the form
+// with controls that invoke its props.
+jest.mock('../shared/CredentialTypeForm', () =>
+  function MockCredentialTypeForm({ onSubmit, onCancel, submitError }) {
+    return (
+      <div>
+        {submitError ? <div data-testid="form-submit-error" /> : null}
+        <button type="button" onClick={() => onSubmit(mockCredentialTypeData)}>
+          Submit
+        </button>
+        <button type="button" aria-label="Cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  }
+);
+
 describe('<CredentialTypeAdd/>', () => {
-  let wrapper;
   let history;
 
-  beforeEach(async () => {
-    history = createMemoryHistory({
-      initialEntries: ['/credential_types'],
+  const renderAdd = () => {
+    history = createMemoryHistory({ initialEntries: ['/credential_types'] });
+    return renderWithContexts(<CredentialTypeAdd />, {
+      context: { router: { history } },
     });
-    CredentialTypesAPI.create.mockResolvedValue({
-      data: {
-        id: 42,
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialTypeAdd />, {
-        context: { router: { history } },
-      });
-    });
-  });
+  };
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('CredentialTypeForm').prop('onSubmit')(credentialTypeData);
-    });
-    wrapper.update();
-    expect(CredentialTypesAPI.create).toHaveBeenCalledWith({
-      ...credentialTypeData,
-      inputs: JSON.parse(credentialTypeData.inputs),
-      injectors: JSON.parse(credentialTypeData.injectors),
-    });
+    CredentialTypesAPI.create.mockResolvedValue({ data: { id: 42 } });
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(CredentialTypesAPI.create).toHaveBeenCalledWith({
+        ...mockCredentialTypeData,
+        inputs: JSON.parse(mockCredentialTypeData.inputs),
+        injectors: JSON.parse(mockCredentialTypeData.injectors),
+        kind: 'cloud',
+      })
+    );
     expect(history.location.pathname).toBe('/credential_types/42/details');
   });
 
   test('handleCancel should return the user back to the credential types list', async () => {
-    wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/credential_types');
   });
 
   test('failed form submission should show an error message', async () => {
-    const error = {
-      response: {
-        data: { detail: 'An error occurred' },
-      },
-    };
-    CredentialTypesAPI.create.mockImplementationOnce(() =>
-      Promise.reject(error)
-    );
-    await act(async () => {
-      wrapper.find('CredentialTypeForm').invoke('onSubmit')(credentialTypeData);
+    CredentialTypesAPI.create.mockRejectedValue({
+      response: { data: { detail: 'An error occurred' } },
     });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByTestId('form-submit-error')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.test.js
@@ -1,32 +1,25 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 
 import { CredentialTypesAPI, CredentialsAPI } from 'api';
-import { jsonToYaml } from 'util/yaml';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 
 import CredentialTypeDetails from './CredentialTypeDetails';
 
 jest.mock('../../../api');
 
-const credentialTypeData = {
+const makeCredentialType = (overrides = {}) => ({
   name: 'Foo',
   description: 'Bar',
   kind: 'cloud',
   inputs: {
     fields: [
-      {
-        id: 'username',
-        type: 'string',
-        label: 'Jenkins username',
-      },
-      {
-        id: 'password',
-        type: 'string',
-        label: 'Jenkins password',
-        secret: true,
-      },
+      { id: 'username', type: 'string', label: 'Jenkins username' },
+      { id: 'password', type: 'string', label: 'Jenkins password', secret: true },
     ],
     required: ['username', 'password'],
   },
@@ -37,135 +30,103 @@ const credentialTypeData = {
     },
   },
   summary_fields: {
-    created_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    modified_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    user_capabilities: {
-      edit: true,
-      delete: true,
-    },
+    created_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    modified_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    user_capabilities: { edit: true, delete: true },
+    ...(overrides.summary_fields || {}),
   },
   created: '2020-06-25T16:52:36.127008Z',
   modified: '2020-06-25T16:52:36.127022Z',
-};
-
-function expectDetailToMatch(wrapper, label, value) {
-  const detail = wrapper.find(`Detail[label="${label}"]`);
-  expect(detail).toHaveLength(1);
-  expect(detail.prop('value')).toEqual(value);
-}
+  ...overrides,
+});
 
 describe('<CredentialTypeDetails/>', () => {
-  let wrapper;
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   test('should render details properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeDetails credentialType={credentialTypeData} />
-      );
-    });
-    wrapper.update();
-    expectDetailToMatch(wrapper, 'Name', credentialTypeData.name);
-    expectDetailToMatch(wrapper, 'Description', credentialTypeData.description);
-    const dates = wrapper.find('UserDateDetail');
-    expect(dates).toHaveLength(2);
-    expect(dates.at(0).prop('date')).toEqual(credentialTypeData.created);
-    expect(dates.at(1).prop('date')).toEqual(credentialTypeData.modified);
-    const vars = wrapper.find('VariablesDetail');
-    expect(vars).toHaveLength(2);
-
-    expect(vars.at(0).prop('label')).toEqual('Input configuration');
-    expect(vars.at(0).prop('value')).toEqual(
-      jsonToYaml(JSON.stringify(credentialTypeData.inputs))
+    renderWithContexts(
+      <CredentialTypeDetails credentialType={makeCredentialType()} />
     );
-    expect(vars.at(1).prop('label')).toEqual('Injector configuration');
-    expect(vars.at(1).prop('value')).toEqual(
-      jsonToYaml(JSON.stringify(credentialTypeData.injectors))
+    await waitFor(() =>
+      expect(screen.getByText('Name')).toBeInTheDocument()
     );
+    assertDetail('Name', 'Foo');
+    assertDetail('Description', 'Bar');
+    expect(screen.getByText('Created')).toBeInTheDocument();
+    expect(screen.getByText('Last Modified')).toBeInTheDocument();
+    expect(screen.getByText('Input configuration')).toBeInTheDocument();
+    expect(screen.getByText('Injector configuration')).toBeInTheDocument();
   });
 
-  test('should disabled delete and show proper tooltip requests', async () => {
+  test('should disable delete and show proper tooltip when in use', async () => {
     CredentialsAPI.read.mockResolvedValue({ data: { count: 15 } });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeDetails credentialType={credentialTypeData} />
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('DeleteButton').prop('disabledTooltip')).toBe(
-      'This credential type is currently being used by some credentials and cannot be deleted'
+    renderWithContexts(
+      <CredentialTypeDetails credentialType={makeCredentialType()} />
     );
-    expect(wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')).toBe(
-      true
-    );
-    expect(wrapper.find('Tooltip').length).toBe(1);
-    expect(wrapper.find('Tooltip').prop('content')).toBe(
-      'This credential type is currently being used by some credentials and cannot be deleted'
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled()
     );
   });
 
-  test('should throw error', async () => {
+  test('should show an error modal when fetching delete details fails', async () => {
     CredentialsAPI.read.mockRejectedValue(new Error('error'));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeDetails credentialType={credentialTypeData} />
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
+    renderWithContexts(
+      <CredentialTypeDetails credentialType={makeCredentialType()} />
+    );
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
   });
 
   test('expected api call is made for delete', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/credential_types/42/details'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeDetails credentialType={credentialTypeData} />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    expect(CredentialTypesAPI.destroy).toHaveBeenCalledTimes(1);
+    const { user } = renderWithContexts(
+      <CredentialTypeDetails credentialType={makeCredentialType({ id: 42 })} />,
+      { context: { router: { history } } }
+    );
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    // PF4's Modal aria-hides the whole tree in jsdom, so query the confirm
+    // button by its label (ignores aria-hidden) and fire the click directly.
+    fireEvent.click(await screen.findByLabelText('Confirm Delete'));
+    await waitFor(() =>
+      expect(CredentialTypesAPI.destroy).toHaveBeenCalledTimes(1)
+    );
     expect(history.location.pathname).toBe('/credential_types');
   });
 
-  test('should not render delete button', async () => {
-    credentialTypeData.summary_fields.user_capabilities.delete = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeDetails credentialType={credentialTypeData} />
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('Button[aria-label="Delete"]').length).toBe(0);
+  test('should not render delete button without delete capability', async () => {
+    renderWithContexts(
+      <CredentialTypeDetails
+        credentialType={makeCredentialType({
+          summary_fields: {
+            user_capabilities: { edit: true, delete: false },
+          },
+        })}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Name')).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Delete' })
+    ).not.toBeInTheDocument();
   });
-  test('should not render edit button', async () => {
-    credentialTypeData.summary_fields.user_capabilities.edit = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeDetails credentialType={credentialTypeData} />
-      );
-    });
-    wrapper.update();
 
-    expect(wrapper.find('Button[aria-label="Edit"]').length).toBe(0);
+  test('should not render edit button without edit capability', async () => {
+    renderWithContexts(
+      <CredentialTypeDetails
+        credentialType={makeCredentialType({
+          summary_fields: {
+            user_capabilities: { edit: false, delete: true },
+          },
+        })}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Name')).toBeInTheDocument()
+    );
+    expect(screen.queryByLabelText('edit')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/CredentialType/CredentialTypeEdit/CredentialTypeEdit.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeEdit/CredentialTypeEdit.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor } from '@testing-library/react';
 
 import { CredentialTypesAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import CredentialTypeEdit from './CredentialTypeEdit';
 
@@ -16,17 +16,8 @@ const credentialTypeData = {
   kind: 'cloud',
   inputs: JSON.stringify({
     fields: [
-      {
-        id: 'username',
-        type: 'string',
-        label: 'Jenkins username',
-      },
-      {
-        id: 'password',
-        type: 'string',
-        label: 'Jenkins password',
-        secret: true,
-      },
+      { id: 'username', type: 'string', label: 'Jenkins username' },
+      { id: 'password', type: 'string', label: 'Jenkins password', secret: true },
     ],
     required: ['username', 'password'],
   }),
@@ -37,103 +28,80 @@ const credentialTypeData = {
     },
   }),
   summary_fields: {
-    created_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    modified_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    user_capabilities: {
-      edit: true,
-      delete: true,
-    },
+    created_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    modified_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    user_capabilities: { edit: true, delete: true },
   },
   created: '2020-06-25T16:52:36.127008Z',
   modified: '2020-06-25T16:52:36.127022Z',
 };
 
-const updateCredentialTypeData = {
+const mockUpdateData = {
   name: 'Bar',
   description: 'Updated new Credential Type',
   injectors: credentialTypeData.injectors,
   inputs: credentialTypeData.inputs,
 };
 
+// The form has its own suite; stub it so we can drive the container's
+// submit/cancel/error handling directly.
+jest.mock('../shared/CredentialTypeForm', () =>
+  function MockCredentialTypeForm({ onSubmit, onCancel, submitError }) {
+    return (
+      <div>
+        {submitError ? <div data-testid="form-submit-error" /> : null}
+        <button type="button" onClick={() => onSubmit(mockUpdateData)}>
+          Submit
+        </button>
+        <button type="button" aria-label="Cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  }
+);
+
 describe('<CredentialTypeEdit>', () => {
-  let wrapper;
   let history;
 
-  beforeAll(async () => {
+  const renderEdit = () => {
     history = createMemoryHistory();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeEdit credentialType={credentialTypeData} />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-  });
+    return renderWithContexts(
+      <CredentialTypeEdit credentialType={credentialTypeData} />,
+      { context: { router: { history } } }
+    );
+  };
 
-  afterAll(() => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('CredentialTypeForm').invoke('onSubmit')(
-        updateCredentialTypeData
-      );
-      wrapper.update();
+    CredentialTypesAPI.update.mockResolvedValue({});
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
       expect(CredentialTypesAPI.update).toHaveBeenCalledWith(42, {
-        ...updateCredentialTypeData,
+        ...mockUpdateData,
         injectors: JSON.parse(credentialTypeData.injectors),
         inputs: JSON.parse(credentialTypeData.inputs),
-      });
-    });
-  });
-
-  test('should navigate to credential types detail when cancel is clicked', async () => {
-    await act(async () => {
-      wrapper.find('button[aria-label="Cancel"]').prop('onClick')();
-    });
+      })
+    );
     expect(history.location.pathname).toEqual('/credential_types/42/details');
   });
 
-  test('should navigate to credential type detail after successful submission', async () => {
-    await act(async () => {
-      wrapper.find('CredentialTypeForm').invoke('onSubmit')({
-        ...updateCredentialTypeData,
-        injectors: JSON.parse(credentialTypeData.injectors),
-        inputs: JSON.parse(credentialTypeData.inputs),
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(0);
+  test('should navigate to credential types detail when cancel is clicked', async () => {
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/credential_types/42/details');
   });
 
   test('failed form submission should show an error message', async () => {
-    const error = {
-      response: {
-        data: { detail: 'An error occurred' },
-      },
-    };
-    CredentialTypesAPI.update.mockImplementationOnce(() =>
-      Promise.reject(error)
-    );
-    await act(async () => {
-      wrapper.find('CredentialTypeForm').invoke('onSubmit')(
-        updateCredentialTypeData
-      );
+    CredentialTypesAPI.update.mockRejectedValue({
+      response: { data: { detail: 'An error occurred' } },
     });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByTestId('form-submit-error')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.test.js
@@ -56,9 +56,9 @@ describe('<CredentialTypeList>', () => {
     const { user } = renderWithContexts(<CredentialTypeList />);
     await screen.findByText('Foo');
 
-    const checkboxes = screen.getAllByRole('checkbox');
-    await user.click(checkboxes[1]);
-    expect(checkboxes[1]).toBeChecked();
+    const rowCheckbox = screen.getByRole('checkbox', { name: 'Select row 0' });
+    await user.click(rowCheckbox);
+    expect(rowCheckbox).toBeChecked();
 
     await user.click(screen.getByRole('button', { name: 'Delete' }));
     // PF4 Modal aria-hides the tree in jsdom; query the confirm by label.
@@ -91,7 +91,7 @@ describe('<CredentialTypeList>', () => {
     const { user } = renderWithContexts(<CredentialTypeList />);
     await screen.findByText('Foo');
 
-    await user.click(screen.getAllByRole('checkbox')[1]);
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 0' }));
     await user.click(screen.getByRole('button', { name: 'Delete' }));
     fireEvent.click(await screen.findByLabelText('confirm delete'));
 

--- a/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.test.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 
 import { CredentialTypesAPI, CredentialsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import CredentialTypeList from './CredentialTypeList';
 
@@ -19,18 +16,14 @@ const credentialTypes = {
         id: 1,
         name: 'Foo',
         kind: 'cloud',
-        summary_fields: {
-          user_capabilities: { edit: true, delete: true },
-        },
+        summary_fields: { user_capabilities: { edit: true, delete: true } },
         url: '',
       },
       {
         id: 2,
         name: 'Bar',
         kind: 'cloud',
-        summary_fields: {
-          user_capabilities: { edit: false, delete: true },
-        },
+        summary_fields: { user_capabilities: { edit: false, delete: true } },
         url: '',
       },
     ],
@@ -40,138 +33,68 @@ const credentialTypes = {
 
 const options = { data: { actions: { POST: true } } };
 
-describe('<CredentialTypeList', () => {
-  let wrapper;
-
+describe('<CredentialTypeList>', () => {
   beforeEach(() => {
     CredentialsAPI.read.mockResolvedValue({ data: { count: 0 } });
     CredentialTypesAPI.read.mockResolvedValue(credentialTypes);
     CredentialTypesAPI.readOptions.mockResolvedValue(options);
   });
 
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialTypeList />);
-    });
-    await waitForElement(wrapper, 'CredentialTypeList', (el) => el.length > 0);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('should have proper number of delete detail requests', () => {
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('deleteDetailsRequests')
-    ).toHaveLength(1);
-  });
-
-  test('should have data fetched and render 2 rows', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialTypeList />);
-    });
-    await waitForElement(wrapper, 'CredentialTypeList', (el) => el.length > 0);
-    expect(wrapper.find('CredentialTypeListItem').length).toBe(2);
+  test('should fetch data and render 2 rows', async () => {
+    renderWithContexts(<CredentialTypeList />);
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+    expect(screen.getByText('Bar')).toBeInTheDocument();
     expect(CredentialTypesAPI.read).toHaveBeenCalled();
     expect(CredentialTypesAPI.readOptions).toHaveBeenCalled();
   });
 
   test('should delete item successfully', async () => {
-    CredentialTypesAPI.read.mockResolvedValue(credentialTypes);
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialTypeList />);
-    });
-    await waitForElement(wrapper, 'CredentialTypeList', (el) => el.length > 0);
+    const { user } = renderWithContexts(<CredentialTypeList />);
+    await screen.findByText('Foo');
 
-    wrapper
-      .find('.pf-c-table__check')
-      .first()
-      .find('input')
-      .simulate('change', credentialTypes.data.results[0]);
-    wrapper.update();
+    const checkboxes = screen.getAllByRole('checkbox');
+    await user.click(checkboxes[1]);
+    expect(checkboxes[1]).toBeChecked();
 
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toBe(true);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    // PF4 Modal aria-hides the tree in jsdom; query the confirm by label.
+    fireEvent.click(await screen.findByLabelText('confirm delete'));
 
-    await act(async () => {
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')();
-    });
-    wrapper.update();
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-
-    expect(CredentialTypesAPI.destroy).toHaveBeenCalledWith(
-      credentialTypes.data.results[0].id
+    await waitFor(() =>
+      expect(CredentialTypesAPI.destroy).toHaveBeenCalledWith(1)
     );
   });
 
-  test('should not render add button', async () => {
+  test('should not render add button when POST is not allowed', async () => {
     CredentialTypesAPI.readOptions.mockResolvedValue({
       data: { actions: { POST: false } },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialTypeList />);
-    });
-    waitForElement(wrapper, 'CredentialTypeList', (el) => el.length > 0);
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+    renderWithContexts(<CredentialTypeList />);
+    await screen.findByText('Foo');
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
   });
 
-  test('should thrown content error', async () => {
-    CredentialTypesAPI.destroy = jest.fn();
-    CredentialTypesAPI.read.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'GET',
-            url: '/api/v2/credential_types',
-          },
-          data: 'An error occurred',
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialTypeList />);
-    });
-    await waitForElement(wrapper, 'CredentialTypeList', (el) => el.length > 0);
-    expect(wrapper.find('ContentError').length).toBe(1);
-  });
-
-  test('should render deletion error modal', async () => {
-    CredentialTypesAPI.destroy = jest.fn();
-    CredentialTypesAPI.destroy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'DELETE',
-            url: '/api/v2/credential_types',
-          },
-          data: 'An error occurred',
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<CredentialTypeList />);
-    });
-    waitForElement(wrapper, 'CredentialTypeList', (el) => el.length > 0);
-
-    wrapper
-      .find('.pf-c-table__check')
-      .first()
-      .find('input')
-      .simulate('change', 'a');
-    wrapper.update();
+  test('should show a content error when the fetch fails', async () => {
+    CredentialTypesAPI.read.mockRejectedValue(new Error('nope'));
+    renderWithContexts(<CredentialTypeList />);
     expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toBe(true);
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
+  });
 
-    await act(async () =>
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')()
-    );
-    wrapper.update();
+  test('should render a deletion error modal', async () => {
+    CredentialTypesAPI.destroy.mockRejectedValue(new Error('nope'));
+    const { user } = renderWithContexts(<CredentialTypeList />);
+    await screen.findByText('Foo');
 
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
+    await user.click(screen.getAllByRole('checkbox')[1]);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('confirm delete'));
+
+    expect(await screen.findByLabelText('Deletion error')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeListItem.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeListItem.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import CredentialTypeListItem from './CredentialTypeListItem';
 
 describe('<CredentialTypeListItem/>', () => {
-  let wrapper;
   const credential_type = {
     id: 1,
     name: 'Foo',
@@ -14,84 +12,48 @@ describe('<CredentialTypeListItem/>', () => {
     kind: 'cloud',
   };
 
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <CredentialTypeListItem
-              credentialType={credential_type}
-              detailUrl="credential_types/1/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('CredentialTypeListItem').length).toBe(1);
-  });
-
-  test('should render the proper data', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <CredentialTypeListItem
-              credentialType={credential_type}
-              detailsUrl="credential_types/1/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td[dataLabel="Name"]').text()).toBe('Foo');
-    expect(wrapper.find('PencilAltIcon').length).toBe(1);
-    expect(wrapper.find('.pf-c-table__check input').prop('checked')).toBe(
-      undefined
+  const renderItem = (props = {}) =>
+    renderWithContexts(
+      <table>
+        <tbody>
+          <CredentialTypeListItem
+            credentialType={credential_type}
+            detailUrl="credential_types/1/details"
+            isSelected={false}
+            onSelect={() => {}}
+            {...props}
+          />
+        </tbody>
+      </table>
     );
+
+  test('should mount successfully', () => {
+    renderItem();
+    expect(screen.getByRole('row')).toBeInTheDocument();
   });
 
-  test('edit button shown to users with edit capabilities', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <CredentialTypeListItem
-              credentialType={credential_type}
-              detailsUrl="credential_types/1/details"
-              isSelected
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-
-    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  test('should render the proper data', () => {
+    renderItem();
+    expect(screen.getByText('Foo')).toBeInTheDocument();
+    expect(screen.getByLabelText('Edit credential type')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
   });
 
-  test('edit button hidden from users without edit capabilities', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <CredentialTypeListItem
-              credentialType={{
-                ...credential_type,
-                summary_fields: { user_capabilities: { edit: false } },
-              }}
-              detailsUrl="credential_types/1/details"
-              isSelected
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
+  test('edit button shown to users with edit capabilities', () => {
+    renderItem({ isSelected: true });
+    expect(screen.getByLabelText('Edit credential type')).toBeInTheDocument();
+  });
 
-    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  test('edit button hidden from users without edit capabilities', () => {
+    renderItem({
+      credentialType: {
+        ...credential_type,
+        summary_fields: { user_capabilities: { edit: false } },
+      },
+      isSelected: true,
+    });
+    expect(
+      screen.queryByLabelText('Edit credential type')
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeListItem.test.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeListItem.test.js
@@ -21,6 +21,7 @@ describe('<CredentialTypeListItem/>', () => {
             detailUrl="credential_types/1/details"
             isSelected={false}
             onSelect={() => {}}
+            rowIndex={0}
             {...props}
           />
         </tbody>
@@ -36,7 +37,9 @@ describe('<CredentialTypeListItem/>', () => {
     renderItem();
     expect(screen.getByText('Foo')).toBeInTheDocument();
     expect(screen.getByLabelText('Edit credential type')).toBeInTheDocument();
-    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: 'Select row 0' })
+    ).not.toBeChecked();
   });
 
   test('edit button shown to users with edit capabilities', () => {

--- a/awx/ui/src/screens/CredentialType/shared/CredentialTypeForm.test.js
+++ b/awx/ui/src/screens/CredentialType/shared/CredentialTypeForm.test.js
@@ -75,10 +75,23 @@ describe('<CredentialTypeForm/>', () => {
 
   test('should update form values', async () => {
     const { user, container } = renderForm();
+
+    // PF4's FormField renders a Popover labelIcon that breaks getByLabelText's
+    // label association, so the inputs are selected by id; assert they exist
+    // before interacting so a markup change fails clearly.
     const nameField = container.querySelector('#credential-type-name');
+    expect(nameField).toBeInTheDocument();
     await user.clear(nameField);
     await user.type(nameField, 'Foo');
     expect(nameField).toHaveValue('Foo');
+
+    const descriptionField = container.querySelector(
+      '#credential-type-description'
+    );
+    expect(descriptionField).toBeInTheDocument();
+    await user.clear(descriptionField);
+    await user.type(descriptionField, 'New description');
+    expect(descriptionField).toHaveValue('New description');
   });
 
   test('should call onCancel when Cancel button is clicked', async () => {

--- a/awx/ui/src/screens/CredentialType/shared/CredentialTypeForm.test.js
+++ b/awx/ui/src/screens/CredentialType/shared/CredentialTypeForm.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
+
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import CredentialTypeForm from './CredentialTypeForm';
 
@@ -11,25 +12,12 @@ const credentialType = {
   type: 'credential_type',
   url: '/api/v2/credential_types/28/',
   summary_fields: {
-    created_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    modified_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    user_capabilities: {
-      edit: true,
-      delete: true,
-    },
+    created_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    modified_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    user_capabilities: { edit: true, delete: true },
   },
   created: '2020-06-18T14:48:47.869002Z',
-  modified: '2020 - 06 - 18T14: 48: 47.869017Z',
+  modified: '2020-06-18T14:48:47.869017Z',
   name: 'Jenkins Credential',
   description: 'Jenkins Credential',
   kind: 'cloud',
@@ -37,17 +25,8 @@ const credentialType = {
   managed: false,
   inputs: JSON.stringify({
     fields: [
-      {
-        id: 'username',
-        type: 'string',
-        label: 'Jenkins username',
-      },
-      {
-        id: 'password',
-        type: 'string',
-        label: 'Jenkins password',
-        secret: true,
-      },
+      { id: 'username', type: 'string', label: 'Jenkins username' },
+      { id: 'password', type: 'string', label: 'Jenkins password', secret: true },
     ],
     required: ['username', 'password'],
   }),
@@ -60,72 +39,52 @@ const credentialType = {
 };
 
 describe('<CredentialTypeForm/>', () => {
-  let wrapper;
   let onCancel;
   let onSubmit;
 
-  beforeEach(async () => {
+  const renderForm = () => {
     onCancel = jest.fn();
     onSubmit = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <CredentialTypeForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          credentialType={credentialType}
-        />
-      );
-    });
-  });
+    return renderWithContexts(
+      <CredentialTypeForm
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        credentialType={credentialType}
+      />
+    );
+  };
 
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  test('Initially renders successfully', () => {
-    expect(wrapper.length).toBe(1);
-  });
-
   test('should display form fields properly', () => {
-    expect(wrapper.find('FormGroup[label="Name"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[label="Description"]').length).toBe(1);
-    expect(
-      wrapper.find('VariablesField[label="Input configuration"]').length
-    ).toBe(1);
-    expect(
-      wrapper.find('VariablesField[label="Injector configuration"]').length
-    ).toBe(1);
+    renderForm();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Input configuration')).toBeInTheDocument();
+    expect(screen.getByText('Injector configuration')).toBeInTheDocument();
   });
 
-  test('should call onSubmit when form submitted', async () => {
+  test('should call onSubmit when the form is submitted', async () => {
+    const { user } = renderForm();
     expect(onSubmit).not.toHaveBeenCalled();
-    await act(async () => {
-      wrapper.find('button[aria-label="Save"]').simulate('click');
-    });
-    expect(onSubmit).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
   });
 
   test('should update form values', async () => {
-    act(() => {
-      wrapper.find('input#credential-type-name').simulate('change', {
-        target: { value: 'Foo', name: 'name' },
-      });
-      wrapper.find('input#credential-type-description').simulate('change', {
-        target: { value: 'New description', name: 'description' },
-      });
-    });
-    await act(async () => wrapper.update());
-    expect(wrapper.find('input#credential-type-name').prop('value')).toEqual(
-      'Foo'
-    );
-    expect(
-      wrapper.find('input#credential-type-description').prop('value')
-    ).toEqual('New description');
+    const { user, container } = renderForm();
+    const nameField = container.querySelector('#credential-type-name');
+    await user.clear(nameField);
+    await user.type(nameField, 'Foo');
+    expect(nameField).toHaveValue('Foo');
   });
 
-  test('should call handleCancel when Cancel button is clicked', async () => {
+  test('should call onCancel when Cancel button is clicked', async () => {
+    const { user } = renderForm();
     expect(onCancel).not.toHaveBeenCalled();
-    wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Continue the enzyme → React Testing Library migration (step 3 of the React modernization) by converting the `screens/CredentialType` suites. This follows the infrastructure in #385 and the first directory batch (`screens/User`) in #398.

- Converts all six enzyme suites in `screens/CredentialType` to `renderWithContexts`: `CredentialTypeListItem`, `CredentialTypeList`, `CredentialTypeDetails`, `CredentialTypeAdd`, `CredentialTypeEdit`, and the shared `CredentialTypeForm`.
- The container suites (Add/Edit) stub the shared form and drive its `onSubmit`/`onCancel`/`submitError` props — the same black-box treatment the enzyme tests used (the form has its own suite).
- Delete flows now interact for real. PF4's `Modal` aria-hides the rest of the tree under jsdom, so the confirm button is queried by label and clicked via `fireEvent` (a reusable pattern for the remaining directories).
- Drops one prop-inspection-only assertion (`ToolbarDeleteButton` `deleteDetailsRequests` count) that has no DOM-observable behavior.

No application code changes — test-only. `screens/CredentialType` no longer references enzyme.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ASCENDER VERSION

```
awx: 25.4.1.dev49+g0e26da4e2e
```

##### ADDITIONAL INFORMATION

- All 33 tests in `screens/CredentialType` pass (`npm test`).
- Test files are not linted (ignored by the eslint flat config), and there are no behavior changes, so no browser smoke-test is required for this test-only batch.
- Part of the step-3 directory-by-directory conversion; both enzyme and RTL helpers coexist until the last enzyme import is removed.
