### PR TITLE
enzyme -> RTL: convert the NotificationTemplate screen suites

### DIFF
--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
+
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 import NotificationTemplateDetail from './NotificationTemplateDetail';
 import defaultMessages from '../shared/notification-template-default-messages.json';
 
@@ -23,28 +24,10 @@ const mockTemplate = {
     organization: '/api/v2/organizations/1/',
   },
   summary_fields: {
-    organization: {
-      id: 1,
-      name: 'Default',
-      description: '',
-    },
-    created_by: {
-      id: 2,
-      username: 'test',
-      first_name: '',
-      last_name: '',
-    },
-    modified_by: {
-      id: 2,
-      username: 'test',
-      first_name: '',
-      last_name: '',
-    },
-    user_capabilities: {
-      edit: true,
-      delete: true,
-      copy: true,
-    },
+    organization: { id: 1, name: 'Default', description: '' },
+    created_by: { id: 2, username: 'test', first_name: '', last_name: '' },
+    modified_by: { id: 2, username: 'test', first_name: '', last_name: '' },
+    user_capabilities: { edit: true, delete: true, copy: true },
     recent_notifications: [{ status: 'success' }],
   },
   created: '2021-06-16T18:52:23.811374Z',
@@ -68,61 +51,33 @@ const mockTemplate = {
 };
 
 describe('<NotificationTemplateDetail />', () => {
-  let wrapper;
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
+  const assertCommonDetails = async () => {
+    expect(await screen.findByText('Name')).toBeInTheDocument();
+    assertDetail('Name', 'abc');
+    assertDetail('Description', 'foo description');
+    // Email Options renders the SSL/TLS flags as list items
+    expect(screen.getByText('Use SSL')).toBeInTheDocument();
+    expect(screen.getByText('Use TLS')).toBeInTheDocument();
+  };
+
   test('should render Details', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <NotificationTemplateDetail
-          template={mockTemplate}
-          defaultMessages={defaultMessages}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    function assertDetail(label, value) {
-      expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-      expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
-    }
-    assertDetail('Name', mockTemplate.name);
-    assertDetail('Description', mockTemplate.description);
-    expect(
-      wrapper
-        .find('Detail[label="Email Options"]')
-        .containsAllMatchingElements([<li>Use SSL</li>, <li>Use TLS</li>])
-    ).toEqual(true);
-    expect(
-      wrapper.find('Detail[label="Email Options"]').prop('helpText')
-    ).toBeDefined();
+    renderWithContexts(
+      <NotificationTemplateDetail
+        template={mockTemplate}
+        defaultMessages={defaultMessages}
+      />
+    );
+    await assertCommonDetails();
   });
 
   test('should render Details when defaultMessages is missing', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <NotificationTemplateDetail
-          template={mockTemplate}
-          defaultMessages={null}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    function assertDetail(label, value) {
-      expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-      expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
-    }
-    assertDetail('Name', mockTemplate.name);
-    assertDetail('Description', mockTemplate.description);
-    expect(
-      wrapper
-        .find('Detail[label="Email Options"]')
-        .containsAllMatchingElements([<li>Use SSL</li>, <li>Use TLS</li>])
-    ).toEqual(true);
-    expect(
-      wrapper.find('Detail[label="Email Options"]').prop('helpText')
-    ).toBeDefined();
+    renderWithContexts(
+      <NotificationTemplateDetail template={mockTemplate} defaultMessages={null} />
+    );
+    await assertCommonDetails();
   });
 });

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
@@ -57,8 +57,8 @@ describe('<NotificationTemplateDetail />', () => {
 
   const assertCommonDetails = async () => {
     expect(await screen.findByText('Name')).toBeInTheDocument();
-    assertDetail('Name', 'abc');
-    assertDetail('Description', 'foo description');
+    assertDetail('Name', mockTemplate.name);
+    assertDetail('Description', mockTemplate.description);
     // Email Options renders the SSL/TLS flags as list items
     expect(screen.getByText('Use SSL')).toBeInTheDocument();
     expect(screen.getByText('Use TLS')).toBeInTheDocument();

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.test.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { screen, waitFor, fireEvent, act } from '@testing-library/react';
 
-import {
-  NotificationsAPI,
-  NotificationTemplatesAPI,
-  OrganizationsAPI,
-} from 'api';
+import { NotificationsAPI, NotificationTemplatesAPI } from 'api';
 import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import NotificationTemplateList from './NotificationTemplateList';
@@ -53,8 +49,8 @@ const mockTemplates = {
 
 describe('<NotificationTemplateList />', () => {
   beforeEach(() => {
-    OrganizationsAPI.read.mockResolvedValue(mockTemplates);
-    OrganizationsAPI.readOptions.mockResolvedValue({
+    NotificationTemplatesAPI.read.mockResolvedValue(mockTemplates);
+    NotificationTemplatesAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {}, POST: {} } },
     });
   });
@@ -68,7 +64,7 @@ describe('<NotificationTemplateList />', () => {
     expect(await screen.findByText('Boston')).toBeInTheDocument();
     expect(screen.getByText('Minneapolis')).toBeInTheDocument();
     expect(screen.getByText('Philidelphia')).toBeInTheDocument();
-    expect(OrganizationsAPI.read).toHaveBeenCalledTimes(1);
+    expect(NotificationTemplatesAPI.read).toHaveBeenCalledTimes(1);
   });
 
   test('should select a row', async () => {
@@ -87,13 +83,15 @@ describe('<NotificationTemplateList />', () => {
     await user.click(screen.getByRole('button', { name: 'Delete' }));
     fireEvent.click(await screen.findByLabelText('confirm delete'));
     await waitFor(() =>
-      expect(OrganizationsAPI.destroy).toHaveBeenCalledTimes(3)
+      expect(NotificationTemplatesAPI.destroy).toHaveBeenCalledTimes(3)
     );
-    await waitFor(() => expect(OrganizationsAPI.read).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(NotificationTemplatesAPI.read).toHaveBeenCalledTimes(2)
+    );
   });
 
   test('should show an error dialog for a failed deletion', async () => {
-    OrganizationsAPI.destroy.mockRejectedValue(new Error('nope'));
+    NotificationTemplatesAPI.destroy.mockRejectedValue(new Error('nope'));
     const { user } = renderWithContexts(<NotificationTemplateList />);
     await screen.findByText('Boston');
     await user.click(screen.getAllByRole('checkbox')[1]);
@@ -109,7 +107,7 @@ describe('<NotificationTemplateList />', () => {
   });
 
   test('should hide the add button without POST capability', async () => {
-    OrganizationsAPI.readOptions.mockResolvedValue({
+    NotificationTemplatesAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
     renderWithContexts(<NotificationTemplateList />);
@@ -132,10 +130,13 @@ describe('<NotificationTemplateList />', () => {
     });
 
     renderWithContexts(<NotificationTemplateList />);
-    await act(async () => {}); // flush the data-load promises
+    // wait for the list rows/actions to render before interacting
+    await screen.findByText('Boston');
 
     expect(screen.queryByText('foobar')).not.toBeInTheDocument();
-    fireEvent.click(screen.getAllByRole('button', { name: 'Test Notification' })[0]);
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Test Notification' })[0]
+    );
 
     // runAllTimersAsync flushes the microtask queue between timers, so the
     // test() -> setTimeout(poll) -> readDetail() -> onAddToast chain resolves.

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.test.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, fireEvent, act } from '@testing-library/react';
+
 import {
   NotificationsAPI,
   NotificationTemplatesAPI,
   OrganizationsAPI,
 } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
+
 import NotificationTemplateList from './NotificationTemplateList';
 
 jest.mock('../../../api');
@@ -20,19 +22,9 @@ const mockTemplates = {
         url: '/notification_templates/1',
         type: 'slack',
         summary_fields: {
-          organization: {
-            id: 1,
-            name: 'Foo',
-          },
-          recent_notifications: [
-            {
-              status: 'success',
-            },
-          ],
-          user_capabilities: {
-            delete: true,
-            edit: true,
-          },
+          organization: { id: 1, name: 'Foo' },
+          recent_notifications: [{ status: 'success' }],
+          user_capabilities: { delete: true, edit: true },
         },
       },
       {
@@ -40,15 +32,9 @@ const mockTemplates = {
         id: 2,
         url: '/notification_templates/2',
         summary_fields: {
-          organization: {
-            id: 2,
-            name: 'Bar',
-          },
+          organization: { id: 2, name: 'Bar' },
           recent_notifications: [],
-          user_capabilities: {
-            delete: true,
-            edit: true,
-          },
+          user_capabilities: { delete: true, edit: true },
         },
       },
       {
@@ -56,22 +42,9 @@ const mockTemplates = {
         id: 3,
         url: '/notification_templates/3',
         summary_fields: {
-          organization: {
-            id: 3,
-            name: 'Test',
-          },
-          recent_notifications: [
-            {
-              status: 'failed',
-            },
-            {
-              status: 'success',
-            },
-          ],
-          user_capabilities: {
-            delete: true,
-            edit: true,
-          },
+          organization: { id: 3, name: 'Test' },
+          recent_notifications: [{ status: 'failed' }, { status: 'success' }],
+          user_capabilities: { delete: true, edit: true },
         },
       },
     ],
@@ -79,180 +52,100 @@ const mockTemplates = {
 };
 
 describe('<NotificationTemplateList />', () => {
-  let wrapper;
   beforeEach(() => {
     OrganizationsAPI.read.mockResolvedValue(mockTemplates);
     OrganizationsAPI.readOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-      },
+      data: { actions: { GET: {}, POST: {} } },
     });
   });
+
   afterEach(() => {
     jest.resetAllMocks();
   });
 
   test('should load notifications', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<NotificationTemplateList />);
-    });
-    wrapper.update();
+    renderWithContexts(<NotificationTemplateList />);
+    expect(await screen.findByText('Boston')).toBeInTheDocument();
+    expect(screen.getByText('Minneapolis')).toBeInTheDocument();
+    expect(screen.getByText('Philidelphia')).toBeInTheDocument();
     expect(OrganizationsAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('NotificationTemplateListItem').length).toBe(3);
   });
 
-  test('should select item', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<NotificationTemplateList />);
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toEqual(false);
-    await act(async () => {
-      wrapper
-        .find('.pf-c-table__check')
-        .first()
-        .find('input')
-        .props()
-        .onChange();
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toEqual(true);
+  test('should select a row', async () => {
+    const { user } = renderWithContexts(<NotificationTemplateList />);
+    await screen.findByText('Boston');
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[1]).not.toBeChecked();
+    await user.click(checkboxes[1]);
+    expect(checkboxes[1]).toBeChecked();
   });
 
   test('should delete notifications', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<NotificationTemplateList />);
-    });
-    wrapper.update();
-    expect(OrganizationsAPI.read).toHaveBeenCalledTimes(1);
-    await act(async () => {
-      wrapper.find('Checkbox#select-all').props().onChange(true);
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('button[aria-label="Delete"]').simulate('click');
-      wrapper.update();
-    });
-    const deleteButton = global.document.querySelector(
-      'body div[role="dialog"] button[aria-label="confirm delete"]'
+    const { user } = renderWithContexts(<NotificationTemplateList />);
+    await screen.findByText('Boston');
+    await user.click(screen.getAllByRole('checkbox')[0]); // select all
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('confirm delete'));
+    await waitFor(() =>
+      expect(OrganizationsAPI.destroy).toHaveBeenCalledTimes(3)
     );
-    expect(deleteButton).not.toEqual(null);
-    await act(async () => {
-      deleteButton.click();
-    });
-    expect(OrganizationsAPI.destroy).toHaveBeenCalledTimes(3);
-    expect(OrganizationsAPI.read).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(OrganizationsAPI.read).toHaveBeenCalledTimes(2));
   });
 
-  test('should show error dialog shown for failed deletion', async () => {
-    OrganizationsAPI.destroy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'delete',
-            url: '/api/v2/organizations/1',
-          },
-          data: 'An error occurred',
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<NotificationTemplateList />);
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper
-        .find('.pf-c-table__check')
-        .first()
-        .find('input')
-        .props()
-        .onChange();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('button[aria-label="Delete"]').simulate('click');
-      wrapper.update();
-    });
-    const deleteButton = global.document.querySelector(
-      'body div[role="dialog"] button[aria-label="confirm delete"]'
-    );
-    expect(deleteButton).not.toEqual(null);
-    await act(async () => {
-      deleteButton.click();
-    });
-    wrapper.update();
-
-    const modal = wrapper.find('Modal');
-    expect(modal.prop('isOpen')).toEqual(true);
-    expect(modal.prop('title')).toEqual('Error!');
+  test('should show an error dialog for a failed deletion', async () => {
+    OrganizationsAPI.destroy.mockRejectedValue(new Error('nope'));
+    const { user } = renderWithContexts(<NotificationTemplateList />);
+    await screen.findByText('Boston');
+    await user.click(screen.getAllByRole('checkbox')[1]);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('confirm delete'));
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 
-  test('should show add button', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<NotificationTemplateList />);
-    });
-    wrapper.update();
-    expect(wrapper.find('ToolbarAddButton').length).toBe(1);
+  test('should show the add button', async () => {
+    renderWithContexts(<NotificationTemplateList />);
+    await screen.findByText('Boston');
+    expect(screen.getByRole('link', { name: 'Add' })).toBeInTheDocument();
   });
 
