### PR TITLE
enzyme -> RTL: convert the Application screen suites

### DIFF
--- a/awx/ui/src/screens/Application/ApplicationAdd/ApplicationAdd.test.js
+++ b/awx/ui/src/screens/Application/ApplicationAdd/ApplicationAdd.test.js
@@ -1,23 +1,48 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { ApplicationsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ApplicationAdd from './ApplicationAdd';
 
 jest.mock('../../../api/models/Applications');
 jest.mock('../../../api/models/Organizations');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  history: () => ({
-    location: '/applications/add',
-  }),
-}));
+// The real form is exercised in ApplicationForm.test.js; here we mock it so the
+// container's readOptions/create/navigation/submit-error logic is what's tested.
+// onSubmit receives the form values (organization as an object, per the form);
+// onCancel is wired to the container's handleCancel.
+jest.mock('../shared/ApplicationForm', () => function MockApplicationForm({
+    onSubmit,
+    onCancel,
+    submitError,
+  }) {
+    return (
+      <div>
+        {submitError ? <div>FormSubmitError</div> : null}
+        <button
+          type="button"
+          onClick={() =>
+            onSubmit({
+              authorization_grant_type: 'authorization-code',
+              client_type: 'confidential',
+              description: 'bar',
+              name: 'foo',
+              organization: { id: 1 },
+              redirect_uris: 'http://www.google.com',
+            })
+          }
+        >
+          Submit
+        </button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  });
+
 const options = {
   data: {
     actions: {
@@ -39,101 +64,53 @@ const options = {
   },
 };
 
-const onSuccessfulAdd = jest.fn();
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('<ApplicationAdd/>', () => {
-  let wrapper;
-  test('should render properly', async () => {
-    ApplicationsAPI.readOptions.mockResolvedValue(options);
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />
-      );
-    });
+  const onSuccessfulAdd = jest.fn();
 
-    expect(wrapper.find('ApplicationAdd').length).toBe(1);
-    expect(wrapper.find('ApplicationForm').length).toBe(1);
+  test('should render properly and read options', async () => {
+    ApplicationsAPI.readOptions.mockResolvedValue(options);
+
+    renderWithContexts(<ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />);
+
+    expect(
+      await screen.findByRole('button', { name: 'Submit' })
+    ).toBeInTheDocument();
     expect(ApplicationsAPI.readOptions).toHaveBeenCalled();
   });
 
-  test('expect values to be updated and submitted properly', async () => {
+  test('should create and redirect on successful submit', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/applications/add'],
     });
     ApplicationsAPI.readOptions.mockResolvedValue(options);
-
     ApplicationsAPI.create.mockResolvedValue({ data: { id: 8 } });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
 
-    await act(async () => {
-      wrapper.find('input#name').simulate('change', {
-        target: { value: 'new foo', name: 'name' },
-      });
-      wrapper.find('input#description').simulate('change', {
-        target: { value: 'new bar', name: 'description' },
-      });
-      wrapper
-        .find('AnsibleSelect[name="authorization_grant_type"]')
-        .prop('onChange')({}, 'authorization code');
-
-      wrapper.find('input#redirect_uris').simulate('change', {
-        target: { value: 'https://www.google.com', name: 'redirect_uris' },
-      });
-      wrapper.find('AnsibleSelect[name="client_type"]').prop('onChange')(
-        {},
-        'confidential'
-      );
-      wrapper.find('OrganizationLookup').invoke('onChange')({
-        id: 1,
-        name: 'organization',
-      });
-    });
-
-    wrapper.update();
-    expect(wrapper.find('input#name').prop('value')).toBe('new foo');
-    expect(wrapper.find('input#description').prop('value')).toBe('new bar');
-    expect(wrapper.find('input#organization').prop('value')).toBe(
-      'organization'
+    const { user } = renderWithContexts(
+      <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />,
+      { context: { router: { history } } }
     );
-    expect(
-      wrapper
-        .find('AnsibleSelect[name="authorization_grant_type"]')
-        .prop('value')
-    ).toBe('authorization code');
-    expect(
-      wrapper.find('AnsibleSelect[name="client_type"]').prop('value')
-    ).toBe('confidential');
-    expect(wrapper.find('input#redirect_uris').prop('value')).toBe(
-      'https://www.google.com'
-    );
-    await act(async () => {
-      wrapper.find('Formik').prop('onSubmit')({
+    await screen.findByRole('button', { name: 'Submit' });
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() =>
+      expect(ApplicationsAPI.create).toHaveBeenCalledWith({
         authorization_grant_type: 'authorization-code',
         client_type: 'confidential',
         description: 'bar',
         name: 'foo',
-        organization: { id: 1 },
+        organization: 1,
         redirect_uris: 'http://www.google.com',
-      });
-    });
-
-    expect(ApplicationsAPI.create).toHaveBeenCalledWith({
-      authorization_grant_type: 'authorization-code',
-      client_type: 'confidential',
-      description: 'bar',
-      name: 'foo',
-      organization: 1,
-      redirect_uris: 'http://www.google.com',
-    });
-    expect(history.location.pathname).toBe('/applications/8/details');
+      })
+    );
     expect(onSuccessfulAdd).toHaveBeenCalledWith({ id: 8 });
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/applications/8/details')
+    );
   });
 
   test('should cancel form properly', async () => {
@@ -142,66 +119,43 @@ describe('<ApplicationAdd/>', () => {
     });
     ApplicationsAPI.readOptions.mockResolvedValue(options);
 
-    ApplicationsAPI.create.mockResolvedValue({ data: { id: 8 } });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await act(async () => {
-      wrapper.find('Button[aria-label="Cancel"]').prop('onClick')();
-    });
+    const { user } = renderWithContexts(
+      <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />,
+      { context: { router: { history } } }
+    );
+    await screen.findByRole('button', { name: 'Cancel' });
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
     expect(history.location.pathname).toBe('/applications');
   });
 
-  test('should throw error on submit', async () => {
-    const error = {
+  test('should show form submit error on failed create', async () => {
+    ApplicationsAPI.readOptions.mockResolvedValue(options);
+    ApplicationsAPI.create.mockRejectedValue({
       response: {
-        config: {
-          method: 'patch',
-          url: '/api/v2/applications/',
-        },
+        config: { method: 'patch', url: '/api/v2/applications/' },
         data: { detail: 'An error occurred' },
       },
-    };
-    ApplicationsAPI.create.mockRejectedValue(error);
-    ApplicationsAPI.readOptions.mockResolvedValue(options);
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />
-      );
-    });
-    await act(async () => {
-      wrapper.find('Formik').prop('onSubmit')({
-        id: 1,
-        organization: { id: 1 },
-      });
     });
 
-    waitForElement(wrapper, 'FormSubmitError', (el) => el.length > 0);
-  });
-  test('should render content error on failed read options request', async () => {
-    ApplicationsAPI.readOptions.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'options',
-          },
-          data: 'An error occurred',
-          status: 403,
-        },
-      })
+    const { user } = renderWithContexts(
+      <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />
     );
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />
-      );
-    });
+    await screen.findByRole('button', { name: 'Submit' });
 
