### PR TITLE
enzyme -> RTL: convert the Metrics screen suites

### DIFF
--- a/awx/ui/src/screens/Metrics/LineChart.test.js
+++ b/awx/ui/src/screens/Metrics/LineChart.test.js
@@ -1,37 +1,38 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import LineChart from './LineChart';
 
 describe('<LineChart/>', () => {
   test('should render properly', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LineChart
-          data={[
-            {
-              name: 'Instance 1',
-              values: [
-                { x: 0, y: 10 },
-                { x: 1, y: 20 },
-                { x: 3, y: 30 },
-              ],
-            },
-            {
-              name: 'Instance 1',
-              values: [
-                { x: 0, y: 40 },
-                { x: 1, y: 50 },
-                { x: 3, y: 60 },
-              ],
-            },
-          ]}
-          helpText="This is the help text"
-        />
-      );
-    });
-    expect(wrapper.find('LineChart').length).toBe(1);
+    const { container } = renderWithContexts(
+      <LineChart
+        data={[
+          {
+            name: 'Instance 1',
+            values: [
+              { x: 0, y: 10 },
+              { x: 1, y: 20 },
+              { x: 3, y: 30 },
+            ],
+          },
+          {
+            name: 'Instance 1',
+            values: [
+              { x: 0, y: 40 },
+              { x: 1, y: 50 },
+              { x: 3, y: 60 },
+            ],
+          },
+        ]}
+        helpText="This is the help text"
+      />
+    );
+    // LineChart draws into a #chart container with d3; in jsdom the d3 draw
+    // runs but the SVG layout is meaningless, so assert the chart container
+    // exists and the help text was rendered into it.
+    const chart = container.querySelector('#chart');
+    expect(chart).toBeInTheDocument();
+    expect(chart).toHaveTextContent('This is the help text');
   });
 });

