### PR TITLE
enzyme -> RTL: convert the ExecutionEnvironment screen suites

### DIFF
--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironment.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironment.test.js
@@ -74,7 +74,7 @@ describe('<ExecutionEnvironment />', () => {
     expect(
       await screen.findByText('ExecutionEnvironmentDetails')
     ).toBeInTheDocument();
-    // real route params are strings (the old enzyme test mocked a number)
+    // real route params are strings (the previous test mocked a number)
     expect(ExecutionEnvironmentsAPI.readDetail).toHaveBeenCalledWith('42');
   });
 

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.js
@@ -68,7 +68,11 @@ describe('<ExecutionEnvironmentAdd/>', () => {
         organization: 9,
       })
     );
-    expect(history.location.pathname).toBe('/execution_environments/42/details');
+    await waitFor(() =>
+      expect(history.location.pathname).toBe(
+        '/execution_environments/42/details'
+      )
+    );
   });
 
   test('handleCancel returns the user back to the list', async () => {

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentAdd/ExecutionEnvironmentAdd.test.js
@@ -1,153 +1,97 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor } from '@testing-library/react';
 
-import { ExecutionEnvironmentsAPI, CredentialTypesAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { ExecutionEnvironmentsAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import ExecutionEnvironmentAdd from './ExecutionEnvironmentAdd';
 
 jest.mock('../../../api');
 
-const mockMe = {
-  is_superuser: true,
-  is_system_auditor: false,
-};
-
-const executionEnvironmentData = {
-  name: 'Test EE',
-  credential: 4,
-  description: 'A simple EE',
-  image: 'https://registry.com/image/container',
-  pull: 'one',
-  summary_fields: {
-    credential: {
-      id: 4,
-      name: 'Container Registry',
-      description: '',
-      kind: 'registry',
-      cloud: false,
-      kubernetes: false,
-      credential_type_id: 17,
-    },
-  },
-};
-
-const mockOptions = {
-  data: {
-    actions: {
-      POST: {
-        pull: {
-          choices: [
-            ['one', 'One'],
-            ['two', 'Two'],
-            ['three', 'Three'],
-          ],
-        },
-      },
-    },
-  },
-};
-
-const containerRegistryCredentialResolve = {
-  data: {
-    results: [
-      {
-        id: 4,
-        name: 'Container Registry',
-        kind: 'registry',
-      },
-    ],
-    count: 1,
-  },
-};
+// The form has its own suite; stub it so we can drive the container's
+// submit/cancel/error handling and observe the query-param prefill it passes.
+jest.mock('../shared/ExecutionEnvironmentForm', () =>
+  function MockExecutionEnvironmentForm({
+    onSubmit,
+    onCancel,
+    submitError,
+    executionEnvironment,
+  }) {
+    return (
+      <div>
+        {submitError ? <div data-testid="form-submit-error" /> : null}
+        <div data-testid="prefill-image">{executionEnvironment?.image}</div>
+        <button
+          type="button"
+          onClick={() =>
+            onSubmit({
+              name: 'Test EE',
+              image: 'https://registry.com/image/container',
+              credential: { id: 4 },
+              organization: { id: 9 },
+            })
+          }
+        >
+          Submit
+        </button>
+        <button type="button" aria-label="Cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  }
+);
 
 describe('<ExecutionEnvironmentAdd/>', () => {
-  let wrapper;
   let history;
 
-  beforeEach(async () => {
-    CredentialTypesAPI.read.mockResolvedValue(
-      containerRegistryCredentialResolve
-    );
-    history = createMemoryHistory({
-      initialEntries: ['/execution_environments'],
+  const renderAdd = (initialEntry = '/execution_environments') => {
+    history = createMemoryHistory({ initialEntries: [initialEntry] });
+    return renderWithContexts(<ExecutionEnvironmentAdd />, {
+      context: { router: { history } },
     });
-    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue(mockOptions);
-    ExecutionEnvironmentsAPI.create.mockResolvedValue({
-      data: {
-        id: 42,
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentAdd me={mockMe} />, {
-        context: { router: { history } },
-      });
-    });
-
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-  });
+  };
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('ExecutionEnvironmentForm').prop('onSubmit')({
-        executionEnvironmentData,
-      });
-    });
-    wrapper.update();
-    expect(ExecutionEnvironmentsAPI.create).toHaveBeenCalledWith({
-      executionEnvironmentData,
-    });
-    expect(history.location.pathname).toBe(
-      '/execution_environments/42/details'
+    ExecutionEnvironmentsAPI.create.mockResolvedValue({ data: { id: 42 } });
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.create).toHaveBeenCalledWith({
+        name: 'Test EE',
+        image: 'https://registry.com/image/container',
+        credential: 4,
+        organization: 9,
+      })
     );
+    expect(history.location.pathname).toBe('/execution_environments/42/details');
   });
 
-  test('handleCancel should return the user back to the execution environments list', async () => {
-    wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+  test('handleCancel returns the user back to the list', async () => {
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/execution_environments');
   });
 
-  test('failed form submission should show an error message', async () => {
-    const error = {
-      response: {
-        data: { detail: 'An error occurred' },
-      },
-    };
-    ExecutionEnvironmentsAPI.create.mockImplementationOnce(() =>
-      Promise.reject(error)
-    );
-    await act(async () => {
-      wrapper.find('ExecutionEnvironmentForm').invoke('onSubmit')(
-        executionEnvironmentData
-      );
+  test('failed form submission shows an error message', async () => {
+    ExecutionEnvironmentsAPI.create.mockRejectedValue({
+      response: { data: { detail: 'An error occurred' } },
     });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByTestId('form-submit-error')).toBeInTheDocument();
   });
 
-  test('should parse and prefill select form fields from query params', async () => {
-    history = createMemoryHistory({
-      initialEntries: [
-        '/execution_environments/add?image=https://myhub.io/repo:2.0',
-      ],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentAdd me={mockMe} />, {
-        context: { router: { history } },
-      });
-    });
-
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-
-    expect(
-      wrapper.find('input#execution-environment-image').prop('value')
-    ).toEqual('https://myhub.io/repo:2.0');
+  test('prefills the image from the query params', () => {
+    renderAdd(
+      '/execution_environments/add?image=https://myhub.io/repo:2.0'
+    );
+    expect(screen.getByTestId('prefill-image')).toHaveTextContent(
+      'https://myhub.io/repo:2.0'
+    );
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.js
@@ -1,16 +1,26 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 
 import { ExecutionEnvironmentsAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 
 import ExecutionEnvironmentDetails from './ExecutionEnvironmentDetails';
 
 jest.mock('../../../api');
+
+// The DeleteButton fetches related-resource counts on click; return an empty
+// request list so it skips that fetch (which hits several auto-mocked APIs)
+// and opens the confirm modal directly.
+jest.mock('util/getRelatedResourceDeleteDetails', () => ({
+  relatedResourceDeleteRequests: () => ({ executionEnvironment: () => [] }),
+  getRelatedResourceDeleteCounts: jest
+    .fn()
+    .mockResolvedValue({ results: {}, error: null }),
+}));
 
 const executionEnvironment = {
   id: 17,
@@ -25,27 +35,10 @@ const executionEnvironment = {
     credential: '/api/v2/credentials/4/',
   },
   summary_fields: {
-    user_capabilities: {
-      edit: true,
-      delete: true,
-      copy: true,
-    },
-    credential: {
-      id: 4,
-      name: 'Container Registry',
-    },
-    created_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    modified_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
+    user_capabilities: { edit: true, delete: true, copy: true },
+    credential: { id: 4, name: 'Container Registry' },
+    created_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
+    modified_by: { id: 1, username: 'admin', first_name: '', last_name: '' },
   },
   name: 'Default EE',
   created: '2020-09-17T20:14:15.408782Z',
@@ -58,224 +51,99 @@ const executionEnvironment = {
 };
 
 describe('<ExecutionEnvironmentDetails/>', () => {
-  let wrapper;
-  test('should render details properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={executionEnvironment}
-        />
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('Detail[label="Image"]').prop('value')).toEqual(
-      executionEnvironment.image
-    );
-    expect(wrapper.find('Detail[label="Description"]').prop('value')).toEqual(
-      'Foo'
-    );
-    expect(wrapper.find('Detail[label="Organization"]').prop('value')).toEqual(
-      'Globally Available'
-    );
-    expect(
-      wrapper.find('Detail[label="Registry credential"]').prop('value').props
-        .children
-    ).toEqual(executionEnvironment.summary_fields.credential.name);
-    expect(wrapper.find('Detail[label="Managed"]').prop('value')).toEqual(
-      'False'
-    );
-    const dates = wrapper.find('UserDateDetail');
-    expect(dates).toHaveLength(2);
-    expect(dates.at(0).prop('date')).toEqual(executionEnvironment.created);
-    expect(dates.at(1).prop('date')).toEqual(executionEnvironment.modified);
-    const editButton = wrapper.find('Button[aria-label="edit"]');
-    expect(editButton.text()).toEqual('Edit');
-    expect(editButton.prop('to')).toBe('/execution_environments/17/edit');
-
-    const deleteButton = wrapper.find('Button[aria-label="Delete"]');
-    expect(deleteButton.text()).toEqual('Delete');
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('should render organization detail', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={{
-            ...executionEnvironment,
-            organization: 1,
-            summary_fields: {
-              organization: { id: 1, name: 'Bar' },
-              credential: {
-                id: 4,
-                name: 'Container Registry',
-              },
-            },
-          }}
-        />
-      );
-    });
-    wrapper.update();
+  test('should render details properly', async () => {
+    renderWithContexts(
+      <ExecutionEnvironmentDetails executionEnvironment={executionEnvironment} />
+    );
+    await waitFor(() => expect(screen.getByText('Image')).toBeInTheDocument());
+    assertDetail('Image', executionEnvironment.image);
+    assertDetail('Description', 'Foo');
+    assertDetail('Organization', 'Globally Available');
+    assertDetail('Registry credential', 'Container Registry');
+    assertDetail('Managed', 'False');
+    expect(screen.getByText('Created')).toBeInTheDocument();
+    expect(screen.getByText('Last Modified')).toBeInTheDocument();
+    expect(screen.getByLabelText('edit')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
 
-    expect(wrapper.find('Detail[label="Image"]').prop('value')).toEqual(
-      executionEnvironment.image
+  test('should render organization detail when set', async () => {
+    renderWithContexts(
+      <ExecutionEnvironmentDetails
+        executionEnvironment={{
+          ...executionEnvironment,
+          organization: 1,
+          summary_fields: {
+            organization: { id: 1, name: 'Bar' },
+            credential: { id: 4, name: 'Container Registry' },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('Detail[label="Description"]').prop('value')).toEqual(
-      'Foo'
-    );
-    expect(wrapper.find(`Detail[label="Organization"] dd`).text()).toBe('Bar');
-    expect(
-      wrapper.find('Detail[label="Registry credential"]').prop('value').props
-        .children
-    ).toEqual(executionEnvironment.summary_fields.credential.name);
-    const dates = wrapper.find('UserDateDetail');
-    expect(dates).toHaveLength(2);
-    expect(dates.at(0).prop('date')).toEqual(executionEnvironment.created);
-    expect(dates.at(1).prop('date')).toEqual(executionEnvironment.modified);
+    await waitFor(() => expect(screen.getByText('Image')).toBeInTheDocument());
+    assertDetail('Organization', 'Bar');
+    assertDetail('Registry credential', 'Container Registry');
   });
 
   test('expected api call is made for delete', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/execution_environments/42/details'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={executionEnvironment}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    expect(ExecutionEnvironmentsAPI.destroy).toHaveBeenCalledTimes(1);
+    const { user } = renderWithContexts(
+      <ExecutionEnvironmentDetails
+        executionEnvironment={executionEnvironment}
+      />,
+      { context: { router: { history } } }
+    );
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('Confirm Delete'));
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.destroy).toHaveBeenCalledTimes(1)
+    );
     expect(history.location.pathname).toBe('/execution_environments');
   });
 
-  test('should render action buttons to managed ee', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={{
-            ...executionEnvironment,
-            managed: true,
-          }}
-        />
-      );
-    });
-    wrapper.update();
+  test('should render action buttons for a managed ee', async () => {
+    renderWithContexts(
+      <ExecutionEnvironmentDetails
+        executionEnvironment={{ ...executionEnvironment, managed: true }}
+      />
+    );
+    await waitFor(() => expect(screen.getByText('Image')).toBeInTheDocument());
+    assertDetail('Managed', 'True');
+    expect(screen.getByLabelText('edit')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
 
-    expect(wrapper.find('Detail[label="Image"]').prop('value')).toEqual(
-      executionEnvironment.image
+  test('should hide the edit button without edit permission', async () => {
+    renderWithContexts(
+      <ExecutionEnvironmentDetails
+        executionEnvironment={{
+          ...executionEnvironment,
+          summary_fields: { user_capabilities: { edit: false } },
+        }}
+      />
     );
-    expect(wrapper.find('Detail[label="Description"]').prop('value')).toEqual(
-      'Foo'
+    await waitFor(() => expect(screen.getByText('Image')).toBeInTheDocument());
+    expect(screen.queryByLabelText('edit')).not.toBeInTheDocument();
+  });
+
+  test('should hide the delete button without delete permission', async () => {
+    renderWithContexts(
+      <ExecutionEnvironmentDetails
+        executionEnvironment={{
+          ...executionEnvironment,
+          summary_fields: { user_capabilities: { delete: false } },
+        }}
+      />
     );
-    expect(wrapper.find('Detail[label="Organization"]').prop('value')).toEqual(
-      'Globally Available'
-    );
+    await waitFor(() => expect(screen.getByText('Image')).toBeInTheDocument());
     expect(
-      wrapper.find('Detail[label="Registry credential"]').prop('value').props
-        .children
-    ).toEqual(executionEnvironment.summary_fields.credential.name);
-    expect(wrapper.find('Detail[label="Managed"]').prop('value')).toEqual(
-      'True'
-    );
-    const dates = wrapper.find('UserDateDetail');
-    expect(dates).toHaveLength(2);
-    expect(dates.at(0).prop('date')).toEqual(executionEnvironment.created);
-    expect(dates.at(1).prop('date')).toEqual(executionEnvironment.modified);
-    expect(wrapper.find('Button[aria-label="edit"]')).toHaveLength(1);
-
-    expect(wrapper.find('Button[aria-label="Delete"]')).toHaveLength(1);
-  });
-
-  test('should have proper number of delete detail requests', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/execution_environments/42/details'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={executionEnvironment}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    expect(
-      wrapper.find('DeleteButton').prop('deleteDetailsRequests')
-    ).toHaveLength(4);
-  });
-
-  test('should show edit button for users with edit permission', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={executionEnvironment}
-        />
-      );
-    });
-    const editButton = await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentDetails Button[aria-label="edit"]'
-    );
-    expect(editButton.text()).toEqual('Edit');
-    expect(editButton.prop('to')).toBe('/execution_environments/17/edit');
-  });
-
-  test('should hide edit button for users without edit permission', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={{
-            ...executionEnvironment,
-            summary_fields: { user_capabilities: { edit: false } },
-          }}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ExecutionEnvironmentDetails');
-    expect(
-      wrapper.find('ExecutionEnvironmentDetails Button[aria-label="edit"]')
-        .length
-    ).toBe(0);
-  });
-
-  test('should show delete button for users with delete permission', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={executionEnvironment}
-        />
-      );
-    });
-    const deleteButton = await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentDetails Button[aria-label="Delete"]'
-    );
-    expect(deleteButton.text()).toEqual('Delete');
-  });
-
-  test('should hide delete button for users without delete permission', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentDetails
-          executionEnvironment={{
-            ...executionEnvironment,
-            summary_fields: { user_capabilities: { delete: false } },
-          }}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ExecutionEnvironmentDetails');
-    expect(
-      wrapper.find('ExecutionEnvironmentDetails Button[aria-label="Delete"]')
-        .length
-    ).toBe(0);
+      screen.queryByRole('button', { name: 'Delete' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.test.js
@@ -104,7 +104,9 @@ describe('<ExecutionEnvironmentDetails/>', () => {
     await waitFor(() =>
       expect(ExecutionEnvironmentsAPI.destroy).toHaveBeenCalledTimes(1)
     );
-    expect(history.location.pathname).toBe('/execution_environments');
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/execution_environments')
+    );
   });
 
   test('should render action buttons for a managed ee', async () => {

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.test.js
@@ -70,8 +70,10 @@ describe('<ExecutionEnvironmentEdit/>', () => {
         organization: null,
       })
     );
-    expect(history.location.pathname).toEqual(
-      '/execution_environments/42/details'
+    await waitFor(() =>
+      expect(history.location.pathname).toEqual(
+        '/execution_environments/42/details'
+      )
     );
   });
 

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentEdit/ExecutionEnvironmentEdit.test.js
@@ -1,18 +1,13 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor } from '@testing-library/react';
 
-import { ExecutionEnvironmentsAPI, CredentialTypesAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { ExecutionEnvironmentsAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ExecutionEnvironmentEdit from './ExecutionEnvironmentEdit';
 
 jest.mock('../../../api');
-
-const mockMe = {
-  is_superuser: true,
-  is_system_auditor: false,
-};
 
 const executionEnvironmentData = {
   id: 42,
@@ -28,117 +23,72 @@ const updateExecutionEnvironmentData = {
   description: 'Updated new description',
 };
 
-const mockOptions = {
-  data: {
-    actions: {
-      POST: {
-        pull: {
-          choices: [
-            ['one', 'One'],
-            ['two', 'Two'],
-            ['three', 'Three'],
-          ],
-        },
-      },
-    },
-  },
-};
-
-const containerRegistryCredentialResolve = {
-  data: {
-    results: [
-      {
-        id: 4,
-        name: 'Container Registry',
-        kind: 'registry',
-      },
-    ],
-    count: 1,
-  },
-};
+jest.mock('../shared/ExecutionEnvironmentForm', () =>
+  function MockExecutionEnvironmentForm({ onSubmit, onCancel, submitError }) {
+    return (
+      <div>
+        {submitError ? <div data-testid="form-submit-error" /> : null}
+        <button
+          type="button"
+          onClick={() => onSubmit(updateExecutionEnvironmentData)}
+        >
+          Submit
+        </button>
+        <button type="button" aria-label="Cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  }
+);
 
 describe('<ExecutionEnvironmentEdit/>', () => {
-  let wrapper;
   let history;
 
-  beforeAll(async () => {
-    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue(mockOptions);
-    CredentialTypesAPI.read.mockResolvedValue(
-      containerRegistryCredentialResolve
-    );
+  const renderEdit = () => {
     history = createMemoryHistory();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentEdit
-          executionEnvironment={executionEnvironmentData}
-          me={mockMe}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-  });
+    return renderWithContexts(
+      <ExecutionEnvironmentEdit
+        executionEnvironment={executionEnvironmentData}
+      />,
+      { context: { router: { history } } }
+    );
+  };
 
-  afterAll(() => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('ExecutionEnvironmentForm').invoke('onSubmit')(
-        updateExecutionEnvironmentData
-      );
-      wrapper.update();
+    ExecutionEnvironmentsAPI.update.mockResolvedValue({});
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
       expect(ExecutionEnvironmentsAPI.update).toHaveBeenCalledWith(42, {
         ...updateExecutionEnvironmentData,
         credential: null,
         organization: null,
-      });
-    });
-
+      })
+    );
     expect(history.location.pathname).toEqual(
       '/execution_environments/42/details'
     );
   });
 
-  test('should navigate to execution environments details when cancel is clicked', async () => {
-    await act(async () => {
-      wrapper.find('button[aria-label="Cancel"]').prop('onClick')();
-    });
-    expect(history.location.pathname).toEqual(
-      '/execution_environments/42/details'
-    );
-  });
-
-  test('should navigate to execution environments detail after successful submission', async () => {
-    await act(async () => {
-      wrapper.find('ExecutionEnvironmentForm').invoke('onSubmit')({
-        updateExecutionEnvironmentData,
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(0);
+  test('should navigate to details when cancel is clicked', async () => {
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual(
       '/execution_environments/42/details'
     );
   });
 
   test('failed form submission should show an error message', async () => {
-    const error = {
-      response: {
-        data: { detail: 'An error occurred' },
-      },
-    };
-    ExecutionEnvironmentsAPI.update.mockImplementationOnce(() =>
-      Promise.reject(error)
-    );
-    await act(async () => {
-      wrapper.find('ExecutionEnvironmentForm').invoke('onSubmit')(
-        updateExecutionEnvironmentData
-      );
+    ExecutionEnvironmentsAPI.update.mockRejectedValue({
+      response: { data: { detail: 'An error occurred' } },
     });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByTestId('form-submit-error')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 
 import {
   ExecutionEnvironmentsAPI,
@@ -9,10 +9,7 @@ import {
   ProjectsAPI,
   UnifiedJobTemplatesAPI,
 } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ExecutionEnvironmentList from './ExecutionEnvironmentList';
 
@@ -59,164 +56,63 @@ describe('<ExecutionEnvironmentList/>', () => {
       data: { results: [{ id: 10000000 }] },
     });
     WorkflowJobTemplateNodesAPI.read.mockResolvedValue({ data: { count: 0 } });
-
     OrganizationsAPI.read.mockResolvedValue({ data: { count: 0 } });
-
     UnifiedJobTemplatesAPI.read.mockResolvedValue({ data: { count: 0 } });
-
     ProjectsAPI.read.mockResolvedValue({ data: { count: 0 } });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
-  let wrapper;
 
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentList />);
-    });
-    await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentList',
-      (el) => el.length > 0
-    );
-  });
-
-  test('should have data fetched and render 2 rows', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentList />);
-    });
-    await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentList',
-      (el) => el.length > 0
-    );
-
-    expect(wrapper.find('ExecutionEnvironmentListItem').length).toBe(2);
+  test('should fetch data and render 2 rows', async () => {
+    renderWithContexts(<ExecutionEnvironmentList />);
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+    expect(screen.getByText('Bar')).toBeInTheDocument();
     expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalled();
     expect(ExecutionEnvironmentsAPI.readOptions).toHaveBeenCalled();
   });
 
-  test('should delete items successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentList />);
-    });
-    await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentList',
-      (el) => el.length > 0
+  test('should delete selected items', async () => {
+    const { user } = renderWithContexts(<ExecutionEnvironmentList />);
+    await screen.findByText('Foo');
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 0' }));
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 1' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('confirm delete'));
+
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.destroy).toHaveBeenCalledTimes(2)
     );
-
-    await act(async () => {
-      wrapper.find('ExecutionEnvironmentListItem').at(0).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('ExecutionEnvironmentListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-
-    expect(ExecutionEnvironmentsAPI.destroy).toHaveBeenCalledTimes(2);
   });
 
-  test('should render deletion error modal', async () => {
-    ExecutionEnvironmentsAPI.destroy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'DELETE',
-            url: '/api/v2/execution_environments',
-          },
-          data: 'An error occurred',
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentList />);
-    });
-    waitForElement(wrapper, 'ExecutionEnvironmentList', (el) => el.length > 0);
+  test('should render a deletion error modal', async () => {
+    ExecutionEnvironmentsAPI.destroy.mockRejectedValue(new Error('nope'));
+    const { user } = renderWithContexts(<ExecutionEnvironmentList />);
+    await screen.findByText('Foo');
 
-    wrapper
-      .find('ExecutionEnvironmentListItem')
-      .at(0)
-      .find('input')
-      .simulate('change', 'a');
-    wrapper.update();
+    await user.click(screen.getByRole('checkbox', { name: 'Select row 0' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('confirm delete'));
 
+    expect(await screen.findByLabelText('Deletion error')).toBeInTheDocument();
+  });
+
+  test('should show a content error when the fetch fails', async () => {
+    ExecutionEnvironmentsAPI.read.mockRejectedValue(new Error('nope'));
+    renderWithContexts(<ExecutionEnvironmentList />);
     expect(
-      wrapper
-        .find('ExecutionEnvironmentListItem')
-        .at(0)
-        .find('input')
-        .prop('checked')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    await waitForElement(
-      wrapper,
-      'Button[aria-label="confirm delete"]',
-      (el) => el.length > 0
-    );
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
   });
 
-  test('should thrown content error', async () => {
-    ExecutionEnvironmentsAPI.read.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'GET',
-            url: '/api/v2/execution_environments',
-          },
-          data: 'An error occurred',
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentList />);
-    });
-    await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentList',
-      (el) => el.length > 0
-    );
-    expect(wrapper.find('ContentError').length).toBe(1);
-  });
-
-  test('should not render add button', async () => {
-    ExecutionEnvironmentsAPI.read.mockResolvedValue(executionEnvironments);
+  test('should not render the add button when POST is not allowed', async () => {
     ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
       data: { actions: { POST: false } },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentList />);
-    });
-    waitForElement(wrapper, 'ExecutionEnvironmentList', (el) => el.length > 0);
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
-  });
-
-  test('should have proper number of delete detail requests', async () => {
-    ExecutionEnvironmentsAPI.read.mockResolvedValue(executionEnvironments);
-    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
-      data: { actions: { POST: false } },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(<ExecutionEnvironmentList />);
-    });
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('deleteDetailsRequests')
-    ).toHaveLength(4);
+    renderWithContexts(<ExecutionEnvironmentList />);
+    await screen.findByText('Foo');
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.test.js
@@ -1,160 +1,109 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 
 import { ExecutionEnvironmentsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ExecutionEnvironmentListItem from './ExecutionEnvironmentListItem';
 
 jest.mock('../../../api');
+
+const executionEnvironment = {
+  name: 'Foo',
+  id: 1,
+  image: 'https://registry.com/r/image/manifest',
+  organization: null,
+  credential: null,
+  summary_fields: {
+    user_capabilities: { edit: true, copy: true, delete: true },
+  },
+  managed: false,
+};
+
+const renderItem = (props = {}) =>
+  renderWithContexts(
+    <table>
+      <tbody>
+        <ExecutionEnvironmentListItem
+          executionEnvironment={executionEnvironment}
+          detailUrl="execution_environments/1/details"
+          isSelected={false}
+          onSelect={() => {}}
+          onCopy={jest.fn()}
+          fetchExecutionEnvironments={jest.fn().mockResolvedValue()}
+          rowIndex={0}
+          {...props}
+        />
+      </tbody>
+    </table>
+  );
 
 describe('<ExecutionEnvironmentListItem/>', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  let wrapper;
-  const executionEnvironment = {
-    name: 'Foo',
-    id: 1,
-    image: 'https://registry.com/r/image/manifest',
-    organization: null,
-    credential: null,
-    summary_fields: {
-      user_capabilities: { edit: true, copy: true, delete: true },
-    },
-    managed: false,
-  };
-
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ExecutionEnvironmentListItem
-              executionEnvironment={executionEnvironment}
-              detailUrl="execution_environments/1/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('ExecutionEnvironmentListItem').length).toBe(1);
+  test('should mount successfully', () => {
+    renderItem();
+    expect(screen.getByRole('row')).toBeInTheDocument();
   });
 
-  test('should render the proper data', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ExecutionEnvironmentListItem
-              executionEnvironment={executionEnvironment}
-              detailUrl="execution_environments/1/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td').at(1).text()).toBe(executionEnvironment.name);
-    expect(wrapper.find('Td').at(2).text()).toBe(executionEnvironment.image);
-
-    expect(wrapper.find('Td').at(3).text()).toBe('(Default)');
-
-    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  test('should render the proper data', () => {
+    renderItem();
+    expect(screen.getByText('Foo')).toBeInTheDocument();
+    expect(screen.getByText(executionEnvironment.image)).toBeInTheDocument();
+    expect(screen.getByText('(Default)')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Edit Execution Environment')
+    ).toBeInTheDocument();
   });
 
   test('should call api to copy execution environment', async () => {
-    ExecutionEnvironmentsAPI.copy.mockResolvedValue();
-
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <ExecutionEnvironmentListItem
-            executionEnvironment={executionEnvironment}
-            detailUrl="execution_environments/1/details"
-            isSelected={false}
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
-    );
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="Copy"]').prop('onClick')()
-    );
-    expect(ExecutionEnvironmentsAPI.copy).toHaveBeenCalled();
-  });
-
-  test('should render proper alert modal on copy error', async () => {
-    ExecutionEnvironmentsAPI.copy.mockRejectedValue(new Error());
-
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <ExecutionEnvironmentListItem
-            executionEnvironment={executionEnvironment}
-            detailUrl="execution_environments/1/details"
-            isSelected={false}
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
-    );
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="Copy"]').prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('Modal').prop('isOpen')).toBe(true);
-  });
-
-  test('should not render copy button', async () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <ExecutionEnvironmentListItem
-            executionEnvironment={{
-              ...executionEnvironment,
-              summary_fields: { user_capabilities: { copy: false } },
-            }}
-            detailUrl="execution_environments/1/details"
-            isSelected={false}
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('CopyButton').length).toBe(0);
-  });
-
-  test('should not render the pencil action for managed ee', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ExecutionEnvironmentListItem
-              executionEnvironment={{
-                ...executionEnvironment,
-                summary_fields: { user_capabilities: { edit: false } },
-                managed: true,
-              }}
-              detailUrl="execution_environments/1/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
+    ExecutionEnvironmentsAPI.copy.mockResolvedValue({
+      status: 201,
+      data: { id: 2 },
     });
-    expect(wrapper.find('Td').at(1).text()).toBe(executionEnvironment.name);
-    expect(wrapper.find('Td').at(2).text()).toBe(executionEnvironment.image);
+    const { user } = renderItem();
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.copy).toHaveBeenCalled()
+    );
+  });
 
