### PR TITLE
enzyme -> RTL: convert the InstanceGroup screen suites

### DIFF
--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.test.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.test.js
@@ -1,12 +1,39 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import ContainerGroupAdd from './ContainerGroupAdd';
 
 jest.mock('../../../api');
+
+// Prefixed `mock` so the jest.mock factory below may reference it.
+const mockInstanceGroupCreateData = {
+  name: 'Fuz',
+  credential: { id: 71, name: 'CG' },
+  max_concurrent_jobs: 0,
+  max_forks: 0,
+  pod_spec_override:
+    'apiVersion: v1\nkind: Pod\nmetadata:\n  namespace: default\nspec:\n  containers:\n    - image: ansible/ansible-runner\n      tty: true\n      stdin: true\n      imagePullPolicy: Always\n      args:\n        - sleep\n        - infinity\n        - test',
+};
+
+// Mock the shared form so the test drives ContainerGroupAdd's own submit/cancel
+// handlers directly. The form itself is covered by ContainerGroupForm.test.js.
+jest.mock('../shared/ContainerGroupForm', () => ({ onSubmit, onCancel, submitError }) => (
+  <div>
+    {submitError && <div>FormSubmitError</div>}
+    <button
+      type="button"
+      onClick={() => onSubmit({ ...mockInstanceGroupCreateData, override: true })}
+    >
+      mock submit
+    </button>
+    <button type="button" aria-label="Cancel" onClick={onCancel}>
+      Cancel
+    </button>
+  </div>
+));
 
 const initialPodSpec = {
   default: {
@@ -30,20 +57,10 @@ const initialPodSpec = {
   },
 };
 
-const instanceGroupCreateData = {
-  name: 'Fuz',
-  credential: { id: 71, name: 'CG' },
-  max_concurrent_jobs: 0,
-  max_forks: 0,
-  pod_spec_override:
-    'apiVersion: v1\nkind: Pod\nmetadata:\n  namespace: default\nspec:\n  containers:\n    - image: ansible/ansible-runner\n      tty: true\n      stdin: true\n      imagePullPolicy: Always\n      args:\n        - sleep\n        - infinity\n        - test',
-};
-
 describe('<ContainerGroupAdd/>', () => {
-  let wrapper;
   let history;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     history = createMemoryHistory({
       initialEntries: ['/instance_groups'],
     });
@@ -56,14 +73,8 @@ describe('<ContainerGroupAdd/>', () => {
 
     InstanceGroupsAPI.readOptions.mockResolvedValue({
       data: {
-        results: initialPodSpec,
+        actions: { POST: { pod_spec_override: { default: initialPodSpec } } },
       },
-    });
-
-    await act(async () => {
-      wrapper = mountWithContexts(<ContainerGroupAdd />, {
-        context: { router: { history } },
-      });
     });
   });
 
@@ -72,26 +83,28 @@ describe('<ContainerGroupAdd/>', () => {
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('ContainerGroupForm').prop('onSubmit')({
-        ...instanceGroupCreateData,
-        override: true,
-      });
+    const { user } = renderWithContexts(<ContainerGroupAdd />, {
+      context: { router: { history } },
     });
-    wrapper.update();
-    expect(InstanceGroupsAPI.create).toHaveBeenCalledWith({
-      ...instanceGroupCreateData,
-      credential: 71,
-      is_container_group: true,
-    });
-    expect(wrapper.find('FormSubmitError').length).toBe(0);
+    await user.click(await screen.findByRole('button', { name: 'mock submit' }));
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.create).toHaveBeenCalledWith({
+        ...mockInstanceGroupCreateData,
+        credential: 71,
+        is_container_group: true,
+      })
+    );
+    expect(screen.queryByText('FormSubmitError')).not.toBeInTheDocument();
     expect(history.location.pathname).toBe(
       '/instance_groups/container_group/123/details'
     );
   });
 
   test('handleCancel should return the user back to the instance group list', async () => {
-    wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+    const { user } = renderWithContexts(<ContainerGroupAdd />, {
+      context: { router: { history } },
+    });
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/instance_groups');
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.test.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.test.js
@@ -1,129 +1,143 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
-import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import {
+  InstanceGroupsAPI,
+  OrganizationsAPI,
+  InventoriesAPI,
+  UnifiedJobTemplatesAPI,
+} from 'api';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 
 import ContainerGroupDetails from './ContainerGroupDetails';
 
 jest.mock('../../../api');
 
-const instanceGroup = {
-  id: 42,
-  type: 'instance_group',
-  url: '/api/v2/instance_groups/128/',
-  related: {
-    named_url: '/api/v2/instance_groups/A1/',
-    jobs: '/api/v2/instance_groups/128/jobs/',
-    instances: '/api/v2/instance_groups/128/instances/',
-    credential: '/api/v2/credentials/71/',
-  },
-  name: 'Foo',
-  created: '2020-09-03T18:26:47.113934Z',
-  modified: '2020-09-03T19:34:23.244694Z',
-  capacity: 0,
-  max_concurrent_jobs: 0,
-  max_forks: 0,
-  committed_capacity: 0,
-  consumed_capacity: 0,
-  percent_capacity_remaining: 0.0,
-  jobs_running: 0,
-  jobs_total: 0,
-  instances: 0,
-  controller: null,
-  is_container_group: true,
-  credential: 71,
-  policy_instance_percentage: 0,
-  policy_instance_minimum: 0,
-  policy_instance_list: [],
-  pod_spec_override:
-    'apiVersion: v1\nkind: Pod\nmetadata:\n  namespace: default\nspec:\n  containers:\n    - image: ansible/ansible-runner\n      tty: true\n      stdin: true\n      imagePullPolicy: Always\n      args:\n        - sleep\n        - infinity\n        - test',
-  summary_fields: {
-    credential: {
-      id: 71,
-      name: 'CG',
-      description: 'Container Group',
-      kind: 'kubernetes_bearer_token',
-      cloud: false,
-      kubernetes: true,
-      credential_type_id: 17,
+function buildInstanceGroup(overrides = {}) {
+  const { summary_fields: summaryOverrides, ...rest } = overrides;
+  return {
+    id: 42,
+    type: 'instance_group',
+    url: '/api/v2/instance_groups/128/',
+    related: {
+      named_url: '/api/v2/instance_groups/A1/',
+      jobs: '/api/v2/instance_groups/128/jobs/',
+      instances: '/api/v2/instance_groups/128/instances/',
+      credential: '/api/v2/credentials/71/',
     },
-    user_capabilities: {
-      edit: true,
-      delete: true,
+    name: 'Foo',
+    created: '2020-09-03T18:26:47.113934Z',
+    modified: '2020-09-03T19:34:23.244694Z',
+    capacity: 0,
+    max_concurrent_jobs: 0,
+    max_forks: 0,
+    committed_capacity: 0,
+    consumed_capacity: 0,
+    percent_capacity_remaining: 0.0,
+    jobs_running: 0,
+    jobs_total: 0,
+    instances: 0,
+    controller: null,
+    is_container_group: true,
+    credential: 71,
+    policy_instance_percentage: 0,
+    policy_instance_minimum: 0,
+    policy_instance_list: [],
+    pod_spec_override:
+      'apiVersion: v1\nkind: Pod\nmetadata:\n  namespace: default\nspec:\n  containers:\n    - image: ansible/ansible-runner\n      tty: true\n      stdin: true\n      imagePullPolicy: Always\n      args:\n        - sleep\n        - infinity\n        - test',
+    summary_fields: {
+      credential: {
+        id: 71,
+        name: 'CG',
+        description: 'Container Group',
+        kind: 'kubernetes_bearer_token',
+        cloud: false,
+        kubernetes: true,
+        credential_type_id: 17,
+      },
+      user_capabilities: {
+        edit: true,
+        delete: true,
+      },
+      ...summaryOverrides,
     },
-  },
-};
+    ...rest,
+  };
+}
 
 describe('<ContainerGroupDetails/>', () => {
-  let wrapper;
-  test('should render details properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ContainerGroupDetails instanceGroup={instanceGroup} />
-      );
-    });
-    wrapper.update();
+  beforeEach(() => {
+    OrganizationsAPI.read.mockResolvedValue({ data: { count: 0 } });
+    InventoriesAPI.read.mockResolvedValue({ data: { count: 0 } });
+    UnifiedJobTemplatesAPI.read.mockResolvedValue({ data: { count: 0 } });
+  });
 
-    expect(wrapper.find('Detail[label="Name"]').prop('value')).toEqual(
-      instanceGroup.name
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should render details properly', () => {
+    renderWithContexts(
+      <ContainerGroupDetails instanceGroup={buildInstanceGroup()} />
     );
-    expect(wrapper.find('Detail[label="Type"]').prop('value')).toEqual(
-      'Container group'
+
+    assertDetail('Name', 'Foo');
+    assertDetail('Type', 'Container group');
+    // The credential renders as a link to its detail page.
+    expect(screen.getByRole('link', { name: 'CG' })).toHaveAttribute(
+      'href',
+      '/credentials/71'
     );
-    expect(wrapper.find('Detail[label="Credential"]').text()).toContain(
-      instanceGroup.summary_fields.credential.name
-    );
-    expect(wrapper.find('VariablesDetail').prop('value')).toEqual(
-      instanceGroup.pod_spec_override
-    );
-    const dates = wrapper.find('UserDateDetail');
-    expect(dates).toHaveLength(2);
-    expect(dates.at(0).prop('date')).toEqual(instanceGroup.created);
-    expect(dates.at(1).prop('date')).toEqual(instanceGroup.modified);
+    // react-ace renders empty under jsdom, so assert the pod-spec label only.
+    expect(screen.getByText('Pod spec override')).toBeInTheDocument();
   });
 
   test('expected api call is made for delete', async () => {
     const history = createMemoryHistory({
-      initialEntries: ['/credential_types/42/details'],
+      initialEntries: ['/instance_groups/container_group/42/details'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ContainerGroupDetails instanceGroup={instanceGroup} />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    expect(InstanceGroupsAPI.destroy).toHaveBeenCalledTimes(1);
+    InstanceGroupsAPI.destroy.mockResolvedValue({});
+    const { user } = renderWithContexts(
+      <ContainerGroupDetails instanceGroup={buildInstanceGroup()} />,
+      { context: { router: { history } } }
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
+    );
+
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.destroy).toHaveBeenCalledTimes(1)
+    );
     expect(history.location.pathname).toBe('/instance_groups');
   });
 
-  test('should not render delete button', async () => {
-    instanceGroup.summary_fields.user_capabilities.delete = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ContainerGroupDetails instanceGroup={instanceGroup} />
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('Button[aria-label="Delete"]').length).toBe(0);
+  test('should not render delete button when delete capability is false', () => {
+    renderWithContexts(
+      <ContainerGroupDetails
+        instanceGroup={buildInstanceGroup({
+          summary_fields: { user_capabilities: { edit: true, delete: false } },
+        })}
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Delete' })
+    ).not.toBeInTheDocument();
   });
 
-  test('should not render edit button', async () => {
-    instanceGroup.summary_fields.user_capabilities.edit = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ContainerGroupDetails instanceGroup={instanceGroup} />
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('Button[aria-label="Edit"]').length).toBe(0);
+  test('should not render edit button when edit capability is false', () => {
+    renderWithContexts(
+      <ContainerGroupDetails
+        instanceGroup={buildInstanceGroup({
+          summary_fields: { user_capabilities: { edit: false, delete: true } },
+        })}
+      />
+    );
+    expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.test.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.test.js
@@ -1,12 +1,35 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import { InstanceGroupsAPI, CredentialsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import ContainerGroupEdit from './ContainerGroupEdit';
 
 jest.mock('../../../api');
+
+// Prefixed `mock` so the jest.mock factory below may reference it.
+const mockUpdatedInstanceGroup = {
+  name: 'Bar',
+  credential: { id: 12, name: 'CGX' },
+};
+
+// Mock the shared form so the test drives ContainerGroupEdit's own submit/cancel
+// handlers directly. The form itself is covered by ContainerGroupForm.test.js.
+jest.mock('../shared/ContainerGroupForm', () => ({ onSubmit, onCancel, submitError }) => (
+  <div>
+    {submitError && <div>FormSubmitError</div>}
+    <button
+      type="button"
+      onClick={() => onSubmit({ ...mockUpdatedInstanceGroup, override: false })}
+    >
+      mock submit
+    </button>
+    <button type="button" aria-label="Cancel" onClick={onCancel}>
+      Cancel
+    </button>
+  </div>
+));
 
 const instanceGroup = {
   id: 123,
@@ -54,11 +77,6 @@ const instanceGroup = {
   },
 };
 
-const updatedInstanceGroup = {
-  name: 'Bar',
-  credential: { id: 12, name: 'CGX' },
-};
-
 const initialPodSpec = {
   default: {
     apiVersion: 'v1',
@@ -80,36 +98,26 @@ const initialPodSpec = {
   },
 };
 
-InstanceGroupsAPI.readOptions.mockResolvedValue({
-  data: {
-    results: initialPodSpec,
-  },
-});
-
-CredentialsAPI.read.mockResolvedValue({
-  data: {
-    results: [
-      {
-        id: 71,
-        name: 'Test',
-      },
-    ],
-  },
-});
-
 describe('<ContainerGroupEdit/>', () => {
-  let wrapper;
   let history;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     history = createMemoryHistory({ initialEntries: ['/instance_groups'] });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ContainerGroupEdit instanceGroup={instanceGroup} />,
-        {
-          context: { router: { history } },
-        }
-      );
+    InstanceGroupsAPI.update.mockResolvedValue({ data: {} });
+    InstanceGroupsAPI.readInstanceGroupOptions.mockResolvedValue({
+      data: {
+        actions: { PUT: { pod_spec_override: { default: initialPodSpec } } },
+      },
+    });
+    CredentialsAPI.read.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 71,
+            name: 'Test',
+          },
+        ],
+      },
     });
   });
 
@@ -117,39 +125,44 @@ describe('<ContainerGroupEdit/>', () => {
     jest.clearAllMocks();
   });
 
-  test('initially renders successfully', async () => {
-    expect(wrapper.find('ContainerGroupEdit').length).toBe(1);
-  });
-
-  test('called InstanceGroupsAPI.readOptions', async () => {
-    expect(InstanceGroupsAPI.readOptions).toHaveBeenCalled();
+  test('called InstanceGroupsAPI.readInstanceGroupOptions', async () => {
+    renderWithContexts(<ContainerGroupEdit instanceGroup={instanceGroup} />, {
+      context: { router: { history } },
+    });
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.readInstanceGroupOptions).toHaveBeenCalledWith(
+        123
+      )
+    );
   });
 
   test('handleCancel returns the user to container group detail', async () => {
-    await act(async () => {
-      wrapper.find('Button[aria-label="Cancel"]').simulate('click');
-    });
+    const { user } = renderWithContexts(
+      <ContainerGroupEdit instanceGroup={instanceGroup} />,
+      { context: { router: { history } } }
+    );
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual(
       '/instance_groups/container_group/123/details'
     );
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('ContainerGroupForm').prop('onSubmit')({
-        ...updatedInstanceGroup,
-        override: false,
-      });
-    });
-    wrapper.update();
-    expect(InstanceGroupsAPI.update).toHaveBeenCalledWith(123, {
-      ...updatedInstanceGroup,
-      credential: 12,
-      pod_spec_override: null,
-      max_concurrent_jobs: 0,
-      max_forks: 0,
-      is_container_group: true,
-    });
+    const { user } = renderWithContexts(
+      <ContainerGroupEdit instanceGroup={instanceGroup} />,
+      { context: { router: { history } } }
+    );
+    await user.click(await screen.findByRole('button', { name: 'mock submit' }));
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.update).toHaveBeenCalledWith(123, {
+        ...mockUpdatedInstanceGroup,
+        credential: 12,
+        pod_spec_override: null,
+        max_concurrent_jobs: 0,
+        max_forks: 0,
+        is_container_group: true,
+      })
+    );
     expect(history.location.pathname).toEqual(
       '/instance_groups/container_group/123/details'
     );

--- a/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import * as ConfigContext from 'contexts/Config';
 import useDebounce from 'hooks/useDebounce';
 import { InstancesAPI, InstanceGroupsAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  settleTooltips,
+} from '../../../../testUtils/rtlContexts';
 import InstanceDetails from './InstanceDetails';
 
 jest.mock('../../../api');
@@ -18,29 +18,6 @@ jest.mock('react-router-dom-v5-compat', () => ({
   useParams: () => ({
     id: 2,
     instanceId: 1,
-  }),
-}));
-
-jest.mock('@lingui/react/macro', () => ({
-  ...jest.requireActual('@lingui/react/macro'),
-  t: (str) => str,
-  Trans: ({ children }) => children,
-  useLingui: () => ({
-    t: (str) => str,
-    i18n: {
-      _: (template, values) => {
-        // Handle plural templates like '{count, plural, one {# fork} other {# forks}}'
-        if (template.includes('plural')) {
-          const count = values?.count || 0;
-          if (count === 1) {
-            return template.replace(/.*one \{([^}]+)\}.*/, '$1').replace('#', count);
-          } else {
-            return template.replace(/.*other \{([^}]+)\}.*/, '$1').replace('#', count);
-          }
-        }
-        return template;
-      },
-    },
   }),
 }));
 
@@ -78,47 +55,68 @@ const instanceGroup = {
     },
   },
 };