-    wrapper.update();
-    expect(wrapper.find('ContentError').length).toBe(1);
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('FormSubmitError')).toBeInTheDocument();
+  });
+
+  test('should render content error on failed read options request', async () => {
+    ApplicationsAPI.readOptions.mockRejectedValue(new Error());
+
+    renderWithContexts(<ApplicationAdd onSuccessfulAdd={onSuccessfulAdd} />);
+
+    expect(
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationDetails/ApplicationDetails.test.js
+++ b/awx/ui/src/screens/Application/ApplicationDetails/ApplicationDetails.test.js
@@ -1,61 +1,15 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import { ApplicationsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 import ApplicationDetails from './ApplicationDetails';
 
 jest.mock('../../../api/models/Applications');
-
-const application = {
-  id: 10,
-  type: 'o_auth2_application',
-  url: '/api/v2/applications/10/',
-  related: {
-    named_url: '/api/v2/applications/Alex++bar/',
-    tokens: '/api/v2/applications/10/tokens/',
-    activity_stream: '/api/v2/applications/10/activity_stream/',
-  },
-  summary_fields: {
-    organization: {
-      id: 230,
-      name: 'bar',
-      description:
-        'SaleNameBedPersonalityManagerWhileFinanceBreakToothPerson魲',
-    },
-    user_capabilities: {
-      edit: true,
-      delete: true,
-    },
-    tokens: {
-      count: 2,
-      results: [
-        {
-          id: 1,
-          token: '************',
-          scope: 'read',
-        },
-        {
-          id: 2,
-          token: '************',
-          scope: 'write',
-        },
-      ],
-    },
-  },
-  created: '2020-06-11T17:54:33.983993Z',
-  modified: '2020-06-11T17:54:33.984039Z',
-  name: 'Alex',
-  description: 'foo',
-  client_id: 'b1dmj8xzkbFm1ZQ27ygw2ZeE9I0AXqqeL74fiyk4',
-  client_secret: '************',
-  client_type: 'confidential',
-  redirect_uris: 'http://www.google.com',
-  authorization_grant_type: 'authorization-code',
-  skip_authorization: false,
-  organization: 230,
-};
 
 const authorizationOptions = [
   {
@@ -75,106 +29,132 @@ const clientTypeOptions = [
   { key: 'public', label: 'Public', value: 'public' },
 ];
 
+// fresh copy per test because some tests mutate user_capabilities
+function buildApplication() {
+  return {
+    id: 10,
+    type: 'o_auth2_application',
+    url: '/api/v2/applications/10/',
+    related: {
+      named_url: '/api/v2/applications/Alex++bar/',
+      tokens: '/api/v2/applications/10/tokens/',
+      activity_stream: '/api/v2/applications/10/activity_stream/',
+    },
+    summary_fields: {
+      organization: {
+        id: 230,
+        name: 'bar',
+        description:
+          'SaleNameBedPersonalityManagerWhileFinanceBreakToothPerson魲',
+      },
+      user_capabilities: {
+        edit: true,
+        delete: true,
+      },
+      tokens: {
+        count: 2,
+        results: [
+          {
+            id: 1,
+            token: '************',
+            scope: 'read',
+          },
+          {
+            id: 2,
+            token: '************',
+            scope: 'write',
+          },
+        ],
+      },
+    },
+    created: '2020-06-11T17:54:33.983993Z',
+    modified: '2020-06-11T17:54:33.984039Z',
+    name: 'Alex',
+    description: 'foo',
+    client_id: 'b1dmj8xzkbFm1ZQ27ygw2ZeE9I0AXqqeL74fiyk4',
+    client_secret: '************',
+    client_type: 'confidential',
+    redirect_uris: 'http://www.google.com',
+    authorization_grant_type: 'authorization-code',
+    skip_authorization: false,
+    organization: 230,
+  };
+}
+
+function renderDetails(application, options) {
+  return renderWithContexts(
+    <ApplicationDetails
+      application={application}
+      authorizationOptions={authorizationOptions}
+      clientTypeOptions={clientTypeOptions}
+    />,
+    options
+  );
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('<ApplicationDetails/>', () => {
-  let wrapper;
-  test('should mount properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationDetails
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(wrapper.find('ApplicationDetails').length).toBe(1);
+  test('should mount properly', () => {
+    renderDetails(buildApplication());
+    expect(screen.getByText('Name')).toBeInTheDocument();
   });
 
-  test('should render proper data', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationDetails
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(wrapper.find('Detail[label="Name"]').prop('value')).toBe('Alex');
-    expect(wrapper.find('Detail[label="Description"]').prop('value')).toBe(
-      'foo'
-    );
-    expect(wrapper.find('Detail[label="Organization"]').length).toBe(1);
-    expect(wrapper.find('Link').at(0).prop('to')).toBe(
-      '/organizations/230/details'
-    );
-    expect(
-      wrapper.find('Detail[label="Authorization grant type"]').prop('value')
-    ).toBe('Authorization code');
-    expect(wrapper.find('Detail[label="Redirect URIs"]').prop('value')).toBe(
-      'http://www.google.com'
-    );
-    expect(wrapper.find('Detail[label="Client type"]').prop('value')).toBe(
-      'Confidential'
-    );
-    expect(wrapper.find('Detail[label="Client ID"]').prop('value')).toBe(
-      'b1dmj8xzkbFm1ZQ27ygw2ZeE9I0AXqqeL74fiyk4'
-    );
-    expect(wrapper.find('Button[aria-label="Edit"]').prop('to')).toBe(
+  test('should render proper data', () => {
+    renderDetails(buildApplication());
+    assertDetail('Name', 'Alex');
+    assertDetail('Description', 'foo');
+    assertDetail('Authorization grant type', 'Authorization code');
+    assertDetail('Redirect URIs', 'http://www.google.com');
+    assertDetail('Client type', 'Confidential');
+    assertDetail('Client ID', 'b1dmj8xzkbFm1ZQ27ygw2ZeE9I0AXqqeL74fiyk4');
+
+    const orgLink = screen.getByRole('link', { name: 'bar' });
+    expect(orgLink).toHaveAttribute('href', '/organizations/230/details');
+
+    expect(screen.getByRole('link', { name: 'Edit' })).toHaveAttribute(
+      'href',
       '/applications/10/edit'
     );
-    expect(wrapper.find('Button[aria-label="Delete"]').length).toBe(1);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
   test('should delete properly', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/applications/1/details'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationDetails
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
+    const { user } = renderDetails(buildApplication(), {
+      context: { router: { history } },
     });
     expect(history.location.pathname).toEqual('/applications/1/details');
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    expect(ApplicationsAPI.destroy).toHaveBeenCalledTimes(1);
-    expect(history.location.pathname).toBe('/applications');
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
+    );
+
+    await waitFor(() => expect(ApplicationsAPI.destroy).toHaveBeenCalledTimes(1));
     expect(ApplicationsAPI.destroy).toHaveBeenCalledWith(10);
+    expect(history.location.pathname).toBe('/applications');
   });
 
-  test(' should not render delete button', async () => {
+  test('should not render delete button', () => {
+    const application = buildApplication();
     application.summary_fields.user_capabilities.delete = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationDetails
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(wrapper.find('Button[aria-label="Delete"]').length).toBe(0);
+    renderDetails(application);
+    expect(
+      screen.queryByRole('button', { name: 'Delete' })
+    ).not.toBeInTheDocument();
   });
-  test(' should not render edit button', async () => {
+
+  test('should not render edit button', () => {
+    const application = buildApplication();
     application.summary_fields.user_capabilities.edit = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationDetails
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(wrapper.find('Button[aria-label="Edit"]').length).toBe(0);
+    renderDetails(application);
+    expect(
+      screen.queryByRole('link', { name: 'Edit' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.test.js
+++ b/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.test.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { ApplicationsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ApplicationEdit from './ApplicationEdit';
 
@@ -17,6 +16,38 @@ jest.mock('react-router-dom-v5-compat', () => ({
   ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({ id: 1 }),
 }));
+
+// The real form is exercised in ApplicationForm.test.js; here we mock it so the
+// container's update/navigation/submit-error logic is what's tested.
+jest.mock('../shared/ApplicationForm', () => function MockApplicationForm({
+    onSubmit,
+    onCancel,
+    submitError,
+  }) {
+    return (
+      <div>
+        {submitError ? <div>FormSubmitError</div> : null}
+        <button
+          type="button"
+          onClick={() =>
+            onSubmit({
+              authorization_grant_type: 'authorization-code',
+              client_type: 'confidential',
+              description: 'bar',
+              name: 'foo',
+              organization: { id: 1 },
+              redirect_uris: 'http://www.google.com',
+            })
+          }
+        >
+          Submit
+        </button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    );
+  });
 
 const authorizationOptions = [
   {
@@ -39,190 +70,80 @@ const clientTypeOptions = [
 const application = {
   id: 1,
   type: 'o_auth2_application',
-  url: '/api/v2/applications/10/',
-  related: {
-    named_url: '/api/v2/applications/Alex++bar/',
-    tokens: '/api/v2/applications/10/tokens/',
-    activity_stream: '/api/v2/applications/10/activity_stream/',
-  },
-  summary_fields: {
-    organization: {
-      id: 230,
-      name: 'bar',
-      description:
-        'SaleNameBedPersonalityManagerWhileFinanceBreakToothPerson魲',
-    },
-    user_capabilities: {
-      edit: true,
-      delete: true,
-    },
-    tokens: {
-      count: 0,
-      results: [],
-    },
-  },
-  created: '2020-06-11T17:54:33.983993Z',
-  modified: '2020-06-11T17:54:33.984039Z',
   name: 'Alex',
   description: '',
-  client_id: 'b1dmj8xzkbFm1ZQ27ygw2ZeE9I0AXqqeL74fiyk4',
-  client_secret: '************',
   client_type: 'confidential',
   redirect_uris: 'http://www.google.com',
   authorization_grant_type: 'authorization-code',
-  skip_authorization: false,
+  summary_fields: {
+    organization: { id: 230, name: 'bar' },
+    user_capabilities: { edit: true, delete: true },
+  },
   organization: 230,
 };
 
-describe('<ApplicationEdit/>', () => {
-  let wrapper;
-  test('should mount properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationEdit
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(wrapper.find('ApplicationEdit').length).toBe(1);
-  });
+function renderEdit(options) {
+  return renderWithContexts(
+    <ApplicationEdit
+      application={application}
+      authorizationOptions={authorizationOptions}
+      clientTypeOptions={clientTypeOptions}
+    />,
+    options
+  );
+}
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('<ApplicationEdit/>', () => {
   test('should cancel form properly', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/applications/1/edit'],
     });
+    const { user } = renderEdit({ context: { router: { history } } });
 
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationEdit
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
-      await act(async () => {
-        wrapper.find('Button[aria-label="Cancel"]').prop('onClick')();
-      });
-      expect(history.location.pathname).toBe('/applications/1/details');
-    });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(history.location.pathname).toBe('/applications/1/details');
   });
 
-  test('should throw error on submit', async () => {
-    const error = {
-      response: {
-        config: {
-          method: 'patch',
-          url: '/api/v2/applications/',
-        },
-        data: { detail: 'An error occurred' },
-      },
-    };
-    ApplicationsAPI.update.mockRejectedValue(error);
+  test('should update and redirect on successful submit', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/applications/1/edit'],
     });
+    ApplicationsAPI.update.mockResolvedValue({ data: {} });
+    const { user } = renderEdit({ context: { router: { history } } });
 
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationEdit
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await act(async () => {
-      wrapper.find('Formik').prop('onSubmit')({
-        id: 1,
-        organization: { id: 4 },
-      });
-    });
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
-  });
-
-  test('expect values to be updated and submitted properly', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/applications/1/edit'],
-    });
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationEdit
-          application={application}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await act(async () => {
-      wrapper.find('input#name').simulate('change', {
-        target: { value: 'new foo', name: 'name' },
-      });
-      wrapper.find('input#description').simulate('change', {
-        target: { value: 'new bar', name: 'description' },
-      });
-
-      wrapper.find('input#redirect_uris').simulate('change', {
-        target: { value: 'https://www.google.com', name: 'redirect_uris' },
-      });
-      wrapper.find('AnsibleSelect[name="client_type"]').prop('onChange')(
-        {},
-        'confidential'
-      );
-      wrapper.find('OrganizationLookup').invoke('onChange')({
-        id: 1,
-        name: 'organization',
-      });
-    });
-
-    wrapper.update();
-    expect(wrapper.find('input#name').prop('value')).toBe('new foo');
-    expect(wrapper.find('input#description').prop('value')).toBe('new bar');
-    expect(wrapper.find('input#organization').prop('value')).toBe(
-      'organization'
-    );
-    expect(
-      wrapper
-        .find('AnsibleSelect[name="authorization_grant_type"]')
-        .prop('value')
-    ).toBe('authorization-code');
-    expect(
-      wrapper.find('AnsibleSelect[name="client_type"]').prop('value')
-    ).toBe('confidential');
-    expect(wrapper.find('input#redirect_uris').prop('value')).toBe(
-      'https://www.google.com'
-    );
-    await act(async () => {
-      wrapper.find('Formik').prop('onSubmit')({
+    await waitFor(() =>
+      expect(ApplicationsAPI.update).toHaveBeenCalledWith(1, {
         authorization_grant_type: 'authorization-code',
         client_type: 'confidential',
         description: 'bar',
         name: 'foo',
-        organization: { id: 1 },
+        organization: 1,
         redirect_uris: 'http://www.google.com',
-      });
-    });
+      })
+    );
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/applications/1/details')
+    );
+  });
 
-    expect(ApplicationsAPI.update).toHaveBeenCalledWith(1, {
-      authorization_grant_type: 'authorization-code',
-      client_type: 'confidential',
-      description: 'bar',
-      name: 'foo',
-      organization: 1,
-      redirect_uris: 'http://www.google.com',
+  test('should show form submit error on failed update', async () => {
+    ApplicationsAPI.update.mockRejectedValue({
+      response: {
+        config: { method: 'patch', url: '/api/v2/applications/' },
+        data: { detail: 'An error occurred' },
+      },
     });
+    const { user } = renderEdit();
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByText('FormSubmitError')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.test.js
+++ b/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Routes, Route } from 'react-router-dom-v5-compat';
 
 import { ApplicationsAPI, TokensAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import ApplicationTokenList from './ApplicationTokenList';
 
 jest.mock('../../../api/models/Applications');
@@ -79,9 +79,8 @@ const tokens = {
     count: 2,
   },
 };
-describe('<ApplicationTokenList/>', () => {
-  let wrapper;
 
+describe('<ApplicationTokenList/>', () => {
   beforeEach(() => {
     ApplicationsAPI.readTokenOptions.mockResolvedValue({
       data: {
@@ -94,13 +93,19 @@ describe('<ApplicationTokenList/>', () => {
     });
   });
 
-  test('should mount properly', async () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should have data fetched and render 2 rows', async () => {
     ApplicationsAPI.readTokens.mockResolvedValue(tokens);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationTokenList />);
-    });
-    wrapper.update();
-    expect(wrapper.find('ApplicationTokenList')).toHaveLength(1);
+
+    renderWithContexts(<ApplicationTokenList />);
+
+    expect(await screen.findAllByRole('link', { name: 'admin' })).toHaveLength(
+      2
+    );
+    expect(ApplicationsAPI.readTokens).toHaveBeenCalled();
   });
 
   // Regression: the application id must come from the v6 route params. When the
@@ -111,71 +116,47 @@ describe('<ApplicationTokenList/>', () => {
     const history = createMemoryHistory({
       initialEntries: ['/applications/5/tokens'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Routes>
-          <Route
-            path="/applications/:id/tokens/*"
-            element={<ApplicationTokenList />}
-          />
-        </Routes>,
-        { context: { router: { history } } }
-      );
-    });
-    expect(ApplicationsAPI.readTokens).toHaveBeenCalledWith(
-      '5',
-      expect.any(Object)
-    );
-  });
 
-  test('should have data fetched and render 2 rows', async () => {
-    ApplicationsAPI.readTokens.mockResolvedValue(tokens);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationTokenList />);
-    });
-    wrapper.update();
-    expect(wrapper.find('ApplicationTokenListItem').length).toBe(2);
-    expect(ApplicationsAPI.readTokens).toHaveBeenCalled();
+    renderWithContexts(
+      <Routes>
+        <Route
+          path="/applications/:id/tokens/*"
+          element={<ApplicationTokenList />}
+        />
+      </Routes>,
+      { context: { router: { history } } }
+    );
+
+    await waitFor(() =>
+      expect(ApplicationsAPI.readTokens).toHaveBeenCalledWith(
+        '5',
+        expect.any(Object)
+      )
+    );
   });
 
   test('should delete item successfully', async () => {
     ApplicationsAPI.readTokens.mockResolvedValue(tokens);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationTokenList />);
-    });
-    wrapper.update();
+    TokensAPI.destroy.mockResolvedValue({});
 
-    wrapper
-      .find('.pf-c-table__check')
-      .at(0)
-      .find('input')
-      .simulate('change', tokens.data.results[0]);
-    wrapper.update();
+    const { user } = renderWithContexts(<ApplicationTokenList />);
+    await screen.findAllByRole('link', { name: 'admin' });
 
-    expect(
-      wrapper.find('.pf-c-table__check').at(0).find('input').prop('checked')
-    ).toBe(true);
-    
-    const deleteButton = wrapper.find('Button').filterWhere(button => 
-      button.prop('aria-label') === 'Delete'
-    );
-    expect(deleteButton).toHaveLength(1);
-    
-    await act(async () =>
-      deleteButton.prop('onClick')()
+    const row = screen
+      .getAllByRole('link', { name: 'admin' })[0]
+      .closest('tr');
+    const checkbox = within(row).getByRole('checkbox');
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
     );
 
-    wrapper.update();
-
-    const confirmButton = wrapper.find('Button').filterWhere(button => 
-      button.prop('aria-label') === 'confirm delete'
+    await waitFor(() =>
+      expect(TokensAPI.destroy).toHaveBeenCalledWith(tokens.data.results[0].id)
     );
-    expect(confirmButton).toHaveLength(1);
-    
-    await act(async () =>
-      confirmButton.prop('onClick')()
-    );
-    expect(TokensAPI.destroy).toHaveBeenCalledWith(tokens.data.results[0].id);
   });
 
   test('should throw content error', async () => {
@@ -190,15 +171,16 @@ describe('<ApplicationTokenList/>', () => {
         },
       })
     );
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationTokenList />);
-    });
-    wrapper.update();
 
-    expect(wrapper.find('ContentError').length).toBe(1);
+    renderWithContexts(<ApplicationTokenList />);
+
+    expect(
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
   });
 
   test('should render deletion error modal', async () => {
+    ApplicationsAPI.readTokens.mockResolvedValue(tokens);
     TokensAPI.destroy.mockRejectedValue(
       new Error({
         response: {
@@ -210,56 +192,31 @@ describe('<ApplicationTokenList/>', () => {
         },
       })
     );
-    ApplicationsAPI.readTokens.mockResolvedValue(tokens);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationTokenList />);
-    });
-    wrapper.update();
 
-    wrapper
-      .find('.pf-c-table__check')
-      .at(0)
-      .find('input')
-      .simulate('change', 'a');
+    const { user } = renderWithContexts(<ApplicationTokenList />);
+    await screen.findAllByRole('link', { name: 'admin' });
 
-    wrapper.update();
+    const row = screen
+      .getAllByRole('link', { name: 'admin' })[0]
+      .closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
 
     expect(
-      wrapper.find('.pf-c-table__check').at(0).find('input').prop('checked')
-    ).toBe(true);
-    
-    const deleteButton = wrapper.find('Button').filterWhere(button => 
-      button.prop('aria-label') === 'Delete'
-    );
-    expect(deleteButton).toHaveLength(1);
-    
-    await act(async () =>
-      deleteButton.prop('onClick')()
-    );
-
-    wrapper.update();
-
-    const confirmButton = wrapper.find('Button').filterWhere(button => 
-      button.prop('aria-label') === 'confirm delete'
-    );
-    expect(confirmButton).toHaveLength(1);
-    
-    await act(async () =>
-      confirmButton.prop('onClick')()
-    );
-    wrapper.update();
-
-    expect(!!wrapper.find('AlertModal').prop('isOpen')).toEqual(true);
-    expect(wrapper.find('ErrorDetail')).toHaveLength(1);
+      await screen.findByText('Error deleting tokens')
+    ).toBeInTheDocument();
   });
 
   test('should not render add button', async () => {
     ApplicationsAPI.readTokens.mockResolvedValue(tokens);
 
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationTokenList />);
-    });
-    wrapper.update();
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+    renderWithContexts(<ApplicationTokenList />);
+    await screen.findAllByRole('link', { name: 'admin' });
+
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.test.js
+++ b/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenList.test.js
@@ -209,6 +209,8 @@ describe('<ApplicationTokenList/>', () => {
     expect(
       await screen.findByText('Error deleting tokens')
     ).toBeInTheDocument();
+    // the error modal includes an ErrorDetail with an expandable "Details" toggle
+    expect(screen.getByText('Details')).toBeInTheDocument();
   });
 
   test('should not render add button', async () => {

--- a/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenListItem.test.js
+++ b/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenListItem.test.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, within } from '@testing-library/react';
 
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ApplicationTokenListItem from './ApplicationTokenListItem';
 
 describe('<ApplicationTokenListItem/>', () => {
-  let wrapper;
   const token = {
     id: 2,
     type: 'o_auth2_access_token',
@@ -39,62 +38,48 @@ describe('<ApplicationTokenListItem/>', () => {
     scope: 'read',
   };
 
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ApplicationTokenListItem
-              token={token}
-              detailUrl="/users/2/details"
-              isSelected={false}
-              onSelect={() => {}}
-              rowIndex={1}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('ApplicationTokenListItem').length).toBe(1);
+  function renderItem(props = {}) {
+    return renderWithContexts(
+      <table>
+        <tbody>
+          <ApplicationTokenListItem
+            token={token}
+            detailUrl="/users/2/details"
+            isSelected={false}
+            onSelect={() => {}}
+            rowIndex={1}
+            {...props}
+          />
+        </tbody>
+      </table>
+    );
+  }
+
+  test('should mount successfully', () => {
+    renderItem();
+    expect(screen.getByRole('row')).toBeInTheDocument();
   });
 
-  test('should render the proper data', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ApplicationTokenListItem
-              token={token}
-              detailUrl="/users/2/details"
-              isSelected={false}
-              onSelect={() => {}}
-              rowIndex={1}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td').at(1).text()).toBe('admin');
-    expect(wrapper.find('Td').at(2).text()).toBe('Read');
-    expect(wrapper.find('Td').at(3).text()).toBe('10/25/3019, 7:56:38 PM');
+  test('should render the proper data', () => {
+    renderItem();
+    const row = screen.getByRole('row');
+    const cells = within(row).getAllByRole('cell');
+    const nameCell = cells.find(
+      (cell) => cell.getAttribute('data-label') === 'Name'
+    );
+    const scopeCell = cells.find(
+      (cell) => cell.getAttribute('data-label') === 'Scope'
+    );
+    const expiresCell = cells.find(
+      (cell) => cell.getAttribute('data-label') === 'Expires'
+    );
+    expect(nameCell).toHaveTextContent('admin');
+    expect(scopeCell).toHaveTextContent('Read');
+    expect(expiresCell).toHaveTextContent('10/25/3019, 7:56:38 PM');
   });
 
-  test('should be checked', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ApplicationTokenListItem
-              token={token}
-              detailUrl="/users/2/details"
-              isSelected
-              onSelect={() => {}}
-              rowIndex={1}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td').at(0).prop('select').isSelected).toBe(true);
+  test('should be checked', () => {
+    renderItem({ isSelected: true });
+    expect(within(screen.getByRole('row')).getByRole('checkbox')).toBeChecked();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationsList/ApplicationList.test.js
+++ b/awx/ui/src/screens/Application/ApplicationsList/ApplicationList.test.js
@@ -128,6 +128,8 @@ describe('<ApplicationsList/>', () => {
     );
 
     expect(await screen.findByText('Error!')).toBeInTheDocument();
+    // the error modal includes an ErrorDetail with an expandable "Details" toggle
+    expect(screen.getByText('Details')).toBeInTheDocument();
   });
 
   test('should not render add button', async () => {

--- a/awx/ui/src/screens/Application/ApplicationsList/ApplicationList.test.js
+++ b/awx/ui/src/screens/Application/ApplicationsList/ApplicationList.test.js
@@ -1,96 +1,82 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { ApplicationsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import ApplicationsList from './ApplicationsList';
 
 jest.mock('../../../api/models/Applications');
 
-const applications = {
-  data: {
-    results: [
-      {
-        id: 1,
-        name: 'Foo',
-        summary_fields: {
-          organization: { name: 'Org 1', id: 10 },
-          user_capabilities: { edit: true, delete: true },
+// fresh data per test because one test mutates user_capabilities.edit
+function buildApplications() {
+  return {
+    data: {
+      results: [
+        {
+          id: 1,
+          name: 'Foo',
+          summary_fields: {
+            organization: { name: 'Org 1', id: 10 },
+            user_capabilities: { edit: true, delete: true },
+          },
+          url: '',
+          organization: 10,
         },
-        url: '',
-        organization: 10,
-      },
-      {
-        id: 2,
-        name: 'Bar',
-        summary_fields: {
-          organization: { name: 'Org 2', id: 20 },
-          user_capabilities: { edit: true, delete: true },
+        {
+          id: 2,
+          name: 'Bar',
+          summary_fields: {
+            organization: { name: 'Org 2', id: 20 },
+            user_capabilities: { edit: true, delete: true },
+          },
+          url: '',
+          organization: 20,
         },
-        url: '',
-        organization: 20,
-      },
-    ],
-    count: 2,
-  },
-};
-const options = { data: { actions: { POST: true } } };
-describe('<ApplicationsList/>', () => {
-  let wrapper;
-  test('should mount properly', async () => {
-    ApplicationsAPI.read.mockResolvedValue(applications);
-    ApplicationsAPI.readOptions.mockResolvedValue(options);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationsList />);
-    });
-    await waitForElement(wrapper, 'ApplicationsList', (el) => el.length > 0);
-  });
+      ],
+      count: 2,
+    },
+  };
+}
 
+const options = { data: { actions: { POST: true } } };
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('<ApplicationsList/>', () => {
   test('should have data fetched and render 2 rows', async () => {
-    ApplicationsAPI.read.mockResolvedValue(applications);
+    ApplicationsAPI.read.mockResolvedValue(buildApplications());
     ApplicationsAPI.readOptions.mockResolvedValue(options);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationsList />);
-    });
-    await waitForElement(wrapper, 'ApplicationsList', (el) => el.length > 0);
-    expect(wrapper.find('ApplicationListItem').length).toBe(2);
+
+    renderWithContexts(<ApplicationsList />);
+
+    expect(await screen.findByRole('link', { name: 'Foo' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Bar' })).toBeInTheDocument();
     expect(ApplicationsAPI.read).toHaveBeenCalled();
     expect(ApplicationsAPI.readOptions).toHaveBeenCalled();
   });
 
   test('should delete item successfully', async () => {
-    ApplicationsAPI.read.mockResolvedValue(applications);
+    ApplicationsAPI.read.mockResolvedValue(buildApplications());
     ApplicationsAPI.readOptions.mockResolvedValue(options);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationsList />);
-    });
-    waitForElement(wrapper, 'ApplicationsList', (el) => el.length > 0);
+    ApplicationsAPI.destroy.mockResolvedValue({});
 
-    wrapper
-      .find('.pf-c-table__check')
-      .first()
-      .find('input')
-      .simulate('change', applications.data.results[0]);
+    const { user } = renderWithContexts(<ApplicationsList />);
+    await screen.findByRole('link', { name: 'Foo' });
 
-    wrapper.update();
+    const row = screen.getByRole('link', { name: 'Foo' }).closest('tr');
+    const checkbox = within(row).getByRole('checkbox');
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
 
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toBe(true);
-    await act(async () =>
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')()
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
     );
 
-    wrapper.update();
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-    expect(ApplicationsAPI.destroy).toHaveBeenCalledWith(
-      applications.data.results[0].id
+    await waitFor(() =>
+      expect(ApplicationsAPI.destroy).toHaveBeenCalledWith(1)
     );
   });
 
@@ -107,15 +93,17 @@ describe('<ApplicationsList/>', () => {
       })
     );
     ApplicationsAPI.readOptions.mockResolvedValue(options);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationsList />);
-    });
 
-    await waitForElement(wrapper, 'ApplicationsList', (el) => el.length > 0);
-    expect(wrapper.find('ContentError').length).toBe(1);
+    renderWithContexts(<ApplicationsList />);
+
+    expect(
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
   });
 
   test('should render deletion error modal', async () => {
+    ApplicationsAPI.read.mockResolvedValue(buildApplications());
+    ApplicationsAPI.readOptions.mockResolvedValue(options);
     ApplicationsAPI.destroy.mockRejectedValue(
       new Error({
         response: {
@@ -127,65 +115,51 @@ describe('<ApplicationsList/>', () => {
         },
       })
     );
-    ApplicationsAPI.read.mockResolvedValue(applications);
-    ApplicationsAPI.readOptions.mockResolvedValue(options);
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationsList />);
-    });
-    waitForElement(wrapper, 'ApplicationsList', (el) => el.length > 0);
 
-    wrapper
-      .find('.pf-c-table__check')
-      .first()
-      .find('input')
-      .simulate('change', 'a');
+    const { user } = renderWithContexts(<ApplicationsList />);
+    await screen.findByRole('link', { name: 'Foo' });
 
-    wrapper.update();
+    const row = screen.getByRole('link', { name: 'Foo' }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
 
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toBe(true);
-    await act(async () =>
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')()
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
     );
 
-    wrapper.update();
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 
   test('should not render add button', async () => {
-    ApplicationsAPI.read.mockResolvedValue(applications);
+    ApplicationsAPI.read.mockResolvedValue(buildApplications());
     ApplicationsAPI.readOptions.mockResolvedValue({
       data: { actions: { POST: false } },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationsList />);
-    });
-    waitForElement(wrapper, 'ApplicationsList', (el) => el.length > 0);
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+
+    renderWithContexts(<ApplicationsList />);
+    await screen.findByRole('link', { name: 'Foo' });
+
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
   });
 
   test('should not render edit button for first list item', async () => {
+    const applications = buildApplications();
     applications.data.results[0].summary_fields.user_capabilities.edit = false;
     ApplicationsAPI.read.mockResolvedValue(applications);
     ApplicationsAPI.readOptions.mockResolvedValue({
       data: { actions: { POST: false } },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<ApplicationsList />);
-    });
-    waitForElement(wrapper, 'ApplicationsList', (el) => el.length > 0);
+
+    renderWithContexts(<ApplicationsList />);
+    await screen.findByRole('link', { name: 'Foo' });
+
+    const fooRow = screen.getByRole('link', { name: 'Foo' }).closest('tr');
+    const barRow = screen.getByRole('link', { name: 'Bar' }).closest('tr');
     expect(
-      wrapper.find('ApplicationListItem').at(0).find('PencilAltIcon').length
-    ).toBe(0);
+      within(fooRow).queryByRole('link', { name: 'Edit application' })
+    ).not.toBeInTheDocument();
     expect(
-      wrapper.find('ApplicationListItem').at(1).find('PencilAltIcon').length
-    ).toBe(1);
+      within(barRow).getByRole('link', { name: 'Edit application' })
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/ApplicationsList/ApplicationListItem.test.js
+++ b/awx/ui/src/screens/Application/ApplicationsList/ApplicationListItem.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen, within } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ApplicationListItem from './ApplicationListItem';
 
 describe('<ApplicationListItem/>', () => {
-  let wrapper;
   const application = {
     id: 1,
     name: 'Foo',
@@ -15,40 +13,40 @@ describe('<ApplicationListItem/>', () => {
       user_capabilities: { edit: true },
     },
   };
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ApplicationListItem
-              application={application}
-              detailUrl="/organizations/2/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('ApplicationListItem').length).toBe(1);
+
+  function renderItem(app = application) {
+    return renderWithContexts(
+      <table>
+        <tbody>
+          <ApplicationListItem
+            application={app}
+            detailUrl="/organizations/2/details"
+            isSelected={false}
+            onSelect={() => {}}
+          />
+        </tbody>
+      </table>
+    );
+  }
+
+  test('should mount successfully', () => {
+    renderItem();
+    expect(screen.getByRole('row')).toBeInTheDocument();
   });
-  test('should render the proper data', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <ApplicationListItem
-              application={application}
-              detailUrl="/organizations/2/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td').at(1).text()).toBe('Foo');
-    expect(wrapper.find('Td').at(2).text()).toBe('Organization');
-    expect(wrapper.find('PencilAltIcon').length).toBe(1);
+
+  test('should render the proper data', () => {
+    renderItem();
+    const row = screen.getByRole('row');
+    const nameCell = within(row)
+      .getAllByRole('cell')
+      .find((cell) => cell.getAttribute('data-label') === 'Name');
+    const orgCell = within(row)
+      .getAllByRole('cell')
+      .find((cell) => cell.getAttribute('data-label') === 'Organization');
+    expect(nameCell).toHaveTextContent('Foo');
+    expect(orgCell).toHaveTextContent('Organization');
+    expect(
+      screen.getByRole('link', { name: 'Edit application' })
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/shared/ApplicationForm.test.js
+++ b/awx/ui/src/screens/Application/shared/ApplicationForm.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { OrganizationsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import ApplicationForm from './ApplicationForm';
 
 jest.mock('../../../api');
@@ -24,217 +24,144 @@ const clientTypeOptions = [
   { key: 'public', label: 'Public', value: 'public' },
 ];
 
-describe('<ApplicationForm', () => {
-  let wrapper;
-  test('should mount properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationForm
-          onSubmit={() => {}}
-          application={{}}
-          onCancel={() => {}}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(wrapper.find('ApplicationForm').length).toBe(1);
-  });
+function renderForm(props = {}) {
+  return renderWithContexts(
+    <ApplicationForm
+      onSubmit={() => {}}
+      onCancel={() => {}}
+      application={{}}
+      authorizationOptions={authorizationOptions}
+      clientTypeOptions={clientTypeOptions}
+      {...props}
+    />
+  );
+}
 
-  test('all fields should render successsfully', async () => {
-    OrganizationsAPI.read.mockResolvedValue({
-      results: [{ id: 1 }, { id: 2 }],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationForm
-          onSubmit={() => {}}
-          application={{}}
-          onCancel={() => {}}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(wrapper.find('input#name').length).toBe(1);
-    expect(wrapper.find('input#description').length).toBe(1);
-    expect(
-      wrapper.find('AnsibleSelect[name="authorization_grant_type"]').length
-    ).toBe(1);
-    expect(wrapper.find('input#redirect_uris').length).toBe(1);
-    expect(wrapper.find('AnsibleSelect[name="client_type"]').length).toBe(1);
-    expect(wrapper.find('OrganizationLookup').length).toBe(1);
+beforeEach(() => {
+  // a single org so OrganizationLookup auto-populates the required field
+  OrganizationsAPI.read.mockResolvedValue({
+    data: { results: [{ id: 1, name: 'Default' }], count: 1 },
+  });
+  OrganizationsAPI.readOptions.mockResolvedValue({
+    data: { actions: { GET: {} }, related_search_fields: [] },
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('<ApplicationForm/>', () => {
+  test('all fields should render successfully', async () => {
+    const { container } = renderForm();
+
+    await screen.findByText('Organization');
+    expect(container.querySelector('#name')).toBeInTheDocument();
+    expect(container.querySelector('#description')).toBeInTheDocument();
+    expect(container.querySelector('#redirect_uris')).toBeInTheDocument();
+    // the two AnsibleSelects render native selects with id authType/clientType
+    expect(container.querySelector('#authType')).toBeInTheDocument();
+    expect(container.querySelector('#clientType')).toBeInTheDocument();
+    // OrganizationLookup renders an Organization form group
+    expect(screen.getByText('Organization')).toBeInTheDocument();
   });
 
   test('should update field values', async () => {
-    OrganizationsAPI.read.mockResolvedValue({
-      results: [{ id: 1 }, { id: 2 }],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationForm
-          onSubmit={() => {}}
-          application={{}}
-          onCancel={() => {}}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-      await act(async () => {
-        wrapper.find('input#name').simulate('change', {
-          target: { value: 'new foo', name: 'name' },
-        });
-        wrapper.find('input#description').simulate('change', {
-          target: { value: 'new bar', name: 'description' },
-        });
-        wrapper
-          .find('AnsibleSelect[name="authorization_grant_type"]')
-          .prop('onChange')({}, 'authorization-code');
+    const { container, user } = renderForm();
+    await screen.findByText('Organization');
 
-        wrapper.find('input#redirect_uris').simulate('change', {
-          target: { value: 'https://www.google.com', name: 'redirect_uris' },
-        });
-        wrapper.find('AnsibleSelect[name="client_type"]').prop('onChange')(
-          {},
-          'confidential'
-        );
-        wrapper.find('OrganizationLookup').invoke('onChange')({
-          id: 3,
-          name: 'organization',
-        });
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find('input#name').prop('value')).toBe('new foo');
-    expect(wrapper.find('input#description').prop('value')).toBe('new bar');
-    expect(wrapper.find('input#organization').prop('value')).toBe(
-      'organization'
+    const nameInput = container.querySelector('#name');
+    await user.type(nameInput, 'new foo');
+    const descriptionInput = container.querySelector('#description');
+    await user.type(descriptionInput, 'new bar');
+    const redirectInput = container.querySelector('#redirect_uris');
+    await user.type(redirectInput, 'https://www.google.com');
+
+    await user.selectOptions(
+      container.querySelector('#authType'),
+      'authorization-code'
     );
-    expect(
-      wrapper
-        .find('AnsibleSelect[name="authorization_grant_type"]')
-        .prop('value')
-    ).toBe('authorization-code');
-    expect(
-      wrapper.find('AnsibleSelect[name="client_type"]').prop('value')
-    ).toBe('confidential');
-    expect(
-      wrapper.find('FormField[label="Redirect URIs"]').prop('isRequired')
-    ).toBe(true);
-    expect(wrapper.find('input#redirect_uris').prop('value')).toBe(
-      'https://www.google.com'
+    await user.selectOptions(
+      container.querySelector('#clientType'),
+      'confidential'
     );
+
+    expect(nameInput).toHaveValue('new foo');
+    expect(descriptionInput).toHaveValue('new bar');
+    expect(redirectInput).toHaveValue('https://www.google.com');
+    expect(container.querySelector('#authType')).toHaveValue(
+      'authorization-code'
+    );
+    expect(container.querySelector('#clientType')).toHaveValue('confidential');
+    // selecting authorization-code makes Redirect URIs required
+    const redirectGroup = container
+      .querySelector('#redirect_uris')
+      .closest('.pf-c-form__group');
+    expect(within(redirectGroup).getByText('*')).toBeInTheDocument();
   });
+
   test('should call onCancel', async () => {
-    OrganizationsAPI.read.mockResolvedValue({
-      results: [{ id: 1 }, { id: 2 }],
-    });
-    const onSubmit = jest.fn();
     const onCancel = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationForm
-          onSubmit={onSubmit}
-          application={{}}
-          onCancel={onCancel}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    wrapper.find('Button[aria-label="Cancel"]').prop('onClick')();
+    const { user } = renderForm({ onCancel });
+    await screen.findByText('Organization');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalled();
   });
+
   test('should call onSubmit', async () => {
-    OrganizationsAPI.read.mockResolvedValue({
-      results: [{ id: 1 }, { id: 2 }],
-    });
     const onSubmit = jest.fn();
-    const onCancel = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationForm
-          onSubmit={onSubmit}
-          application={{}}
-          onCancel={onCancel}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    wrapper.find('Formik').prop('onSubmit')({
-      authorization_grant_type: 'authorization-code',
-      client_type: 'confidential',
-      description: 'bar',
-      name: 'foo',
-      organization: 1,
-      redirect_uris: 'http://www.google.com',
-    });
-    expect(onSubmit).toHaveBeenCalledWith({
-      authorization_grant_type: 'authorization-code',
-      client_type: 'confidential',
-      description: 'bar',
-      name: 'foo',
-      organization: 1,
-      redirect_uris: 'http://www.google.com',
-    });
+    const { container, user } = renderForm({ onSubmit });
+    await screen.findByText('Organization');
+
+    // required selects must be filled before the form will submit
+    await user.type(container.querySelector('#name'), 'foo');
+    await user.selectOptions(
+      container.querySelector('#authType'),
+      'authorization-code'
+    );
+    await user.selectOptions(
+      container.querySelector('#clientType'),
+      'confidential'
+    );
+    await user.type(
+      container.querySelector('#redirect_uris'),
+      'http://www.google.com'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization_grant_type: 'authorization-code',
+        client_type: 'confidential',
+        name: 'foo',
+        redirect_uris: 'http://www.google.com',
+      })
+    );
   });
-  test('should render required on Redirect URIs', async () => {
-    OrganizationsAPI.read.mockResolvedValue({
-      results: [{ id: 1 }, { id: 2 }],
-    });
-    const onSubmit = jest.fn();
-    const onCancel = jest.fn();
+
+  test('should render required on Redirect URIs for authorization-code apps', async () => {
     const application = {
       id: 1,
-      type: 'o_auth2_application',
-      url: '/api/v2/applications/10/',
-      related: {
-        named_url: '/api/v2/applications/Alex++bar/',
-        tokens: '/api/v2/applications/10/tokens/',
-        activity_stream: '/api/v2/applications/10/activity_stream/',
-      },
-      summary_fields: {
-        organization: {
-          id: 230,
-          name: 'bar',
-          description:
-            'SaleNameBedPersonalityManagerWhileFinanceBreakToothPerson魲',
-        },
-        user_capabilities: {
-          edit: true,
-          delete: true,
-        },
-        tokens: {
-          count: 0,
-          results: [],
-        },
-      },
-      created: '2020-06-11T17:54:33.983993Z',
-      modified: '2020-06-11T17:54:33.984039Z',
       name: 'Alex',
       description: '',
-      client_id: 'b1dmj8xzkbFm1ZQ27ygw2ZeE9I0AXqqeL74fiyk4',
-      client_secret: '************',
       client_type: 'confidential',
       redirect_uris: 'http://www.google.com',
       authorization_grant_type: 'authorization-code',
-      skip_authorization: false,
+      summary_fields: {
+        organization: { id: 230, name: 'bar' },
+        user_capabilities: { edit: true, delete: true },
+      },
       organization: 230,
     };
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ApplicationForm
-          onSubmit={onSubmit}
-          application={application}
-          onCancel={onCancel}
-          authorizationOptions={authorizationOptions}
-          clientTypeOptions={clientTypeOptions}
-        />
-      );
-    });
-    expect(
-      wrapper.find('FormField[name="redirect_uris"]').prop('isRequired')
-    ).toBe(true);
+    const { container } = renderForm({ application });
+    await screen.findByText('Organization');
+
+    const redirectGroup = container
+      .querySelector('#redirect_uris')
+      .closest('.pf-c-form__group');
+    expect(within(redirectGroup).getByText('*')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Application/shared/ApplicationForm.test.js
+++ b/awx/ui/src/screens/Application/shared/ApplicationForm.test.js
@@ -138,6 +138,9 @@ describe('<ApplicationForm/>', () => {
         client_type: 'confidential',
         name: 'foo',
         redirect_uris: 'http://www.google.com',
+        // ApplicationAdd/Edit read values.organization.id, so the form must
+        // submit organization as an object with an id (auto-populated here)
+        organization: expect.objectContaining({ id: 1 }),
       })
     );
   });


### PR DESCRIPTION
##### SUMMARY

Converts the **Application** screen's test suite from enzyme to React Testing Library, continuing the incremental enzyme → RTL migration (one screen directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`:

- `ApplicationsList` / `ApplicationListItem` — load, selection, bulk delete + deletion error, edit-link visibility
- `ApplicationTokens` list / item — load, delete + token deletion error
- `ApplicationDetails` — detail fields and actions
- `ApplicationAdd` / `ApplicationEdit` — create/update API args + redirect, cancel, submit-error (shared `ApplicationForm` mocked)
- `ApplicationForm` — field updates, organization auto-populate, required Redirect URIs, submit/cancel

Interactions now go through accessible roles and real user events. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for the Application directory: **10 suites, 44 tests, all passing.** ESLint clean. No production code changed — test-only.
