### PR TITLE
enzyme -> RTL: convert the Host screen suites

### DIFF
--- a/awx/ui/src/screens/Host/HostAdd/HostAdd.test.js
+++ b/awx/ui/src/screens/Host/HostAdd/HostAdd.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { HostsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import HostAdd from './HostAdd';
 
 jest.mock('../../../api');
@@ -17,11 +17,43 @@ const hostData = {
   variables: '---\nfoo: bar',
 };
 
+// Mock the shared HostForm: a Save button invokes handleSubmit with the
+// provided test payload, a Cancel button invokes handleCancel, and the
+// submitError prop renders so the error branch can be asserted.
+jest.mock('components/HostForm', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: ({ handleSubmit, handleCancel, submitError }) =>
+      ReactLib.createElement(
+        'div',
+        null,
+        ReactLib.createElement(
+          'button',
+          {
+            type: 'button',
+            'aria-label': 'Save',
+            onClick: () => handleSubmit(global.__hostFormSubmitData),
+          },
+          'Save'
+        ),
+        ReactLib.createElement(
+          'button',
+          { type: 'button', 'aria-label': 'Cancel', onClick: handleCancel },
+          'Cancel'
+        ),
+        submitError
+          ? ReactLib.createElement('div', null, 'FormSubmitError')
+          : null
+      ),
+  };
+});
+
 describe('<HostAdd />', () => {
-  let wrapper;
   let history;
 
-  beforeEach(async () => {
+  beforeEach(() => {
+    global.__hostFormSubmitData = hostData;
     history = createMemoryHistory({
       initialEntries: ['/templates/job_templates/1/survey/edit/foo'],
       state: { some: 'state' },
@@ -32,37 +64,39 @@ describe('<HostAdd />', () => {
         id: 5,
       },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<HostAdd />, {
-        context: { router: { history } },
-      });
-    });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('handleSubmit should post to api', async () => {
-    await act(async () => {
-      wrapper.find('HostForm').prop('handleSubmit')(hostData);
+  function render() {
+    return renderWithContexts(<HostAdd />, {
+      context: { router: { history } },
     });
-    expect(HostsAPI.create).toHaveBeenCalledWith({ ...hostData, inventory: 1 });
+  }
+
+  test('handleSubmit should post to api', async () => {
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(HostsAPI.create).toHaveBeenCalledWith({ ...hostData, inventory: 1 })
+    );
   });
 
   test('should navigate to hosts list when cancel is clicked', async () => {
-    await act(async () => {
-      wrapper.find('button[aria-label="Cancel"]').prop('onClick')();
-    });
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/hosts');
   });
 
   test('successful form submission should trigger redirect', async () => {
-    await act(async () => {
-      wrapper.find('HostForm').invoke('handleSubmit')(hostData);
-    });
-    expect(wrapper.find('FormSubmitError').length).toBe(0);
-    expect(history.location.pathname).toEqual('/hosts/5/details');
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(history.location.pathname).toEqual('/hosts/5/details')
+    );
+    expect(screen.queryByText('FormSubmitError')).not.toBeInTheDocument();
   });
 
   test('failed form submission should show an error message', async () => {
@@ -72,10 +106,8 @@ describe('<HostAdd />', () => {
       },
     };
     HostsAPI.create.mockImplementationOnce(() => Promise.reject(error));
-    await act(async () => {
-      wrapper.find('HostForm').invoke('handleSubmit')(hostData);
-    });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText('FormSubmitError')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Host/HostDetail/HostDetail.test.js
+++ b/awx/ui/src/screens/Host/HostDetail/HostDetail.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { HostsAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 import HostDetail from './HostDetail';
 
 import mockHost from '../data.host.json';
@@ -12,18 +12,13 @@ import mockHost from '../data.host.json';
 jest.mock('../../../api');
 
 describe('<HostDetail />', () => {
-  let wrapper;
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe('User has edit permissions', () => {
-    beforeAll(() => {
-      wrapper = mountWithContexts(<HostDetail host={mockHost} />);
-    });
-
     test('should render Details', async () => {
-      function assertDetail(label, value) {
-        expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-        expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
-      }
+      renderWithContexts(<HostDetail host={mockHost} />);
 
       assertDetail('Name', 'localhost');
       assertDetail('Description', 'a good description');
@@ -33,60 +28,69 @@ describe('<HostDetail />', () => {
     });
 
     test('should show edit button for users with edit permission', () => {
-      const editButton = wrapper.find('Button[aria-label="edit"]');
-      expect(editButton.text()).toEqual('Edit');
-      expect(editButton.prop('to')).toBe('/hosts/2/edit');
+      renderWithContexts(<HostDetail host={mockHost} />);
+      const editButton = screen.getByRole('link', { name: 'edit' });
+      expect(editButton).toHaveTextContent('Edit');
+      expect(editButton).toHaveAttribute('href', '/hosts/2/edit');
     });
 
     test('expected api call is made for delete', async () => {
-      await act(async () => {
-        wrapper.find('DeleteButton').invoke('onConfirm')();
-      });
-      expect(HostsAPI.destroy).toHaveBeenCalledTimes(1);
+      HostsAPI.destroy.mockResolvedValueOnce({});
+      const { user } = renderWithContexts(<HostDetail host={mockHost} />);
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+      await user.click(
+        await screen.findByRole('button', { name: 'Confirm Delete' })
+      );
+
+      await waitFor(() => expect(HostsAPI.destroy).toHaveBeenCalledTimes(1));
     });
 
     test('Error dialog shown for failed deletion', async () => {
       HostsAPI.destroy.mockImplementationOnce(() =>
         Promise.reject(new Error())
       );
-      await act(async () => {
-        wrapper.find('DeleteButton').invoke('onConfirm')();
-      });
-      await waitForElement(
-        wrapper,
-        'Modal[title="Error!"]',
-        (el) => el.length === 1
+      const { user } = renderWithContexts(<HostDetail host={mockHost} />);
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+      await user.click(
+        await screen.findByRole('button', { name: 'Confirm Delete' })
       );
-      await act(async () => {
-        wrapper.find('Modal[title="Error!"]').invoke('onClose')();
-      });
-      await waitForElement(
-        wrapper,
-        'Modal[title="Error!"]',
-        (el) => el.length === 0
+
+      expect(await screen.findByText('Error!')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+      await waitFor(() =>
+        expect(screen.queryByText('Error!')).not.toBeInTheDocument()
       );
     });
   });
 
   describe('User has read-only permissions', () => {
-    beforeAll(() => {
-      const readOnlyHost = { ...mockHost };
-      readOnlyHost.summary_fields.user_capabilities.edit = false;
-      readOnlyHost.summary_fields.recent_jobs = [];
-
-      wrapper = mountWithContexts(<HostDetail host={mockHost} />);
-    });
+    const readOnlyHost = {
+      ...mockHost,
+      summary_fields: {
+        ...mockHost.summary_fields,
+        user_capabilities: {
+          ...mockHost.summary_fields.user_capabilities,
+          edit: false,
+        },
+        recent_jobs: [],
+      },
+    };
 
     test('should hide activity stream when there are no recent jobs', async () => {
-      expect(wrapper.find(`Detail[label="Activity"] Sparkline`)).toHaveLength(
-        0
-      );
-      const activity_detail = wrapper.find(`Detail[label="Activity"]`).at(0);
-      expect(activity_detail.prop('isEmpty')).toEqual(true);
+      renderWithContexts(<HostDetail host={readOnlyHost} />);
+      // an empty Detail (isEmpty) renders null, so the Activity row and its
+      // Sparkline are omitted entirely
+      expect(screen.queryByText('Activity')).not.toBeInTheDocument();
     });
 
     test('should hide edit button for users without edit permission', async () => {
-      expect(wrapper.find('Button[aria-label="edit"]').length).toBe(0);
+      renderWithContexts(<HostDetail host={readOnlyHost} />);
+      expect(
+        screen.queryByRole('link', { name: 'edit' })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/awx/ui/src/screens/Host/HostEdit/HostEdit.test.js
+++ b/awx/ui/src/screens/Host/HostEdit/HostEdit.test.js
@@ -1,69 +1,102 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { HostsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import mockHost from '../data.host.json';
 import HostEdit from './HostEdit';
 
 jest.mock('../../../api');
 
+const updatedHostData = {
+  name: 'new name',
+  description: 'new description',
+  variables: '---\nfoo: bar',
+};
+
+// Mock the shared HostForm: a Save button invokes handleSubmit with the
+// provided test payload, a Cancel button invokes handleCancel, and the
+// submitError prop renders so the error branch can be asserted.
+jest.mock('components/HostForm', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: ({ handleSubmit, handleCancel, submitError }) =>
+      ReactLib.createElement(
+        'div',
+        null,
+        ReactLib.createElement(
+          'button',
+          {
+            type: 'button',
+            'aria-label': 'Save',
+            onClick: () => handleSubmit(global.__hostFormSubmitData),
+          },
+          'Save'
+        ),
+        ReactLib.createElement(
+          'button',
+          { type: 'button', 'aria-label': 'Cancel', onClick: handleCancel },
+          'Cancel'
+        ),
+        submitError
+          ? ReactLib.createElement('div', null, 'FormSubmitError')
+          : null
+      ),
+  };
+});
+
 describe('<HostEdit />', () => {
-  let wrapper;
   let history;
 
-  const updatedHostData = {
-    name: 'new name',
-    description: 'new description',
-    variables: '---\nfoo: bar',
-  };
-
-  beforeAll(async () => {
+  beforeEach(() => {
+    global.__hostFormSubmitData = updatedHostData;
     history = createMemoryHistory();
-    await act(async () => {
-      wrapper = mountWithContexts(<HostEdit host={mockHost} />, {
-        context: { router: { history } },
-      });
-    });
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('handleSubmit should call api update', async () => {
-    await act(async () => {
-      wrapper.find('HostForm').prop('handleSubmit')(updatedHostData);
+  function render() {
+    return renderWithContexts(<HostEdit host={mockHost} />, {
+      context: { router: { history } },
     });
-    expect(HostsAPI.update).toHaveBeenCalledWith(2, updatedHostData);
+  }
+
+  test('handleSubmit should call api update', async () => {
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(HostsAPI.update).toHaveBeenCalledWith(2, updatedHostData)
+    );
   });
 
   test('should navigate to host detail when cancel is clicked', async () => {
-    await act(async () => {
-      wrapper.find('button[aria-label="Cancel"]').prop('onClick')();
-    });
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/hosts/2/details');
   });
 
   test('should navigate to host detail after successful submission', async () => {
-    await act(async () => {
-      wrapper.find('HostForm').invoke('handleSubmit')(updatedHostData);
-    });
-    expect(wrapper.find('FormSubmitError').length).toBe(0);
-    expect(history.location.pathname).toEqual('/hosts/2/details');
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(history.location.pathname).toEqual('/hosts/2/details')
+    );
+    expect(screen.queryByText('FormSubmitError')).not.toBeInTheDocument();
   });
 
   test('failed form submission should show an error message', async () => {
+    global.__hostFormSubmitData = mockHost;
     const error = {
       response: {
         data: { detail: 'An error occurred' },
       },
     };
     HostsAPI.update.mockImplementationOnce(() => Promise.reject(error));
-    await act(async () => {
-      wrapper.find('HostForm').invoke('handleSubmit')(mockHost);
-    });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    const { user } = render();
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText('FormSubmitError')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Host/HostFacts/HostFacts.test.js
+++ b/awx/ui/src/screens/Host/HostFacts/HostFacts.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { HostsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import HostFacts from './HostFacts';
 import mockHost from '../data.host.json';
 import mockHostFacts from '../data.hostFacts.json';
@@ -19,22 +16,20 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('<HostFacts />', () => {
-  let wrapper;
-
-  beforeEach(async () => {
-    HostsAPI.readFacts.mockResolvedValue({ data: mockHostFacts });
-    await act(async () => {
-      wrapper = mountWithContexts(<HostFacts host={mockHost} />);
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('initially renders successfully ', () => {
-    expect(wrapper.find('HostFacts').length).toBe(1);
+  test('initially renders successfully', async () => {
+    HostsAPI.readFacts.mockResolvedValue({ data: mockHostFacts });
+    renderWithContexts(<HostFacts host={mockHost} />);
+    // react-ace renders empty under jsdom, so assert the Facts detail label
+    // rather than the JSON body
+    expect(await screen.findByText('Facts')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    );
+    expect(HostsAPI.readFacts).toHaveBeenCalledWith(mockHost.id);
   });
 
   test('renders ContentError when facts GET fails', async () => {
@@ -50,9 +45,9 @@ describe('<HostFacts />', () => {
         },
       })
     );
-    await act(async () => {
-      wrapper = mountWithContexts(<HostFacts host={mockHost} />);
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+    renderWithContexts(<HostFacts host={mockHost} />);
+    expect(
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Host/HostGroups/HostGroupItem.test.js
+++ b/awx/ui/src/screens/Host/HostGroups/HostGroupItem.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import HostGroupItem from './HostGroupItem';
 
 describe('<HostGroupItem />', () => {
-  let wrapper;
   const mockGroup = {
     id: 2,
     type: 'group',
@@ -16,12 +16,12 @@ describe('<HostGroupItem />', () => {
     },
   };
 
-  beforeEach(() => {
-    wrapper = mountWithContexts(
+  function renderItem(group) {
+    return renderWithContexts(
       <table>
         <tbody>
           <HostGroupItem
-            group={mockGroup}
+            group={group}
             inventoryId={1}
             isSelected={false}
             onSelect={() => {}}
@@ -29,32 +29,34 @@ describe('<HostGroupItem />', () => {
         </tbody>
       </table>
     );
-  });
+  }
 
   test('initially renders successfully', () => {
-    expect(wrapper.find('HostGroupItem').length).toBe(1);
+    renderItem(mockGroup);
+    expect(screen.getByRole('link', { name: 'foo' })).toBeInTheDocument();
   });
 
   test('edit button should be shown to users with edit capabilities', () => {
-    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+    const { container } = renderItem({
+      ...mockGroup,
+      summary_fields: { user_capabilities: { edit: true } },
+    });
+    expect(
+      container.querySelector(
+        'a[href="/inventories/inventory/1/groups/2/edit"]'
+      )
+    ).toBeInTheDocument();
   });
 
   test('edit button should be hidden from users without edit capabilities', () => {
-    const copyMockGroup = { ...mockGroup };
-    copyMockGroup.summary_fields.user_capabilities.edit = false;
-
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <HostGroupItem
-            group={copyMockGroup}
-            inventoryId={1}
-            isSelected={false}
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+    const { container } = renderItem({
+      ...mockGroup,
+      summary_fields: { user_capabilities: { edit: false } },
+    });
+    expect(
+      container.querySelector(
+        'a[href="/inventories/inventory/1/groups/2/edit"]'
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Host/HostGroups/HostGroupsList.test.js
+++ b/awx/ui/src/screens/Host/HostGroups/HostGroupsList.test.js
@@ -280,5 +280,12 @@ describe('<HostGroupsList />', () => {
     );
 
     expect(await screen.findByText('Error!')).toBeInTheDocument();
+    // Close the error modal while still mounted (unmounting through an open
+    // focus trap re-engages a toolbar tooltip), then settle.
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
+    );
+    await settleTooltips();
   });
 });

--- a/awx/ui/src/screens/Host/HostGroups/HostGroupsList.test.js
+++ b/awx/ui/src/screens/Host/HostGroups/HostGroupsList.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { Route } from 'react-router-dom';
+import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { HostsAPI, InventoriesAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  settleTooltips,
+} from '../../../../testUtils/rtlContexts';
 import HostGroupsList from './HostGroupsList';
 
 jest.mock('../../../api');
@@ -70,10 +70,30 @@ const mockGroups = [
   },
 ];
 
-describe('<HostGroupsList />', () => {
-  let wrapper;
+// HostGroupsList reads the host id from useParams (v5-compat), so mount it
+// under a real v6 route at the same /hosts/:id/groups path the app uses.
+function renderList(props = {}) {
+  const history = createMemoryHistory({
+    initialEntries: ['/hosts/3/groups'],
+  });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/hosts/:id/groups/*"
+        element={<HostGroupsList host={host} {...props} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
 
-  beforeEach(async () => {
+function rowSelect(name) {
+  const row = screen.getByRole('link', { name }).closest('tr');
+  return within(row).getByRole('checkbox');
+}
+
+describe('<HostGroupsList />', () => {
+  beforeEach(() => {
     HostsAPI.readAllGroups.mockResolvedValue({
       data: {
         count: mockGroups.length,
@@ -88,100 +108,66 @@ describe('<HostGroupsList />', () => {
         },
       },
     });
-    const history = createMemoryHistory({
-      initialEntries: ['/hosts/3/groups'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/hosts/:id/groups">
-          <HostGroupsList host={host} />
-        </Route>,
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('initially renders successfully', () => {
-    expect(wrapper.find('HostGroupsList').length).toBe(1);
+  test('initially renders successfully', async () => {
+    renderList();
+    expect(await screen.findByRole('link', { name: 'foo' })).toBeInTheDocument();
   });
 
   test('should fetch groups from api and render them in the list', async () => {
+    renderList();
+    await screen.findByRole('link', { name: 'foo' });
     expect(HostsAPI.readAllGroups).toHaveBeenCalled();
-    expect(wrapper.find('HostGroupItem').length).toBe(3);
+    expect(screen.getByRole('link', { name: 'foo' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'bar' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'baz' })).toBeInTheDocument();
   });
 
   test('should check and uncheck the row item', async () => {
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').props().checked
-    ).toBe(false);
+    const { user } = renderList();
+    await screen.findByRole('link', { name: 'foo' });
 
-    await act(async () => {
-      wrapper
-        .find('.pf-c-table__check')
-        .first()
-        .find('input')
-        .invoke('onChange')(true);
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').props().checked
-    ).toBe(true);
-
-    await act(async () => {
-      wrapper
-        .find('.pf-c-table__check')
-        .first()
-        .find('input')
-        .invoke('onChange')(false);
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('.pf-c-table__check').first().find('input').props().checked
-    ).toBe(false);
+    const checkbox = rowSelect('foo');
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
   });
 
   test('should check all row items when select all is checked', async () => {
-    expect.assertions(9);
-    wrapper.find('.pf-c-table__check input').forEach((el) => {
-      expect(el.props().checked).toBe(false);
-    });
-    await act(async () => {
-      wrapper.find('Checkbox#select-all').invoke('onChange')(true);
-    });
-    wrapper.update();
-    wrapper.find('.pf-c-table__check input').forEach((el) => {
-      expect(el.props().checked).toBe(true);
-    });
-    await act(async () => {
-      wrapper.find('Checkbox#select-all').invoke('onChange')(false);
-    });
-    wrapper.update();
-    wrapper.find('.pf-c-table__check input').forEach((el) => {
-      expect(el.props().checked).toBe(false);
-    });
+    const { user } = renderList();
+    await screen.findByRole('link', { name: 'foo' });
+
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+    const rowCheckboxes = ['foo', 'bar', 'baz'].map(rowSelect);
+
+    rowCheckboxes.forEach((box) => expect(box).not.toBeChecked());
+    await user.click(selectAll);
+    rowCheckboxes.forEach((box) => expect(box).toBeChecked());
+    await user.click(selectAll);
+    rowCheckboxes.forEach((box) => expect(box).not.toBeChecked());
   });
 
   test('should show content error when api throws error on initial render', async () => {
-    HostsAPI.readAllGroups.mockImplementation(() =>
-      Promise.reject(new Error())
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<HostGroupsList host={host} />);
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+    HostsAPI.readAllGroups.mockRejectedValueOnce(new Error());
+    renderList();
+    expect(
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
   });
 
   test('should show add button according to permissions', async () => {
-    expect(wrapper.find('ToolbarAddButton').length).toBe(1);
+    const { unmount } = renderList();
+    expect(await screen.findByText('foo')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+    unmount();
+
     HostsAPI.readGroupsOptions.mockResolvedValueOnce({
       data: {
         actions: {
@@ -189,18 +175,30 @@ describe('<HostGroupsList />', () => {
         },
       },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<HostGroupsList host={host} />);
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+    renderList();
+    await screen.findByText('foo');
+    expect(screen.queryByRole('button', { name: 'Add' })).not.toBeInTheDocument();
   });
 
-  test('should show associate group modal when adding an existing group', () => {
-    wrapper.find('ToolbarAddButton').simulate('click');
-    expect(wrapper.find('AssociateModal').length).toBe(1);
-    wrapper.find('ModalBoxCloseButton').simulate('click');
-    expect(wrapper.find('AssociateModal').length).toBe(0);
+  test('should show associate group modal when adding an existing group', async () => {
+    InventoriesAPI.readGroups.mockResolvedValue({
+      data: { count: 0, results: [] },
+    });
+    InventoriesAPI.readGroupsOptions.mockResolvedValue({
+      data: { actions: { GET: {}, POST: {} }, related_search_fields: [] },
+    });
+    const { user } = renderList();
+    await screen.findByRole('link', { name: 'foo' });
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    expect(await screen.findByText('Select Groups')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Select Groups')).not.toBeInTheDocument()
+    );
+    // closing the modal refocuses the Tooltip-wrapped Add button
+    await settleTooltips();
   });
 
   test('should make expected api request when associating groups', async () => {
@@ -208,7 +206,7 @@ describe('<HostGroupsList />', () => {
     InventoriesAPI.readGroups.mockResolvedValue({
       data: {
         count: 1,
-        results: [{ id: 123, name: 'foo', url: '/api/v2/groups/123/' }],
+        results: [{ id: 123, name: 'associate me', url: '/api/v2/groups/123/' }],
       },
     });
     InventoriesAPI.readGroupsOptions.mockResolvedValue({
@@ -220,66 +218,67 @@ describe('<HostGroupsList />', () => {
         related_search_fields: [],
       },
     });
-    await act(async () => {
-      wrapper.find('ToolbarAddButton').simulate('click');
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('CheckboxListItem').first().invoke('onSelect')();
-    });
-    await act(async () => {
-      wrapper.find('button[aria-label="Save"]').simulate('click');
-    });
-    await waitForElement(wrapper, 'AssociateModal', (el) => el.length === 0);
+    const { user } = renderList();
+    await screen.findByRole('link', { name: 'foo' });
+
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+    const associateItem = await screen.findByText('associate me');
+    const associateRow = associateItem.closest('tr');
+    await user.click(within(associateRow).getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('Select Groups')).not.toBeInTheDocument()
+    );
     expect(InventoriesAPI.readGroups).toHaveBeenCalledTimes(1);
     expect(HostsAPI.associateGroup).toHaveBeenCalledTimes(1);
+    // closing the modal refocuses the Tooltip-wrapped Add button
+    await settleTooltips();
   });
 
   test('expected api calls are made for multi-disassociation', async () => {
-    expect.assertions(11);
+    HostsAPI.disassociateGroup.mockResolvedValue();
+    const { user } = renderList();
+    await screen.findByRole('link', { name: 'foo' });
+
     expect(HostsAPI.disassociateGroup).toHaveBeenCalledTimes(0);
     expect(HostsAPI.readAllGroups).toHaveBeenCalledTimes(1);
 
-    wrapper.find('.pf-c-table__check input').forEach((el) => {
-      expect(el.props().checked).toBe(false);
-    });
-    await act(async () => {
-      wrapper.find('Checkbox#select-all').invoke('onChange')(true);
-    });
-    wrapper.update();
-    wrapper.find('.pf-c-table__check input').forEach((el) => {
-      expect(el.props().checked).toBe(true);
-    });
-    wrapper.find('button[aria-label="Disassociate"]').simulate('click');
-    expect(wrapper.find('AlertModal Title').text()).toEqual(
-      'Disassociate group from host?'
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    ['foo', 'bar', 'baz'].forEach((name) =>
+      expect(rowSelect(name)).toBeChecked()
     );
-    await act(async () => {
-      wrapper
-        .find('button[aria-label="confirm disassociate"]')
-        .simulate('click');
-    });
-    expect(HostsAPI.disassociateGroup).toHaveBeenCalledTimes(3);
+
+    await user.click(screen.getByRole('button', { name: 'Disassociate' }));
+    expect(
+      await screen.findByText('Disassociate group from host?')
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'confirm disassociate' })
+    );
+
+    await waitFor(() =>
+      expect(HostsAPI.disassociateGroup).toHaveBeenCalledTimes(3)
+    );
     expect(HostsAPI.readAllGroups).toHaveBeenCalledTimes(2);
   });
 
   test('should show error modal for failed disassociation', async () => {
     HostsAPI.disassociateGroup.mockRejectedValue(new Error());
-    await act(async () => {
-      wrapper.find('Checkbox#select-all').invoke('onChange')(true);
-    });
-    wrapper.update();
-    wrapper.find('button[aria-label="Disassociate"]').simulate('click');
-    expect(wrapper.find('AlertModal Title').text()).toEqual(
-      'Disassociate group from host?'
+    const { user } = renderList();
+    await screen.findByRole('link', { name: 'foo' });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    await user.click(screen.getByRole('button', { name: 'Disassociate' }));
+    expect(
+      await screen.findByText('Disassociate group from host?')
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'confirm disassociate' })
     );
-    await act(async () => {
-      wrapper
-        .find('button[aria-label="confirm disassociate"]')
-        .simulate('click');
-    });
-    wrapper.update();
-    expect(wrapper.find('AlertModal ErrorDetail').length).toBe(1);
+
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Host/HostList/HostList.test.js
+++ b/awx/ui/src/screens/Host/HostList/HostList.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { HostsAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  settleTooltips,
+} from '../../../../testUtils/rtlContexts';
 
 import HostList from './HostList';
 
@@ -17,6 +17,7 @@ const mockHosts = [
     name: 'Host 1',
     url: '/api/v2/hosts/1',
     inventory: 1,
+    enabled: true,
     summary_fields: {
       inventory: {
         id: 1,
@@ -25,6 +26,7 @@ const mockHosts = [
       user_capabilities: {
         delete: true,
         update: true,
+        edit: true,
       },
       recent_jobs: [],
     },
@@ -34,6 +36,7 @@ const mockHosts = [
     name: 'Host 2',
     url: '/api/v2/hosts/2',
     inventory: 1,
+    enabled: true,
     summary_fields: {
       inventory: {
         id: 1,
@@ -42,6 +45,7 @@ const mockHosts = [
       user_capabilities: {
         delete: true,
         update: true,
+        edit: true,
       },
       recent_jobs: [],
     },
@@ -51,6 +55,7 @@ const mockHosts = [
     name: 'Host 3',
     url: '/api/v2/hosts/3',
     inventory: 1,
+    enabled: true,
     summary_fields: {
       inventory: {
         id: 1,
@@ -67,17 +72,22 @@ const mockHosts = [
       user_capabilities: {
         delete: false,
         update: false,
+        edit: false,
       },
     },
   },
 ];
 
-function waitForLoaded(wrapper) {
-  return waitForElement(
-    wrapper,
-    'HostList',
-    (el) => el.find('ContentLoading').length === 0
-  );
+function getRow(name) {
+  return screen.getByRole('link', { name }).closest('tr');
+}
+
+// each host row has two checkbox-role controls: the row select and the
+// HostToggle switch (aria-label "Toggle host"); this returns the select one
+function getRowSelect(name) {
+  return within(getRow(name))
+    .getAllByRole('checkbox')
+    .find((box) => box.getAttribute('aria-label') !== 'Toggle host');
 }
 
 describe('<HostList />', () => {
@@ -105,114 +115,68 @@ describe('<HostList />', () => {
   });
 
   test('initially renders successfully', async () => {
-    await act(async () => {
-      mountWithContexts(
-        <HostList
-          match={{ path: '/hosts', url: '/hosts' }}
-          location={{ search: '', pathname: '/hosts' }}
-        />
-      );
-    });
+    renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
   });
 
   test('Hosts are retrieved from the api and the components finishes loading', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
-
-    expect(
-      wrapper.find('PaginatedTable').props().toolbarRelatedSearchableKeys
-    ).toStrictEqual(['first_key', 'ansible_facts']);
+    renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
     expect(HostsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('HostListItem')).toHaveLength(3);
+    expect(
+      screen.getAllByRole('link', { name: /^Host \d$/ })
+    ).toHaveLength(3);
   });
 
   test('should select and deselect a single item', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    const { user } = renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    act(() => {
-      wrapper
-        .find('.pf-c-table__check')
-        .first()
-        .find('input')
-        .invoke('onChange')();
-    });
-    wrapper.update();
-    expect(wrapper.find('HostListItem').first().prop('isSelected')).toEqual(
-      true
-    );
-    act(() => {
-      wrapper
-        .find('.pf-c-table__check')
-        .first()
-        .find('input')
-        .invoke('onChange')();
-    });
-    wrapper.update();
-    expect(wrapper.find('HostListItem').first().prop('isSelected')).toEqual(
-      false
-    );
+    const checkbox = getRowSelect('Host 1');
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
   });
 
   test('should select all items', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    const { user } = renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    act(() => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
-    });
-    wrapper.update();
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+    await user.click(selectAll);
 
-    wrapper.find('HostListItem').forEach((item) => {
-      expect(item.prop('isSelected')).toEqual(true);
+    ['Host 1', 'Host 2', 'Host 3'].forEach((name) => {
+      const rowCheckbox = getRowSelect(name);
+      expect(rowCheckbox).toBeChecked();
     });
   });
 
   test('delete button is disabled if user does not have delete capabilities on a selected host', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    const { user } = renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    act(() => {
-      wrapper.find('HostListItem').at(2).invoke('onSelect')();
-    });
-    expect(wrapper.find('ToolbarDeleteButton button').prop('disabled')).toEqual(
-      true
-    );
+    // Host 3 has delete:false
+    await user.click(getRowSelect('Host 3'));
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
   });
 
   test('api is called to delete hosts for each selected host.', async () => {
-    HostsAPI.destroy = jest.fn();
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    HostsAPI.destroy = jest.fn().mockResolvedValue({});
+    const { user } = renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    await act(async () => {
-      wrapper.find('HostListItem').at(0).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('HostListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-    expect(HostsAPI.destroy).toHaveBeenCalledTimes(2);
+    await user.click(getRowSelect('Host 1'));
+    await user.click(getRowSelect('Host 2'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+
+    await waitFor(() => expect(HostsAPI.destroy).toHaveBeenCalledTimes(2));
   });
 
   test('error is shown when host not successfully deleted from api', async () => {
@@ -227,35 +191,32 @@ describe('<HostList />', () => {
         },
       })
     );
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    const { user } = renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    await act(async () => {
-      wrapper.find('HostListItem').at(0).invoke('onSelect')();
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-    wrapper.update();
+    await user.click(getRowSelect('Host 1'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
 
-    const modal = wrapper.find('Modal');
-    expect(modal).toHaveLength(1);
-    expect(modal.prop('title')).toEqual('Error!');
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
+    );
+    await settleTooltips();
   });
 
   test('should show Add and Smart Inventory buttons according to permissions', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    expect(wrapper.find('ToolbarAddButton').length).toBe(1);
-    expect(wrapper.find('Button[aria-label="Smart Inventory"]').length).toBe(1);
+    expect(screen.getByRole('link', { name: 'Add' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Smart Inventory' })
+    ).toBeInTheDocument();
   });
 
   test('should hide Add and Smart Inventory buttons according to permissions', async () => {
@@ -266,65 +227,53 @@ describe('<HostList />', () => {
         },
       },
     });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
-    expect(wrapper.find('Button[aria-label="Smart Inventory"]').length).toBe(0);
+    expect(screen.queryByRole('link', { name: 'Add' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Smart Inventory' })
+    ).not.toBeInTheDocument();
   });
 
   test('Smart Inventory button should be disabled when no search params are present', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />);
-    });
-    await waitForLoaded(wrapper);
+    renderWithContexts(<HostList />);
+    await screen.findByRole('link', { name: 'Host 1' });
     expect(
-      wrapper.find('Button[aria-label="Smart Inventory"]').props().isDisabled
-    ).toBe(true);
+      screen.getByRole('button', { name: 'Smart Inventory' })
+    ).toBeDisabled();
   });
 
-  test('Smart Inventory button should be disable to ansible facts search', async () => {
-    let wrapper;
+  test('Smart Inventory button should be disabled with ansible facts search', async () => {
     const history = createMemoryHistory({
       initialEntries: [
         '/hosts?host.host_filter=ansible_facts__ansible_date_time__weekday_number%3D"3"',
       ],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />, {
-        context: { router: { history } },
-      });
+    renderWithContexts(<HostList />, {
+      context: { router: { history } },
     });
-
-    await waitForLoaded(wrapper);
+    await screen.findByRole('link', { name: 'Host 1' });
     expect(
-      wrapper.find('Button[aria-label="Smart Inventory"]').props().isDisabled
-    ).toBe(true);
+      screen.getByRole('button', { name: 'Smart Inventory' })
+    ).toBeDisabled();
   });
 
   test('Clicking Smart Inventory button should navigate to smart inventory form with correct query param', async () => {
-    let wrapper;
     const history = createMemoryHistory({
       initialEntries: ['/hosts?host.name__icontains=foo'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<HostList />, {
-        context: { router: { history } },
-      });
+    const { user } = renderWithContexts(<HostList />, {
+      context: { router: { history } },
     });
+    await screen.findByRole('link', { name: 'Host 1' });
 
-    await waitForLoaded(wrapper);
-    expect(
-      wrapper.find('Button[aria-label="Smart Inventory"]').props().isDisabled
-    ).toBe(false);
-    await act(async () => {
-      wrapper.find('Button[aria-label="Smart Inventory"]').simulate('click');
+    const smartInventoryButton = screen.getByRole('button', {
+      name: 'Smart Inventory',
     });
-    wrapper.update();
+    expect(smartInventoryButton).not.toBeDisabled();
+    await user.click(smartInventoryButton);
+
     expect(history.location.pathname).toEqual(
       '/inventories/smart_inventory/add'
     );

--- a/awx/ui/src/screens/Host/HostList/HostListItem.test.js
+++ b/awx/ui/src/screens/Host/HostList/HostListItem.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
-
+import { screen, within } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import HostsListItem from './HostListItem';
 
 const mockHost = {
@@ -9,6 +9,7 @@ const mockHost = {
   url: '/api/v2/hosts/1',
   description: 'Buzz',
   inventory: 1,
+  enabled: true,
   summary_fields: {
     inventory: {
       id: 1,
@@ -21,55 +22,58 @@ const mockHost = {
   },
 };
 
+function renderItem(host) {
+  return renderWithContexts(
+    <table>
+      <tbody>
+        <HostsListItem
+          isSelected={false}
+          detailUrl="/host/1"
+          onSelect={() => {}}
+          host={host}
+        />
+      </tbody>
+    </table>
+  );
+}
+
 describe('<HostsListItem />', () => {
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <HostsListItem
-            isSelected={false}
-            detailUrl="/host/1"
-            onSelect={() => {}}
-            host={mockHost}
-          />
-        </tbody>
-      </table>
-    );
-  });
-
   test('should display expected details', () => {
-    expect(wrapper.find('HostListItem').length).toBe(1);
-    expect(wrapper.find('Td[dataLabel="Name"]').find('Link').prop('to')).toBe(
-      '/host/1'
-    );
-    expect(wrapper.find('Td[dataLabel="Description"]').text()).toBe('Buzz');
+    renderItem(mockHost);
+    const nameLink = screen.getByRole('link', { name: 'Host 1' });
+    expect(nameLink).toHaveAttribute('href', '/host/1');
+
+    const row = nameLink.closest('tr');
+    const descriptionCell = within(row)
+      .getAllByRole('cell')
+      .find((cell) => cell.getAttribute('data-label') === 'Description');
+    expect(descriptionCell).toHaveTextContent('Buzz');
   });
 
   test('edit button shown to users with edit capabilities', () => {
-    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+    renderItem(mockHost);
+    expect(
+      screen.getByRole('link', { name: 'Edit Host' })
+    ).toHaveAttribute('href', '/hosts/1/edit');
   });
 
   test('edit button hidden from users without edit capabilities', () => {
-    const copyMockHost = { ...mockHost };
-    copyMockHost.summary_fields.user_capabilities.edit = false;
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <HostsListItem
-            isSelected={false}
-            detailUrl="/host/1"
-            onSelect={() => {}}
-            host={copyMockHost}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+    renderItem({
+      ...mockHost,
+      summary_fields: {
+        ...mockHost.summary_fields,
+        user_capabilities: { edit: false },
+      },
+    });
+    expect(
+      screen.queryByRole('link', { name: 'Edit Host' })
+    ).not.toBeInTheDocument();
   });
 
   test('should display host toggle', () => {
-    expect(wrapper.find('HostToggle').length).toBe(1);
+    renderItem(mockHost);
+    expect(
+      screen.getByRole('checkbox', { name: 'Toggle host' })
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Host/HostList/SmartInventoryButton.test.js
+++ b/awx/ui/src/screens/Host/HostList/SmartInventoryButton.test.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import SmartInventoryButton from './SmartInventoryButton';
 
 describe('<SmartInventoryButton />', () => {
-  test('should render button', () => {
+  test('should render button', async () => {
     const onClick = jest.fn();
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <SmartInventoryButton onClick={onClick} />
     );
-    const button = wrapper.find('button');
-    expect(button).toHaveLength(1);
-    button.simulate('click');
+    const button = screen.getByRole('button', { name: 'Smart Inventory' });
+    expect(button).toBeInTheDocument();
+    await user.click(button);
     expect(onClick).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **Host** screen's test suite from enzyme to React Testing Library, continuing the incremental enzyme → RTL migration (one screen directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`:

- `HostList` / `HostListItem` — load, row selection (disambiguated from the host enable/disable toggle), bulk delete, edit-link visibility
- `HostDetail` — detail fields, activity-stream hide behaviour
- `HostFacts` — facts load + content error
- `HostAdd` / `HostEdit` — create/update API args + redirect, cancel, submit-error (`components/HostForm` mocked)
- `SmartInventoryButton`, `HostGroups` list/item — navigation, associate modal (under a real v6 route)

Interactions now go through accessible roles and real user events. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for the Host directory: **12 suites, 58 tests, all passing.** ESLint clean. No production code changed — test-only.