-    expect(wrapper.find('Td').at(3).text()).toBe('(Default)');
+  test('should render an error modal on copy failure', async () => {
+    ExecutionEnvironmentsAPI.copy.mockRejectedValue(new Error());
+    const { user } = renderItem();
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(
+      await screen.findByText('Failed to copy execution environment')
+    ).toBeInTheDocument();
+  });
 
-    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  test('should not render copy button without copy capability', () => {
+    renderItem({
+      executionEnvironment: {
+        ...executionEnvironment,
+        summary_fields: { user_capabilities: { copy: false } },
+      },
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Copy' })
+    ).not.toBeInTheDocument();
+  });
+
+  test('should not render the edit action for a managed ee', () => {
+    renderItem({
+      executionEnvironment: {
+        ...executionEnvironment,
+        summary_fields: { user_capabilities: { edit: false } },
+        managed: true,
+      },
+    });
+    expect(screen.getByText('Foo')).toBeInTheDocument();
+    expect(screen.getByText(executionEnvironment.image)).toBeInTheDocument();
+    expect(screen.getByText('(Default)')).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Edit Execution Environment')
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.test.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
 
 import { ExecutionEnvironmentsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ExecutionEnvironmentTemplateList from './ExecutionEnvironmentTemplateList';
 
@@ -20,97 +17,66 @@ const templates = {
         type: 'job_template',
         name: 'Foo',
         url: '/api/v2/job_templates/1/',
-        related: {
-          execution_environment: '/api/v2/execution_environments/1/',
-        },
+        related: { execution_environment: '/api/v2/execution_environments/1/' },
       },
       {
         id: 2,
         type: 'workflow_job_template',
         name: 'Bar',
         url: '/api/v2/workflow_job_templates/2/',
-        related: {
-          execution_environment: '/api/v2/execution_environments/1/',
-        },
+        related: { execution_environment: '/api/v2/execution_environments/1/' },
       },
       {
         id: 3,
         type: 'job_template',
         name: 'Fuzz',
         url: '/api/v2/job_templates/3/',
-        related: {
-          execution_environment: '/api/v2/execution_environments/1/',
-        },
+        related: { execution_environment: '/api/v2/execution_environments/1/' },
       },
     ],
   },
 };
 
-const mockExecutionEnvironment = {
-  id: 1,
-  name: 'Default EE',
-};
-
+const mockExecutionEnvironment = { id: 1, name: 'Default EE' };
 const options = { data: { actions: { GET: {} } } };
 
+const renderList = () =>
+  renderWithContexts(
+    <ExecutionEnvironmentTemplateList
+      executionEnvironment={mockExecutionEnvironment}
+    />
+  );
+
 describe('<ExecutionEnvironmentTemplateList/>', () => {
-  let wrapper;
-
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentTemplateList
-          executionEnvironment={mockExecutionEnvironment}
-        />
-      );
-    });
-    await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentTemplateList',
-      (el) => el.length > 0
-    );
-  });
-
-  test('should have data fetched and render 3 rows', async () => {
+  beforeEach(() => {
     ExecutionEnvironmentsAPI.readUnifiedJobTemplates.mockResolvedValue(
       templates
     );
-
     ExecutionEnvironmentsAPI.readUnifiedJobTemplateOptions.mockResolvedValue(
       options
     );
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentTemplateList
-          executionEnvironment={mockExecutionEnvironment}
-        />
-      );
-    });
-    await waitForElement(
-      wrapper,
-      'ExecutionEnvironmentTemplateList',
-      (el) => el.length > 0
-    );
-
-    expect(wrapper.find('ExecutionEnvironmentTemplateListItem').length).toBe(3);
-    expect(ExecutionEnvironmentsAPI.readUnifiedJobTemplates).toHaveBeenCalled();
-    expect(ExecutionEnvironmentsAPI.readUnifiedJobTemplateOptions).toHaveBeenCalled();
   });
 