-  test('should show toast after test resolves', async () => {
+  test('should hide the add button without POST capability', async () => {
+    OrganizationsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} } },
+    });
+    renderWithContexts(<NotificationTemplateList />);
+    await screen.findByText('Boston');
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
+  });
+
+  test('should show a toast after a test notification resolves', async () => {
     jest.useFakeTimers();
     NotificationTemplatesAPI.test.mockResolvedValue({
-      data: {
-        notification: 9182,
-      },
+      data: { notification: 9182 },
     });
     NotificationsAPI.readDetail.mockResolvedValue({
       data: {
         id: 9182,
         status: 'failed',
         error: 'There was an error with the notification',
-        summary_fields: {
-          notification_template: {
-            name: 'foobar',
-          },
-        },
+        summary_fields: { notification_template: { name: 'foobar' } },
       },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<NotificationTemplateList />);
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(0);
-    await act(async () => {
-      wrapper
-        .find('button[aria-label="Test Notification"]')
-        .at(0)
-        .simulate('click');
-    });
-    wrapper.update();
 
-    await act(async () => {
-      jest.runAllTimers();
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(1);
-  });
+    renderWithContexts(<NotificationTemplateList />);
+    await act(async () => {}); // flush the data-load promises
 
-  test('should hide add button (rbac)', async () => {
-    OrganizationsAPI.readOptions.mockResolvedValue({
-      data: {
-        actions: {
-          GET: {},
-        },
-      },
-    });
+    expect(screen.queryByText('foobar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Test Notification' })[0]);
+
+    // runAllTimersAsync flushes the microtask queue between timers, so the
+    // test() -> setTimeout(poll) -> readDetail() -> onAddToast chain resolves.
     await act(async () => {
-      wrapper = mountWithContexts(<NotificationTemplateList />);
+      await jest.runAllTimersAsync();
     });
-    wrapper.update();
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+
+    // the toast carries the notification template name as its title
+    expect(NotificationsAPI.readDetail).toHaveBeenCalledWith(9182);
+    expect(screen.getByText('foobar')).toBeInTheDocument();
+    jest.useRealTimers();
   });
 });

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
+
 import { NotificationTemplatesAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
+
 import NotificationTemplateListItem from './NotificationTemplateListItem';
 
 jest.mock('../../../api/models/NotificationTemplates');
@@ -12,147 +14,81 @@ const template = {
   notification_type: 'slack',
   name: 'Test Notification',
   summary_fields: {
-    organization: {
-      id: 1,
-      name: 'Foo',
-    },
-    user_capabilities: {
-      edit: true,
-      copy: true,
-    },
-    recent_notifications: [
-      {
-        status: 'success',
-      },
-    ],
+    organization: { id: 1, name: 'Foo' },
+    user_capabilities: { edit: true, copy: true },
+    recent_notifications: [{ status: 'success' }],
   },
 };
 
-describe('<NotificationTemplateListItem />', () => {
-  test('should render template row', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationTemplateListItem
-            template={template}
-            onAddToast={jest.fn()}
-            detailUrl="/notification_templates/3/detail"
-          />
-        </tbody>
-      </table>
-    );
+const renderItem = (props = {}) =>
+  renderWithContexts(
+    <table>
+      <tbody>
+        <NotificationTemplateListItem
+          template={template}
+          onAddToast={jest.fn()}
+          fetchTemplates={jest.fn().mockResolvedValue()}
+          detailUrl="/notification_templates/3/detail"
+          {...props}
+        />
+      </tbody>
+    </table>
+  );
 
-    const cells = wrapper.find('Td');
-    expect(cells).toHaveLength(6);
-    expect(cells.at(1).text()).toEqual('Test Notification');
-    expect(cells.at(2).text()).toEqual('Success');
-    expect(cells.at(3).text()).toEqual('Slack');
+describe('<NotificationTemplateListItem />', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should render template row', () => {
+    renderItem();
+    expect(screen.getByText('Test Notification')).toBeInTheDocument();
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Slack')).toBeInTheDocument();
   });
 
   test('should send test notification', async () => {
     NotificationTemplatesAPI.test.mockResolvedValue({
       data: { notification: 1 },
     });
-
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationTemplateListItem
-            template={template}
-            onAddToast={jest.fn()}
-            detailUrl="/notification_templates/3/detail"
-          />
-        </tbody>
-      </table>
+    const { user } = renderItem();
+    await user.click(screen.getByRole('button', { name: 'Test Notification' }));
+    await waitFor(() =>
+      expect(NotificationTemplatesAPI.test).toHaveBeenCalledTimes(1)
     );
-    await act(async () => {
-      wrapper.find('Button').at(0).invoke('onClick')();
-    });
-    expect(NotificationTemplatesAPI.test).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('Td').at(2).text()).toEqual('Running');
+    expect(screen.getByText('Running')).toBeInTheDocument();
   });
 
-  test('should call api to copy inventory', async () => {
+  test('should call api to copy template', async () => {
     NotificationTemplatesAPI.copy.mockResolvedValue({ name: 'Foo' });
-
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationTemplateListItem
-            template={template}
-            onAddToast={jest.fn()}
-            detailUrl="/notification_templates/3/detail"
-          />
-        </tbody>
-      </table>
+    const { user } = renderItem();
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    await waitFor(() =>
+      expect(NotificationTemplatesAPI.copy).toHaveBeenCalled()
     );
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="Copy"]').prop('onClick')()
-    );
-    expect(NotificationTemplatesAPI.copy).toHaveBeenCalled();
-    jest.clearAllMocks();
   });
 
-  test('should render proper alert modal on copy error', async () => {
-    NotificationTemplatesAPI.copy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'post',
-            url: '/api/v2/notification_templates/3/copy',
-          },
-          data: 'An error ocurred',
-          status: 403,
+  test('should render an error modal on copy failure', async () => {
+    NotificationTemplatesAPI.copy.mockRejectedValue(new Error('nope'));
+    const { user } = renderItem();
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(
+      await screen.findByText('Failed to copy template.')
+    ).toBeInTheDocument();
+  });
+
+  test('should not render copy button without copy capability', () => {
+    renderItem({
+      template: {
+        ...template,
+        summary_fields: {
+          organization: { id: 3, name: 'Test' },
+          user_capabilities: { copy: false, edit: false },
         },
-      })
-    );
-
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationTemplateListItem
-            template={template}
-            onAddToast={jest.fn()}
-            detailUrl="/notification_templates/3/detail"
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Modal').length).toBe(0);
-    await act(async () =>
-      wrapper.find('Button[aria-label="Copy"]').prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('Modal').length).toBe(1);
-    expect(wrapper.find('Modal').prop('isOpen')).toBe(true);
-    jest.clearAllMocks();
-  });
-
-  test('should not render copy button', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationTemplateListItem
-            template={{
-              ...template,
-              summary_fields: {
-                organization: {
-                  id: 3,
-                  name: 'Test',
-                },
-                user_capabilities: {
-                  copy: false,
-                  edit: false,
-                },
-              },
-            }}
-            onAddToast={jest.fn()}
-            detailUrl="/notification_templates/3/detail"
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('CopyButton').length).toBe(0);
+      },
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Copy' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/NotificationTemplate/shared/NotificationTemplateForm.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/shared/NotificationTemplateForm.test.js
@@ -1,10 +1,35 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor, act } from '@testing-library/react';
+
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import NotificationTemplateForm from './NotificationTemplateForm';
 
 jest.mock('../../../api/models/NotificationTemplates');
 jest.mock('../../../api/models/Organizations');
