### PR TITLE
enzyme -> RTL: convert the WorkflowApproval screen suites

### DIFF
--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { WorkflowApprovalsAPI, WorkflowJobsAPI } from 'api';
 import { formatDateString } from 'util/dates';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 import WorkflowApprovalDetail from './WorkflowApprovalDetail';
 import mockWorkflowApprovals from '../data.workflowApprovals.json';
 
@@ -36,13 +36,27 @@ jest.mock('@lingui/react/macro', () => ({
   }),
 }));
 
+// react-ace does not render its value into the DOM under jsdom, so surface the
+// value VariablesDetail receives as plain text to keep the original assertion.
+jest.mock('components/CodeEditor', () => ({
+  ...jest.requireActual('components/CodeEditor'),
+  VariablesDetail: ({ label, value }) => (
+    <div>
+      <div>{label}</div>
+      <div data-testid="variables-detail-value">{value}</div>
+    </div>
+  ),
+}));
+
 jest.mock('../shared/WorkflowApprovalUtils', () => ({
   ...jest.requireActual('../shared/WorkflowApprovalUtils'),
   getDetailPendingLabel: (workflowApproval, t) => {
     if (!workflowApproval.approval_expiration) {
       return 'Never';
     }
-    return jest.requireActual('util/dates').formatDateString(workflowApproval.approval_expiration);
+    return jest
+      .requireActual('util/dates')
+      .formatDateString(workflowApproval.approval_expiration);
   },
   getStatus: (workflowApproval) => {
     if (workflowApproval.status === 'successful') {
@@ -157,6 +171,16 @@ const workflowJob = {
   webhook_guid: '',
 };
 
+async function renderDetail(approval, props = {}) {
+  const utils = renderWithContexts(
+    <WorkflowApprovalDetail workflowApproval={approval} {...props} />
+  );
+  // wait for the workflow job fetch to resolve and the card body to render
+  await screen.findByText('Workflow job details');
+  return utils;
+}
+
+
 describe('<WorkflowApprovalDetail />', () => {
   beforeEach(() => {
     WorkflowJobsAPI.readDetail.mockResolvedValue({ data: workflowJob });
@@ -167,17 +191,8 @@ describe('<WorkflowApprovalDetail />', () => {
   });
 
   test('should render Details', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail workflowApproval={workflowApproval} />
-      );
-    });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    function assertDetail(label, value) {
-      expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-      expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
-    }
+    await renderDetail(workflowApproval);
+
     assertDetail('Name', workflowApproval.name);
     assertDetail('Description', workflowApproval.description);
     assertDetail('Expires', 'Never');
@@ -189,182 +204,119 @@ describe('<WorkflowApprovalDetail />', () => {
       'Workflow Job Template',
       workflowApproval.summary_fields.workflow_job_template.name
     );
-    const dateDetails = wrapper.find('UserDateDetail');
-    expect(dateDetails).toHaveLength(1);
-    expect(dateDetails.at(0).prop('label')).toEqual('Created');
-    expect(dateDetails.at(0).prop('date')).toEqual(
-      '2020-10-09T17:13:12.067947Z'
+
+    const createdLabel = screen.getByText('Created');
+    expect(createdLabel.nextElementSibling).toHaveTextContent(
+      formatDateString('2020-10-09T17:13:12.067947Z')
     );
-    expect(dateDetails.at(0).prop('user')).toEqual(
-      workflowApproval.summary_fields.created_by
-    );
+    expect(createdLabel.nextElementSibling).toHaveTextContent('admin');
+
     assertDetail('Last Modified', formatDateString(workflowApproval.modified));
     assertDetail('Elapsed', '00:00:22');
     assertDetail('Limit', 'localhost');
     assertDetail('Source Control Branch', 'main');
-    const linkInventory = wrapper
-      .find('Detail[label="Inventory"]')
-      .find('Link');
-    expect(linkInventory.prop('to')).toEqual(
+
+    const inventoryLabel = screen.getByText('Inventory');
+    const inventoryLink = within(inventoryLabel.nextElementSibling).getByRole(
+      'link'
+    );
+    expect(inventoryLink).toHaveAttribute(
+      'href',
       '/inventories/inventory/1/details'
     );
+
     assertDetail('Labels', 'Test2');
-    expect(wrapper.find('VariablesDetail').prop('value')).toEqual(
+
+    expect(screen.getByTestId('variables-detail-value')).toHaveTextContent(
       '{"foo": "bar", "baz": "qux", "first_one": 10}'
     );
   });
 
   test('should show expiration date/time', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            approval_expiration: '2020-10-10T17:13:12.067947Z',
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      approval_expiration: '2020-10-10T17:13:12.067947Z',
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    expect(wrapper.find(`Detail[label="Expires"] dd`).text()).toBe(
-      `${formatDateString('2020-10-10T17:13:12.067947Z')}`
-    );
+    assertDetail('Expires', formatDateString('2020-10-10T17:13:12.067947Z'));
   });
 
   test('should show finished date/time', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            finished: '2020-10-10T17:13:12.067947Z',
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      finished: '2020-10-10T17:13:12.067947Z',
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    expect(wrapper.find(`Detail[label="Finished"] dd`).text()).toBe(
-      `${formatDateString('2020-10-10T17:13:12.067947Z')}`
-    );
+    assertDetail('Finished', formatDateString('2020-10-10T17:13:12.067947Z'));
   });
 
   test('should show canceled date/time', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            canceled_on: '2020-10-10T17:13:12.067947Z',
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      canceled_on: '2020-10-10T17:13:12.067947Z',
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-
-    expect(wrapper.find(`Detail[label="Canceled"] dd`).text()).toBe(
-      `${formatDateString('2020-10-10T17:13:12.067947Z')}`
-    );
+    assertDetail('Canceled', formatDateString('2020-10-10T17:13:12.067947Z'));
   });
 
   test('should show explanation', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            job_explanation: 'Some explanation text',
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      job_explanation: 'Some explanation text',
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    expect(wrapper.find(`Detail[label="Explanation"] dd`).text()).toBe(
-      'Some explanation text'
-    );
+    assertDetail('Explanation', 'Some explanation text');
   });
 
   test('should show status when not pending', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            status: 'successful',
-            summary_fields: {
-              ...workflowApproval.summary_fields,
-              approved_or_denied_by: {
-                id: 1,
-                username: 'Foobar',
-              },
-            },
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      status: 'successful',
+      summary_fields: {
+        ...workflowApproval.summary_fields,
+        approved_or_denied_by: {
+          id: 1,
+          username: 'Foobar',
+        },
+      },
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    expect(wrapper.find('StatusLabel').text()).toBe('Approved');
+    const statusLabel = screen.getByText('Status');
+    expect(statusLabel.nextElementSibling).toHaveTextContent('Approved');
   });
 
   test('should show actor when available', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            summary_fields: {
-              ...workflowApproval.summary_fields,
-              approved_or_denied_by: {
-                id: 1,
-                username: 'Foobar',
-              },
-            },
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      summary_fields: {
+        ...workflowApproval.summary_fields,
+        approved_or_denied_by: {
+          id: 1,
+          username: 'Foobar',
+        },
+      },
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    expect(wrapper.find(`Detail[label="Actor"] dd`).text()).toBe('Foobar');
+    assertDetail('Actor', 'Foobar');
   });
 
   test('action buttons should be hidden when user cannot approve or deny', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            can_approve_or_deny: false,
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      can_approve_or_deny: false,
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    expect(wrapper.find('WorkflowApprovalActionButtons').length).toBe(0);
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Deny' })
+    ).not.toBeInTheDocument();
   });
 
   test('only the delete button should render when approval is not pending', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            can_approve_or_deny: true,
-            status: 'successful',
-          }}
-        />
-      );
+    await renderDetail({
+      ...workflowApproval,
+      can_approve_or_deny: true,
+      status: 'successful',
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    expect(wrapper.find('WorkflowApprovalControls').length).toBe(0);
-    expect(wrapper.find('Button[aria-label="Approve"]').length).toBe(0);
-    expect(wrapper.find('DeleteButton').length).toBe(1);
+    expect(
+      screen.queryByRole('button', { name: 'Approve' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
   test('should not load Labels', async () => {
@@ -380,50 +332,25 @@ describe('<WorkflowApprovalDetail />', () => {
       },
     });
 
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail workflowApproval={workflowApproval} />
-      );
-    });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    const labels_detail = wrapper.find(`Detail[label="Labels"]`).at(0);
-    expect(labels_detail.prop('isEmpty')).toEqual(true);
+    await renderDetail(workflowApproval);
+    // when there are no labels the Detail is empty and not rendered
+    expect(screen.queryByText('Labels')).not.toBeInTheDocument();
   });
 
   test('Error dialog shown for failed approval', async () => {
     WorkflowApprovalsAPI.approve.mockImplementationOnce(() =>
       Promise.reject(new Error())
     );
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={workflowApproval}
-          fetchWorkflowApproval={jest.fn()}
-        />
-      );
+    const { user } = await renderDetail(workflowApproval, {
+      fetchWorkflowApproval: jest.fn(),
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    await act(async () => {
-      wrapper
-        .find('Button[ouiaId="workflow-approve-button"]')
-        .at(0)
-        .invoke('onClick')();
-    });
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
     expect(WorkflowApprovalsAPI.approve).toHaveBeenCalledTimes(1);
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 1
-    );
-    await act(async () => {
-      wrapper.find('Modal[title="Error!"]').invoke('onClose')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 0
+
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
     );
   });
 
@@ -431,32 +358,16 @@ describe('<WorkflowApprovalDetail />', () => {
     WorkflowApprovalsAPI.deny.mockImplementationOnce(() =>
       Promise.reject(new Error())
     );
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={workflowApproval}
-          fetchWorkflowApproval={jest.fn()}
-        />
-      );
+    const { user } = await renderDetail(workflowApproval, {
+      fetchWorkflowApproval: jest.fn(),
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    await act(async () => {
-      wrapper.find('Button[ouiaId="workflow-deny-button"]').invoke('onClick')();
-    });
+    await user.click(screen.getByRole('button', { name: 'Deny' }));
     expect(WorkflowApprovalsAPI.deny).toHaveBeenCalledTimes(1);
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 1
-    );
-    await act(async () => {
-      wrapper.find('Modal[title="Error!"]').invoke('onClose')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 0
+
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
     );
   });
 
@@ -464,55 +375,31 @@ describe('<WorkflowApprovalDetail />', () => {
     WorkflowApprovalsAPI.destroy.mockImplementationOnce(() =>
       Promise.reject(new Error())
     );
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail
-          workflowApproval={{
-            ...workflowApproval,
-            status: 'successful',
-            summary_fields: {
-              ...workflowApproval.summary_fields,
-              approved_or_denied_by: {
-                id: 1,
-                username: 'Foobar',
-              },
-            },
-          }}
-        />
-      );
+    const { user } = await renderDetail({
+      ...workflowApproval,
+      status: 'successful',
+      summary_fields: {
+        ...workflowApproval.summary_fields,
+        approved_or_denied_by: {
+          id: 1,
+          username: 'Foobar',
+        },
+      },
     });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
-    await waitForElement(
-      wrapper,
-      'WorkflowApprovalDetail Button[aria-label="Delete"]'
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
     );
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 1
-    );
-    await act(async () => {
-      wrapper.find('Modal[title="Error!"]').invoke('onClose')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Error!"]',
-      (el) => el.length === 0
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
     );
   });
 
   test('should fetch its workflow job details', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalDetail workflowApproval={workflowApproval} />
-      );
-    });
-    waitForElement(wrapper, 'WorkflowApprovalDetail', (el) => el.length > 0);
+    await renderDetail(workflowApproval);
     expect(WorkflowJobsAPI.readDetail).toHaveBeenCalledTimes(1);
     expect(WorkflowJobsAPI.readDetail).toHaveBeenCalledWith(216);
   });

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.test.js
@@ -1,14 +1,23 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { WorkflowApprovalsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowApprovalList from './WorkflowApprovalList';
 import mockWorkflowApprovals from '../data.workflowApprovals.json';
 
 jest.mock('../../../api');
 
+// Row id=221 ("220 - approval copy") is failed + deletable: the only row used
+// in the delete tests below.
+const deletableRowName = '220 - approval copy';
+
+async function renderList() {
+  const utils = renderWithContexts(<WorkflowApprovalList />);
+  await screen.findByRole('link', { name: deletableRowName });
+  return utils;
+}
+
 describe('<WorkflowApprovalList />', () => {
-  let wrapper;
   beforeEach(() => {
     WorkflowApprovalsAPI.read.mockResolvedValue({
       data: {
@@ -33,88 +42,61 @@ describe('<WorkflowApprovalList />', () => {
   });
 
   test('should load and render workflow approvals', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovalList />);
-    });
-    wrapper.update();
-
-    expect(wrapper.find('WorkflowApprovalListItem')).toHaveLength(4);
+    await renderList();
+    // header row + 4 data rows
+    expect(screen.getAllByRole('row')).toHaveLength(5);
   });
 
   test('should select workflow approval when checked', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovalList />);
-    });
-    wrapper.update();
+    const { user } = await renderList();
 
-    await act(async () => {
-      wrapper.find('WorkflowApprovalListItem').first().invoke('onSelect')();
-    });
-    wrapper.update();
+    const row = screen.getByRole('link', { name: deletableRowName }).closest('tr');
+    const checkbox = within(row).getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
 
-    expect(
-      wrapper.find('WorkflowApprovalListItem').first().prop('isSelected')
-    ).toEqual(true);
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
   });
 
   test('should select all', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovalList />);