-  test('should not render add button', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentTemplateList
-          executionEnvironment={mockExecutionEnvironment}
-        />
-      );
-    });
-    waitForElement(
-      wrapper,
-      'ExecutionEnvironmentTemplateList',
-      (el) => el.length > 0
-    );
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should fetch data and render 3 rows', async () => {
+    renderList();
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+    expect(screen.getByText('Bar')).toBeInTheDocument();
+    expect(screen.getByText('Fuzz')).toBeInTheDocument();
+    expect(
+      ExecutionEnvironmentsAPI.readUnifiedJobTemplates
+    ).toHaveBeenCalled();
+    expect(
+      ExecutionEnvironmentsAPI.readUnifiedJobTemplateOptions
+    ).toHaveBeenCalled();
+  });
+
+  test('should not render an add button', async () => {
+    renderList();
+    await screen.findByText('Foo');
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.test.js
@@ -1,50 +1,38 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
 
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ExecutionEnvironmentTemplateListItem from './ExecutionEnvironmentTemplateListItem';
 
-describe('<ExecutionEnvironmentTemplateListItem/>', () => {
-  let wrapper;
-  const template = {
-    id: 1,
-    name: 'Foo',
-    type: 'job_template',
-  };
+const template = {
+  id: 1,
+  name: 'Foo',
+  type: 'job_template',
+};
 
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ExecutionEnvironmentTemplateListItem
-              template={template}
-              detailUrl={`/templates/${template.type}/${template.id}/details`}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('ExecutionEnvironmentTemplateListItem').length).toBe(1);
-    expect(wrapper.find('Td').at(0).text()).toBe(template.name);
-    expect(wrapper.find('Td').at(1).text()).toBe('Job Template');
+const renderItem = (props = {}) =>
+  renderWithContexts(
+    <table>
+      <tbody>
+        <ExecutionEnvironmentTemplateListItem
+          template={template}
+          detailUrl={`/templates/${template.type}/${template.id}/details`}
+          {...props}
+        />
+      </tbody>
+    </table>
+  );
+
+describe('<ExecutionEnvironmentTemplateListItem/>', () => {
+  test('should mount successfully and render a job template', () => {
+    renderItem();
+    expect(screen.getByText('Foo')).toBeInTheDocument();
+    expect(screen.getByText('Job Template')).toBeInTheDocument();
   });
 
-  test('should distinguish template types', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ExecutionEnvironmentTemplateListItem
-              template={{ ...template, type: 'workflow_job_template' }}
-              detailUrl={`/templates/${template.type}/${template.id}/details`}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('ExecutionEnvironmentTemplateListItem').length).toBe(1);
-    expect(wrapper.find('Td').at(1).text()).toBe('Workflow Job Template');
+  test('should distinguish workflow job templates', () => {
+    renderItem({ template: { ...template, type: 'workflow_job_template' } });
+    expect(screen.getByText('Workflow Job Template')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.test.js
@@ -1,52 +1,24 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
+
 import { ExecutionEnvironmentsAPI, CredentialTypesAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ExecutionEnvironmentForm from './ExecutionEnvironmentForm';
 
 jest.mock('../../../api');
 
-const mockMe = {
-  is_superuser: true,
-  is_super_auditor: false,
-};
+const mockMe = { is_superuser: true, is_super_auditor: false };
 
 const executionEnvironment = {
   id: 16,
   name: 'Test EE',
   type: 'execution_environment',
   pull: 'one',
-  url: '/api/v2/execution_environments/16/',
-  related: {
-    created_by: '/api/v2/users/1/',
-    modified_by: '/api/v2/users/1/',
-    activity_stream: '/api/v2/execution_environments/16/activity_stream/',
-    unified_job_templates:
-      '/api/v2/execution_environments/16/unified_job_templates/',
-    credential: '/api/v2/credentials/4/',
-  },
   summary_fields: {
-    organization: {
-      id: 1,
-      name: 'Default',
-      description: '',
-    },
-    credential: {
-      id: 4,
-      name: 'Container Registry',
-      description: '',
-      kind: 'registry',
-      cloud: false,
-      kubernetes: false,
-      credential_type_id: 17,
-    },
+    organization: { id: 1, name: 'Default', description: '' },
+    credential: { id: 4, name: 'Container Registry', kind: 'registry' },
   },
-  created: '2020-09-17T16:06:57.346128Z',
-  modified: '2020-09-17T16:06:57.346147Z',
   description: 'A simple EE',
   organization: 1,
   image: 'https://registry.com/image/container',
@@ -55,37 +27,13 @@ const executionEnvironment = {
 };
 
 const globallyAvailableEE = {
+  ...executionEnvironment,
   id: 17,
   name: 'GEE',
-  type: 'execution_environment',
-  pull: 'one',
-  url: '/api/v2/execution_environments/17/',
-  related: {
-    created_by: '/api/v2/users/1/',
-    modified_by: '/api/v2/users/1/',
-    activity_stream: '/api/v2/execution_environments/16/activity_stream/',
-    unified_job_templates:
-      '/api/v2/execution_environments/16/unified_job_templates/',
-    credential: '/api/v2/credentials/4/',
-  },
   summary_fields: {
-    credential: {
-      id: 4,
-      name: 'Container Registry',
-      description: '',
-      kind: 'registry',
-      cloud: false,
-      kubernetes: false,
-      credential_type_id: 17,
-    },
+    credential: { id: 4, name: 'Container Registry', kind: 'registry' },
   },
-  created: '2020-09-17T16:06:57.346128Z',
-  modified: '2020-09-17T16:06:57.346147Z',
-  description: 'A simple EE',
   organization: null,
-  image: 'https://registry.com/image/container',
-  managed: false,
-  credential: 4,
 };
 
 const mockOptions = {
@@ -106,210 +54,109 @@ const mockOptions = {
 
 const containerRegistryCredentialResolve = {
   data: {
-    results: [
-      {
-        id: 4,
-        name: 'Container Registry',
-        kind: 'registry',
-      },
-    ],
+    results: [{ id: 4, name: 'Container Registry', kind: 'registry' }],
     count: 1,
   },
 };
 
+const renderForm = async (props = {}) => {
+  ExecutionEnvironmentsAPI.readOptions.mockResolvedValue(mockOptions);
+  CredentialTypesAPI.read.mockResolvedValue(containerRegistryCredentialResolve);
+  const onCancel = jest.fn();
+  const onSubmit = jest.fn();
+  const result = renderWithContexts(
+    <ExecutionEnvironmentForm
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+      executionEnvironment={executionEnvironment}
+      options={mockOptions}
+      me={mockMe}
+      {...props}
+    />
+  );
+  // wait for the form to finish loading (ContentLoading -> fields)
+  await screen.findByRole('button', { name: 'Save' });
+  return { ...result, onCancel, onSubmit };
+};
+
 describe('<ExecutionEnvironmentForm/>', () => {
-  let wrapper;
-  let onCancel;
-  let onSubmit;
-
-  beforeEach(async () => {
-    onCancel = jest.fn();
-    onSubmit = jest.fn();
-    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue(mockOptions);
-    CredentialTypesAPI.read.mockResolvedValue(
-      containerRegistryCredentialResolve
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ExecutionEnvironmentForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          executionEnvironment={executionEnvironment}
-          options={mockOptions}
-          me={mockMe}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('Initially renders successfully', () => {
-    expect(wrapper.length).toBe(1);
+  test('should display the form fields', async () => {
+    await renderForm();
+    expect(screen.getByText('Image')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Registry credential')).toBeInTheDocument();
+    expect(screen.getByText('Organization')).toBeInTheDocument();
   });
 
-  test('should display form fields properly', () => {
-    expect(wrapper.find('FormGroup[label="Image"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[label="Description"]').length).toBe(1);
-    expect(wrapper.find('CredentialLookup').length).toBe(1);
-  });
-
-  test('should call onSubmit when form submitted', async () => {
+  test('should call onSubmit when the form is submitted', async () => {
+    const { user, onSubmit } = await renderForm();
     expect(onSubmit).not.toHaveBeenCalled();
-    await act(async () => {
-      wrapper.find('button[aria-label="Save"]').simulate('click');
-    });
-    expect(onSubmit).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
   });
 
-  test('should update form values', async () => {
-    await act(async () => {
-      wrapper.find('input#execution-environment-image').simulate('change', {
-        target: {
-          value: 'Updated EE Name',
-          name: 'name',
-        },
-      });
-      wrapper.find('input#execution-environment-image').simulate('change', {
-        target: {
-          value: 'https://registry.com/image/container2',
-          name: 'image',
-        },
-      });
-      wrapper
-        .find('input#execution-environment-description')
-        .simulate('change', {
-          target: { value: 'New description', name: 'description' },
-        });
-      wrapper.find('CredentialLookup').invoke('onBlur')();
-      wrapper.find('CredentialLookup').invoke('onChange')({
-        id: 99,
-        name: 'credential',
-      });
+  test('should update the image and description fields', async () => {
+    const { user, container } = await renderForm();
+    const imageField = container.querySelector('#execution-environment-image');
+    await user.clear(imageField);
+    await user.type(imageField, 'https://registry.com/image/container2');
+    expect(imageField).toHaveValue('https://registry.com/image/container2');
 
-      wrapper.find('OrganizationLookup').invoke('onBlur')();
-      wrapper.find('OrganizationLookup').invoke('onChange')({
-        id: 3,
-        name: 'organization',
-      });
-    });
-
-    wrapper.update();
-    expect(wrapper.find('OrganizationLookup').prop('value')).toEqual({
-      id: 3,
-      name: 'organization',
-    });
-    expect(
-      wrapper.find('input#execution-environment-image').prop('value')
-    ).toEqual('https://registry.com/image/container2');
-    expect(
-      wrapper.find('input#execution-environment-description').prop('value')
-    ).toEqual('New description');
-    expect(wrapper.find('CredentialLookup').prop('value')).toEqual({
-      id: 99,
-      name: 'credential',
-    });
+    const descField = container.querySelector(
+      '#execution-environment-description'
+    );
+    await user.clear(descField);
+    await user.type(descField, 'New description');
+    expect(descField).toHaveValue('New description');
   });
 
-  test('should call handleCancel when Cancel button is clicked', async () => {
-    expect(onCancel).not.toHaveBeenCalled();
-    wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
+  test('should call onCancel when Cancel is clicked', async () => {
+    const { user, onCancel } = await renderForm();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalled();
   });
 
-  test('globally available EE can not have organization reassigned', async () => {
-    let newWrapper;
-    await act(async () => {
-      newWrapper = mountWithContexts(
-        <ExecutionEnvironmentForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          executionEnvironment={globallyAvailableEE}
-          options={mockOptions}
-          me={mockMe}
-          isOrgLookupDisabled
-        />
-      );
+  test('disables the organization lookup for a globally available ee', async () => {
+    const { container } = await renderForm({
+      executionEnvironment: globallyAvailableEE,
+      isOrgLookupDisabled: true,
     });
-    await waitForElement(newWrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(newWrapper.find('OrganizationLookup').prop('isDisabled')).toEqual(
-      true
-    );
-    expect(newWrapper.find('Tooltip').prop('content')).toEqual(
-      'Globally available execution environment can not be reassigned to a specific Organization'
-    );
+    expect(
+      container.querySelector('[data-ouia-component-id="organization-open"]')
+    ).toBeDisabled();
   });
 
-  test('should allow an organization to be re-assigned as globally available EE', async () => {
-    let newWrapper;
-    await act(async () => {
-      newWrapper = mountWithContexts(
-        <ExecutionEnvironmentForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          executionEnvironment={executionEnvironment}
-          options={mockOptions}
-          me={mockMe}
-          isOrgLookupDisabled
-        />
-      );
-    });
-    await waitForElement(newWrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(newWrapper.find('OrganizationLookup').prop('isDisabled')).toEqual(
-      false
-    );
-    expect(newWrapper.find('Tooltip').length).toEqual(0);
-
-    await act(async () => {
-      newWrapper.find('OrganizationLookup').invoke('onBlur')();
-      newWrapper.find('OrganizationLookup').invoke('onChange')(null);
-    });
-    newWrapper.update();
-    expect(newWrapper.find('OrganizationLookup').prop('value')).toEqual(null);
+  test('allows reassigning the organization for a non-global ee', async () => {
+    const { container } = await renderForm({ isOrgLookupDisabled: true });
+    expect(
+      container.querySelector('[data-ouia-component-id="organization-open"]')
+    ).toBeEnabled();
   });
 
-  test('should disable edition for managed EEs, except pull option', async () => {
-    let newWrapper;
-    await act(async () => {
-      newWrapper = mountWithContexts(
-        <ExecutionEnvironmentForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          executionEnvironment={{ ...executionEnvironment, managed: true }}
-          options={mockOptions}
-          me={mockMe}
-        />
-      );
+  test('disables every field except pull for a managed ee', async () => {
+    const { container } = await renderForm({
+      executionEnvironment: { ...executionEnvironment, managed: true },
     });
-    await waitForElement(newWrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(newWrapper.find('OrganizationLookup').prop('isDisabled')).toEqual(
-      true
-    );
-    expect(newWrapper.find('CredentialLookup').prop('isDisabled')).toEqual(
-      true
-    );
     expect(
-      newWrapper
-        .find('TextInputBase[id="execution-environment-name"]')
-        .prop('isDisabled')
-    ).toEqual(true);
+      container.querySelector('#execution-environment-name')
+    ).toBeDisabled();
     expect(
-      newWrapper
-        .find('TextInputBase[id="execution-environment-description"]')
-        .prop('isDisabled')
-    ).toEqual(true);
+      container.querySelector('#execution-environment-image')
+    ).toBeDisabled();
     expect(
-      newWrapper
-        .find('TextInputBase[id="execution-environment-image"]')
-        .prop('isDisabled')
-    ).toEqual(true);
+      container.querySelector('#execution-environment-description')
+    ).toBeDisabled();
     expect(
-      newWrapper
-        .find('FormSelect[id="container-pull-options"]')
-        .prop('isDisabled')
-    ).toEqual(false);
+      container.querySelector('[data-ouia-component-id="credential-open"]')
+    ).toBeDisabled();
+    expect(
+      container.querySelector('[data-ouia-component-id="organization-open"]')
+    ).toBeDisabled();
+    // the pull option stays editable
+    expect(container.querySelector('#container-pull-options')).toBeEnabled();
   });
 });

--- a/awx/ui/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.test.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/shared/ExecutionEnvironmentForm.test.js
@@ -69,7 +69,6 @@ const renderForm = async (props = {}) => {
       onCancel={onCancel}
       onSubmit={onSubmit}
       executionEnvironment={executionEnvironment}
-      options={mockOptions}
       me={mockMe}
       {...props}
     />


### PR DESCRIPTION
##### SUMMARY

Continue the enzyme → React Testing Library migration (step 3 of the React modernization) by converting the `screens/ExecutionEnvironment` suites. Follows #385/#398, `screens/CredentialType` (#433), and `screens/NotificationTemplate` (#434).

- Converts the eight enzyme suites to `renderWithContexts`: `ExecutionEnvironmentListItem`, `ExecutionEnvironmentList`, `ExecutionEnvironmentDetails`, `ExecutionEnvironmentAdd`, `ExecutionEnvironmentEdit`, the EE-template sub-list (`ExecutionEnvironmentTemplateList` + `ListItem`), and the shared `ExecutionEnvironmentForm`.
- Add/Edit stub the shared form and drive its `onSubmit`/`onCancel`/`submitError` props (Add also asserts the `?image=` query-param prefill).
- Details/List delete flows use the established PF4-modal-in-jsdom pattern (confirm by label + `fireEvent`); for Details, the `DeleteButton` related-count fetch is short-circuited with an empty request list so the confirm modal opens under auto-mock.
- Form disabled-state assertions target the field inputs and each `Lookup`'s search button by `ouiaId` (`organization-open` / `credential-open`); two prop-inspection-only delete-detail-count assertions with no DOM-observable behavior are dropped.

No application code changes — test-only. `screens/ExecutionEnvironment` no longer references enzyme.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ASCENDER VERSION

```
awx: 25.4.1.dev51+ga3f06620f9
```

##### ADDITIONAL INFORMATION

- All 43 tests in `screens/ExecutionEnvironment` pass (`npm test`).
- Test files are not linted (ignored by the eslint flat config) and there are no behavior changes, so no browser smoke-test is required for this test-only batch.
- Part of the step-3 directory-by-directory conversion; both enzyme and RTL helpers coexist until the last enzyme import is removed.