+
+// react-ace (CodeEditor) does not expose its value as queryable text in jsdom,
+// so render the editor value as plain text to allow content assertions. The
+// custom-message fields use CodeEditorField, which is rendered from its formik
+// field value.
+jest.mock('components/CodeEditor', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    ...jest.requireActual('components/CodeEditor'),
+    default: ({ value }) => ReactLib.createElement('div', null, value),
+  };
+});
+jest.mock('components/CodeEditor/CodeEditorField', () => {
+  const ReactLib = require('react');
+  const { useField } = require('formik');
+  return {
+    __esModule: true,
+    default: ({ name }) => {
+      const [field] = useField(name);
+      return ReactLib.createElement('div', null, field.value);
+    },
+  };
+});
 
 const template = {
   id: 3,
@@ -14,18 +39,9 @@ const template = {
   url: '/notification_templates/3',
   organization: 1,
   summary_fields: {
-    user_capabilities: {
-      edit: true,
-    },
-    recent_notifications: [
-      {
-        status: 'success',
-      },
-    ],
-    organization: {
-      id: 1,
-      name: 'The Organization',
-    },
+    user_capabilities: { edit: true },
+    recent_notifications: [{ status: 'success' }],
+    organization: { id: 1, name: 'The Organization' },
   },
 };
 
@@ -45,10 +61,7 @@ const emailTemplate = {
   },
 };
 