+
+const associatedInstances = {
+  data: {
+    results: [{ id: 1 }, { id: 2 }],
+  },
+};
+
+function instanceDetail(overrides = {}) {
+  return {
+    data: {
+      id: 1,
+      type: 'instance',
+      url: '/api/v2/instances/1/',
+      related: {
+        named_url: '/api/v2/instances/awx_1/',
+        jobs: '/api/v2/instances/1/jobs/',
+        instance_groups: '/api/v2/instances/1/instance_groups/',
+        health_check: '/api/v2/instances/1/health_check/',
+      },
+      uuid: '00000000-0000-0000-0000-000000000000',
+      hostname: 'awx_1',
+      created: '2021-09-08T17:10:34.484569Z',
+      modified: '2021-09-09T13:55:44.219900Z',
+      last_seen: '2021-09-09T20:20:31.623148Z',
+      last_health_check: '2021-09-09T20:20:31.623148Z',
+      errors: '',
+      capacity_adjustment: '1.00',
+      version: '19.1.0',
+      capacity: 38,
+      consumed_capacity: 0,
+      percent_capacity_remaining: 100.0,
+      jobs_running: 0,
+      jobs_total: 0,
+      cpu: 8,
+      memory: 6232231936,
+      cpu_capacity: 32,
+      mem_capacity: 38,
+      enabled: true,
+      managed_by_policy: true,
+      node_type: 'execution',
+      node_state: 'ready',
+      health_check_pending: false,
+      ...overrides,
+    },
+  };
+}
+
+function setMe(me) {
+  jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({ me }));
+}
+
+function renderDetails() {
+  return renderWithContexts(
+    <InstanceDetails instanceGroup={instanceGroup} setBreadcrumb={() => {}} />
+  );
+}
+
 describe('<InstanceDetails/>', () => {
-  let wrapper;
   beforeEach(() => {
     useDebounce.mockImplementation((fn) => fn);
-
-    InstancesAPI.readDetail.mockResolvedValue({
-      data: {
-        id: 1,
-        type: 'instance',
-        url: '/api/v2/instances/1/',
-        related: {
-          named_url: '/api/v2/instances/awx_1/',
-          jobs: '/api/v2/instances/1/jobs/',
-          instance_groups: '/api/v2/instances/1/instance_groups/',
-          health_check: '/api/v2/instances/1/health_check/',
-        },
-        uuid: '00000000-0000-0000-0000-000000000000',
-        hostname: 'awx_1',
-        created: '2021-09-08T17:10:34.484569Z',
-        modified: '2021-09-09T13:55:44.219900Z',
-        last_seen: '2021-09-09T20:20:31.623148Z',
-        last_health_check: '2021-09-09T20:20:31.623148Z',
-        errors: '',
-        capacity_adjustment: '1.00',
-        version: '19.1.0',
-        capacity: 38,
-        consumed_capacity: 0,
-        percent_capacity_remaining: 100.0,
-        jobs_running: 0,
-        jobs_total: 0,
-        cpu: 8,
-        memory: 6232231936,
-        cpu_capacity: 32,
-        mem_capacity: 38,
-        enabled: true,
-        managed_by_policy: true,
-        node_type: 'execution',
-        node_state: 'ready',
-        health_check_pending: false,
-      },
-    });
+    InstanceGroupsAPI.readInstances.mockResolvedValue(associatedInstances);
+    InstancesAPI.readDetail.mockResolvedValue(instanceDetail());
     InstancesAPI.readHealthCheckDetail.mockResolvedValue({
       data: {
         uuid: '00000000-0000-0000-0000-000000000000',
@@ -134,396 +132,160 @@ describe('<InstanceDetails/>', () => {
       },
     });
   });
+
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
-  test('Should render proper data', async () => {
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-          {
-            id: 2,
-          },
-        ],
-      },
-    });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_superuser: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find('InstanceDetails')).toHaveLength(1);
+
+  test('should render proper data', async () => {
+    setMe({ is_superuser: true });
+    renderDetails();
+    await screen.findByRole('button', { name: 'Run health check' });
 
     expect(InstanceGroupsAPI.readInstances).toHaveBeenCalledWith(2);
     expect(InstancesAPI.readHealthCheckDetail).toHaveBeenCalledWith(1);
     expect(InstancesAPI.readDetail).toHaveBeenCalledWith(1);
+
     expect(
-      wrapper.find("Button[ouiaId='disassociate-button']").prop('isDisabled')
-    ).toBe(false);
+      screen.getByRole('button', { name: 'Disassociate' })
+    ).toBeEnabled();
     expect(
-      wrapper.find("Button[ouiaId='health-check-button']").prop('isDisabled')
-    ).toBe(false);
+      screen.getByRole('button', { name: 'Run health check' })
+    ).toBeEnabled();
   });
 