-    });
-    wrapper.update();
+    const { user } = await renderList();
 
-    await act(async () => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
-    });
-    wrapper.update();
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+    const rowCheckboxes = screen
+      .getAllByRole('checkbox')
+      .filter((box) => box !== selectAll);
 
-    const items = wrapper.find('WorkflowApprovalListItem');
-    expect(items).toHaveLength(4);
-    items.forEach((item) => {
-      expect(item.prop('isSelected')).toEqual(true);
-    });
+    expect(rowCheckboxes).toHaveLength(4);
+    rowCheckboxes.forEach((box) => expect(box).not.toBeChecked());
 
-    expect(
-      wrapper.find('WorkflowApprovalListItem').first().prop('isSelected')
-    ).toEqual(true);
+    await user.click(selectAll);
+    rowCheckboxes.forEach((box) => expect(box).toBeChecked());
   });
 
   test('Delete button is active', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovalList />);
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('WorkflowApprovalListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
-    expect(wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')).toBe(
-      false
-    );
+    const { user } = await renderList();
+
+    const row = screen.getByRole('link', { name: deletableRowName }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
   });
 
   test('should call delete api', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovalList />);
-    });
-    wrapper.update();
+    const { user } = await renderList();
 
-    await act(async () => {
-      wrapper.find('WorkflowApprovalListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')
-    ).toEqual(false);
-    await act(async () =>
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')()
+    const row = screen.getByRole('link', { name: deletableRowName }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
     );
 
-    wrapper.update();
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
+    await waitFor(() =>
+      expect(WorkflowApprovalsAPI.destroy).toHaveBeenCalledTimes(1)
     );
-    expect(WorkflowApprovalsAPI.destroy).toHaveBeenCalledTimes(1);
   });
 
   test('should show deletion error', async () => {
@@ -129,31 +111,18 @@ describe('<WorkflowApprovalList />', () => {
         },
       })
     );