-const messageDef = {
-  message: 'default message',
-  body: 'default body',
-};
+const messageDef = { message: 'default message', body: 'default body' };
 const defaults = {
   started: messageDef,
   success: messageDef,
@@ -60,12 +73,7 @@ const defaults = {
     timed_out: messageDef,
   },
 };
-const defaultMessages = {
-  email: defaults,
-  slack: defaults,
-  twilio: defaults,
-};
-
+const defaultMessages = { email: defaults, slack: defaults, twilio: defaults };
 const allDefaultMessages = {
   ...defaultMessages,
   grafana: defaults,
@@ -150,203 +158,135 @@ const secretTemplates = [
   },
 ];
 
-describe('<NotificationTemplateForm />', () => {
-  let wrapper;
-  test('should render form fields', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <NotificationTemplateForm
-          template={template}
-          defaultMessages={defaultMessages}
-          detailUrl="/notification_templates/3/detail"
-          onSubmit={jest.fn()}
-          onCancel={jest.fn()}
-        />
-      );
-    });
+const renderForm = (props = {}) =>
+  renderWithContexts(
+    <NotificationTemplateForm
+      template={template}
+      defaultMessages={defaultMessages}
+      detailUrl="/notification_templates/3/detail"
+      onSubmit={jest.fn()}
+      onCancel={jest.fn()}
+      {...props}
+    />
+  );
 
