### PR TITLE
enzyme -> RTL: convert the Team screen suites

### DIFF
--- a/awx/ui/src/screens/Team/Team.test.js
+++ b/awx/ui/src/screens/Team/Team.test.js
@@ -72,7 +72,7 @@ describe('<Team />', () => {
   test('fetches the team detail', async () => {
     renderAt('/teams/1/details');
     expect(await screen.findByText('TeamDetail')).toBeInTheDocument();
-    // real route params are strings (the old enzyme test mocked a number)
+    // real route params come through as strings
     expect(TeamsAPI.readDetail).toHaveBeenCalledWith('1');
   });
 

--- a/awx/ui/src/screens/Team/TeamAdd/TeamAdd.test.js
+++ b/awx/ui/src/screens/Team/TeamAdd/TeamAdd.test.js
@@ -1,82 +1,78 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor } from '@testing-library/react';
+
 import { TeamsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import TeamAdd from './TeamAdd';
 
 jest.mock('../../../api');
 
+jest.mock('../shared/TeamForm', () =>
+  function MockTeamForm({ handleSubmit, handleCancel, submitError }) {
+    return (
+      <div>
+        {submitError ? <div data-testid="form-submit-error" /> : null}
+        <button
+          type="button"
+          onClick={() =>
+            handleSubmit({
+              name: 'new name',
+              description: 'new description',
+              organization: { id: 1, name: 'Default' },
+            })
+          }
+        >
+          Submit
+        </button>
+        <button type="button" aria-label="Cancel" onClick={handleCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  }
+);
+
 describe('<TeamAdd />', () => {
-  test('handleSubmit should post to api', async () => {
-    const history = createMemoryHistory({});
-    const updatedTeamData = {
-      name: 'new name',
-      description: 'new description',
-      organization: {
-        id: 1,
-        name: 'Default',
-      },
-    };
-    TeamsAPI.create.mockResolvedValueOnce({ data: {} });
-    const wrapper = mountWithContexts(<TeamAdd />, {
+  let history;
+
+  const renderAdd = () => {
+    history = createMemoryHistory({});
+    return renderWithContexts(<TeamAdd />, {
       context: { router: { history } },
     });
-    await act(async () => {
-      wrapper.find('TeamForm').invoke('handleSubmit')(updatedTeamData);
-    });
-    expect(TeamsAPI.create).toHaveBeenCalledWith({
-      ...updatedTeamData,
-      organization: 1,
-    });
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('handleSubmit posts to the api and redirects', async () => {
+    TeamsAPI.create.mockResolvedValue({ data: { id: 5 } });
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(TeamsAPI.create).toHaveBeenCalledWith({
+        name: 'new name',
+        description: 'new description',
+        organization: 1,
+      })
+    );
+    expect(history.location.pathname).toEqual('/teams/5');
   });
 
   test('should navigate to teams list when cancel is clicked', async () => {
-    const history = createMemoryHistory({});
-    const wrapper = mountWithContexts(<TeamAdd />, {
-      context: { router: { history } },
-    });
-    await act(async () => {
-      wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
-    });
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/teams');
   });
 
-  test('successful form submission should trigger redirect', async () => {
-    const history = createMemoryHistory({});
-    const teamData = {
-      name: 'new name',
-      description: 'new description',
-      organization: {
-        id: 1,
-        name: 'Default',
-      },
-    };
-    TeamsAPI.create.mockResolvedValueOnce({
-      data: {
-        id: 5,
-        ...teamData,
-        summary_fields: {
-          organization: {
-            id: 1,
-            name: 'Default',
-          },
-        },
-      },
+  test('failed form submission shows an error message', async () => {
+    TeamsAPI.create.mockRejectedValue({
+      response: { data: { detail: 'An error occurred' } },
     });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamAdd />, {
-        context: { router: { history } },
-      });
-    });
-    await waitForElement(wrapper, 'button[aria-label="Save"]');
-    await act(async () => {
-      await wrapper.find('TeamForm').invoke('handleSubmit')(teamData);
-    });
-    expect(history.location.pathname).toEqual('/teams/5');
+    const { user } = renderAdd();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByTestId('form-submit-error')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Team/TeamDetail/TeamDetail.test.js
+++ b/awx/ui/src/screens/Team/TeamDetail/TeamDetail.test.js
@@ -10,17 +10,17 @@ import TeamDetail from './TeamDetail';
 
 jest.mock('../../../api');
 
-const makeTeam = (overrides = {}) => ({
+const makeTeam = ({ summary_fields, ...overrides } = {}) => ({
   name: 'Foo',
   description: 'Bar',
   created: '2015-07-07T17:21:26.429745Z',
   modified: '2019-08-11T19:47:37.980466Z',
+  ...overrides,
   summary_fields: {
     organization: { id: 1, name: 'Default' },
     user_capabilities: { edit: true, delete: true },
-    ...(overrides.summary_fields || {}),
+    ...(summary_fields || {}),
   },
-  ...overrides,
 });
 
 describe('<TeamDetail />', () => {

--- a/awx/ui/src/screens/Team/TeamDetail/TeamDetail.test.js
+++ b/awx/ui/src/screens/Team/TeamDetail/TeamDetail.test.js
@@ -1,103 +1,72 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+
 import { TeamsAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 import TeamDetail from './TeamDetail';
 
 jest.mock('../../../api');
 
+const makeTeam = (overrides = {}) => ({
+  name: 'Foo',
+  description: 'Bar',
+  created: '2015-07-07T17:21:26.429745Z',
+  modified: '2019-08-11T19:47:37.980466Z',
+  summary_fields: {
+    organization: { id: 1, name: 'Default' },
+    user_capabilities: { edit: true, delete: true },
+    ...(overrides.summary_fields || {}),
+  },
+  ...overrides,
+});
+
 describe('<TeamDetail />', () => {
-  let wrapper;
-  const mockTeam = {
-    name: 'Foo',
-    description: 'Bar',
-    created: '2015-07-07T17:21:26.429745Z',
-    modified: '2019-08-11T19:47:37.980466Z',
-    summary_fields: {
-      organization: {
-        id: 1,
-        name: 'Default',
-      },
-      user_capabilities: {
-        edit: true,
-        delete: true,
-      },
-    },
-  };
-
-  beforeEach(async () => {
-    wrapper = mountWithContexts(<TeamDetail team={mockTeam} />);
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('initially renders successfully', async () => {
-    await waitForElement(wrapper, 'TeamDetail');
+  test('should render the details', async () => {
+    renderWithContexts(<TeamDetail team={makeTeam()} />);
+    await waitFor(() => expect(screen.getByText('Name')).toBeInTheDocument());
+    assertDetail('Name', 'Foo');
+    assertDetail('Description', 'Bar');
+    assertDetail('Organization', 'Default');
+    assertDetail('Created', '7/7/2015, 5:21:26 PM');
+    assertDetail('Last Modified', '8/11/2019, 7:47:37 PM');
+    expect(screen.getByLabelText('Edit')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
-  test('should render Details', async () => {
-    const testParams = [
-      { label: 'Name', value: 'Foo' },
-      { label: 'Description', value: 'Bar' },
-      { label: 'Organization', value: 'Default' },
-      { label: 'Created', value: '7/7/2015, 5:21:26 PM' },
-      { label: 'Last Modified', value: '8/11/2019, 7:47:37 PM' },
-    ];
-    for (let i = 0; i < testParams.length; i++) {
-      const { label, value } = testParams[i];
-      // eslint-disable-next-line no-await-in-loop
-      const detail = await waitForElement(wrapper, `Detail[label="${label}"]`);
-      expect(detail.find('dt').text()).toBe(label);
-      expect(detail.find('dd').text()).toBe(value);
-    }
-  });
-
-  test('should show edit button for users with edit permission', async () => {
-    const editButton = await waitForElement(
-      wrapper,
-      'TeamDetail Button[aria-label="Edit"]'
+  test('should hide the edit button without edit permission', async () => {
+    renderWithContexts(
+      <TeamDetail
+        team={makeTeam({
+          summary_fields: {
+            organization: { id: 1, name: 'Default' },
+            user_capabilities: { edit: false, delete: true },
+          },
+        })}
+      />
     );
-    expect(editButton.text()).toEqual('Edit');
-    expect(editButton.prop('to')).toBe('/teams/undefined/edit');
-  });
-
-  test('should hide edit button for users without edit permission', async () => {
-    const readOnlyTeam = { ...mockTeam };
-    readOnlyTeam.summary_fields.user_capabilities.edit = false;
-    wrapper = mountWithContexts(<TeamDetail team={readOnlyTeam} />);
-    await waitForElement(wrapper, 'TeamDetail');
-    expect(wrapper.find('TeamDetail Button[aria-label="Edit"]').length).toBe(0);
+    await waitFor(() => expect(screen.getByText('Name')).toBeInTheDocument());
+    expect(screen.queryByLabelText('Edit')).not.toBeInTheDocument();
   });
 
   test('expected api call is made for delete', async () => {
-    await waitForElement(wrapper, 'TeamDetail Button[aria-label="Delete"]');
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    expect(TeamsAPI.destroy).toHaveBeenCalledTimes(1);
+    const { user } = renderWithContexts(<TeamDetail team={makeTeam()} />);
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('Confirm Delete'));
+    await waitFor(() => expect(TeamsAPI.destroy).toHaveBeenCalledTimes(1));
   });
 
-  test('Error dialog shown for failed deletion', async () => {
-    TeamsAPI.destroy.mockImplementationOnce(() => Promise.reject(new Error()));
-    wrapper = mountWithContexts(<TeamDetail team={mockTeam} />);
-    await waitForElement(wrapper, 'TeamDetail Button[aria-label="Delete"]');
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 1
-    );
-    await act(async () => {
-      wrapper.find('Modal[title="Error!"]').invoke('onClose')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 0
-    );
+  test('shows an error dialog for a failed deletion', async () => {
+    TeamsAPI.destroy.mockRejectedValue(new Error('nope'));
+    const { user } = renderWithContexts(<TeamDetail team={makeTeam()} />);
+    await user.click(await screen.findByRole('button', { name: 'Delete' }));
+    fireEvent.click(await screen.findByLabelText('Confirm Delete'));
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Team/TeamEdit/TeamEdit.test.js
+++ b/awx/ui/src/screens/Team/TeamEdit/TeamEdit.test.js
@@ -1,61 +1,90 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createMemoryHistory } from 'history';
+import { screen, waitFor } from '@testing-library/react';
+
 import { TeamsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import TeamEdit from './TeamEdit';
 
 jest.mock('../../../api');
 
+const updatedTeamData = {
+  name: 'new name',
+  description: 'new description',
+  organization: { id: 2, name: 'Other Org' },
+};
+
+jest.mock('../shared/TeamForm', () =>
+  function MockTeamForm({ handleSubmit, handleCancel, submitError }) {
+    return (
+      <div>
+        {submitError ? <div data-testid="form-submit-error" /> : null}
+        <button
+          type="button"
+          onClick={() =>
+            handleSubmit({
+              name: 'new name',
+              description: 'new description',
+              organization: { id: 2, name: 'Other Org' },
+            })
+          }
+        >
+          Submit
+        </button>
+        <button type="button" aria-label="Cancel" onClick={handleCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  }
+);
+
+const mockData = {
+  name: 'Foo',
+  description: 'Bar',
+  id: 1,
+  summary_fields: { organization: { id: 1, name: 'Default' } },
+};
+
 describe('<TeamEdit />', () => {
-  const mockData = {
-    name: 'Foo',
-    description: 'Bar',
-    id: 1,
-    summary_fields: {
-      organization: {
-        id: 1,
-        name: 'Default',
-      },
-    },
-  };
+  let history;
 
-  test('handleSubmit should call api update and then navigate to the details page', async () => {
-    const history = createMemoryHistory({});
-
-    const wrapper = mountWithContexts(<TeamEdit team={mockData} />, {
+  const renderEdit = () => {
+    history = createMemoryHistory({});
+    return renderWithContexts(<TeamEdit team={mockData} />, {
       context: { router: { history } },
     });
+  };
 
-    const updatedTeamData = {
-      name: 'new name',
-      description: 'new description',
-      organization: {
-        id: 2,
-        name: 'Other Org',
-      },
-    };
-    await act(async () => {
-      wrapper.find('TeamForm').invoke('handleSubmit')(updatedTeamData);
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    expect(TeamsAPI.update).toHaveBeenCalledWith(1, {
-      ...updatedTeamData,
-      organization: 2,
-    });
+  test('handleSubmit calls api update and navigates to the details page', async () => {
+    TeamsAPI.update.mockResolvedValue({ data: { ...mockData } });
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    await waitFor(() =>
+      expect(TeamsAPI.update).toHaveBeenCalledWith(1, {
+        ...updatedTeamData,
+        organization: 2,
+      })
+    );
     expect(history.location.pathname).toEqual('/teams/1/details');
   });
 
   test('should navigate to team detail when cancel is clicked', async () => {
-    const history = createMemoryHistory({});
-    const wrapper = mountWithContexts(<TeamEdit team={mockData} />, {
-      context: { router: { history } },
-    });
-
-    await act(async () => {
-      wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
-    });
-
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/teams/1/details');
+  });
+
+  test('failed form submission shows an error message', async () => {
+    TeamsAPI.update.mockRejectedValue(
+      new Error({ response: { data: { detail: 'An error occurred' } } })
+    );
+    const { user } = renderEdit();
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByTestId('form-submit-error')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Team/TeamList/TeamList.test.js
+++ b/awx/ui/src/screens/Team/TeamList/TeamList.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { TeamsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import TeamList from './TeamList';
 
@@ -15,209 +15,130 @@ const mockAPITeamList = {
         name: 'Team 0',
         id: 1,
         url: '/teams/1',
-        summary_fields: {
-          user_capabilities: {
-            delete: true,
-            edit: true,
-          },
-        },
+        summary_fields: { user_capabilities: { delete: true, edit: true } },
       },
       {
         name: 'Team 1',
         id: 2,
         url: '/teams/2',
-        summary_fields: {
-          user_capabilities: {
-            delete: true,
-            edit: true,
-          },
-        },
+        summary_fields: { user_capabilities: { delete: true, edit: true } },
       },
       {
         name: 'Team 2',
         id: 3,
         url: '/teams/3',
-        summary_fields: {
-          user_capabilities: {
-            delete: true,
-            edit: true,
-          },
-        },
+        summary_fields: { user_capabilities: { delete: true, edit: true } },
       },
     ],
   },
-  isModalOpen: false,
-  warningTitle: 'title',
-  warningMsg: 'message',
 };
 
-describe('<TeamList />', () => {
-  beforeEach(() => {
-    TeamsAPI.read = jest.fn(() =>
-      Promise.resolve({
-        data: mockAPITeamList.data,
-      })
-    );
-    TeamsAPI.readOptions = jest.fn(() =>
-      Promise.resolve({
-        data: {
-          actions: {
-            GET: {},
-            POST: {},
-          },
-        },
-      })
-    );
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('<TeamList /> with full permissions', () => {
+  let user;
+
+  beforeEach(async () => {
+    TeamsAPI.read.mockResolvedValue({ data: mockAPITeamList.data });
+    TeamsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {}, POST: {} } },
+    });
+
+    ({ user } = renderWithContexts(<TeamList />));
+    await screen.findByRole('link', { name: 'Team 0' });
   });
 
-  test('should load and render teams', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
-    });
-    wrapper.update();
-
-    expect(wrapper.find('TeamListItem')).toHaveLength(3);
+  test('should load and render teams', () => {
+    expect(TeamsAPI.read).toHaveBeenCalled();
+    expect(screen.getByRole('link', { name: 'Team 0' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Team 1' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Team 2' })).toBeInTheDocument();
   });
 
   test('should select team when checked', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
-    });
-    wrapper.update();
-
-    await act(async () => {
-      wrapper.find('TeamListItem').first().invoke('onSelect')();
-    });
-    wrapper.update();
-
-    expect(wrapper.find('TeamListItem').first().prop('isSelected')).toEqual(
-      true
-    );
+    const row = screen.getByRole('link', { name: 'Team 0' }).closest('tr');
+    const checkbox = within(row).getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
   });
 
   test('should select all', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
-    });
-    wrapper.update();
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+    const rowCheckboxes = screen
+      .getAllByRole('checkbox')
+      .filter((box) => box !== selectAll);
 
-    await act(async () => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
-    });
-    wrapper.update();
-
-    const items = wrapper.find('TeamListItem');
-    expect(items).toHaveLength(3);
-    items.forEach((item) => {
-      expect(item.prop('isSelected')).toEqual(true);
-    });
-
-    expect(wrapper.find('TeamListItem').first().prop('isSelected')).toEqual(
-      true
-    );
+    expect(rowCheckboxes).toHaveLength(3);
+    await user.click(selectAll);
+    rowCheckboxes.forEach((box) => expect(box).toBeChecked());
   });
 
   test('should call delete api', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
-    });
-    wrapper.update();
-
-    await act(async () => {
-      wrapper.find('TeamListItem').at(0).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('TeamListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-
-    expect(TeamsAPI.destroy).toHaveBeenCalledTimes(2);
+    TeamsAPI.destroy.mockResolvedValue({});
+    await user.click(
+      within(
+        screen.getByRole('link', { name: 'Team 0' }).closest('tr')
+      ).getByRole('checkbox')
+    );
+    await user.click(
+      within(
+        screen.getByRole('link', { name: 'Team 1' }).closest('tr')
+      ).getByRole('checkbox')
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+    await waitFor(() => expect(TeamsAPI.destroy).toHaveBeenCalledTimes(2));
   });
 
   test('should re-fetch teams after team(s) have been deleted', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
-    });
-    wrapper.update();
+    TeamsAPI.destroy.mockResolvedValue({});
     expect(TeamsAPI.read).toHaveBeenCalledTimes(1);
-    await act(async () => {
-      wrapper.find('TeamListItem').at(0).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-
-    expect(TeamsAPI.read).toHaveBeenCalledTimes(2);
+    await user.click(
+      within(
+        screen.getByRole('link', { name: 'Team 0' }).closest('tr')
+      ).getByRole('checkbox')
+    );
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+    await waitFor(() => expect(TeamsAPI.read).toHaveBeenCalledTimes(2));
   });
 
   test('should show deletion error', async () => {
-    TeamsAPI.destroy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'delete',
-            url: '/api/v2/teams/1',
-          },
-          data: 'An error occurred',
-        },
-      })
+    TeamsAPI.destroy.mockRejectedValue(new Error());
+    await user.click(
+      within(
+        screen.getByRole('link', { name: 'Team 0' }).closest('tr')
+      ).getByRole('checkbox')
     );
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
-    });
-    wrapper.update();
-    expect(TeamsAPI.read).toHaveBeenCalledTimes(1);
-    await act(async () => {
-      wrapper.find('TeamListItem').at(0).invoke('onSelect')();
-    });
-    wrapper.update();
-
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-    wrapper.update();
-
-    const modal = wrapper.find('Modal');
-    expect(modal).toHaveLength(1);
-    expect(modal.prop('title')).toEqual('Error!');
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 
-  test('Add button shown for users without ability to POST', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
-    });
-    wrapper.update();
-
-    expect(wrapper.find('ToolbarAddButton').length).toBe(1);
+  test('Add button shown for users with ability to POST', () => {
+    expect(screen.getByRole('link', { name: 'Add' })).toBeInTheDocument();
   });
+});
 
+describe('<TeamList /> without full permissions', () => {
   test('Add button hidden for users without ability to POST', async () => {
-    TeamsAPI.readOptions = () =>
-      Promise.resolve({
-        data: {
-          actions: {
-            GET: {},
-          },
-        },
-      });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamList />);
+    TeamsAPI.read.mockResolvedValue({ data: mockAPITeamList.data });
+    TeamsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} } },
     });
-    wrapper.update();
 
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+    renderWithContexts(<TeamList />);
+    await screen.findByRole('link', { name: 'Team 0' });
+
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Team/TeamList/TeamListItem.test.js
+++ b/awx/ui/src/screens/Team/TeamList/TeamListItem.test.js
@@ -1,82 +1,42 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import TeamListItem from './TeamListItem';
 
+const renderItem = (capabilities = { edit: true }) =>
+  renderWithContexts(
+    <table>
+      <tbody>
+        <TeamListItem
+          team={{
+            id: 1,
+            name: 'Team 1',
+            summary_fields: { user_capabilities: capabilities },
+          }}
+          detailUrl="/team/1"
+          isSelected
+          onSelect={() => {}}
+          rowIndex={0}
+        />
+      </tbody>
+    </table>
+  );
+
 describe('<TeamListItem />', () => {
   test('initially renders successfully', () => {
-    mountWithContexts(
-      <MemoryRouter initialEntries={['/teams']} initialIndex={0}>
-        <table>
-          <tbody>
-            <TeamListItem
-              team={{
-                id: 1,
-                name: 'Team 1',
-                summary_fields: {
-                  user_capabilities: {
-                    edit: true,
-                  },
-                },
-              }}
-              detailUrl="/team/1"
-              isSelected
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      </MemoryRouter>
-    );
+    renderItem();
+    expect(screen.getByText('Team 1')).toBeInTheDocument();
   });
+
   test('edit button shown to users with edit capabilities', () => {
-    const wrapper = mountWithContexts(
-      <MemoryRouter initialEntries={['/teams']} initialIndex={0}>
-        <table>
-          <tbody>
-            <TeamListItem
-              team={{
-                id: 1,
-                name: 'Team',
-                summary_fields: {
-                  user_capabilities: {
-                    edit: true,
-                  },
-                },
-              }}
-              detailUrl="/team/1"
-              isSelected
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      </MemoryRouter>
-    );
-    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+    renderItem({ edit: true });
+    expect(screen.getByLabelText('Edit Team')).toBeInTheDocument();
   });
+
   test('edit button hidden from users without edit capabilities', () => {
-    const wrapper = mountWithContexts(
-      <MemoryRouter initialEntries={['/teams']} initialIndex={0}>
-        <table>
-          <tbody>
-            <TeamListItem
-              team={{
-                id: 1,
-                name: 'Team',
-                summary_fields: {
-                  user_capabilities: {
-                    edit: false,
-                  },
-                },
-              }}
-              detailUrl="/team/1"
-              isSelected
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      </MemoryRouter>
-    );
-    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+    renderItem({ edit: false });
+    expect(screen.queryByLabelText('Edit Team')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Team/TeamRoles/TeamRoleListItem.test.js
+++ b/awx/ui/src/screens/Team/TeamRoles/TeamRoleListItem.test.js
@@ -1,83 +1,52 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import TeamRoleListItem from './TeamRoleListItem';
 
+const makeRole = (overrides = {}) => ({
+  id: 1,
+  name: 'Admin',
+  type: 'role',
+  url: '/api/v2/roles/257/',
+  summary_fields: {
+    resource_name: 'template delete project',
+    resource_id: 15,
+    resource_type: 'job_template',
+    resource_type_display_name: 'Job Template',
+    user_capabilities: { unattach: true, ...(overrides.user_capabilities || {}) },
+  },
+});
+
+const renderItem = (role = makeRole()) =>
+  renderWithContexts(
+    <table>
+      <tbody>
+        <TeamRoleListItem
+          role={role}
+          detailUrl="/templates/job_template/15/details"
+          onDisassociate={() => {}}
+        />
+      </tbody>
+    </table>
+  );
+
 describe('<TeamRoleListItem/>', () => {
-  let wrapper;
-  const role = {
-    id: 1,
-    name: 'Admin',
-    type: 'role',
-    url: '/api/v2/roles/257/',
-    summary_fields: {
-      resource_name: 'template delete project',
-      resource_id: 15,
-      resource_type: 'job_template',
-      resource_type_display_name: 'Job Template',
-      user_capabilities: { unattach: true },
-    },
-  };
-
-  test('should mount properly', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TeamRoleListItem
-            role={role}
-            detailUrl="/templates/job_template/15/details"
-          />
-        </tbody>
-      </table>
-    );
-
-    expect(wrapper.length).toBe(1);
-  });
-
   test('should render proper list item data', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TeamRoleListItem
-            role={role}
-            detailUrl="/templates/job_template/15/details"
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Td[dataLabel="Resource Name"]').text()).toBe(
-      'template delete project'
-    );
-    expect(wrapper.find('Td[dataLabel="Type"]').text()).toContain(
-      'Job Template'
-    );
-    expect(wrapper.find('Td[dataLabel="Role"]').text()).toContain('Admin');
+    renderItem();
+    expect(
+      screen.getByRole('link', { name: 'template delete project' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Job Template')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
   });
 
   test('should render deletable chip', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TeamRoleListItem
-            role={role}
-            detailUrl="/templates/job_template/15/details"
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Chip').prop('isReadOnly')).toBe(false);
+    renderItem();
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
+
   test('should render read only chip', () => {
-    role.summary_fields.user_capabilities.unattach = false;
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TeamRoleListItem
-            role={role}
-            detailUrl="/templates/job_template/15/details"
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Chip').prop('isReadOnly')).toBe(true);
+    renderItem(makeRole({ user_capabilities: { unattach: false } }));
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Team/TeamRoles/TeamRolesList.test.js
+++ b/awx/ui/src/screens/Team/TeamRoles/TeamRolesList.test.js
@@ -1,78 +1,23 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { TeamsAPI, RolesAPI, UsersAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import TeamRolesList from './TeamRolesList';
 
 jest.mock('../../../api/models/Teams');
 jest.mock('../../../api/models/Roles');
 jest.mock('../../../api/models/Users');
 
-const me = {
-  id: 1,
-};
+const me = { id: 1 };
 
 const team = {
   id: 18,
   type: 'team',
   url: '/api/v2/teams/1/',
-  related: {
-    created_by: '/api/v2/users/1/',
-    modified_by: '/api/v2/users/1/',
-    projects: '/api/v2/teams/1/projects/',
-    users: '/api/v2/teams/1/users/',
-    credentials: '/api/v2/teams/1/credentials/',
-    roles: '/api/v2/teams/1/roles/',
-    object_roles: '/api/v2/teams/1/object_roles/',
-    activity_stream: '/api/v2/teams/1/activity_stream/',
-    access_list: '/api/v2/teams/1/access_list/',
-    organization: '/api/v2/organizations/1/',
-  },
   summary_fields: {
-    organization: {
-      id: 1,
-      name: 'Default',
-      description: '',
-    },
-    created_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    modified_by: {
-      id: 1,
-      username: 'admin',
-      first_name: '',
-      last_name: '',
-    },
-    object_roles: {
-      admin_role: {
-        description: 'Can manage all aspects of the team',
-        name: 'Admin',
-        id: 33,
-      },
-      member_role: {
-        description: 'User is a member of the team',
-        name: 'Member',
-        id: 34,
-      },
-      read_role: {
-        description: 'May view settings for the team',
-        name: 'Read',
-        id: 35,
-      },
-    },
-    user_capabilities: {
-      edit: false,
-      delete: false,
-    },
+    organization: { id: 1, name: 'Default', description: '' },
+    user_capabilities: { edit: false, delete: false },
   },
-  created: '2020-07-22T18:21:54.233411Z',
-  modified: '2020-07-22T18:21:54.233442Z',
   name: 'a team',
   description: '',
   organization: 1,
@@ -100,7 +45,7 @@ const roles = {
         type: 'role',
         url: '/api/v2/roles/257/',
         summary_fields: {
-          resource_name: 'template delete project',
+          resource_name: 'workflow delete project',
           resource_id: 16,
           resource_type: 'workflow_job_template',
           resource_type_display_name: 'Job Template',
@@ -152,69 +97,60 @@ const roles = {
 };
 
 describe('<TeamRolesList />', () => {
-  let wrapper;
-
   beforeEach(() => {
     UsersAPI.readAdminOfOrganizations.mockResolvedValue({
       count: 1,
-      results: [
-        {
-          id: 1,
-          name: 'Foo Org',
-        },
-      ],
+      results: [{ id: 1, name: 'Foo Org' }],
     });
-
     TeamsAPI.readRoleOptions.mockResolvedValue({
-      data: {
-        actions: { GET: {} },
-        related_search_fields: [],
-      },
+      data: { actions: { GET: {} }, related_search_fields: [] },
     });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   test('should render properly', async () => {
     TeamsAPI.readRoles.mockResolvedValue(roles);
-
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamRolesList me={me} team={team} />);
-    });
-    expect(wrapper.find('TeamRolesList').length).toBe(1);
+    renderWithContexts(<TeamRolesList me={me} team={team} />);
+    expect(await screen.findByText('Credential Bar')).toBeInTheDocument();
   });
 
   test('should create proper detailUrl', async () => {
     TeamsAPI.readRoles.mockResolvedValue(roles);
+    const { container } = renderWithContexts(
+      <TeamRolesList me={me} team={team} />
+    );
+    await screen.findByText('Credential Bar');
 
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamRolesList me={me} team={team} />);
-    });
-    waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-
-    expect(
-      wrapper.find('Tr#role-item-row-2').find(`LinkAnchor`).prop('href')
-    ).toBe('/templates/job_template/15/details');
-    expect(
-      wrapper.find('Tr#role-item-row-3').find(`LinkAnchor`).prop('href')
-    ).toBe('/templates/workflow_job_template/16/details');
-    expect(
-      wrapper.find('Tr#role-item-row-4').find('LinkAnchor').prop('href')
-    ).toBe('/credentials/75/details');
-    expect(
-      wrapper.find('Tr#role-item-row-5').find('LinkAnchor').prop('href')
-    ).toBe('/inventories/inventory/76/details');
-    expect(
-      wrapper.find('Tr#role-item-row-6').find('LinkAnchor').prop('href')
-    ).toBe('/inventories/smart_inventory/77/details');
+    expect(container.querySelector('#role-item-row-2 a')).toHaveAttribute(
+      'href',
+      '/templates/job_template/15/details'
+    );
+    expect(container.querySelector('#role-item-row-3 a')).toHaveAttribute(
+      'href',
+      '/templates/workflow_job_template/16/details'
+    );
+    expect(container.querySelector('#role-item-row-4 a')).toHaveAttribute(
+      'href',
+      '/credentials/75/details'
+    );
+    expect(container.querySelector('#role-item-row-5 a')).toHaveAttribute(
+      'href',
+      '/inventories/inventory/76/details'
+    );
+    expect(container.querySelector('#role-item-row-6 a')).toHaveAttribute(
+      'href',
+      '/inventories/smart_inventory/77/details'
+    );
   });
+
   test('should not render add button when user cannot edit team and is not an admin of the org', async () => {
     UsersAPI.readAdminOfOrganizations.mockResolvedValueOnce({
       count: 0,
       results: [],
     });
-
     TeamsAPI.readRoles.mockResolvedValue({
       data: {
         results: [
@@ -236,104 +172,48 @@ describe('<TeamRolesList />', () => {
         count: 1,
       },
     });
-
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamRolesList me={me} team={team} />);
-    });
-
-    waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-    expect(wrapper.find('Button[aria-label="Add resource roles"]').length).toBe(
-      0
-    );
+    renderWithContexts(<TeamRolesList me={me} team={team} />);
+    await screen.findByText('template delete project');
+    expect(
+      screen.queryByRole('button', { name: 'Add' })
+    ).not.toBeInTheDocument();
   });
 
-  test('should render disassociate modal', async () => {
+  test('should render disassociate modal and call the api', async () => {
     TeamsAPI.readRoles.mockResolvedValue(roles);
-
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamRolesList me={me} team={team} />);
-    });
-
-    waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-
-    await act(async () =>
-      wrapper.find('Chip[aria-label="Execute"]').prop('onClick')({
-        id: 4,
-        name: 'Execute',
-        type: 'role',
-        url: '/api/v2/roles/258/',
-        summary_fields: {
-          resource_name: 'Credential Bar',
-          resource_id: 75,
-          resource_type: 'credential',
-          resource_type_display_name: 'Credential',
-          user_capabilities: { unattach: true },
-        },
-      })
+    RolesAPI.disassociateTeamRole.mockResolvedValue({});
+    const { user } = renderWithContexts(
+      <TeamRolesList me={me} team={team} />
     );
-    wrapper.update();
-    expect(
-      wrapper.find('AlertModal[aria-label="Disassociate role"]').length
-    ).toBe(1);
-    await act(async () =>
-      wrapper
-        .find('button[aria-label="confirm disassociate"]')
-        .prop('onClick')()
+    const row = (await screen.findByText('Credential Bar')).closest('tr');
+    await user.click(within(row).getByRole('button'));
+
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm disassociate' })
     );
-    expect(RolesAPI.disassociateTeamRole).toHaveBeenCalledWith(4, 18);
-    wrapper.update();
-    expect(
-      wrapper.find('AlertModal[aria-label="Disassociate role"]').length
-    ).toBe(0);
+    await waitFor(() =>
+      expect(RolesAPI.disassociateTeamRole).toHaveBeenCalledWith(4, 18)
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'confirm disassociate' })
+      ).not.toBeInTheDocument()
+    );
   });
 
   test('should throw disassociation error', async () => {
     TeamsAPI.readRoles.mockResolvedValue(roles);
-    RolesAPI.disassociateTeamRole.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'post',
-            url: '/api/v2/roles/18/roles',
-          },
-          data: 'An error occurred',
-          status: 403,
-        },
-      })
+    RolesAPI.disassociateTeamRole.mockRejectedValue(new Error());
+    const { user } = renderWithContexts(
+      <TeamRolesList me={me} team={team} />
     );
+    const row = (await screen.findByText('Credential Bar')).closest('tr');
+    await user.click(within(row).getByRole('button'));
 
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamRolesList me={me} team={team} />);
-    });
-
-    waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-
-    await act(async () =>
-      wrapper.find('Chip[aria-label="Execute"]').prop('onClick')({
-        id: 4,
-        name: 'Execute',
-        type: 'role',
-        url: '/api/v2/roles/258/',
-        summary_fields: {
-          resource_name: 'Credential Bar',
-          resource_id: 75,
-          resource_type: 'credential',
-          resource_type_display_name: 'Credential',
-          user_capabilities: { unattach: true },
-        },
-      })
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm disassociate' })
     );
-    wrapper.update();
-    expect(
-      wrapper.find('AlertModal[aria-label="Disassociate role"]').length
-    ).toBe(1);
-    await act(async () =>
-      wrapper
-        .find('button[aria-label="confirm disassociate"]')
-        .prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('AlertModal[title="Error!"]').length).toBe(1);
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 
   test('user with sys admin privilege should show empty state', async () => {
@@ -357,15 +237,9 @@ describe('<TeamRolesList />', () => {
         count: 1,
       },
     });
-
-    await act(async () => {
-      wrapper = mountWithContexts(<TeamRolesList me={me} team={team} />);
-    });
-
-    waitForElement(
-      wrapper,
-      'EmptyState[title="System Administrator"]',
-      (el) => el.length === 1
-    );
+    renderWithContexts(<TeamRolesList me={me} team={team} />);
+    expect(
+      await screen.findByText('System Administrator')
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Team/shared/TeamForm.test.js
+++ b/awx/ui/src/screens/Team/shared/TeamForm.test.js
@@ -1,109 +1,73 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
 
+import { OrganizationsAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import TeamForm from './TeamForm';
 
 jest.mock('../../../api');
 
+const meConfig = { me: { is_superuser: false } };
+const mockData = {
+  id: 1,
+  name: 'Foo',
+  description: 'Bar',
+  organization: 1,
+  summary_fields: { organization: { id: 1, name: 'Default' } },
+};
+
 describe('<TeamForm />', () => {
-  let wrapper;
-  const meConfig = {
-    me: {
-      is_superuser: false,
-    },
-  };
-  const mockData = {
-    id: 1,
-    name: 'Foo',
-    description: 'Bar',
-    organization: 1,
-    summary_fields: {
-      organization: {
-        id: 1,
-        name: 'Default',
-      },
-    },
-  };
+  beforeEach(() => {
+    OrganizationsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
+    });
+    OrganizationsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} } },
+    });
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('changing inputs should update form values', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <TeamForm
-          team={mockData}
-          handleSubmit={jest.fn()}
-          handleCancel={jest.fn()}
-          me={meConfig.me}
-        />
-      );
-    });
-
-    await act(async () => {
-      wrapper.find('input#team-name').simulate('change', {
-        target: { value: 'new foo', name: 'name' },
-      });
-      wrapper.find('input#team-description').simulate('change', {
-        target: { value: 'new bar', name: 'description' },
-      });
-      wrapper.find('OrganizationLookup').invoke('onBlur')();
-      wrapper.find('OrganizationLookup').invoke('onChange')({
-        id: 2,
-        name: 'Other Org',
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find('input#team-name').prop('value')).toEqual('new foo');
-    expect(wrapper.find('input#team-description').prop('value')).toEqual(
-      'new bar'
+  const renderForm = (props = {}) =>
+    renderWithContexts(
+      <TeamForm
+        team={mockData}
+        handleSubmit={jest.fn()}
+        handleCancel={jest.fn()}
+        me={meConfig.me}
+        {...props}
+      />
     );
-    expect(wrapper.find('OrganizationLookup').prop('value')).toEqual({
-      id: 2,
-      name: 'Other Org',
-    });
+
+  test('changing inputs should update form values', async () => {
+    const { user, container } = renderForm();
+    const nameInput = container.querySelector('#team-name');
+    const descriptionInput = container.querySelector('#team-description');
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'new foo');
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, 'new bar');
+
+    expect(nameInput).toHaveValue('new foo');
+    expect(descriptionInput).toHaveValue('new bar');
   });
 
   test('should call handleSubmit when Submit button is clicked', async () => {
     const handleSubmit = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <TeamForm
-          team={mockData}
-          handleSubmit={handleSubmit}
-          handleCancel={jest.fn()}
-          me={meConfig.me}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+    const { user } = renderForm({ handleSubmit });
     expect(handleSubmit).not.toHaveBeenCalled();
-    await act(async () => {
-      wrapper.find('button[aria-label="Save"]').simulate('click');
-    });
-    expect(handleSubmit).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalled());
   });
 
   test('calls handleCancel when Cancel button is clicked', async () => {
     const handleCancel = jest.fn();
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <TeamForm
-          team={mockData}
-          handleSubmit={jest.fn()}
-          handleCancel={handleCancel}
-          me={meConfig.me}
-        />
-      );
-    });
+    const { user } = renderForm({ handleCancel });
     expect(handleCancel).not.toHaveBeenCalled();
-    wrapper.find('button[aria-label="Cancel"]').prop('onClick')();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(handleCancel).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **Team** screen's test suite from enzyme to React Testing Library, continuing the incremental enzyme → RTL migration (one screen directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`:

- `TeamList` / `TeamListItem` — load, row selection, select-all, bulk delete + re-fetch, deletion-error modal, add-button visibility
- `TeamDetail` — detail fields, edit-button visibility, delete + deletion-error dialog
- `TeamAdd` / `TeamEdit` — submit-to-API + redirect, cancel navigation, submit-error surface (shared `TeamForm` mocked)
- `TeamForm` — input updates, Save/Cancel handlers
- `TeamRoleListItem` / `TeamRolesList` — row data, detail URLs, disassociate modal + API call, disassociation error, sys-admin empty state

Interactions now go through accessible roles and real user events. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for the Team directory: **10 suites, 43 tests, all passing.** ESLint clean. No production code changed — test-only.