-  test('should calculate number of forks when slide changes', async () => {
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-          {
-            id: 2,
-          },
-        ],
-      },
-    });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_superuser: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+  test('should recalculate number of forks when slider changes', async () => {
+    setMe({ is_superuser: true });
+    InstancesAPI.update.mockResolvedValue({ data: {} });
+    const { container, user } = renderDetails();
+    await screen.findByRole('button', { name: 'Run health check' });
 
-    expect(wrapper.find('InstanceDetails').length).toBe(1);
-    expect(wrapper.find('div[data-cy="number-forks"]').text()).toContain(
-      '38 forks'
-    );
+    const forks = () =>
+      container.querySelector('[data-cy="number-forks"]').textContent;
+    // mem 38, cpu 32, adjustment 1.0 -> floor(32 + 6*1) = 38 forks
+    expect(forks()).toContain('38 forks');
 
-    await act(async () => {
-      wrapper.find('Slider').prop('onChange')(4);
-    });
-
-    wrapper.update();
-
-    expect(wrapper.find('div[data-cy="number-forks"]').text()).toContain(
-      '56 forks'
-    );
-
-    await act(async () => {
-      wrapper.find('Slider').prop('onChange')(0);
-    });
-    wrapper.update();
-    expect(wrapper.find('div[data-cy="number-forks"]').text()).toContain(
-      '32 forks'
-    );
-
-    await act(async () => {
-      wrapper.find('Slider').prop('onChange')(0.5);
-    });
-    wrapper.update();
-    expect(wrapper.find('div[data-cy="number-forks"]').text()).toContain(
-      '35 forks'
-    );
+    // ArrowLeft steps the slider down one 0.1 step: 1.0 -> 0.9 ->
+    // floor(32 + 6*0.9) = 37 forks.
+    screen.getByRole('slider').focus();
+    await user.keyboard('{ArrowLeft}');
+    await waitFor(() => expect(forks()).toContain('37 forks'));
   });
 
-  test('buttons should be disabled', async () => {
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-          {
-            id: 2,
-          },
-        ],
-      },
-    });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_system_auditor: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find("Button[ouiaId='disassociate-button']")).toHaveLength(
-      0
-    );
+  test('buttons should be disabled for non-superuser', async () => {
+    setMe({ is_system_auditor: true });
+    renderDetails();
+    await screen.findByRole('button', { name: 'Run health check' });
+
+    // Disassociate is only rendered for superusers.
     expect(
-      wrapper.find("Button[ouiaId='health-check-button']").prop('isDisabled')
-    ).toBe(true);
+      screen.queryByRole('button', { name: 'Disassociate' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Run health check' })
+    ).toBeDisabled();
   });
 
   test('should display instance toggle', async () => {
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-          {
-            id: 2,
-          },
-        ],
-      },
-    });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_system_auditor: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find('InstanceToggle').length).toBe(1);
+    setMe({ is_system_auditor: true });
+    renderDetails();
+    await screen.findByRole('button', { name: 'Run health check' });
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Toggle instance' })
+    ).toBeInTheDocument();
   });
 
-  test('should throw error because intance is not associated with instance group', async () => {
+  test('should throw error because instance is not associated with instance group', async () => {
+    setMe({ is_superuser: true });
     InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 3,
-          },
-          {
-            id: 3,
-          },
-        ],
-      },
+      data: { results: [{ id: 3 }, { id: 3 }] },
     });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_superuser: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find('ContentError')).toHaveLength(1);
+    renderDetails();
+
+    expect(
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
     expect(InstanceGroupsAPI.readInstances).toHaveBeenCalledWith(2);
     expect(InstancesAPI.readHealthCheckDetail).not.toHaveBeenCalled();
     expect(InstancesAPI.readDetail).not.toHaveBeenCalled();
   });
 
-  test('Should handle api error for health check', async () => {
-    InstancesAPI.healthCheck.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'post',
-            url: '/api/v2/instances/1/health_check',
-          },
-          data: 'An error occurred',
-          status: 403,
-        },
-      })
+  test('should handle api error for health check', async () => {
+    setMe({ is_superuser: true });
+    InstancesAPI.healthCheck.mockRejectedValue(new Error());
+    const { user } = renderDetails();
+    const healthCheck = await screen.findByRole('button', {
+      name: 'Run health check',
+    });
+    expect(healthCheck).toBeEnabled();
+
+    await user.click(healthCheck);
+    await waitFor(() =>
+      expect(InstancesAPI.healthCheck).toHaveBeenCalledWith(1)
     );
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-          {
-            id: 2,
-          },
-        ],
-      },
-    });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_superuser: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(
-      wrapper.find("Button[ouiaId='health-check-button']").prop('isDisabled')
-    ).toBe(false);
-    await act(async () => {
-      wrapper.find("Button[ouiaId='health-check-button']").prop('onClick')();
-    });
-    expect(InstancesAPI.healthCheck).toHaveBeenCalledWith(1);
-    wrapper.update();
-    expect(wrapper.find('AlertModal')).toHaveLength(1);
-    expect(wrapper.find('ErrorDetail')).toHaveLength(1);
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
+    );
+    // Closing the modal refocuses the Tooltip-wrapped health-check button.
+    await settleTooltips();
   });
 
   test.each([
-    [1, 'hybrid', 0],
-    [2, 'hop', 0],
-    [3, 'control', 0],
-  ])(
-    'hide health check button for non-execution type nodes',
-    async (a, b, expected) => {
-      InstancesAPI.readDetail.mockResolvedValue({
-        data: {
-          id: a,
-          type: 'instance',
-          url: '/api/v2/instances/1/',
-          related: {
-            named_url: '/api/v2/instances/awx_1/',
-            jobs: '/api/v2/instances/1/jobs/',
-            instance_groups: '/api/v2/instances/1/instance_groups/',
-            health_check: '/api/v2/instances/1/health_check/',
-          },
-          uuid: '00000000-0000-0000-0000-000000000000',
-          hostname: 'awx_1',
-          created: '2021-09-08T17:10:34.484569Z',
-          modified: '2021-09-09T13:55:44.219900Z',
-          last_seen: '2021-09-09T20:20:31.623148Z',
-          last_health_check: '2021-09-09T20:20:31.623148Z',
-          errors: '',
-          capacity_adjustment: '1.00',
-          version: '19.1.0',
-          capacity: 38,
-          consumed_capacity: 0,
-          percent_capacity_remaining: 100.0,
-          jobs_running: 0,
-          jobs_total: 0,
-          cpu: 8,
-          memory: 6232231936,
-          cpu_capacity: 32,
-          mem_capacity: 38,
-          enabled: true,
-          managed_by_policy: true,
-          node_type: b,
-          node_state: 'ready',
-          health_check_pending: false,
-        },
-      });
-      jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-        me: { is_superuser: true },
-      }));
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <InstanceDetails
-            instanceGroup={instanceGroup}
-            setBreadcrumb={() => {}}
-          />
-        );
-      });
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-      expect(wrapper.find("Button[ouiaId='health-check-button']")).toHaveLength(
-        expected
-      );
-    }
-  );
-
-  test('Should call disassociate', async () => {
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-          {
-            id: 2,
-          },
-        ],
-      },
-    });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_superuser: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    await act(async () =>
-      wrapper.find('Button[ouiaId="disassociate-button"]').prop('onClick')()
+    ['hybrid'],
+    ['hop'],
+    ['control'],
+  ])('hide health check button for %s (non-execution) nodes', async (nodeType) => {
+    setMe({ is_superuser: true });
+    InstancesAPI.readDetail.mockResolvedValue(
+      instanceDetail({ node_type: nodeType })
     );
-    wrapper.update();
-    await act(async () =>
-      wrapper
-        .find('Button[ouiaId="disassociate-modal-confirm"]')
-        .prop('onClick')()
-    );
-    wrapper.update();
+    renderDetails();
+    // The toggle always renders once details load; use it as a ready signal.
+    await screen.findByRole('checkbox', { name: 'Toggle instance' });
 
-    expect(InstanceGroupsAPI.disassociateInstance).toHaveBeenCalledWith(2, 1);
+    expect(
+      screen.queryByRole('button', { name: 'Run health check' })
+    ).not.toBeInTheDocument();
   });
 