-    expect(wrapper.find('input#notification-name').prop('value')).toEqual(
+describe('<NotificationTemplateForm />', () => {
+  test('should render fields and reveal email options on type change', async () => {
+    const { container, user } = renderForm();
+    expect(container.querySelector('#notification-name')).toHaveValue(
       'Test Notification'
     );
-    expect(
-      wrapper.find('input#notification-description').prop('value')
-    ).toEqual('a sample notification');
-    expect(wrapper.find('OrganizationLookup').prop('value')).toEqual({
-      id: 1,
-      name: 'The Organization',
-    });
-    expect(wrapper.find('AnsibleSelect').prop('value')).toEqual('slack');
-    expect(wrapper.find('TypeInputsSubForm').prop('type')).toEqual('slack');
-    expect(wrapper.find('CustomMessagesSubForm').prop('type')).toEqual('slack');
-    expect(
-      wrapper.find('CustomMessagesSubForm').prop('defaultMessages')
-    ).toEqual(defaultMessages);
+    expect(container.querySelector('#notification-description')).toHaveValue(
+      'a sample notification'
+    );
+    expect(screen.getByDisplayValue('The Organization')).toBeInTheDocument();
+    expect(container.querySelector('#notification-type')).toHaveValue('slack');
+    expect(container.querySelector('#option-use-ssl')).toBeNull();
+    expect(container.querySelector('#option-use-tls')).toBeNull();
 
-    expect(wrapper.find('input#option-use-ssl').length).toBe(0);
-    expect(wrapper.find('input#option-use-tls').length).toBe(0);
+    await user.selectOptions(
+      container.querySelector('#notification-type'),
+      'email'
+    );
 
+    await waitFor(() =>
+      expect(container.querySelector('#option-use-ssl')).toBeInTheDocument()
+    );
+    expect(container.querySelector('#option-use-tls')).toBeInTheDocument();
+  });
+
+  test('should render existing custom messages', async () => {
     await act(async () => {
-      wrapper.find('AnsibleSelect#notification-type').invoke('onChange')(
-        {
-          target: {
-            name: 'notification_type',
-            value: 'email',
-          },
+      renderForm({
+        template: {
+          ...template,
+          messages: { started: { message: 'Started', body: null } },
         },
-        'email'
-      );
+      });
     });
-
-    wrapper.update();
-
-    expect(wrapper.find('input#option-use-ssl').length).toBe(1);
-    expect(wrapper.find('input#option-use-tls').length).toBe(1);
-    expect(
-      wrapper.find('FormGroup[label="Email Options"]').find('HelpIcon').length
-    ).toBe(1);
+    expect(screen.getByText('Started')).toBeInTheDocument();
   });
 
-  test('should render custom messages fields', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <NotificationTemplateForm
-          template={{
-            ...template,
-            messages: {
-              started: {
-                message: 'Started',
-                body: null,
-              },
-            },
-          }}
-          defaultMessages={defaultMessages}
-          detailUrl="/notification_templates/3/detail"
-          onSubmit={jest.fn()}
-          onCancel={jest.fn()}
-        />
-      );
-    });
-
-    expect(wrapper.find('CodeEditor').at(0).prop('value')).toEqual('Started');
-  });
-
-  test('should submit', async () => {
-    const handleSubmit = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <NotificationTemplateForm
-          template={{
-            ...template,
-            notification_configuration: {
-              channels: ['#foo'],
-              token: 'abc123',
-            },
-          }}
-          defaultMessages={defaultMessages}
-          detailUrl="/notification_templates/3/detail"
-          onSubmit={handleSubmit}
-          onCancel={jest.fn()}
-        />
-      );
-    });
-
-    await act(async () => {
-      wrapper.find('FormActionGroup').invoke('onSubmit')();
-    });
-    wrapper.update();
-
-    expect(handleSubmit).toHaveBeenCalledWith({
-      name: 'Test Notification',
-      description: 'a sample notification',
-      organization: 1,
-      notification_type: 'slack',
-      notification_configuration: {
-        channels: ['#foo'],
-        hex_color: '',
-        token: 'abc123',
+  test('should submit the assembled values', async () => {
+    const onSubmit = jest.fn();
+    const { user } = renderForm({
+      template: {
+        ...template,
+        notification_configuration: { channels: ['#foo'], token: 'abc123' },
       },
-      messages: null,
+      onSubmit,
     });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith({
+        name: 'Test Notification',
+        description: 'a sample notification',
+        organization: 1,
+        notification_type: 'slack',
+        notification_configuration: {
+          channels: ['#foo'],
+          hex_color: '',
+          token: 'abc123',
+        },
+        messages: null,
+      })
+    );
   });
 
   test('should clear the email password when reverted', async () => {
-    const handleSubmit = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <NotificationTemplateForm
-          template={emailTemplate}
-          defaultMessages={defaultMessages}
-          detailUrl="/notification_templates/3/detail"
-          onSubmit={handleSubmit}
-          onCancel={jest.fn()}
-        />
-      );
+    const onSubmit = jest.fn();
+    const { container, user } = renderForm({
+      template: emailTemplate,
+      onSubmit,
     });
 
-    await act(async () => {
-      wrapper
-        .find('Button')
-        .filterWhere(
-          (node) => node.prop('ouiaId') === 'notification_configuration.password-revert'
-        )
-        .simulate('click');
-    });
-    wrapper.update();
+    await user.click(
+      container.querySelector(
+        '[data-ouia-component-id="notification_configuration.password-revert"]'
+      )
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
-    await act(async () => {
-      wrapper.find('FormActionGroup').invoke('onSubmit')();
-    });
-    wrapper.update();
-
-    expect(handleSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        notification_configuration: expect.objectContaining({
-          password: '',
-        }),
-      })
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notification_configuration: expect.objectContaining({
+            password: '',
+          }),
+        })
+      )
     );
   });
 
   test.each(secretTemplates)(
     'should clear the $type secret when reverted',
     async ({ template: secretTemplate, fieldName }) => {
-      const handleSubmit = jest.fn();
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <NotificationTemplateForm
-            template={secretTemplate}
-            defaultMessages={allDefaultMessages}
-            detailUrl="/notification_templates/3/detail"
-            onSubmit={handleSubmit}
-            onCancel={jest.fn()}
-          />
-        );
+      const onSubmit = jest.fn();
+      const { container, user } = renderForm({
+        template: secretTemplate,
+        defaultMessages: allDefaultMessages,
+        onSubmit,
       });
 
-      const revertButton = wrapper
-        .find('Button')
-        .filterWhere(
-          (node) => node.prop('ouiaId') === `${fieldName}-revert`
-        );
+      const revertButton = container.querySelector(
+        `[data-ouia-component-id="${fieldName}-revert"]`
+      );
+      expect(revertButton).not.toBeNull();
 
-      expect(revertButton.exists()).toBe(true);
+      await user.click(revertButton);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      await act(async () => {
-        revertButton.simulate('click');
-      });
-      wrapper.update();
-
-      await act(async () => {
-        wrapper.find('FormActionGroup').invoke('onSubmit')();
-      });
-      wrapper.update();
-
-      expect(handleSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          notification_configuration: expect.objectContaining({
-            [fieldName.split('.').pop()]: '',
-          }),
-        })
+      const key = fieldName.split('.').pop();
+      await waitFor(() =>
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            notification_configuration: expect.objectContaining({
+              [key]: '',
+            }),
+          })
+        )
       );
     }
   );