-    await act(async () => {
-      wrapper = mountWithContexts(<WorkflowApprovalList />);
-    });
-    wrapper.update();
+    const { user } = await renderList();
     expect(WorkflowApprovalsAPI.read).toHaveBeenCalledTimes(1);
 
-    await act(async () => {
-      wrapper.find('WorkflowApprovalListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')
-    ).toEqual(false);
-    await act(async () =>
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')()
+    const row = screen.getByRole('link', { name: deletableRowName }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
     );
 
-    wrapper.update();
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    const modal = wrapper.find('Modal');
-    expect(modal).toHaveLength(1);
-    expect(modal.prop('title')).toEqual('Error!');
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.test.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import { WorkflowApprovalsAPI } from 'api';
-import { renderWithContexts } from '../../../../testUtils/rtlContexts';
+import {
+  renderWithContexts,
+  settleTooltips,
+} from '../../../../testUtils/rtlContexts';
 import WorkflowApprovalList from './WorkflowApprovalList';
 import mockWorkflowApprovals from '../data.workflowApprovals.json';
 
@@ -97,6 +100,10 @@ describe('<WorkflowApprovalList />', () => {
     await waitFor(() =>
       expect(WorkflowApprovalsAPI.destroy).toHaveBeenCalledTimes(1)
     );
+
+    // confirming delete closes the modal and refocuses the Tooltip-wrapped
+    // toolbar Delete button
+    await settleTooltips();
   });
 
   test('should show deletion error', async () => {
@@ -124,5 +131,12 @@ describe('<WorkflowApprovalList />', () => {
     );
 
     expect(await screen.findByText('Error!')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
+    );
+    // closing the modal refocuses the Tooltip-wrapped toolbar Delete button
+    await settleTooltips();
   });
 });

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowApprovalListApproveButton from './WorkflowApprovalListApproveButton';
 
 const workflowApproval = {
@@ -11,46 +12,44 @@ const workflowApproval = {
 
 describe('<WorkflowApprovalListApproveButton />', () => {
   test('should render button', () => {
-    const wrapper = mountWithContexts(
-      <WorkflowApprovalListApproveButton
-        onApprove={() => {}}
-        selectedItems={[]}
-      />
+    renderWithContexts(
+      <WorkflowApprovalListApproveButton onApprove={() => {}} selectedItems={[]} />
     );
-    expect(wrapper.find('button')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
   });
 
-  test('should invoke onApprove prop', () => {
+  test('should invoke onApprove prop', async () => {
     const onApprove = jest.fn();
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <WorkflowApprovalListApproveButton
         onApprove={onApprove}
         selectedItems={[workflowApproval]}
       />
     );
-    wrapper.find('button').simulate('click');
-    wrapper.update();
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
     expect(onApprove).toHaveBeenCalled();
   });
 
   test('should disable button when no approve/deny permissions', () => {
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <WorkflowApprovalListApproveButton
         onApprove={() => {}}
         selectedItems={[{ ...workflowApproval, can_approve_or_deny: false }]}
       />
     );
-    expect(wrapper.find('button[disabled]')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeDisabled();
   });
 
-  test('should render tooltip', () => {
-    const wrapper = mountWithContexts(
+  test('should render tooltip', async () => {
+    const { user } = renderWithContexts(
       <WorkflowApprovalListApproveButton
         onApprove={() => {}}
         selectedItems={[workflowApproval]}
       />
     );
-    expect(wrapper.find('Tooltip')).toHaveLength(1);
-    expect(wrapper.find('Tooltip').prop('content')).toEqual('Approve');
+    await user.hover(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() =>
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Approve')
+    );
   });
 });

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListDenyButton.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListDenyButton.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowApprovalListDenyButton from './WorkflowApprovalListDenyButton';
 
 const workflowApproval = {
@@ -11,43 +12,44 @@ const workflowApproval = {
 
 describe('<WorkflowApprovalListDenyButton />', () => {
   test('should render button', () => {
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <WorkflowApprovalListDenyButton onDeny={() => {}} selectedItems={[]} />
     );
-    expect(wrapper.find('button')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeInTheDocument();
   });
 
-  test('should invoke onDeny prop', () => {
+  test('should invoke onDeny prop', async () => {
     const onDeny = jest.fn();
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <WorkflowApprovalListDenyButton
         onDeny={onDeny}
         selectedItems={[workflowApproval]}
       />
     );
-    wrapper.find('button').simulate('click');
-    wrapper.update();
+    await user.click(screen.getByRole('button', { name: 'Deny' }));
     expect(onDeny).toHaveBeenCalled();
   });
 
   test('should disable button when no approve/deny permissions', () => {
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <WorkflowApprovalListDenyButton
         onDeny={() => {}}
         selectedItems={[{ ...workflowApproval, can_approve_or_deny: false }]}
       />
     );
-    expect(wrapper.find('button[disabled]')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeDisabled();
   });
 
-  test('should render tooltip', () => {
-    const wrapper = mountWithContexts(
+  test('should render tooltip', async () => {
+    const { user } = renderWithContexts(
       <WorkflowApprovalListDenyButton
         onDeny={() => {}}
         selectedItems={[workflowApproval]}
       />
     );
-    expect(wrapper.find('Tooltip')).toHaveLength(1);
-    expect(wrapper.find('Tooltip').prop('content')).toEqual('Deny');
+    await user.hover(screen.getByRole('button', { name: 'Deny' }));
+    await waitFor(() =>
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Deny')
+    );
   });
 });

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowApprovalListItem from './WorkflowApprovalListItem';
 import mockWorkflowApprovals from '../data.workflowApprovals.json';
 
@@ -7,120 +8,79 @@ const workflowApproval = mockWorkflowApprovals.results[0];
 
 jest.mock('../../../api/models/WorkflowApprovals');
 
-describe('<WorkflowApprovalListItem />', () => {
-  let wrapper;
+function renderItem(approval) {
+  return renderWithContexts(
+    <table>
+      <tbody>
+        <WorkflowApprovalListItem
+          isSelected={false}
+          detailUrl={`/workflow_approvals/${approval.id}`}
+          onSelect={() => {}}
+          rowIndex={0}
+          workflowApproval={approval}
+        />
+      </tbody>
+    </table>
+  );
+}
 
+describe('<WorkflowApprovalListItem />', () => {
   test('should display never expires status', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <WorkflowApprovalListItem
-            isSelected={false}
-            detailUrl={`/workflow_approvals/${workflowApproval.id}`}
-            onSelect={() => {}}
-            workflowApproval={workflowApproval}
-          />
-        </tbody>
-      </table>
-    );
-    // For pending status with no expiration, StatusLabel should show "Never expires"
-    expect(wrapper.find('StatusLabel').text()).toBe('Never expires');
+    renderItem(workflowApproval);
+    // For pending status with no expiration, StatusLabel shows "Never expires"
+    expect(screen.getByText('Never expires')).toBeInTheDocument();
   });
 
   test('should display timed out status', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <WorkflowApprovalListItem
-            isSelected={false}
-            detailUrl={`/workflow_approvals/${workflowApproval.id}`}
-            onSelect={() => {}}
-            workflowApproval={{
-              ...workflowApproval,
-              status: 'failed',
-              timed_out: true,
-            }}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Label[children="Timed out"]').length).toBe(1);
+    renderItem({
+      ...workflowApproval,
+      status: 'failed',
+      timed_out: true,
+    });
+    expect(screen.getByText('Timed out')).toBeInTheDocument();
   });
 
   test('should display canceled status', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <WorkflowApprovalListItem
-            isSelected={false}
-            detailUrl={`/workflow_approvals/${workflowApproval.id}`}
-            onSelect={() => {}}
-            workflowApproval={{
-              ...workflowApproval,
-              canceled_on: '2020-10-09T19:59:26.974046Z',
-              status: 'canceled',
-            }}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Label[children="Canceled"]').length).toBe(1);
+    renderItem({
+      ...workflowApproval,
+      canceled_on: '2020-10-09T19:59:26.974046Z',
+      status: 'canceled',
+    });
+    expect(screen.getByText('Canceled')).toBeInTheDocument();
   });
 
   test('should display approved status', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <WorkflowApprovalListItem
-            isSelected={false}
-            detailUrl={`/workflow_approvals/${workflowApproval.id}`}
-            onSelect={() => {}}
-            workflowApproval={{
-              ...workflowApproval,
-              status: 'successful',
-              summary_fields: {
-                ...workflowApproval.summary_fields,
-                approved_or_denied_by: {
-                  id: 1,
-                  username: 'admin',
-                  first_name: '',
-                  last_name: '',
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Label[children="Approved"]').length).toBe(1);
+    renderItem({
+      ...workflowApproval,
+      status: 'successful',
+      summary_fields: {
+        ...workflowApproval.summary_fields,
+        approved_or_denied_by: {
+          id: 1,
+          username: 'admin',
+          first_name: '',
+          last_name: '',
+        },
+      },
+    });
+    expect(screen.getByText('Approved')).toBeInTheDocument();
   });
 
   test('should display denied status', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <WorkflowApprovalListItem
-            isSelected={false}
-            detailUrl={`/workflow_approvals/${workflowApproval.id}`}
-            onSelect={() => {}}
-            workflowApproval={{
-              ...workflowApproval,
-              failed: true,
-              status: 'failed',
-              summary_fields: {
-                ...workflowApproval.summary_fields,
-                approved_or_denied_by: {
-                  id: 1,
-                  username: 'admin',
-                  first_name: '',
-                  last_name: '',
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Label[children="Denied"]').length).toBe(1);
+    renderItem({
+      ...workflowApproval,
+      failed: true,
+      status: 'failed',
+      summary_fields: {
+        ...workflowApproval.summary_fields,
+        approved_or_denied_by: {
+          id: 1,
+          username: 'admin',
+          first_name: '',
+          last_name: '',
+        },
+      },
+    });
+    expect(screen.getByText('Denied')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/useWsWorkflowApprovals.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/useWsWorkflowApprovals.test.js
@@ -1,23 +1,21 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import WS from 'jest-websocket-mock';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import useWsWorkflowApprovals from './useWsWorkflowApprovals';
 
-function TestInner() {
-  return <div />;
-}
 function Test({ workflowApprovals, fetchWorkflowApprovals }) {
   const updatedWorkflowApprovals = useWsWorkflowApprovals(
     workflowApprovals,
     fetchWorkflowApprovals
   );
-  return <TestInner workflowApprovals={updatedWorkflowApprovals} />;
+  return (
+    <div data-testid="result">{JSON.stringify(updatedWorkflowApprovals)}</div>
+  );
 }
 
 describe('useWsWorkflowApprovals hook', () => {
   let debug;
-  let wrapper;
   beforeEach(() => {
     debug = global.console.debug; // eslint-disable-line prefer-destructuring
     global.console.debug = () => {};
@@ -34,21 +32,18 @@ describe('useWsWorkflowApprovals hook', () => {
   afterEach(() => {
     global.console.debug = debug;
     WS.clean();
-    if (wrapper) {
-      wrapper.unmount();
-    }
   });
 
   test('should return workflow approvals list', () => {
     const workflowApprovals = [{ id: 1, status: 'successful' }];
-    wrapper = mountWithContexts(
+    const { getByTestId } = renderWithContexts(
       <Test
         workflowApprovals={workflowApprovals}
         fetchWorkflowApprovals={() => {}}
       />
     );
 
-    expect(wrapper.find('TestInner').prop('workflowApprovals')).toEqual(
+    expect(JSON.parse(getByTestId('result').textContent)).toEqual(
       workflowApprovals
     );
   });
@@ -59,7 +54,7 @@ describe('useWsWorkflowApprovals hook', () => {
 
     const workflowApprovals = [{ id: 1, status: 'successful' }];
     await act(async () => {
-      wrapper = mountWithContexts(
+      renderWithContexts(
         <Test
           workflowApprovals={workflowApprovals}
           fetchWorkflowApprovals={() => {}}
@@ -85,7 +80,7 @@ describe('useWsWorkflowApprovals hook', () => {
     const workflowApprovals = [{ id: 1, status: 'successful' }];
     const fetchWorkflowApprovals = jest.fn(() => []);
     await act(async () => {
-      wrapper = await mountWithContexts(
+      renderWithContexts(
         <Test
           workflowApprovals={workflowApprovals}
           fetchWorkflowApprovals={fetchWorkflowApprovals}
@@ -113,7 +108,7 @@ describe('useWsWorkflowApprovals hook', () => {
     const workflowApprovals = [{ id: 1, status: 'pending' }];
     const fetchWorkflowApprovals = jest.fn(() => []);
     await act(async () => {
-      wrapper = await mountWithContexts(
+      renderWithContexts(
         <Test
           workflowApprovals={workflowApprovals}
           fetchWorkflowApprovals={fetchWorkflowApprovals}
@@ -141,7 +136,7 @@ describe('useWsWorkflowApprovals hook', () => {
     const workflowApprovals = [{ id: 1, status: 'successful' }];
     const fetchWorkflowApprovals = jest.fn(() => []);
     await act(async () => {
-      wrapper = await mountWithContexts(
+      renderWithContexts(
         <Test
           workflowApprovals={workflowApprovals}
           fetchWorkflowApprovals={fetchWorkflowApprovals}

--- a/awx/ui/src/screens/WorkflowApproval/shared/WorkflowApprovalButton.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/shared/WorkflowApprovalButton.test.js
@@ -1,65 +1,53 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-
-import {
-  mountWithContexts,
-  shallowWithContexts,
-} from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
 import { WorkflowApprovalsAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowApprovalButton from './WorkflowApprovalButton';
 import mockData from '../data.workflowApprovals.json';
 
 jest.mock('api');
 
-describe('<WorkflowApprovalButton/> shallow mount', () => {
-  let wrapper;
+const mockApprovalList = mockData.results;
 
-  let mockApprovalList = mockData.results;
+describe('<WorkflowApprovalButton/>', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   test('initially render successfully', () => {
-    wrapper = shallowWithContexts(
+    renderWithContexts(
       <WorkflowApprovalButton
         workflowApproval={mockApprovalList[0]}
         onHandleToast={jest.fn()}
       />
     );
-
-    expect(wrapper.find('WorkflowApprovalButton')).toHaveLength(1);
-    wrapper
-      .find('Button')
-      .forEach((button) => expect(button.prop('isDisabled')).toBe(false));
-  });
-});
-
-describe('<WorkflowApprovalButton/>, full mount', () => {
-  let wrapper;
-  let mockApprovalList = mockData.results;
-  const approveButton = 'Button[ouiaId="workflow-approve-button"]';
-  afterEach(() => {
-    wrapper.unmount();
-    jest.clearAllMocks();
+    expect(screen.getByRole('button', { name: 'Approve' })).toBeEnabled();
   });
 
   test('should be disabled', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <WorkflowApprovalButton
         workflowApproval={mockApprovalList[2]}
         onHandleToast={jest.fn()}
       />
     );
-    expect(wrapper.find(approveButton)).toHaveLength(1);
-    expect(wrapper.find(approveButton).prop('isDisabled')).toBe(true);
+    expect(
+      screen.getByRole('button', {
+        name: 'This workflow has already been acted on',
+      })
+    ).toBeDisabled();
   });
+
   test('should handle approve', async () => {
-    act(() => {
-      wrapper = mountWithContexts(
-        <WorkflowApprovalButton
-          workflowApproval={mockApprovalList[0]}
-          onHandleToast={jest.fn()}
-        />
-      );
-    });
-    await act(() => wrapper.find(approveButton).prop('onClick')());
-    expect(WorkflowApprovalsAPI.approve).toHaveBeenCalledWith(218);
+    const { user } = renderWithContexts(
+      <WorkflowApprovalButton
+        workflowApproval={mockApprovalList[0]}
+        onHandleToast={jest.fn()}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() =>
+      expect(WorkflowApprovalsAPI.approve).toHaveBeenCalledWith(218)
+    );
   });
 });

--- a/awx/ui/src/screens/WorkflowApproval/shared/WorkflowDenyButton.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/shared/WorkflowDenyButton.test.js
@@ -1,64 +1,54 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-
-import {
-  mountWithContexts,
-  shallowWithContexts,
-} from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
 import { WorkflowApprovalsAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowDenyButton from './WorkflowDenyButton';
 import mockData from '../data.workflowApprovals.json';
 
 jest.mock('api');
 
-describe('<WorkflowDenyButton/> shallow mount', () => {
-  let wrapper;
+const mockApprovalList = mockData.results;
 
-  let mockApprovalList = mockData.results;
-
-  test('initially render successfully', () => {
-    wrapper = shallowWithContexts(
-      <WorkflowDenyButton workflowApproval={mockApprovalList[0]} />
-    );
-
-    expect(wrapper.find('WorkflowDenyButton')).toHaveLength(1);
-    wrapper
-      .find('Button')
-      .forEach((button) => expect(button.prop('isDisabled')).toBe(false));
-  });
-});
-
-describe('<WorkflowDenyButton/>, full mount', () => {
-  let wrapper;
-  let mockApprovalList = mockData.results;
-  const denyButton = 'Button[ouiaId="workflow-deny-button"]';
+describe('<WorkflowDenyButton/>', () => {
   afterEach(() => {
-    wrapper.unmount();
     jest.clearAllMocks();
   });
 
+  test('initially render successfully', () => {
+    renderWithContexts(
+      <WorkflowDenyButton
+        workflowApproval={mockApprovalList[0]}
+        onHandleToast={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeEnabled();
+  });
+
   test('should be disabled', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <WorkflowDenyButton
         workflowApproval={mockApprovalList[2]}
         onHandleToast={jest.fn()}
       />
     );
-    expect(wrapper.find(denyButton)).toHaveLength(1);
-    expect(wrapper.find(denyButton).prop('isDisabled')).toBe(true);
+    expect(
+      screen.getByRole('button', {
+        name: 'This workflow has already been acted on',
+      })
+    ).toBeDisabled();
   });
 
   test('should handle deny', async () => {
-    act(() => {
-      wrapper = mountWithContexts(
-        <WorkflowDenyButton
-          workflowApproval={mockApprovalList[0]}
-          onHandleToast={jest.fn()}
-        />
-      );
-    });
-    await act(() => wrapper.find(denyButton).prop('onClick')());
-    expect(WorkflowApprovalsAPI.deny).toHaveBeenCalledWith(218);
+    const { user } = renderWithContexts(
+      <WorkflowDenyButton
+        workflowApproval={mockApprovalList[0]}
+        onHandleToast={jest.fn()}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Deny' }));
+    await waitFor(() =>
+      expect(WorkflowApprovalsAPI.deny).toHaveBeenCalledWith(218)
+    );
   });
 
   test('Should handle deny error', async () => {
@@ -74,16 +64,13 @@ describe('<WorkflowDenyButton/>, full mount', () => {
         },
       })
     );
-    act(() => {
-      wrapper = mountWithContexts(
-        <WorkflowDenyButton
-          workflowApproval={mockApprovalList[0]}
-          onHandleToast={jest.fn()}
-        />
-      );
-    });
-    await act(() => wrapper.find(denyButton).prop('onClick')());
-    wrapper.update();
-    expect(wrapper.find('ErrorDetail')).toHaveLength(1);
+    const { user } = renderWithContexts(
+      <WorkflowDenyButton
+        workflowApproval={mockApprovalList[0]}
+        onHandleToast={jest.fn()}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Deny' }));
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **WorkflowApproval** screen's test suite from enzyme to React Testing Library, continuing the incremental enzyme → RTL migration (one screen directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`:

- approve/deny buttons (shared + list variants) — enabled/disabled state by accessible name, tooltip on hover
- `WorkflowApprovalList` / `WorkflowApprovalListItem` — load, selection, bulk delete + deletion error, approve/deny API calls
- `WorkflowApprovalDetail` — detail fields, variables (CodeEditor mocked for value assertion)
- `useWsWorkflowApprovals` — websocket connect/refetch (hook result rendered to a testid)

Interactions now go through accessible roles and real user events. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for the WorkflowApproval directory: **11 suites, 61 tests, all passing.** ESLint clean. No production code changed — test-only.