--- a/awx/ui/src/screens/Metrics/Metrics.test.js
+++ b/awx/ui/src/screens/Metrics/Metrics.test.js
@@ -1,15 +1,25 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { MetricsAPI, InstancesAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Metrics from './Metrics';
 
 jest.mock('../../api/models/Instances');
 jest.mock('../../api/models/Metrics');
 
 describe('<Metrics/>', () => {
-  let wrapper;
+  let user;
+  let container;
+
+  const openSelect = async (ouiaId) => {
+    const select = container.querySelector(
+      `[data-ouia-component-id="${ouiaId}"]`
+    );
+    await user.click(within(select).getByRole('button'));
+    return select;
+  };
+
   beforeEach(async () => {
     InstancesAPI.read.mockResolvedValue({
       data: {
@@ -32,57 +42,49 @@ describe('<Metrics/>', () => {
         },
       },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<Metrics />);
-    });
+    ({ user, container } = renderWithContexts(<Metrics />));
+    // wait for the initial instances/metrics fetch to settle
+    await waitFor(() => expect(InstancesAPI.read).toHaveBeenCalled());
   });
   afterEach(() => {
     jest.clearAllMocks();
   });
-  test('should mound properly', () => {
-    expect(wrapper.find('Metrics').length).toBe(1);
-    expect(wrapper.find('EmptyStateBody').length).toBe(1);
-    expect(wrapper.find('ChartLine').length).toBe(0);
+
+  test('should mount properly', async () => {
+    // Before an instance + metric are selected, the empty state is shown and
+    // no chart is rendered.
+    expect(
+      await screen.findByText('Select an instance and a metric to show chart')
+    ).toBeInTheDocument();
+    expect(document.querySelector('#chart')).toBeNull();
   });
+
   test('should render chart after selecting metric and instance', async () => {
-    await act(async () => {
-      wrapper.find('Select[ouiaId="Instance-select"]').prop('onToggle')(true);
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper
-        .find('SelectOption[value="instance 1"]')
-        .find('button')
-        .prop('onClick')({}, 'instance 1');
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('Select[ouiaId="Metric-select"]').prop('onToggle')(true);
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper
-        .find('SelectOption[value="metric1"]')
-        .find('button')
-        .prop('onClick')({}, 'metric1');
-    });
-    wrapper.update();
-    expect(MetricsAPI.read).toHaveBeenCalledWith({
-      subsystemonly: 1,
-      format: 'json',
-      metric: 'metric1',
-      node: 'instance 1',
-    });
+    // open the Instance select and pick "instance 1"
+    const instanceSelect = await openSelect('Instance-select');
+    await user.click(within(instanceSelect).getByText('instance 1'));
+
+    // open the Metric select and pick "metric1"
+    const metricSelect = await openSelect('Metric-select');
+    await user.click(within(metricSelect).getByText('metric1'));
+
+    await waitFor(() =>
+      expect(MetricsAPI.read).toHaveBeenCalledWith({
+        subsystemonly: 1,
+        format: 'json',
+        metric: 'metric1',
+        node: 'instance 1',
+      })
+    );
   });
 
   test('should not include receptor instances', async () => {
-    await act(async () => {
-      wrapper.find('Select[ouiaId="Instance-select"]').prop('onToggle')(true);
-    });
-    wrapper.update();
-    expect(wrapper.find('SelectOption[value="receptor"]')).toHaveLength(0);
-    expect(
-      wrapper.find('Select[ouiaId="Instance-select"]').find('SelectOption')
-    ).toHaveLength(3);
+    const instanceSelect = await openSelect('Instance-select');
+
+    const listbox = await within(instanceSelect).findByRole('listbox');
+    // execution-node ("receptor") instances are filtered out; the two
+    // non-execution instances plus the "All" option remain (3 total).
+    expect(within(listbox).queryByText('receptor')).toBeNull();
+    expect(within(listbox).getAllByRole('option')).toHaveLength(3);
   });
 });

--- a/awx/ui/src/screens/Metrics/Metrics.test.js
+++ b/awx/ui/src/screens/Metrics/Metrics.test.js
@@ -17,7 +17,10 @@ describe('<Metrics/>', () => {
       `[data-ouia-component-id="${ouiaId}"]`
     );
     await user.click(within(select).getByRole('button'));
-    return select;
+    // The menu may be rendered in a Popper/portal outside the select's DOM
+    // subtree, so resolve the open listbox from `screen` rather than scoping
+    // to the select container.
+    return screen.findByRole('listbox');
   };
 
   beforeEach(async () => {
@@ -61,12 +64,12 @@ describe('<Metrics/>', () => {
 
   test('should render chart after selecting metric and instance', async () => {
     // open the Instance select and pick "instance 1"
-    const instanceSelect = await openSelect('Instance-select');
-    await user.click(within(instanceSelect).getByText('instance 1'));
+    const instanceListbox = await openSelect('Instance-select');
+    await user.click(within(instanceListbox).getByText('instance 1'));
 
     // open the Metric select and pick "metric1"
-    const metricSelect = await openSelect('Metric-select');
-    await user.click(within(metricSelect).getByText('metric1'));
+    const metricListbox = await openSelect('Metric-select');
+    await user.click(within(metricListbox).getByText('metric1'));
 
     await waitFor(() =>
       expect(MetricsAPI.read).toHaveBeenCalledWith({
@@ -79,9 +82,7 @@ describe('<Metrics/>', () => {
   });
 
   test('should not include receptor instances', async () => {
-    const instanceSelect = await openSelect('Instance-select');
-
-    const listbox = await within(instanceSelect).findByRole('listbox');
+    const listbox = await openSelect('Instance-select');
     // execution-node ("receptor") instances are filtered out; the two
     // non-execution instances plus the "All" option remain (3 total).
     expect(within(listbox).queryByText('receptor')).toBeNull();


### PR DESCRIPTION
##### SUMMARY

Converts the **Metrics** screen's test suite from enzyme to React Testing Library, continuing the incremental enzyme → RTL migration (one screen directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`:

- `LineChart` — asserts the `#chart` container renders and the help text lands in it
- `Metrics` — empty state, instance/metric Select interactions driving the exact `MetricsAPI.read` call, and exclusion of receptor/execution nodes from the instance list

Interactions now go through accessible roles (Selects scoped by their `ouiaId`) and real user events. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for the Metrics directory: **2 suites, 4 tests, all passing.** ESLint clean. No production code changed — test-only.