-  test('Should throw disassociate error', async () => {
-    InstanceGroupsAPI.disassociateInstance.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'post',
-            url: '/api/v2/instance_groups',
-          },
-          data: 'An error occurred',
-          status: 403,
-        },
-      })
-    );
-    InstanceGroupsAPI.readInstances.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-          {
-            id: 2,
-          },
-        ],
-      },
-    });
-    jest.spyOn(ConfigContext, 'useConfig').mockImplementation(() => ({
-      me: { is_superuser: true },
-    }));
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceDetails
-          instanceGroup={instanceGroup}
-          setBreadcrumb={() => {}}
-        />
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+  test('should call disassociate', async () => {
+    setMe({ is_superuser: true });
+    InstanceGroupsAPI.disassociateInstance.mockResolvedValue({});
+    const { user } = renderDetails();
+    await screen.findByRole('button', { name: 'Disassociate' });
 
-    await act(async () =>
-      wrapper.find('Button[ouiaId="disassociate-button"]').prop('onClick')()
+    await user.click(screen.getByRole('button', { name: 'Disassociate' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm disassociate' })
     );
-    wrapper.update();
-    await act(async () =>
-      wrapper
-        .find('Button[ouiaId="disassociate-modal-confirm"]')
-        .prop('onClick')()
+
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.disassociateInstance).toHaveBeenCalledWith(2, 1)
     );
-    wrapper.update();
-    expect(wrapper.find('AlertModal')).toHaveLength(1);
-    expect(wrapper.find('ErrorDetail')).toHaveLength(1);
+    // Closing the modal refocuses the Tooltip-wrapped health-check button.
+    await settleTooltips();
+  });
+
+  test('should throw disassociate error', async () => {
+    setMe({ is_superuser: true });
+    InstanceGroupsAPI.disassociateInstance.mockRejectedValue(new Error());
+    const { user } = renderDetails();
+    await screen.findByRole('button', { name: 'Disassociate' });
+
+    await user.click(screen.getByRole('button', { name: 'Disassociate' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm disassociate' })
+    );
+
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
+    );
+    // Closing the modal refocuses the Tooltip-wrapped health-check button.
+    await settleTooltips();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.test.js
@@ -1,14 +1,16 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import InstanceGroupAdd from './InstanceGroupAdd';
 
 jest.mock('../../../api');
 
-const instanceGroupData = {
+// Prefixed `mock` so the jest.mock factory below may reference it (jest allows
+// out-of-scope refs only when the name begins with "mock").
+const mockInstanceGroupData = {
   id: 42,
   type: 'instance_group',
   url: '/api/v2/instance_groups/42/',
@@ -41,11 +43,24 @@ const instanceGroupData = {
   },
 };
 
+// Mock the shared form so the test drives InstanceGroupAdd's own submit/cancel
+// handlers directly. The form itself is covered by InstanceGroupForm.test.js.
+jest.mock('../shared/InstanceGroupForm', () => ({ onSubmit, onCancel, submitError }) => (
+  <div>
+    {submitError && <div>FormSubmitError</div>}
+    <button type="button" onClick={() => onSubmit(mockInstanceGroupData)}>
+      mock submit
+    </button>
+    <button type="button" aria-label="Cancel" onClick={onCancel}>
+      Cancel
+    </button>
+  </div>
+));
+
 describe('<InstanceGroupAdd/>', () => {
-  let wrapper;
   let history;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     history = createMemoryHistory({
       initialEntries: ['/instance_groups'],
     });
@@ -54,11 +69,6 @@ describe('<InstanceGroupAdd/>', () => {
         id: 42,
       },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroupAdd />, {
-        context: { router: { history } },
-      });
-    });
   });
 
   afterEach(() => {
@@ -66,16 +76,23 @@ describe('<InstanceGroupAdd/>', () => {
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('InstanceGroupForm').prop('onSubmit')(instanceGroupData);
+    const { user } = renderWithContexts(<InstanceGroupAdd />, {
+      context: { router: { history } },
     });
-    wrapper.update();
-    expect(InstanceGroupsAPI.create).toHaveBeenCalledWith(instanceGroupData);
+    await user.click(screen.getByRole('button', { name: 'mock submit' }));
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.create).toHaveBeenCalledWith(
+        mockInstanceGroupData
+      )
+    );
     expect(history.location.pathname).toBe('/instance_groups/42/details');
   });
 
   test('handleCancel should return the user back to the instance group list', async () => {
-    wrapper.find('Button[aria-label="Cancel"]').simulate('click');
+    const { user } = renderWithContexts(<InstanceGroupAdd />, {
+      context: { router: { history } },
+    });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/instance_groups');
   });
 
@@ -85,13 +102,11 @@ describe('<InstanceGroupAdd/>', () => {
         data: { detail: 'An error occurred' },
       },
     };
-    InstanceGroupsAPI.create.mockImplementationOnce(() =>
-      Promise.reject(error)
-    );
-    await act(async () => {
-      wrapper.find('InstanceGroupForm').invoke('onSubmit')(instanceGroupData);
+    InstanceGroupsAPI.create.mockImplementationOnce(() => Promise.reject(error));
+    const { user } = renderWithContexts(<InstanceGroupAdd />, {
+      context: { router: { history } },
     });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    await user.click(screen.getByRole('button', { name: 'mock submit' }));
+    expect(await screen.findByText('FormSubmitError')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.test.js
@@ -1,16 +1,25 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
-import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import {
+  InstanceGroupsAPI,
+  OrganizationsAPI,
+  InventoriesAPI,
+  UnifiedJobTemplatesAPI,
+} from 'api';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 
 import InstanceGroupDetails from './InstanceGroupDetails';
 
 jest.mock('../../../api');
 
-const instanceGroups = [
-  {
+// Build fresh objects per test so capability mutations don't leak between tests.
+function buildInstanceGroup(overrides = {}) {
+  return {
     id: 1,
     name: 'Foo',
     type: 'instance_group',
@@ -30,125 +39,75 @@ const instanceGroups = [
         delete: true,
       },
     },
-  },
-  {
-    id: 2,
-    name: 'Bar',
-    type: 'instance_group',
-    url: '/api/v2/instance_groups/2/',
-    capacity: 0,
-    policy_instance_minimum: 0,
-    policy_instance_percentage: 0,
-    percent_capacity_remaining: 0,
-    max_concurrent_jobs: 0,
-    max_forks: 0,
-    is_container_group: true,
-    created: '2020-07-21T18:41:02.818081Z',
-    modified: '2020-07-24T20:32:03.121079Z',
-    summary_fields: {
-      user_capabilities: {
-        edit: false,
-        delete: false,
-      },
-    },
-  },
-];
-
-function expectDetailToMatch(wrapper, label, value) {
-  const detail = wrapper.find(`Detail[label="${label}"]`);
-  expect(detail).toHaveLength(1);
-  expect(detail.prop('value')).toEqual(value);
+    ...overrides,
+  };
 }
 
 describe('<InstanceGroupDetails/>', () => {
-  let wrapper;
-  test('should render details properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceGroupDetails instanceGroup={instanceGroups[0]} />
-      );
-    });
+  beforeEach(() => {
+    // The DeleteButton fetches related-resource counts before confirming.
+    OrganizationsAPI.read.mockResolvedValue({ data: { count: 0 } });
+    InventoriesAPI.read.mockResolvedValue({ data: { count: 0 } });
+    UnifiedJobTemplatesAPI.read.mockResolvedValue({ data: { count: 0 } });
+  });
 
-    wrapper.update();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    expect(wrapper.find('Detail[label="Name"]').text()).toEqual(
-      expect.stringContaining(instanceGroups[0].name)
+  test('should render details properly', () => {
+    const instanceGroup = buildInstanceGroup();
+    renderWithContexts(<InstanceGroupDetails instanceGroup={instanceGroup} />);
+
+    assertDetail('Name', 'Foo');
+    assertDetail('Type', 'Instance group');
+    assertDetail('Policy instance minimum', '10');
+    assertDetail('Policy instance percentage', '50 %');
+    assertDetail(
+      'Used capacity',
+      `${100 - instanceGroup.percent_capacity_remaining} %`
     );
-    expect(wrapper.find('Detail[label="Name"]')).toHaveLength(1);
-    expectDetailToMatch(wrapper, 'Type', `Instance group`);
-    const dates = wrapper.find('UserDateDetail');
-    expect(dates).toHaveLength(2);
-    expect(dates.at(0).prop('date')).toEqual(instanceGroups[0].created);
-    expect(dates.at(1).prop('date')).toEqual(instanceGroups[0].modified);
-
-    expect(
-      wrapper.find('DetailBadge[label="Used capacity"]').prop('content')
-    ).toBe(`${100 - instanceGroups[0].percent_capacity_remaining} %`);
-
-    expect(
-      wrapper
-        .find('DetailBadge[label="Policy instance minimum"]')
-        .prop('content')
-    ).toBe(instanceGroups[0].policy_instance_minimum);
-
-    expect(
-      wrapper
-        .find('DetailBadge[label="Policy instance percentage"]')
-        .prop('content')
-    ).toBe(`${instanceGroups[0].policy_instance_percentage} %`);
   });
 
   test('expected api call is made for delete', async () => {
+    const instanceGroup = buildInstanceGroup();
     const history = createMemoryHistory({
       initialEntries: ['/instance_groups/1/details'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceGroupDetails instanceGroup={instanceGroups[0]} />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    expect(InstanceGroupsAPI.destroy).toHaveBeenCalledTimes(1);
+    InstanceGroupsAPI.destroy.mockResolvedValue({});
+    const { user } = renderWithContexts(
+      <InstanceGroupDetails instanceGroup={instanceGroup} />,
+      { context: { router: { history } } }
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
+    );
+
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.destroy).toHaveBeenCalledTimes(1)
+    );
     expect(history.location.pathname).toBe('/instance_groups');
   });
 
-  test('should not render delete button for tower instance group', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceGroupDetails instanceGroup={instanceGroups[1]} />
-      );
+  test('should not render delete button when delete capability is false', () => {
+    const instanceGroup = buildInstanceGroup({
+      summary_fields: { user_capabilities: { edit: true, delete: false } },
     });
-    wrapper.update();
+    renderWithContexts(<InstanceGroupDetails instanceGroup={instanceGroup} />);
 
-    expect(wrapper.find('Button[aria-label="Delete"]').length).toBe(0);
+    expect(
+      screen.queryByRole('button', { name: 'Delete' })
+    ).not.toBeInTheDocument();
   });
 
-  test('should not render delete button', async () => {
-    instanceGroups[0].summary_fields.user_capabilities.delete = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceGroupDetails instanceGroup={instanceGroups[0]} />
-      );
+  test('should not render edit button when edit capability is false', () => {
+    const instanceGroup = buildInstanceGroup({
+      summary_fields: { user_capabilities: { edit: false, delete: true } },
     });
-    wrapper.update();
+    renderWithContexts(<InstanceGroupDetails instanceGroup={instanceGroup} />);
 
-    expect(wrapper.find('Button[aria-label="Delete"]').length).toBe(0);
-  });
-
-  test('should not render edit button', async () => {
-    instanceGroups[0].summary_fields.user_capabilities.edit = false;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceGroupDetails instanceGroup={instanceGroups[0]} />
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('Button[aria-label="Edit"]').length).toBe(0);
+    expect(screen.queryByRole('link', { name: 'Edit' })).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.js
@@ -1,13 +1,33 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import InstanceGroupEdit from './InstanceGroupEdit';
 
 jest.mock('../../../api');
+
+// Prefixed `mock` so the jest.mock factory below may reference it.
+const mockUpdatedInstanceGroup = {
+  name: 'Bar',
+  policy_instance_percentage: 42,
+};
+
+// Mock the shared form so the test drives InstanceGroupEdit's own submit/cancel
+// handlers directly. The form itself is covered by InstanceGroupForm.test.js.
+jest.mock('../shared/InstanceGroupForm', () => ({ onSubmit, onCancel, submitError }) => (
+  <div>
+    {submitError && <div>FormSubmitError</div>}
+    <button type="button" onClick={() => onSubmit(mockUpdatedInstanceGroup)}>
+      mock submit
+    </button>
+    <button type="button" aria-label="Cancel" onClick={onCancel}>
+      Cancel
+    </button>
+  </div>
+));
 
 const instanceGroupData = {
   id: 42,
@@ -42,59 +62,52 @@ const instanceGroupData = {
   },
 };
 
-const updatedInstanceGroup = {
-  name: 'Bar',
-  policy_instance_percentage: 42,
-};
-
 describe('<InstanceGroupEdit>', () => {
-  let wrapper;
   let history;
 
-  beforeAll(async () => {
+  beforeEach(() => {
     history = createMemoryHistory();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceGroupEdit instanceGroup={instanceGroupData} />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
+    InstanceGroupsAPI.update.mockResolvedValue({ data: {} });
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {
-    await act(async () => {
-      wrapper.find('InstanceGroupForm').invoke('onSubmit')(
-        updatedInstanceGroup
-      );
-    });
-    expect(InstanceGroupsAPI.update).toHaveBeenCalledWith(
-      42,
-      updatedInstanceGroup
+    const { user } = renderWithContexts(
+      <InstanceGroupEdit instanceGroup={instanceGroupData} />,
+      { context: { router: { history } } }
     );
+    await user.click(screen.getByRole('button', { name: 'mock submit' }));
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.update).toHaveBeenCalledWith(
+        42,
+        mockUpdatedInstanceGroup
+      )
+    );
+    expect(history.location.pathname).toEqual('/instance_groups/42/details');
   });
 
   test('should navigate to instance group details when cancel is clicked', async () => {
-    await act(async () => {
-      wrapper.find('button[aria-label="Cancel"]').prop('onClick')();
-    });
+    const { user } = renderWithContexts(
+      <InstanceGroupEdit instanceGroup={instanceGroupData} />,
+      { context: { router: { history } } }
+    );
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(history.location.pathname).toEqual('/instance_groups/42/details');
   });
 
   test('should navigate to instance group details after successful submission', async () => {
-    await act(async () => {
-      wrapper.find('InstanceGroupForm').invoke('onSubmit')(
-        updatedInstanceGroup
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(0);
-    expect(history.location.pathname).toEqual('/instance_groups/42/details');
+    const { user } = renderWithContexts(
+      <InstanceGroupEdit instanceGroup={instanceGroupData} />,
+      { context: { router: { history } } }
+    );
+    await user.click(screen.getByRole('button', { name: 'mock submit' }));
+    await waitFor(() =>
+      expect(history.location.pathname).toEqual('/instance_groups/42/details')
+    );
+    expect(screen.queryByText('FormSubmitError')).not.toBeInTheDocument();
   });
 
   test('failed form submission should show an error message', async () => {
@@ -103,15 +116,12 @@ describe('<InstanceGroupEdit>', () => {
         data: { detail: 'An error occurred' },
       },
     };
-    InstanceGroupsAPI.update.mockImplementationOnce(() =>
-      Promise.reject(error)
+    InstanceGroupsAPI.update.mockImplementationOnce(() => Promise.reject(error));
+    const { user } = renderWithContexts(
+      <InstanceGroupEdit instanceGroup={instanceGroupData} />,
+      { context: { router: { history } } }
     );
-    await act(async () => {
-      wrapper.find('InstanceGroupForm').invoke('onSubmit')(
-        updatedInstanceGroup
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('FormSubmitError').length).toBe(1);
+    await user.click(screen.getByRole('button', { name: 'mock submit' }));
+    expect(await screen.findByText('FormSubmitError')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.test.js
@@ -1,25 +1,17 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import {
   InstanceGroupsAPI,
   OrganizationsAPI,
   InventoriesAPI,
   UnifiedJobTemplatesAPI,
-  SettingsAPI,
 } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import InstanceGroupList from './InstanceGroupList';
 
-jest.mock('../../../api/models/InstanceGroups');
-jest.mock('../../../api/models/Organizations');
-jest.mock('../../../api/models/Inventories');
-jest.mock('../../../api/models/UnifiedJobTemplates');
-jest.mock('../../../api/models/Settings');
+jest.mock('../../../api');
 
 const instanceGroups = {
   data: {
@@ -62,167 +54,101 @@ const instanceGroups = {
 };
 
 const options = { data: { actions: { POST: true } } };
-const settings = {
-  data: {
-    DEFAULT_CONTROL_PLANE_QUEUE_NAME: 'controlplan',
-    DEFAULT_EXECUTION_QUEUE_NAME: 'default',
-  },
-};
 
 describe('<InstanceGroupList />', () => {
-  let wrapper;
-
   beforeEach(() => {
     OrganizationsAPI.read.mockResolvedValue({ data: { count: 0 } });
     InventoriesAPI.read.mockResolvedValue({ data: { count: 0 } });
     UnifiedJobTemplatesAPI.read.mockResolvedValue({ data: { count: 0 } });
     InstanceGroupsAPI.read.mockResolvedValue(instanceGroups);
     InstanceGroupsAPI.readOptions.mockResolvedValue(options);
-    SettingsAPI.readAll.mockResolvedValue(settings);
   });
 
-  test('should have data fetched and render 3 rows', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroupList />);
-    });
-    await waitForElement(wrapper, 'InstanceGroupList', (el) => el.length > 0);
-    expect(wrapper.find('InstanceGroupListItem').length).toBe(4);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should have data fetched and render all rows', async () => {
+    renderWithContexts(<InstanceGroupList />);
+    await screen.findByRole('link', { name: 'Foo' });
+
     expect(InstanceGroupsAPI.read).toHaveBeenCalled();
     expect(InstanceGroupsAPI.readOptions).toHaveBeenCalled();
+    expect(
+      screen.getAllByRole('link', {
+        name: /^(Foo|controlplan|default|Bar)$/,
+      })
+    ).toHaveLength(4);
   });
 
   test('should delete item successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroupList />);
-    });
-    await waitForElement(wrapper, 'InstanceGroupList', (el) => el.length > 0);
+    InstanceGroupsAPI.destroy.mockResolvedValue({});
+    const { user } = renderWithContexts(<InstanceGroupList />);
+    await screen.findByRole('link', { name: 'Foo' });
 
-    wrapper
-      .find('.pf-c-table__check')
-      .first()
-      .find('input')
-      .simulate('change', instanceGroups);
-    wrapper.update();
+    const row = screen.getByRole('link', { name: 'Foo' }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.destroy).toHaveBeenCalledWith(
+        instanceGroups.data.results[0].id
+      )
+    );
+  });
+
+  test('delete button is disabled when a protected (non-deletable) group is selected', async () => {
+    const { user } = renderWithContexts(<InstanceGroupList />);
+    await screen.findByRole('link', { name: 'Foo' });
+
+    // Select all rows; "Bar" has delete=false, which disables the toolbar Delete.
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+
+  test('should show content error', async () => {
+    InstanceGroupsAPI.read.mockRejectedValue(new Error());
+    renderWithContexts(<InstanceGroupList />);
 
     expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toBe(true);
-
-    await act(async () => {
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')();
-    });
-    wrapper.update();
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-
-    expect(InstanceGroupsAPI.destroy).toHaveBeenCalledWith(
-      instanceGroups.data.results[0].id
-    );
-  });
-
-  test('should not be able to delete controlplan or default instance group', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroupList />);
-    });
-    await waitForElement(wrapper, 'InstanceGroupList', (el) => el.length > 0);
-
-    const instanceGroupIndex = [0, 1, 2, 3];
-
-    instanceGroupIndex.forEach((element) => {
-      wrapper
-        .find('.pf-c-table__check')
-        .at(element)
-        .find('input')
-        .simulate('change', instanceGroups);
-      wrapper.update();
-
-      expect(
-        wrapper
-          .find('.pf-c-table__check')
-          .at(element)
-          .find('input')
-          .prop('checked')
-      ).toBe(true);
-    });
-
-    expect(wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')).toBe(
-      true
-    );
-  });
-
-  test('should thrown content error', async () => {
-    InstanceGroupsAPI.read = jest.fn();
-    InstanceGroupsAPI.read.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'GET',
-            url: '/api/v2/instance_groups',
-          },
-          data: 'An error occurred',
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroupList />);
-    });
-    await waitForElement(wrapper, 'InstanceGroupList', (el) => el.length > 0);
-    expect(wrapper.find('ContentError').length).toBe(1);
+      await screen.findByText('Something went wrong...')
+    ).toBeInTheDocument();
   });
 
   test('should render deletion error modal', async () => {
-    InstanceGroupsAPI.destroy = jest.fn();
-    InstanceGroupsAPI.destroy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'DELETE',
-            url: '/api/v2/instance_groups',
-          },
-          data: 'An error occurred',
-        },
-      })
-    );
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroupList />);
-    });
-    waitForElement(wrapper, 'InstanceGroupList', (el) => el.length > 0);
+    InstanceGroupsAPI.destroy.mockRejectedValue(new Error());
+    const { user } = renderWithContexts(<InstanceGroupList />);
+    await screen.findByRole('link', { name: 'Foo' });
 
-    wrapper
-      .find('.pf-c-table__check')
-      .first()
-      .find('input')
-      .simulate('change', 'a');
-    wrapper.update();
+    const row = screen.getByRole('link', { name: 'Foo' }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+
     expect(
-      wrapper.find('.pf-c-table__check').first().find('input').prop('checked')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="Delete"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    await act(async () =>
-      wrapper.find('Button[aria-label="confirm delete"]').prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
+      await screen.findByText(
+        'Failed to delete one or more instance groups.'
+      )
+    ).toBeInTheDocument();
   });
 
   test('should not render add button', async () => {
-    InstanceGroupsAPI.read.mockResolvedValue(instanceGroups);
     InstanceGroupsAPI.readOptions.mockResolvedValue({
       data: { actions: { POST: false } },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(<InstanceGroupList />);
-    });
-    waitForElement(wrapper, 'InstanceGroupList', (el) => el.length > 0);
-    expect(wrapper.find('ToolbarAddButton').length).toBe(0);
+    renderWithContexts(<InstanceGroupList />);
+    await screen.findByRole('link', { name: 'Foo' });
+
+    expect(
+      screen.queryByRole('button', { name: /Add/ })
+    ).not.toBeInTheDocument();
   });
 });
-
-describe('modifyInstanceGroups', () => {});

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.test.js
@@ -1,147 +1,106 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, within } from '@testing-library/react';
 
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import InstanceGroupListItem from './InstanceGroupListItem';
 
+const instanceGroups = [
+  {
+    id: 1,
+    name: 'Foo',
+    type: 'instance_group',
+    url: '/api/v2/instance_groups/1',
+    capacity: 10,
+    policy_instance_minimum: 10,
+    policy_instance_percentage: 50,
+    percent_capacity_remaining: 60,
+    is_container_group: false,
+    summary_fields: {
+      user_capabilities: {
+        edit: true,
+        delete: true,
+      },
+    },
+  },
+  {
+    id: 2,
+    name: 'Bar',
+    type: 'instance_group',
+    url: '/api/v2/instance_groups/2',
+    capacity: 0,
+    policy_instance_minimum: 0,
+    policy_instance_percentage: 0,
+    percent_capacity_remaining: 0,
+    is_container_group: true,
+    summary_fields: {
+      user_capabilities: {
+        edit: false,
+        delete: false,
+      },
+    },
+  },
+];
+
+function renderItem(instanceGroup, props = {}) {
+  return renderWithContexts(
+    <table>
+      <tbody>
+        <InstanceGroupListItem
+          instanceGroup={instanceGroup}
+          detailUrl={`instance_groups/${instanceGroup.id}/details`}
+          isSelected={false}
+          onSelect={() => {}}
+          {...props}
+        />
+      </tbody>
+    </table>
+  );
+}
+
 describe('<InstanceGroupListItem/>', () => {
-  let wrapper;
-  const instanceGroups = [
-    {
-      id: 1,
-      name: 'Foo',
-      type: 'instance_group',
-      url: '/api/v2/instance_groups/1',
-      capacity: 10,
-      policy_instance_minimum: 10,
-      policy_instance_percentage: 50,
-      percent_capacity_remaining: 60,
-      is_container_group: false,
-      summary_fields: {
-        user_capabilities: {
-          edit: true,
-          delete: true,
-        },
-      },
-    },
-    {
-      id: 2,
-      name: 'Bar',
-      type: 'instance_group',
-      url: '/api/v2/instance_groups/2',
-      capacity: 0,
-      policy_instance_minimum: 0,
-      policy_instance_percentage: 0,
-      percent_capacity_remaining: 0,
-      is_container_group: true,
-      summary_fields: {
-        user_capabilities: {
-          edit: false,
-          delete: false,
-        },
-      },
-    },
-  ];
-
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceGroupListItem
-              instanceGroup={instanceGroups[1]}
-              detailUrl="instance_groups/1/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('InstanceGroupListItem').length).toBe(1);
-  });
-
-  test('should render the proper data instance group', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceGroupListItem
-              instanceGroup={instanceGroups[0]}
-              detailUrl="instance_groups/1/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td').at(1).text()).toBe('Foo');
-    expect(wrapper.find('Progress').prop('value')).toBe(40);
-    expect(wrapper.find('Td').at(2).text()).toBe('Instance group');
-    expect(wrapper.find('PencilAltIcon').length).toBe(1);
-    expect(wrapper.find('.pf-c-table__check input').prop('checked')).toBe(
-      undefined
+  test('should render the proper data for an instance group', () => {
+    renderItem(instanceGroups[0]);
+    const row = screen.getByRole('link', { name: 'Foo' }).closest('tr');
+    const typeCell = within(row)
+      .getAllByRole('cell')
+      .find((cell) => cell.getAttribute('data-label') === 'Type');
+    expect(typeCell).toHaveTextContent('Instance group');
+    // Used capacity is rendered as a Progress bar (100 - 60 = 40).
+    expect(within(row).getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '40'
     );
+    // edit capability is true -> the edit button is present.
+    expect(
+      within(row).getByRole('link', { name: 'Edit instance group' })
+    ).toBeInTheDocument();
   });
 
-  test('should render the proper data container group', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceGroupListItem
-              instanceGroup={instanceGroups[1]}
-              detailUrl="instance_groups/2/details"
-              isSelected={false}
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td').at(1).text()).toBe('Bar');
-
-    expect(wrapper.find('Td').at(2).text()).toBe('Container group');
-    expect(wrapper.find('PencilAltIcon').length).toBe(0);
+  test('should render the proper data for a container group', () => {
+    renderItem(instanceGroups[1]);
+    const row = screen.getByRole('link', { name: 'Bar' }).closest('tr');
+    const typeCell = within(row)
+      .getAllByRole('cell')
+      .find((cell) => cell.getAttribute('data-label') === 'Type');
+    expect(typeCell).toHaveTextContent('Container group');
+    // edit capability is false -> no edit button.
+    expect(
+      within(row).queryByRole('link', { name: 'Edit instance group' })
+    ).not.toBeInTheDocument();
   });
 
-  test('edit button shown to users with edit capabilities', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceGroupListItem
-              instanceGroup={instanceGroups[0]}
-              detailUrl="instance_groups/1/details"
-              isSelected
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-
-    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+  test('edit button shown to users with edit capabilities', () => {
+    renderItem(instanceGroups[0], { isSelected: true });
+    expect(
+      screen.getByRole('link', { name: 'Edit instance group' })
+    ).toBeInTheDocument();
   });
 
-  test('edit button hidden from users without edit capabilities', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceGroupListItem
-              instanceGroup={instanceGroups[1]}
-              detailsUrl="instance_group/2/details"
-              isSelected
-              onSelect={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-
-    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+  test('edit button hidden from users without edit capabilities', () => {
+    renderItem(instanceGroups[1], { isSelected: true });
+    expect(
+      screen.queryByRole('link', { name: 'Edit instance group' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.test.js
@@ -1,19 +1,21 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { Route } from 'react-router-dom';
+import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import { InstancesAPI, InstanceGroupsAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  settleTooltips,
+} from '../../../../testUtils/rtlContexts';
 
 import InstanceList from './InstanceList';
 
 jest.mock('../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// InstanceList reads useParams from react-router-dom-v5-compat (the route tree
+// is v6); mock it there, keeping the rest of the module real.
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
   useParams: () => ({
     id: 1,
     instanceGroupId: 2,
@@ -109,10 +111,20 @@ const instances = [
 
 const options = { data: { actions: { POST: true } } };
 
-describe('<InstanceList/>', () => {
-  let wrapper;
+function setup() {
+  const history = createMemoryHistory({
+    initialEntries: ['/instance_groups/1/instances'],
+  });
+  return renderWithContexts(
+    <Route path="/instance_groups/:id/instances">
+      <InstanceList instanceGroup={{ name: 'Alex' }} />
+    </Route>,
+    { context: { router: { history } } }
+  );
+}
 
-  beforeEach(async () => {
+describe('<InstanceList/>', () => {
+  beforeEach(() => {
     InstanceGroupsAPI.readInstances.mockResolvedValue({
       data: {
         count: instances.length,
@@ -120,112 +132,108 @@ describe('<InstanceList/>', () => {
       },
     });
     InstanceGroupsAPI.readInstanceOptions.mockResolvedValue(options);
-    const history = createMemoryHistory({
-      initialEntries: ['/instance_groups/1/instances'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Route path="/instance_groups/:id/instances">
-          <InstanceList instanceGroup={{ name: 'Alex' }} />
-        </Route>,
-        {
-          context: {
-            router: { history, route: { location: history.location } },
-          },
-        }
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('should have data fetched', () => {
-    expect(wrapper.find('InstanceList').length).toBe(1);
-  });
+  test('should fetch instances from the api and render them in the list', async () => {
+    setup();
+    await screen.findByRole('link', { name: 'awx' });
 
-  test('should fetch instances from the api and render them in the list', () => {
     expect(InstanceGroupsAPI.readInstances).toHaveBeenCalled();
     expect(InstanceGroupsAPI.readInstanceOptions).toHaveBeenCalled();
-    expect(wrapper.find('InstanceListItem').length).toBe(3);
+    expect(screen.getByRole('link', { name: 'awx' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'foo' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'bar' })).toBeInTheDocument();
   });
 
-  test('should show associate group modal when adding an existing group', () => {
-    wrapper.find('ToolbarAddButton').simulate('click');
-    expect(wrapper.find('AssociateModal').length).toBe(1);
-    wrapper.find('ModalBoxCloseButton').simulate('click');
-    expect(wrapper.find('AssociateModal').length).toBe(0);
-  });
-  test('should run health check', async () => {
+  test('should show associate modal when adding an existing instance', async () => {
+    InstancesAPI.read.mockResolvedValue({ data: { count: 0, results: [] } });
+    InstancesAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} }, related_search_fields: [] },
+    });
+    const { user } = setup();
+    await screen.findByRole('link', { name: 'awx' });
+
+    await user.click(screen.getByRole('button', { name: /Associate/ }));
     expect(
-      wrapper.find('Button[ouiaId="health-check"]').prop('isDisabled')
-    ).toBe(true);
-    await act(async () =>
-      wrapper.find('DataListToolbar').prop('onSelectAll')(instances)
+      await screen.findByRole('dialog', { name: /Select Instances/ })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: /Select Instances/ })
+      ).not.toBeInTheDocument()
     );
-    wrapper.update();
-    expect(
-      wrapper.find('Button[ouiaId="health-check"]').prop('isDisabled')
-    ).toBe(false);
-    await act(async () =>
-      wrapper.find('Button[ouiaId="health-check"]').prop('onClick')()
-    );
-    expect(InstancesAPI.healthCheck).toHaveBeenCalledTimes(1);
+    // Closing the modal refocuses the Tooltip-wrapped Associate button.
+    await settleTooltips();
   });
+
+  test('should run health check on selected execution instances', async () => {
+    InstancesAPI.healthCheck.mockResolvedValue({ data: {} });
+    const { user } = setup();
+    await screen.findByRole('link', { name: 'awx' });
+
+    const healthCheck = screen.getByRole('button', { name: 'Run health check' });
+    expect(healthCheck).toBeDisabled();
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    await waitFor(() => expect(healthCheck).toBeEnabled());
+
+    await user.click(healthCheck);
+    // Only the execution node (id 3) is health-checked.
+    await waitFor(() =>
+      expect(InstancesAPI.healthCheck).toHaveBeenCalledTimes(1)
+    );
+    expect(InstancesAPI.healthCheck).toHaveBeenCalledWith(3);
+    // A success alert appears; await it so async state settles before unmount.
+    expect(
+      await screen.findByText(/Health check request\(s\) submitted/)
+    ).toBeInTheDocument();
+    // handleHealthCheck clears the selection after the request resolves; wait
+    // for the resulting re-render so no state update lands after unmount.
+    await waitFor(() => expect(healthCheck).toBeDisabled());
+  });
+
   test('should render health check error', async () => {
-    InstancesAPI.healthCheck.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'create',
-            url: '/api/v2/instances',
-          },
-          data: 'An error occurred',
-          status: 403,
-        },
-      })
+    InstancesAPI.healthCheck.mockRejectedValue(new Error());
+    const { user } = setup();
+    await screen.findByRole('link', { name: 'awx' });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    const healthCheck = screen.getByRole('button', { name: 'Run health check' });
+    await waitFor(() => expect(healthCheck).toBeEnabled());
+
+    await user.click(healthCheck);
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+    // Dismiss the modal so the error/selection state unwinds before unmount.
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
     );
-    expect(
-      wrapper.find('Button[ouiaId="health-check"]').prop('isDisabled')
-    ).toBe(true);
-    await act(async () =>
-      wrapper.find('DataListToolbar').prop('onSelectAll')(instances)
-    );
-    wrapper.update();
-    expect(
-      wrapper.find('Button[ouiaId="health-check"]').prop('isDisabled')
-    ).toBe(false);
-    await act(async () =>
-      wrapper.find('Button[ouiaId="health-check"]').prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('AlertModal')).toHaveLength(1);
   });
 
-  test('should disable disassociate button', async () => {
-    expect(
-      wrapper.find('Button[ouiaId="disassociate-button"]').prop('isDisabled')
-    ).toBe(true);
-    await act(async () =>
-      wrapper.find('DataListToolbar').prop('onSelectAll')(instances)
-    );
+  test('disassociate button is disabled until a non-control instance is selected', async () => {
+    const { user } = setup();
+    await screen.findByRole('link', { name: 'awx' });
 
-    wrapper.update();
-    expect(
-      wrapper.find('Button[ouiaId="disassociate-button"]').prop('isDisabled')
-    ).toBe(true);
-    await act(async () =>
-      wrapper
-        .find('Tr#instance-row-1')
-        .find('SelectColumn[aria-label="Select row 0"]')
-        .prop('onSelect')(false)
-    );
+    const disassociate = screen.getByRole('button', { name: 'Disassociate' });
+    expect(disassociate).toBeDisabled();
 
-    wrapper.update();
-    expect(
-      wrapper.find('Button[ouiaId="disassociate-button"]').prop('isDisabled')
-    ).toBe(false);
+    // Selecting all includes the control node (awx), keeping it disabled.
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    expect(disassociate).toBeDisabled();
+
+    // Deselecting the control node leaves only non-control nodes -> enabled.
+    const controlRow = screen.getByRole('link', { name: 'awx' }).closest('tr');
+    const controlCheckbox = within(controlRow)
+      .getAllByRole('checkbox')
+      .find((box) => box.getAttribute('aria-label') !== 'Toggle instance');
+    await user.click(controlCheckbox);
+
+    await waitFor(() => expect(disassociate).toBeEnabled());
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import { InstancesAPI } from 'api';
 import useDebounce from 'hooks/useDebounce';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import InstanceListItem from './InstanceListItem';
 
@@ -18,6 +18,7 @@ jest.mock('react-router-dom-v5-compat', () => ({
     id: 1,
   }),
 }));
+
 const instance = [
   {
     id: 1,
@@ -48,243 +49,139 @@ const instance = [
     node_type: 'hybrid',
     node_state: 'ready',
   },
-  {
-    id: 2,
-    type: 'instance',
-    url: '/api/v2/instances/1/',
-    related: {
-      jobs: '/api/v2/instances/1/jobs/',
-      instance_groups: '/api/v2/instances/1/instance_groups/',
-    },
-    uuid: '00000000-0000-0000-0000-000000000001',
-    hostname: 'awx-control',
-    created: '2020-07-14T19:03:49.000054Z',
-    modified: '2020-08-12T20:08:02.836748Z',
-    capacity_adjustment: '0.40',
-    version: '13.0.0',
-    last_health_check: '2021-09-15T18:02:07.270664Z',
-    capacity: 10,
-    consumed_capacity: 0,
-    percent_capacity_remaining: 60.0,
-    jobs_running: 0,
-    jobs_total: 68,
-    cpu: 6,
-    memory: 2087469056,
-    cpu_capacity: 24,
-    mem_capacity: 1,
-    enabled: true,
-    managed_by_policy: true,
-    node_type: 'control',
-    node_state: 'ready',
-  },
 ];
 
-describe('<InstanceListItem/>', () => {
-  let wrapper;
+function renderItem(props = {}) {
+  return renderWithContexts(
+    <table>
+      <tbody>
+        <InstanceListItem
+          instance={instance[0]}
+          isSelected={false}
+          onSelect={() => {}}
+          fetchInstances={() => {}}
+          {...props}
+        />
+      </tbody>
+    </table>
+  );
+}
 
+describe('<InstanceListItem/>', () => {
   beforeEach(() => {
     useDebounce.mockImplementation((fn) => fn);
   });
 
-  test('should mount successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceListItem
-              instance={instance[0]}
-              isSelected={false}
-              onSelect={() => {}}
-              fetchInstances={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('InstanceListItem').length).toBe(1);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  test('should calculate number of forks when slide changes', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceListItem
-              instance={instance[0]}
-              isSelected={false}
-              onSelect={() => {}}
-              fetchInstances={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('InstanceListItem').length).toBe(1);
-    const forksText = wrapper.find('InstanceListItem__SliderForks').text();
-    expect(forksText).toContain('10');
-    expect(forksText).toContain('forks');
-
-    await act(async () => {
-      wrapper.find('Slider').prop('onChange')(1);
-    });
-
-    wrapper.update();
-    const forksText24 = wrapper.find('InstanceListItem__SliderForks').text();
-    expect(forksText24).toContain('24');
-    expect(forksText24).toContain('forks');
-
-    await act(async () => {
-      wrapper.find('Slider').prop('onChange')(0);
-    });
-    wrapper.update();
-    const forkText1 = wrapper.find('InstanceListItem__SliderForks').text();
-    expect(forkText1).toContain('1');
-    expect(forkText1).toContain('fork');
-
-    await act(async () => {
-      wrapper.find('Slider').prop('onChange')(0.5);
-    });
-    wrapper.update();
-    const forksText12 = wrapper.find('InstanceListItem__SliderForks').text();
-    expect(forksText12).toContain('12');
-    expect(forksText12).toContain('forks');
-  });
-
-  test('should render the proper data instance', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceListItem
-              instance={instance[0]}
-              isSelected={false}
-              onSelect={() => {}}
-              fetchInstances={() => {}}
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('Td[dataLabel="Name"]').find('Link').prop('to')).toBe(
+  test('should render the proper data instance', () => {
+    const { container } = renderItem();
+    // name cell links to the instance detail page
+    expect(screen.getByRole('link', { name: 'awx' })).toHaveAttribute(
+      'href',
       '/instance_groups/1/instances/1/details'
     );
-    expect(wrapper.find('Td').at(2).text()).toBe('awx');
-    expect(wrapper.find('Progress').prop('value')).toBe(40);
-    expect(
-      wrapper
-        .find('Td')
-        .at(5)
-        .containsMatchingElement(<div>CPU 24</div>)
+    // used capacity progress bar = 100 - 60 = 40
+    expect(screen.getByRole('progressbar')).toHaveAttribute(
+      'aria-valuenow',
+      '40'
     );
-    expect(
-      wrapper
-        .find('Td')
-        .at(5)
-        .containsMatchingElement(<div>RAM 24</div>)
+    expect(container.querySelector('[data-cy="cpu-capacity"]')).toHaveTextContent(
+      'CPU 24'
     );
-    const forksTextData = wrapper.find('InstanceListItem__SliderForks').text();
-    expect(forksTextData).toContain('10');
-    expect(forksTextData).toContain('forks');
+    expect(container.querySelector('[data-cy="mem-capacity"]')).toHaveTextContent(
+      'RAM 1'
+    );
+    expect(container.querySelector('[data-cy="number-forks"]')).toHaveTextContent(
+      '10 forks'
+    );
   });
 
-  test('should render checkbox', async () => {
-    const onSelect = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceListItem
-              instance={instance[0]}
-              onSelect={onSelect}
-              fetchInstances={() => {}}
-            />
-          </tbody>
-        </table>
-      );
+  test('moving the slider up recalculates forks and updates capacity', async () => {
+    InstancesAPI.update.mockResolvedValue({ data: {} });
+    const { container, user } = renderItem();
+    const forks = () =>
+      container.querySelector('[data-cy="number-forks"]').textContent;
+
+    // capacity_adjustment 0.40 -> floor(1 + 23*0.4) = 10 forks
+    expect(forks()).toContain('10 forks');
+
+    // jsdom has no layout, so a keyboard ArrowRight on the PF slider snaps the
+    // value to the max (1.0) -> floor(1 + 23*1) = 24 forks. The handler also
+    // pushes the rounded capacity_adjustment to the API.
+    screen.getByRole('slider').focus();
+    await user.keyboard('{ArrowRight}');
+    await waitFor(() => expect(forks()).toContain('24 forks'));
+    expect(InstancesAPI.update).toHaveBeenCalledWith(1, {
+      capacity_adjustment: 1,
     });
-    expect(wrapper.find('Td').at(1).prop('select').onSelect).toEqual(onSelect);
+  });
+
+  test('moving the slider down recalculates forks', async () => {
+    InstancesAPI.update.mockResolvedValue({ data: {} });
+    const { container, user } = renderItem();
+    const forks = () =>
+      container.querySelector('[data-cy="number-forks"]').textContent;
+
+    expect(forks()).toContain('10 forks');
+
+    // ArrowLeft steps the slider down by one 0.1 step: 0.40 -> 0.30 ->
+    // floor(1 + 23*0.3) = 7 forks.
+    screen.getByRole('slider').focus();
+    await user.keyboard('{ArrowLeft}');
+    await waitFor(() => expect(forks()).toContain('7 forks'));
+    expect(InstancesAPI.update).toHaveBeenCalledWith(1, {
+      capacity_adjustment: 0.3,
+    });
+  });
+
+  test('should render checkbox wired to onSelect', async () => {
+    const onSelect = jest.fn();
+    const { user } = renderItem({ onSelect });
+    const row = screen.getByRole('link', { name: 'awx' }).closest('tr');
+    // The first checkbox in the row is the row-select; the toggle is named.
+    const checkbox = within(row)
+      .getAllByRole('checkbox')
+      .find((box) => box.getAttribute('aria-label') !== 'Toggle instance');
+    await user.click(checkbox);
+    expect(onSelect).toHaveBeenCalled();
   });
 
   test('should display instance toggle', () => {
-    expect(wrapper.find('InstanceToggle').length).toBe(1);
+    renderItem();
+    expect(
+      screen.getByRole('checkbox', { name: 'Toggle instance' })
+    ).toBeInTheDocument();
   });
 
-  test('should display error', async () => {
-    jest.useFakeTimers();
-    InstancesAPI.update.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'patch',
-            url: '/api/v2/instances/1',
-            data: { capacity_adjustment: 0.30001 },
-          },
-          data: {
-            capacity_adjustment: [
-              'Ensure that there are no more than 3 digits in total.',
-            ],
-          },
-          status: 400,
-          statusText: 'Bad Request',
-        },
-      })
+  test('should display error when capacity update fails', async () => {
+    InstancesAPI.update.mockRejectedValue(new Error());
+    const { user } = renderItem();
+    expect(screen.queryByText('Error!')).not.toBeInTheDocument();
+
+    const slider = screen.getByRole('slider');
+    slider.focus();
+    await user.keyboard('{ArrowRight}');
+
+    await waitFor(() => expect(InstancesAPI.update).toHaveBeenCalled());
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+  });
+
+  test('should render expanded row with the correct data points', () => {
+    renderItem({ isExpanded: true });
+    expect(screen.getByText('Running Jobs').nextElementSibling).toHaveTextContent(
+      '0'
     );
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceListItem
-              instance={instance[0]}
-              isSelected={false}
-              onSelect={() => {}}
-              fetchInstances={() => {}}
-            />
-          </tbody>
-        </table>,
-        { context: { network: { handleHttpError: () => {} } } }
-      );
-    });
-    await act(async () => {
-      wrapper.update();
-    });
-    expect(wrapper.find('ErrorDetail').length).toBe(0);
-    await act(async () => {
-      wrapper.find('Slider').prop('onChange')(0.30001);
-    });
-    await act(async () => {
-      wrapper.update();
-    });
-    jest.advanceTimersByTime(210);
-    await act(async () => {
-      wrapper.update();
-    });
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
-  });
-
-  test('Should render expanded row with the correct data points', async () => {
-    const onSelect = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <table>
-          <tbody>
-            <InstanceListItem
-              instance={instance[0]}
-              onSelect={onSelect}
-              fetchInstances={() => {}}
-              isExpanded
-            />
-          </tbody>
-        </table>
-      );
-    });
-    expect(wrapper.find('InstanceListItem').prop('isExpanded')).toBe(true);
-    expect(wrapper.find('Detail[label="Running Jobs"]').prop('value')).toBe(0);
-    expect(wrapper.find('Detail[label="Total Jobs"]').prop('value')).toBe(68);
-    expect(wrapper.find('Detail[label="Policy Type"]').prop('value')).toBe(
+    expect(screen.getByText('Total Jobs').nextElementSibling).toHaveTextContent(
+      '68'
+    );
+    expect(screen.getByText('Policy Type').nextElementSibling).toHaveTextContent(
       'Auto'
     );
-    expect(wrapper.find('Detail[label="Last Health Check"]').text()).toBe(
-      'Last Health Check9/15/2021, 6:02:07 PM'
-    );
+    expect(
+      screen.getByText('Last Health Check').parentElement
+    ).toHaveTextContent('9/15/2021, 6:02:07 PM');
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/shared/ContainerGroupForm.test.js
+++ b/awx/ui/src/screens/InstanceGroup/shared/ContainerGroupForm.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
+import { CredentialsAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import ContainerGroupForm from './ContainerGroupForm';
 
@@ -70,22 +71,17 @@ const initialPodSpec = {
 };
 
 describe('<ContainerGroupForm/>', () => {
-  let wrapper;
   let onCancel;
   let onSubmit;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     onCancel = jest.fn();
     onSubmit = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ContainerGroupForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          instanceGroup={instanceGroup}
-          initialPodSpec={initialPodSpec}
-        />
-      );
+    CredentialsAPI.read.mockResolvedValue({
+      data: { count: 0, results: [] },
+    });
+    CredentialsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} }, related_search_fields: [] },
     });
   });
 
@@ -93,57 +89,65 @@ describe('<ContainerGroupForm/>', () => {
     jest.clearAllMocks();
   });
 
-  test('Initially renders successfully', () => {
-    expect(wrapper.length).toBe(1);
+  function setup() {
+    return renderWithContexts(
+      <ContainerGroupForm
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        instanceGroup={instanceGroup}
+        initialPodSpec={initialPodSpec}
+      />
+    );
+  }
+
+  test('should display form fields properly', async () => {
+    const { container } = setup();
+    // FormField labelIcon Popovers break getByLabelText; query inputs by id.
+    expect(container.querySelector('#container-group-name')).toHaveValue('Bar');
+    // The "Customize pod specification" checkbox starts unchecked, so the
+    // pod-spec CodeEditor section is not rendered.
+    const overrideCheckbox = container.querySelector(
+      '#container-groups-override-pod-specification'
+    );
+    expect(overrideCheckbox).not.toBeChecked();
+    expect(screen.queryByText('Custom pod spec')).not.toBeInTheDocument();
+    // The CredentialLookup pre-fills the credential name from summary_fields.
+    // findBy awaits the lookup's async credential fetch settling.
+    expect(
+      await screen.findByRole('textbox', { name: /Credential/i })
+    ).toHaveValue('test');
   });
 
-  test('should display form fields properly', () => {
-    expect(wrapper.find('FormGroup[label="Name"]').length).toBe(1);
-    expect(wrapper.find('VariablesField[label="Custom pod spec"]').length).toBe(
-      0
+  test('checking customize pod specification reveals the pod spec editor', async () => {
+    const { user, container } = setup();
+    const overrideCheckbox = container.querySelector(
+      '#container-groups-override-pod-specification'
     );
-    expect(
-      wrapper
-        .find('Checkbox[aria-label="Customize pod specification"]')
-        .prop('isChecked')
-    ).toBeFalsy();
-    expect(wrapper.find('CredentialLookup').prop('value').name).toBe('test');
+    await user.click(overrideCheckbox);
+    expect(overrideCheckbox).toBeChecked();
+    // react-ace renders empty under jsdom, so assert the surrounding label.
+    expect(await screen.findByText('Custom pod spec')).toBeInTheDocument();
   });
 
   test('should update form values', async () => {
-    act(() => {
-      wrapper.find('CredentialLookup').invoke('onBlur')();
-      wrapper.find('CredentialLookup').invoke('onChange')({
-        id: 99,
-        name: 'credential',
-      });
-      wrapper.find('TextInputBase#container-group-name').simulate('change', {
-        target: { value: 'new Foo', name: 'name' },
-      });
-    });
-    await act(async () => {
-      wrapper.update();
-    });
-    expect(wrapper.find('CredentialLookup').prop('value')).toEqual({
-      id: 99,
-      name: 'credential',
-    });
-    expect(
-      wrapper.find('TextInputBase#container-group-name').prop('value')
-    ).toEqual('new Foo');
+    const { user, container } = setup();
+    const nameInput = container.querySelector('#container-group-name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'new Foo');
+    expect(nameInput).toHaveValue('new Foo');
   });
 
   test('should call onSubmit when form submitted', async () => {
+    const { user } = setup();
     expect(onSubmit).not.toHaveBeenCalled();
-    await act(async () => {
-      wrapper.find('button[aria-label="Save"]').simulate('click');
-    });
-    expect(onSubmit).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
   });
 
   test('should call handleCancel when Cancel button is clicked', async () => {
+    const { user } = setup();
     expect(onCancel).not.toHaveBeenCalled();
-    wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.test.js
+++ b/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import InstanceGroupForm from './InstanceGroupForm';
 
@@ -40,81 +40,70 @@ const instanceGroup = {
 };
 
 describe('<InstanceGroupForm/>', () => {
-  let wrapper;
   let onCancel;
   let onSubmit;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     onCancel = jest.fn();
     onSubmit = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <InstanceGroupForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          instanceGroup={instanceGroup}
-        />
-      );
-    });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-    wrapper.unmount();
   });
 
-  test('Initially renders successfully', () => {
-    expect(wrapper.length).toBe(1);
-  });
+  function setup() {
+    return renderWithContexts(
+      <InstanceGroupForm
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        instanceGroup={instanceGroup}
+      />
+    );
+  }
 
   test('should display form fields properly', () => {
-    expect(wrapper.find('FormGroup[label="Name"]').length).toBe(1);
+    const { container } = setup();
+    // FormField labelIcon Popovers break getByLabelText, so query inputs by id.
+    expect(container.querySelector('#instance-group-name')).toBeInTheDocument();
     expect(
-      wrapper.find('FormGroup[label="Policy instance minimum"]').length
-    ).toBe(1);
+      container.querySelector('#instance-group-policy-instance-minimum')
+    ).toBeInTheDocument();
     expect(
-      wrapper.find('FormGroup[label="Policy instance percentage"]').length
-    ).toBe(1);
+      container.querySelector('#instance-group-policy-instance-percentage')
+    ).toBeInTheDocument();
   });
 
   test('should call onSubmit when form submitted', async () => {
+    const { user } = setup();
     expect(onSubmit).not.toHaveBeenCalled();
-    await act(async () => {
-      wrapper.find('button[aria-label="Save"]').simulate('click');
-    });
-    expect(onSubmit).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
   });
 
   test('should update form values', async () => {
-    act(() => {
-      wrapper.find('input#instance-group-name').simulate('change', {
-        target: { value: 'Foo', name: 'name' },
-      });
-      wrapper
-        .find('input#instance-group-policy-instance-minimum')
-        .simulate('change', {
-          target: { value: 10, name: 'policy_instance_minimum' },
-        });
-    });
-    await act(async () => {
-      wrapper.update();
-    });
-    expect(wrapper.find('input#instance-group-name').prop('value')).toEqual(
-      'Foo'
+    const { user, container } = setup();
+    const nameInput = container.querySelector('#instance-group-name');
+    const minInput = container.querySelector(
+      '#instance-group-policy-instance-minimum'
     );
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Foo');
+    await user.clear(minInput);
+    await user.type(minInput, '10');
+
+    expect(nameInput).toHaveValue('Foo');
+    expect(minInput).toHaveValue(10);
     expect(
-      wrapper.find('input#instance-group-policy-instance-minimum').prop('value')
-    ).toEqual(10);
-    expect(
-      wrapper
-        .find('input#instance-group-policy-instance-percentage')
-        .prop('value')
-    ).toEqual(46);
+      container.querySelector('#instance-group-policy-instance-percentage')
+    ).toHaveValue(46);
   });
 
   test('should call handleCancel when Cancel button is clicked', async () => {
+    const { user } = setup();
     expect(onCancel).not.toHaveBeenCalled();
-    wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **InstanceGroup** screen's test suite from enzyme to React Testing Library, continuing the incremental enzyme → RTL migration (one screen directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`:

- InstanceGroup + ContainerGroup `Add` / `Edit` (shared forms mocked) and their `Form`s (pod-spec editor label asserted, not YAML text)
- InstanceGroup + ContainerGroup `Details` — fields, delete (related-count reads mocked) + error
- `InstanceGroupList` / `InstanceGroupListItem` — load, selection, bulk delete enable/disable
- `Instances` sublist (`InstanceList` / `InstanceListItem`, `InstanceDetails`) — capacity/forks sliders (keyboard), enable toggle, API updates

Interactions now go through accessible roles and real user events. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for the InstanceGroup directory: **17 suites, 81 tests, all passing.** ESLint clean. No production code changed — test-only.

A couple of enzyme-only no-op assertions (`wrapper.length === 1`, duplicate hidden-button cases) were folded into stronger behavioural checks, and one mislabeled list test was renamed to reflect the real mechanism (select-all disables Delete when a row lacks delete capability).