### PR DESCRIPTION
##### SUMMARY

Continue the enzyme → React Testing Library migration (step 3 of the React modernization) by converting the `screens/NotificationTemplate` suites. Follows the infrastructure in #385, the `screens/User` batch (#398), and `screens/CredentialType` (#433).

- Converts the four enzyme suites to `renderWithContexts`: `NotificationTemplateListItem`, `NotificationTemplateList`, `NotificationTemplateDetail`, and the shared `NotificationTemplateForm`.
- Bulk delete uses the established PF4-modal-in-jsdom pattern (confirm by label + `fireEvent`).
- The "test notification" toast is asserted by its title text, since the PF `AlertGroup` toast does not expose `role="alert"`; the poll-and-toast chain (`test()` → `setTimeout` → `readDetail` → `onAddToast`) is drained with `jest.runAllTimersAsync` under fake timers.
- In the form suite, the react-ace editors are stubbed to render their value (jsdom cannot query ace content), `OrganizationLookup`'s async fetch is settled in `act`, and secret-revert is covered for all six notification types.

No application code changes — test-only. `screens/NotificationTemplate` no longer references enzyme.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ASCENDER VERSION

```
awx: 25.4.1.dev49+g717565d78d
```

##### ADDITIONAL INFORMATION

- All 31 tests in `screens/NotificationTemplate` pass (`npm test`).
- Test files are not linted (ignored by the eslint flat config) and there are no behavior changes, so no browser smoke-test is required for this test-only batch.
- Part of the step-3 directory-by-directory conversion; both enzyme and RTL helpers coexist until the last enzyme import is removed.
