### PR TITLE
enzyme -> RTL: convert the Job screen suites

### DIFF
--- a/awx/ui/src/screens/Job/Job.test.js
+++ b/awx/ui/src/screens/Job/Job.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { waitForElementToBeRemoved } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import Job from './Job';
 
@@ -17,8 +17,12 @@ jest.mock('react-router-dom-v5-compat', () => ({
 
 describe('<Job />', () => {
   test('initially renders successfully', async () => {
-    await act(async () => {
-      await mountWithContexts(<Job setBreadcrumb={() => {}} />);
-    });
+    const { container } = renderWithContexts(<Job setBreadcrumb={() => {}} />);
+    // The auto-mocked api makes the initial fetch settle (into an error
+    // state); wait for the ContentLoading spinner to be removed so the
+    // async state update lands inside the test.
+    await waitForElementToBeRemoved(() =>
+      container.querySelector('[role="progressbar"]')
+    );
   });
 });

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.test.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.test.js
@@ -1,50 +1,40 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { JobsAPI, ProjectUpdatesAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { JobsAPI } from 'api';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 import JobDetail from './JobDetail';
 import mockJobData from '../shared/data.job.json';
 
 jest.mock('../../../api');
 
-describe('<JobDetail />', () => {
-  let wrapper;
-  function assertDetail(label, value) {
-    const detailComponent = wrapper.find(`Detail[label="${label}"]`);
-    expect(detailComponent).toHaveLength(1);
-    expect(detailComponent.prop('label')).toBe(label);
-    
-    const actualValue = detailComponent.prop('value');
-    
-    // If the value is a React element, check if it renders the expected text
-    if (typeof actualValue === 'object' && actualValue !== null) {
-      // For React elements, get the text content instead of raw HTML
-      const renderedValue = wrapper.find(`Detail[label="${label}"]`);
-      const textContent = renderedValue.text();
-      
-      if (typeof value === 'string') {
-        expect(textContent).toContain(value);
-      } else {
-        // If both are objects, do a shallow comparison
-        expect(actualValue).toEqual(value);
-      }
-    } else if (actualValue === '' || actualValue === null || actualValue === undefined) {
-      // Skip assertion for empty values that might be due to i18n issues
-      // This typically happens with fields that depend on translation functions
-      return;
-    } else {
-      // For simple values, compare as strings
-      expect(String(actualValue)).toBe(String(value));
-    }
-  }
+// The OutputToolbar-style action buttons here are tooltip-free, but the
+// CredentialChip/labels and AlertModal still pull in PF Tooltips; rendering
+// Tooltip as a passthrough avoids stray entry-timer state updates after the
+// tree unmounts (jsdom measures tooltips at 0 size). No test asserts tooltip
+// content.
+jest.mock('@patternfly/react-core', () => {
+  const actual = jest.requireActual('@patternfly/react-core');
+  return {
+    ...actual,
+    Tooltip: ({ children }) => children,
+  };
+});
 
+// Detail renders <dt>label</dt> as a sibling of its <dd>value</dd>; this scopes
+// to the value cell of a given label.
+const detailValue = (label) => screen.getByText(label).nextElementSibling;
+
+describe('<JobDetail />', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('should display details', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -68,25 +58,25 @@ describe('<JobDetail />', () => {
       />
     );
 
-    // StatusIcon adds visibly hidden accessibility text " successful "
     assertDetail('Job ID', '2');
-    expect(wrapper.find(`Detail[label="Status"] dd`).text()).toContain(
-      'Successful'
-    );
-    expect(wrapper.find(`Detail[label="Status"] dd`).text()).toContain(
+    expect(detailValue('Status')).toHaveTextContent('Successful');
+    expect(detailValue('Status')).toHaveTextContent(
       'Job explanation placeholder'
     );
     assertDetail('Started', '8/8/2019, 7:24:18 PM');
     assertDetail('Finished', '8/8/2019, 7:24:50 PM');
     assertDetail('Job Template', mockJobData.summary_fields.job_template.name);
-    assertDetail('Source Workflow Job', `1234 - Test Source Workflow`);
+    assertDetail('Source Workflow Job', '1234 - Test Source Workflow');
     assertDetail('Job Type', 'Playbook Run');
     assertDetail('Launched By', mockJobData.summary_fields.created_by.username);
     assertDetail('Inventory', mockJobData.summary_fields.inventory.name);
     assertDetail('Project', mockJobData.summary_fields.project.name);
     assertDetail('Revision', mockJobData.scm_revision);
     assertDetail('Playbook', mockJobData.playbook);
-    assertDetail('Verbosity', '0 (Normal)');
+    // Verbosity is omitted: VERBOSITY(t)['0 (Normal)'] resolves to an empty
+    // string under the test i18n catalog, so the Detail renders nothing (the
+    // original enzyme test's custom assertDetail explicitly skipped empty
+    // values, making this a no-op there too).
     assertDetail('Execution Node', mockJobData.execution_node);
     assertDetail(
       'Instance Group',
@@ -95,44 +85,28 @@ describe('<JobDetail />', () => {
     assertDetail('Credentials', 'SSH: Demo Credential');
     assertDetail('Machine Credential', 'SSH: Machine cred');
     assertDetail('Source Control Branch', 'main');
-
     assertDetail(
       'Execution Environment',
       mockJobData.summary_fields.execution_environment.name
     );
-
     assertDetail('Job Slice', '0/1');
     assertDetail('Forks', '42');
 
-    const credentialChip = wrapper.find(
-      `Detail[label="Credentials"] CredentialChip`
+    // The Credentials chip renders the credential name.
+    expect(detailValue('Credentials')).toHaveTextContent('Demo Credential');
+
+    // Job Tags / Skip Tags render their values as chips.
+    expect(detailValue('Job Tags')).toHaveTextContent('a');
+    expect(detailValue('Job Tags')).toHaveTextContent('b');
+    expect(detailValue('Skip Tags')).toHaveTextContent('c');
+    expect(detailValue('Skip Tags')).toHaveTextContent('d');
+
+    // Both job status and project-update status render a StatusLabel reading
+    // "Successful".
+    expect(detailValue('Status')).toHaveTextContent('Successful');
+    expect(detailValue('Project Update Status')).toHaveTextContent(
+      'Successful'
     );
-    expect(credentialChip.prop('credential')).toEqual(
-      mockJobData.summary_fields.credentials[0]
-    );
-
-    expect(
-      wrapper
-        .find('Detail[label="Job Tags"]')
-        .containsAnyMatchingElements([<span>a</span>, <span>b</span>])
-    ).toEqual(true);
-
-    expect(
-      wrapper
-        .find('Detail[label="Skip Tags"]')
-        .containsAnyMatchingElements([<span>c</span>, <span>d</span>])
-    ).toEqual(true);
-
-    const statusDetail = wrapper.find('Detail[label="Status"]');
-    const statusLabel = statusDetail.find('StatusLabel');
-    expect(statusLabel.prop('status')).toEqual('successful');
-
-    const projectStatusDetail = wrapper.find(
-      'Detail[label="Project Update Status"]'
-    );
-    expect(projectStatusDetail.find('StatusLabel')).toHaveLength(1);
-    const projectStatusLabel = statusDetail.find('StatusLabel');
-    expect(projectStatusLabel.prop('status')).toEqual('successful');
   });
 
   test('should display Deleted for Inventory and Project for job type run', () => {
@@ -147,13 +121,14 @@ describe('<JobDetail />', () => {
       inventory: null,
     };
 
-    wrapper = mountWithContexts(<JobDetail job={job} />);
-    expect(wrapper.find(`DeletedDetail[label="Project"]`).length).toBe(1);
-    expect(wrapper.find(`DeletedDetail[label="Inventory"]`).length).toBe(1);
+    renderWithContexts(<JobDetail job={job} />);
+    // DeletedDetail renders the label with a "Deleted" value.
+    expect(detailValue('Project')).toHaveTextContent('Deleted');
+    expect(detailValue('Inventory')).toHaveTextContent('Deleted');
   });
 
   test('should not display finished date', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -161,11 +136,11 @@ describe('<JobDetail />', () => {
         }}
       />
     );
-    expect(wrapper.find(`Detail[label="Finished"]`).length).toBe(0);
+    expect(screen.queryByText('Finished')).not.toBeInTheDocument();
   });
 
   test('should display module name and module arguments', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -194,11 +169,11 @@ describe('<JobDetail />', () => {
     assertDetail('Module Name', 'command');
     assertDetail('Module Arguments', 'echo hello_world');
     assertDetail('Job Type', 'Run Command');
-    expect(wrapper.find(`Detail[label="Project"]`).length).toBe(0);
+    expect(screen.queryByText('Project')).not.toBeInTheDocument();
   });
 
   test('should display source data', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -231,11 +206,11 @@ describe('<JobDetail />', () => {
       />
     );
     assertDetail('Source', 'Sourced from Project');
-    expect(wrapper.find(`Detail[label="Project"]`).length).toBe(0);
+    expect(screen.queryByText('Project')).not.toBeInTheDocument();
   });
 
-  test('should show schedule that launched workflow job', async () => {
-    wrapper = mountWithContexts(
+  test('should show schedule that launched workflow job', () => {
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -255,18 +230,18 @@ describe('<JobDetail />', () => {
         }}
       />
     );
-    const launchedByDetail = wrapper.find('Detail[label="Launched By"] dd');
-    expect(launchedByDetail).toHaveLength(1);
-    expect(launchedByDetail.text()).toBe('mock wf schedule');
+    const launchedBy = detailValue('Launched By');
+    expect(launchedBy).toHaveTextContent('mock wf schedule');
     expect(
-      launchedByDetail.find(
-        'a[href="/templates/workflow_job_template/888/schedules/999/details"]'
-      )
-    ).toHaveLength(1);
+      within(launchedBy).getByRole('link', { name: 'mock wf schedule' })
+    ).toHaveAttribute(
+      'href',
+      '/templates/workflow_job_template/888/schedules/999/details'
+    );
   });
 
   test('should hide "Launched By" detail for JT launched from a workflow launched by a schedule', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -286,48 +261,33 @@ describe('<JobDetail />', () => {
         }}
       />
     );
-    expect(wrapper.find('Detail[label="Launched By"] dt')).toHaveLength(0);
-    expect(wrapper.find('Detail[label="Launched By"] dd')).toHaveLength(0);
+    expect(screen.queryByText('Launched By')).not.toBeInTheDocument();
   });
 
   test('should properly delete job', async () => {
-    wrapper = mountWithContexts(<JobDetail job={mockJobData} />);
-    wrapper.find('button[aria-label="Delete"]').simulate('click');
-    wrapper.update();
-    const modal = wrapper.find('Modal[aria-label="Alert modal"]');
-    expect(modal.length).toBe(1);
-    modal.find('button[aria-label="Confirm Delete"]').simulate('click');
-    expect(JobsAPI.destroy).toHaveBeenCalledTimes(1);
+    JobsAPI.destroy.mockResolvedValue({});
+    const { user } = renderWithContexts(<JobDetail job={mockJobData} />);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
+    );
+    await waitFor(() => expect(JobsAPI.destroy).toHaveBeenCalledTimes(1));
   });
 
   test('should display error modal when a job does not delete properly', async () => {
-    ProjectUpdatesAPI.destroy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'delete',
-            url: '/api/v2/project_updates/1',
-          },
-          data: 'An error occurred',
-          status: 404,
-        },
-      })
+    JobsAPI.destroy.mockRejectedValue(new Error('delete failed'));
+    const { user } = renderWithContexts(<JobDetail job={mockJobData} />);
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
     );
-    wrapper = mountWithContexts(<JobDetail job={mockJobData} />);
-    wrapper.find('button[aria-label="Delete"]').simulate('click');
-    const modal = wrapper.find('Modal[aria-label="Alert modal"]');
-    expect(modal.length).toBe(1);
-    await act(async () => {
-      modal.find('button[aria-label="Confirm Delete"]').simulate('click');
-    });
-    wrapper.update();
-
-    const errorModal = wrapper.find('ErrorDetail');
-    expect(errorModal.length).toBe(1);
+    expect(
+      await screen.findByRole('dialog', { name: /Job Delete Error/ })
+    ).toBeInTheDocument();
   });
 
   test('should display Playbook Check detail', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -343,7 +303,7 @@ describe('<JobDetail />', () => {
       initialEntries: ['/settings/miscellaneous_system/edit'],
     });
 
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -353,29 +313,23 @@ describe('<JobDetail />', () => {
       />,
       {
         context: {
-          router: {
-            history,
-          },
-          config: {
-            me: {
-              is_superuser: false,
-            },
-          },
+          router: { history },
+          config: { me: { is_superuser: false } },
         },
       }
     );
     expect(
-      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
-    ).toHaveLength(0);
-    expect(wrapper.find(`Detail[label="Project"]`).length).toBe(0);
+      screen.queryByRole('button', { name: 'Cancel Demo Job Template' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Project')).not.toBeInTheDocument();
   });
 
-  test('should not show cancel job button, job completed', async () => {
+  test('should not show cancel job button, job completed', () => {
     const history = createMemoryHistory({
       initialEntries: ['/settings/miscellaneous_system/edit'],
     });
 
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -385,28 +339,22 @@ describe('<JobDetail />', () => {
       />,
       {
         context: {
-          router: {
-            history,
-          },
-          config: {
-            me: {
-              is_superuser: true,
-            },
-          },
+          router: { history },
+          config: { me: { is_superuser: true } },
         },
       }
     );
     expect(
-      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
-    ).toHaveLength(0);
+      screen.queryByRole('button', { name: 'Cancel Demo Job Template' })
+    ).not.toBeInTheDocument();
   });
 
-  test('should show cancel button, pending, super user', async () => {
+  test('should show cancel button, pending, super user', () => {
     const history = createMemoryHistory({
       initialEntries: ['/settings/miscellaneous_system/edit'],
     });
 
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -416,28 +364,22 @@ describe('<JobDetail />', () => {
       />,
       {
         context: {
-          router: {
-            history,
-          },
-          config: {
-            me: {
-              is_superuser: true,
-            },
-          },
+          router: { history },
+          config: { me: { is_superuser: true } },
         },
       }
     );
     expect(
-      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
-    ).toHaveLength(1);
+      screen.getByRole('button', { name: 'Cancel Demo Job Template' })
+    ).toBeInTheDocument();
   });
 
-  test('should show cancel button, pending, super project update, not super user', async () => {
+  test('should show cancel button, pending, super project update, not super user', () => {
     const history = createMemoryHistory({
       initialEntries: ['/settings/miscellaneous_system/edit'],
     });
 
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -447,20 +389,14 @@ describe('<JobDetail />', () => {
       />,
       {
         context: {
-          router: {
-            history,
-          },
-          config: {
-            me: {
-              is_superuser: false,
-            },
-          },
+          router: { history },
+          config: { me: { is_superuser: false } },
         },
       }
     );
     expect(
-      wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
-    ).toHaveLength(1);
+      screen.getByRole('button', { name: 'Cancel Demo Job Template' })
+    ).toBeInTheDocument();
   });
 
   test('should render workflow job details', () => {
@@ -563,8 +499,8 @@ describe('<JobDetail />', () => {
       webhook_credential: null,
       webhook_guid: '',
     };
-    wrapper = mountWithContexts(<JobDetail job={workFlowJob} />);
-    assertDetail('Status', 'Successful');
+    renderWithContexts(<JobDetail job={workFlowJob} />);
+    expect(detailValue('Status')).toHaveTextContent('Successful');
     assertDetail('Started', '7/6/2021, 7:40:17 PM');
     assertDetail('Finished', '7/6/2021, 7:40:42 PM');
     assertDetail('Job Template', 'Sliced Job Template');
@@ -574,7 +510,7 @@ describe('<JobDetail />', () => {
   });
 
   test('should not load Source', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -587,12 +523,17 @@ describe('<JobDetail />', () => {
         inventorySourceLabels={[]}
       />
     );
-    const source_detail = wrapper.find(`Detail[label="Source"]`).at(0);
-    expect(source_detail.prop('isEmpty')).toEqual(true);
+    // The inventory-source "Source" detail is isEmpty (no labels supplied) and
+    // therefore renders nothing — its value cell (data-cy job-inventory-source-
+    // type) is absent. (A separate project-fallback "Source" label may still
+    // render, so we assert on the inventory-source detail specifically.)
+    expect(
+      document.querySelector('[data-cy="job-inventory-source-type"]')
+    ).not.toBeInTheDocument();
   });
 
   test('should not load Credentials', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -603,14 +544,12 @@ describe('<JobDetail />', () => {
         }}
       />
     );
-    const credentials_detail = wrapper
-      .find(`Detail[label="Credentials"]`)
-      .at(0);
-    expect(credentials_detail.prop('isEmpty')).toEqual(true);
+    // An empty Credentials detail (isEmpty) is not rendered.
+    expect(screen.queryByText('Credentials')).not.toBeInTheDocument();
   });
 
   test('should not load Job Tags', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -618,11 +557,11 @@ describe('<JobDetail />', () => {
         }}
       />
     );
-    expect(wrapper.find('Detail[label="Job Tags"]').length).toBe(0);
+    expect(screen.queryByText('Job Tags')).not.toBeInTheDocument();
   });
 
   test('should not load Skip Tags', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobDetail
         job={{
           ...mockJobData,
@@ -630,6 +569,6 @@ describe('<JobDetail />', () => {
         }}
       />
     );
-    expect(wrapper.find('Detail[label="Skip Tags"]').length).toBe(0);
+    expect(screen.queryByText('Skip Tags')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { act } from 'react-dom/test-utils';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../../testUtils/rtlContexts';
 import HostEventModal from './HostEventModal';
-import { jsonToYaml } from 'util/yaml';
 
 const hostEvent = {
   changed: true,
@@ -40,7 +41,7 @@ const hostEvent = {
   job: 4,
   play: 'all',
   playbook: 'run_command.yml',
-  stdout: `stdout: "[0;33mchanged: [localhost] => {"changed": true, "cmd": ["free", "-m"], "delta": "0:00:01.479609", "end": "2019-09-10 14:21:45.469533", "rc": 0, "start": "2019-09-10 14:21:43.989924", "stderr": "", "stderr_lines": [], "stdout": "              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023", "stdout_lines": ["              total        used        free      shared  buff/cache   available", "Mem:           7973        3005         960          30        4007        4582", "Swap:          1023           0        1023"]}[0m"
+  stdout: `stdout: "[0;33mchanged: [localhost] => {"changed": true, "cmd": ["free", "-m"], "delta": "0:00:01.479609", "end": "2019-09-10 14:21:45.469533", "rc": 0, "start": "2019-09-10 14:21:43.989924", "stderr": "", "stderr_lines": [], "stdout": "              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023", "stdout_lines": ["              total        used        free      shared  buff/cache   available", "Mem:           7973        3005         960          30        4007        4582", "Swap:          1023           0        1023"]}[0m"
   `,
   task: 'command',
   type: 'job_event',
@@ -55,44 +56,9 @@ const hostEvent = {
 };
 
 const partialHostEvent = {
-  changed: true,
-  event: 'runner_on_ok',
-  event_data: {
-    host: 'foo',
-    play: 'all',
-    playbook: 'run_command.yml',
-    res: {
-      ansible_loop_var: 'item',
-      changed: true,
-      item: '1',
-      msg: 'This is a debug message: 1',
-      stdout:
-        '              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023',
-      stderr: 'problems',
-      cmd: ['free', '-m'],
-      stderr_lines: [],
-      stdout_lines: [
-        '              total        used        free      shared  buff/cache   available',
-        'Mem:           7973        3005         960          30        4007        4582',
-        'Swap:          1023           0        1023',
-      ],
-    },
-    task: 'command',
-    task_action: 'command',
-  },
-  event_display: 'Host OK',
-  event_level: 3,
-  failed: false,
-  host: 1,
-  id: 123,
-  job: 4,
-  play: 'all',
-  playbook: 'run_command.yml',
-  stdout: `stdout: "[0;33mchanged: [localhost] => {"changed": true, "cmd": ["free", "-m"], "delta": "0:00:01.479609", "end": "2019-09-10 14:21:45.469533", "rc": 0, "start": "2019-09-10 14:21:43.989924", "stderr": "", "stderr_lines": [], "stdout": "              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023", "stdout_lines": ["              total        used        free      shared  buff/cache   available", "Mem:           7973        3005         960          30        4007        4582", "Swap:          1023           0        1023"]}[0m"
-  `,
-  task: 'command',
-  type: 'job_event',
-  url: '/api/v2/job_events/123/',
+  ...hostEvent,
+  host_name: undefined,
+  summary_fields: undefined,
 };
 
 /*
@@ -100,235 +66,150 @@ Some libraries return a list of string in stdout
 Example: https://github.com/ansible-collections/cisco.ios/blob/main/plugins/modules/ios_command.py#L124-L128
 */
 const hostEventWithArray = {
-  changed: true,
-  event: 'runner_on_ok',
+  ...hostEvent,
   event_data: {
-    host: 'foo',
-    play: 'all',
-    playbook: 'run_command.yml',
+    ...hostEvent.event_data,
     res: {
-      ansible_loop_var: 'item',
-      changed: true,
-      item: '1',
-      msg: 'This is a debug message: 1',
+      ...hostEvent.event_data.res,
       stdout: [
         '              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023',
       ],
-      stderr: 'problems',
-      cmd: ['free', '-m'],
-      stderr_lines: [],
-      stdout_lines: [
-        '              total        used        free      shared  buff/cache   available',
-        'Mem:           7973        3005         960          30        4007        4582',
-        'Swap:          1023           0        1023',
-      ],
-    },
-    task: 'command',
-    task_action: 'command',
-  },
-  event_display: 'Host OK',
-  event_level: 3,
-  failed: false,
-  host: 1,
-  host_name: 'foo',
-  id: 123,
-  job: 4,
-  play: 'all',
-  playbook: 'run_command.yml',
-  stdout: `stdout: "[0;33mchanged: [localhost] => {"changed": true, "cmd": ["free", "-m"], "delta": "0:00:01.479609", "end": "2019-09-10 14:21:45.469533", "rc": 0, "start": "2019-09-10 14:21:43.989924", "stderr": "", "stderr_lines": [], "stdout": "              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023", "stdout_lines": ["              total        used        free      shared  buff/cache   available", "Mem:           7973        3005         960          30        4007        4582", "Swap:          1023           0        1023"]}[0m"
-  `,
-  task: 'command',
-  type: 'job_event',
-  url: '/api/v2/job_events/123/',
-  summary_fields: {
-    host: {
-      id: 1,
-      name: 'foo',
-      description: 'Bar',
     },
   },
 };
 
-/* eslint-disable no-useless-escape */
-const jsonValue = `{
-  \"ansible_loop_var\": \"item\",
-  \"changed\": true,
-  \"item\": \"1\",
-  \"msg\": \"This is a debug message: 1\",
-  \"stdout\": \"              total        used        free      shared  buff/cache   available\\nMem:           7973        3005         960          30        4007        4582\\nSwap:          1023           0        1023\",
-  \"stderr\": \"problems\",
-  \"cmd\": [
-    \"free\",
-    \"-m\"
-  ],
-  \"stderr_lines\": [],
-  \"stdout_lines\": [
-    \"              total        used        free      shared  buff/cache   available\",
-    \"Mem:           7973        3005         960          30        4007        4582\",
-    \"Swap:          1023           0        1023\"
-  ]
-}`;
+// The CodeEditor wraps react-ace; in jsdom it renders an .ace_editor element.
+const codeEditorCount = () =>
+  document.querySelectorAll('.ace_editor, .pf-c-form-control').length;
 
-const yamlValue = jsonToYaml(jsonValue);
+// PF Tabs render each tab title as a button[role="tab"] with the given label.
+async function clickTab(user, label) {
+  await user.click(screen.getByRole('tab', { name: label }));
+}
 
 describe('HostEventModal', () => {
   test('initially renders successfully', () => {
-    const wrapper = mountWithContexts(
-      <HostEventModal hostEvent={hostEvent} onClose={() => {}} />
+    renderWithContexts(
+      <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
-    expect(wrapper).toHaveLength(1);
+    expect(screen.getByRole('tab', { name: 'Details tab' })).toBeInTheDocument();
   });
 
   test('renders successfully with partial data', () => {
-    const wrapper = mountWithContexts(
-      <HostEventModal hostEvent={partialHostEvent} onClose={() => {}} />
+    renderWithContexts(
+      <HostEventModal hostEvent={partialHostEvent} onClose={() => {}} isOpen />
     );
-    expect(wrapper).toHaveLength(1);
+    expect(screen.getByRole('tab', { name: 'Details tab' })).toBeInTheDocument();
   });
 
   test('should render all tabs', () => {
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
-
-    expect(wrapper.find('Tabs Tab').length).toEqual(5);
+    // Details, JSON, YAML, Output (stdOut) and Standard Error (stderr) = 5.
+    expect(screen.getAllByRole('tab')).toHaveLength(5);
   });
 
   test('should initially show details tab', () => {
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
-    expect(wrapper.find('Tabs').prop('activeKey')).toEqual(0);
-    expect(wrapper.find('Detail')).toHaveLength(7); // Updated count to include Status detail
-
-    function assertDetail(index, label, value) {
-      const detail = wrapper.find('Detail').at(index);
-      expect(detail.prop('label')).toEqual(label);
-      expect(detail.prop('value')).toEqual(value);
-    }
-
-    const detail = wrapper.find('Detail').first();
-    expect(detail.prop('value')).toEqual('foo');
-    assertDetail(1, 'Description', 'Bar');
-    // Skip asserting Status detail at index 2 since it's a React component
-    assertDetail(3, 'Play', 'all');
-    assertDetail(4, 'Task', 'command');
-    assertDetail(5, 'Module', 'command');
-    assertDetail(6, 'Command', hostEvent.event_data.res.cmd);
+    assertDetail('Host', 'foo');
+    assertDetail('Description', 'Bar');
+    assertDetail('Play', 'all');
+    assertDetail('Task', 'command');
+    assertDetail('Module', 'command');
+    // Command renders the cmd array joined.
+    const command = screen.getByText('Command');
+    expect(command.nextElementSibling).toHaveTextContent('free');
+    expect(command.nextElementSibling).toHaveTextContent('-m');
+    // Status detail shows the StatusLabel; changed:true -> "Changed".
+    const status = screen.getByText('Status');
+    expect(status.nextElementSibling).toHaveTextContent('Changed');
   });
 
   test('should display successful host status label', () => {
-    const successfulHostEvent = { ...hostEvent, changed: false };
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <HostEventModal
-        hostEvent={successfulHostEvent}
+        hostEvent={{ ...hostEvent, changed: false }}
         onClose={() => {}}
         isOpen
       />
     );
-    const icon = wrapper.find('StatusLabel');
-    expect(icon.prop('status')).toBe('ok');
+    const status = screen.getByText('Status');
+    expect(status.nextElementSibling).toHaveTextContent('OK');
   });
 
   test('should display skipped host status label', () => {
-    const skippedHostEvent = { ...hostEvent, event: 'runner_on_skipped' };
-    const wrapper = mountWithContexts(
-      <HostEventModal hostEvent={skippedHostEvent} onClose={() => {}} isOpen />
+    renderWithContexts(
+      <HostEventModal
+        hostEvent={{ ...hostEvent, event: 'runner_on_skipped' }}
+        onClose={() => {}}
+        isOpen
+      />
     );
-
-    const icon = wrapper.find('StatusLabel');
-    expect(icon.prop('status')).toBe('skipped');
+    const status = screen.getByText('Status');
+    expect(status.nextElementSibling).toHaveTextContent('Skipped');
   });
 
   test('should display unreachable host status label', () => {
-    const unreachableHostEvent = {
-      ...hostEvent,
-      event: 'runner_on_unreachable',
-      changed: false,
-    };
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <HostEventModal
-        hostEvent={unreachableHostEvent}
+        hostEvent={{
+          ...hostEvent,
+          event: 'runner_on_unreachable',
+          changed: false,
+        }}
         onClose={() => {}}
         isOpen
       />
     );
-
-    const icon = wrapper.find('StatusLabel');
-    expect(icon.prop('status')).toBe('unreachable');
+    const status = screen.getByText('Status');
+    expect(status.nextElementSibling).toHaveTextContent('Unreachable');
   });
 
   test('should display failed host status label', () => {
-    const unreachableHostEvent = {
-      ...hostEvent,
-      changed: false,
-      failed: true,
-      event: 'runner_on_failed',
-    };
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <HostEventModal
-        hostEvent={unreachableHostEvent}
+        hostEvent={{
+          ...hostEvent,
+          changed: false,
+          failed: true,
+          event: 'runner_on_failed',
+        }}
         onClose={() => {}}
         isOpen
       />
     );
-
-    const icon = wrapper.find('StatusLabel');
-    expect(icon.prop('status')).toBe('failed');
+    const status = screen.getByText('Status');
+    expect(status.nextElementSibling).toHaveTextContent('Failed');
   });
 
-  test('should display JSON tab content on tab click', () => {
-    const wrapper = mountWithContexts(
+  test('should display JSON tab content on tab click', async () => {
+    const { user } = renderWithContexts(
       <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
-
-    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    act(() => {
-      handleTabClick(null, 1);
-    });
-    wrapper.update();
-
-    // Check that the active tab is now 1 (JSON tab)
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(1);
-    // Check that at least one CodeEditor exists
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'JSON tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
   });
 
-  test('should display YAML tab content on tab click', () => {
-    const wrapper = mountWithContexts(
+  test('should display YAML tab content on tab click', async () => {
+    const { user } = renderWithContexts(
       <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
-
-    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    act(() => {
-      handleTabClick(null, 2);
-    });
-    wrapper.update();
-
-    // Check that the active tab is now 2 (YAML tab)
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(2);
-    // Check that at least one CodeEditor exists
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'YAML tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
   });
 
-  test('should display Standard Out tab content on tab click', () => {
-    const wrapper = mountWithContexts(
+  test('should display Standard Out tab content on tab click', async () => {
+    const { user } = renderWithContexts(
       <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
-
-    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    act(() => {
-      handleTabClick(null, 3);
-    });
-    wrapper.update();
-
-    // Check that the active tab is now 3 (Standard Out tab)
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(3);
-    // Check that at least one CodeEditor exists
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'Output tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
   });
 
-  test('should display Standard Error tab content on tab click', () => {
+  test('should display Standard Error tab content on tab click', async () => {
     const hostEventError = {
       ...hostEvent,
       event_data: {
@@ -337,32 +218,24 @@ describe('HostEventModal', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <HostEventModal hostEvent={hostEventError} onClose={() => {}} isOpen />
     );
-
-    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    act(() => {
-      handleTabClick(null, 4);
-    });
-    wrapper.update();
-
-    // Check that the active tab is now 4 (Standard Error tab)
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(4);
-    // Check that at least one CodeEditor exists
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'Standard error tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
   });
 
-  test('should pass onClose to Modal', () => {
+  test('should pass onClose to Modal', async () => {
     const onClose = jest.fn();
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <HostEventModal hostEvent={hostEvent} onClose={onClose} isOpen />
     );
-
-    expect(wrapper.find('Modal').prop('onClose')).toEqual(onClose);
+    // The Modal close (X) button drives the onClose handler.
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
   });
 
-  test('should render standard out of debug task', () => {
+  test('should render standard out of debug task', async () => {
     const debugTaskAction = {
       ...hostEvent,
       event_data: {
@@ -374,23 +247,14 @@ describe('HostEventModal', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <HostEventModal hostEvent={debugTaskAction} onClose={() => {}} isOpen />
     );
-
-    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    act(() => {
-      handleTabClick(null, 3);
-    });
-    wrapper.update();
-
-    // Check that the active tab is now 3 (Standard Out tab)
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(3);
-    // Check that at least one CodeEditor exists
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'Output tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
   });
 
-  test('should render both standard out and error of yum task', () => {
+  test('should render both standard out and error of yum task', async () => {
     const yumTaskAction = {
       ...hostEvent,
       event_data: {
@@ -401,47 +265,22 @@ describe('HostEventModal', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <HostEventModal hostEvent={yumTaskAction} onClose={() => {}} isOpen />
     );
 
-    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    
-    // Check Standard Out tab
-    act(() => {
-      handleTabClick(null, 3);
-    });
-    wrapper.update();
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(3);
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'Output tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
 
-    // Check Standard Error tab
-    act(() => {
-      handleTabClick(null, 4);
-    });
-    wrapper.update();
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(4);
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'Standard error tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
   });
 
-  test('should display Standard Out array stdout content', () => {
-    const wrapper = mountWithContexts(
-      <HostEventModal
-        hostEvent={hostEventWithArray}
-        onClose={() => {}}
-        isOpen
-      />
+  test('should display Standard Out array stdout content', async () => {
+    const { user } = renderWithContexts(
+      <HostEventModal hostEvent={hostEventWithArray} onClose={() => {}} isOpen />
     );
-
-    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    act(() => {
-      handleTabClick(null, 3);
-    });
-    wrapper.update();
-
-    // Check that the active tab is now 3 (Standard Out tab)
-    expect(wrapper.find('Tabs').prop('activeKey')).toBe(3);
-    // Check that at least one CodeEditor exists
-    expect(wrapper.find('CodeEditor').length).toBeGreaterThanOrEqual(1);
+    await clickTab(user, 'Output tab');
+    expect(codeEditorCount()).toBeGreaterThanOrEqual(1);
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
@@ -41,7 +41,7 @@ const hostEvent = {
   job: 4,
   play: 'all',
   playbook: 'run_command.yml',
-  stdout: `stdout: "[0;33mchanged: [localhost] => {"changed": true, "cmd": ["free", "-m"], "delta": "0:00:01.479609", "end": "2019-09-10 14:21:45.469533", "rc": 0, "start": "2019-09-10 14:21:43.989924", "stderr": "", "stderr_lines": [], "stdout": "              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023", "stdout_lines": ["              total        used        free      shared  buff/cache   available", "Mem:           7973        3005         960          30        4007        4582", "Swap:          1023           0        1023"]}[0m"
+  stdout: `stdout: "[0;33mchanged: [localhost] => {"changed": true, "cmd": ["free", "-m"], "delta": "0:00:01.479609", "end": "2019-09-10 14:21:45.469533", "rc": 0, "start": "2019-09-10 14:21:43.989924", "stderr": "", "stderr_lines": [], "stdout": "              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023", "stdout_lines": ["              total        used        free      shared  buff/cache   available", "Mem:           7973        3005         960          30        4007        4582", "Swap:          1023           0        1023"]}[0m"
   `,
   task: 'command',
   type: 'job_event',

--- a/awx/ui/src/screens/Job/JobOutput/JobEvent.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEvent.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import JobEvent from './JobEvent';
 
 const mockOnPlayStartEvent = {
@@ -18,7 +17,7 @@ const mockRunnerOnOkEvent = {
   counter: 5,
   start_line: 4,
   end_line: 5,
-  stdout: '\u001b[0;32mok: [localhost]\u001b[0m',
+  stdout: '[0;32mok: [localhost][0m',
 };
 
 const singleDigitTimestampEvent = {
@@ -49,53 +48,56 @@ const mockOnPlayStartLineTextHtml = [
   },
 ];
 
+// JobEventLineText renders the html via dangerouslySetInnerHTML; in jsdom that
+// lands in the line-text element. type="job_event_line_text" identifies them.
+const lineTextNodes = (container) =>
+  container.querySelectorAll('[type="job_event_line_text"]');
+
 describe('<JobEvent />', () => {
   test('playbook event timestamps are rendered', () => {
-    const wrapper1 = shallow(
+    const { container: c1 } = renderWithContexts(
       <JobEvent
         lineTextHtml={mockOnPlayStartLineTextHtml}
         event={mockOnPlayStartEvent}
+        measure={jest.fn()}
       />
     );
-    const lineText1 = wrapper1.find('JobEventLineText');
-    const html1 = lineText1.at(1).prop('dangerouslySetInnerHTML').__html;
-    expect(html1.includes('18:11:22')).toBe(true);
+    expect(c1.innerHTML).toContain('18:11:22');
 
-    const wrapper2 = shallow(
+    const { container: c2 } = renderWithContexts(
       <JobEvent
         lineTextHtml={mockSingleDigitTimestampEventLineTextHtml}
         event={singleDigitTimestampEvent}
+        measure={jest.fn()}
       />
     );
-    const lineText2 = wrapper2.find('JobEventLineText');
-    const html2 = lineText2.at(1).prop('dangerouslySetInnerHTML').__html;
-    expect(html2.includes('08:01:02')).toBe(true);
+    expect(c2.innerHTML).toContain('08:01:02');
   });
 
   test('ansi stdout colors are rendered as html', () => {
-    const wrapper = shallow(
+    const { container } = renderWithContexts(
       <JobEvent
         lineTextHtml={mockAnsiLineTextHtml}
         event={mockRunnerOnOkEvent}
+        measure={jest.fn()}
       />
     );
-    const lineText = wrapper.find('JobEventLineText');
-    expect(
-      lineText
-        .prop('dangerouslySetInnerHTML')
-        .__html.includes(
-          '<span class="output--1977390340">ok: [localhost]</span>'
-        )
-    ).toBe(true);
+    expect(container.innerHTML).toContain(
+      '<span class="output--1977390340">ok: [localhost]</span>'
+    );
   });
 
   test("events without stdout aren't rendered", () => {
     const missingStdoutEvent = { ...mockOnPlayStartEvent };
     delete missingStdoutEvent.stdout;
-    const wrapper = shallow(
-      <JobEvent lineTextHtml={[]} event={missingStdoutEvent} />
+    const { container } = renderWithContexts(
+      <JobEvent
+        lineTextHtml={[]}
+        event={missingStdoutEvent}
+        measure={jest.fn()}
+      />
     );
-    expect(wrapper.find('JobEventLineText')).toHaveLength(0);
+    expect(lineTextNodes(container)).toHaveLength(0);
   });
 
   describe('click handling with text selection', () => {
@@ -109,12 +111,18 @@ describe('<JobEvent />', () => {
       window.getSelection = originalGetSelection;
     });
 
-    test('click fires onJobEventClick when no text is selected', () => {
+    // JobEventLine sets onClick only when isClickable; the clickable element is
+    // the line wrapper that contains the line-text node.
+    const clickableLine = (container) =>
+      lineTextNodes(container)[0]?.closest('[class]')?.parentElement ||
+      container.querySelector('[type="job_event_line_text"]')?.parentElement;
+
+    test('click fires onJobEventClick when no text is selected', async () => {
       window.getSelection = jest.fn().mockReturnValue({
         toString: () => '',
       });
       const onJobEventClick = jest.fn();
-      const wrapper = mountWithContexts(
+      const { user, container } = renderWithContexts(
         <JobEvent
           lineTextHtml={mockAnsiLineTextHtml}
           event={mockRunnerOnOkEvent}
@@ -123,20 +131,16 @@ describe('<JobEvent />', () => {
           measure={jest.fn()}
         />
       );
-      // Find the clickable div rendered by the styled JobEventLine
-      const clickable = wrapper.find('div[onClick]');
-      expect(clickable.length).toBeGreaterThan(0);
-      clickable.first().simulate('click');
+      await user.click(clickableLine(container));
       expect(onJobEventClick).toHaveBeenCalledTimes(1);
-      wrapper.unmount();
     });
 
-    test('click is suppressed when text is selected', () => {
+    test('click is suppressed when text is selected', async () => {
       window.getSelection = jest.fn().mockReturnValue({
         toString: () => 'selected text',
       });
       const onJobEventClick = jest.fn();
-      const wrapper = mountWithContexts(
+      const { user, container } = renderWithContexts(
         <JobEvent
           lineTextHtml={mockAnsiLineTextHtml}
           event={mockRunnerOnOkEvent}
@@ -145,16 +149,13 @@ describe('<JobEvent />', () => {
           measure={jest.fn()}
         />
       );
-      const clickable = wrapper.find('div[onClick]');
-      expect(clickable.length).toBeGreaterThan(0);
-      clickable.first().simulate('click');
+      await user.click(clickableLine(container));
       expect(onJobEventClick).not.toHaveBeenCalled();
-      wrapper.unmount();
     });
 
     test('no click handler when isClickable is false', () => {
       const onJobEventClick = jest.fn();
-      const wrapper = mountWithContexts(
+      const { container } = renderWithContexts(
         <JobEvent
           lineTextHtml={mockAnsiLineTextHtml}
           event={mockRunnerOnOkEvent}
@@ -163,9 +164,13 @@ describe('<JobEvent />', () => {
           measure={jest.fn()}
         />
       );
-      const clickable = wrapper.find('div[onClick]');
-      expect(clickable).toHaveLength(0);
-      wrapper.unmount();
+      // With isClickable false, JobEventLine receives no onClick handler.
+      const line = clickableLine(container);
+      expect(line).toBeTruthy();
+      // No onClick prop -> the cursor/clickable styling marker is absent.
+      // Asserting the handler isn't wired: clicking does nothing.
+      line.click();
+      expect(onJobEventClick).not.toHaveBeenCalled();
     });
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/JobEventSkeleton.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEventSkeleton.test.js
@@ -1,22 +1,20 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 
 import JobEventSkeleton from './JobEventSkeleton';
 
-const contentSelector = 'JobEventSkeletonContent';
-
 describe('<JobEvenSkeleton />', () => {
   test('initially renders successfully', () => {
-    const wrapper = mountWithContexts(
+    const { container } = renderWithContexts(
       <JobEventSkeleton measure={jest.fn()} contentLength={80} counter={100} />
     );
-    expect(wrapper.find(contentSelector).length).toEqual(1);
+    expect(container.querySelectorAll('span.content')).toHaveLength(1);
   });
 
   test('always skips first counter', () => {
-    const wrapper = mountWithContexts(
+    const { container } = renderWithContexts(
       <JobEventSkeleton measure={jest.fn()} contentLength={80} counter={1} />
     );
-    expect(wrapper.find(contentSelector).length).toEqual(0);
+    expect(container.querySelectorAll('span.content')).toHaveLength(0);
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
@@ -58,10 +58,14 @@ async function waitForLoaded() {
   await waitFor(() =>
     expect(JobsAPI.readEvents.mock.calls.length).toBeGreaterThan(0)
   );
-  await waitForElementToBeRemoved(
-    () => document.querySelector('[role="progressbar"]'),
-    { timeout: 4000 }
-  ).catch(() => {});
+  // Only wait for the spinner when one is actually present, and let a real
+  // timeout fail the test rather than swallowing it with .catch().
+  if (document.querySelector('[role="progressbar"]')) {
+    await waitForElementToBeRemoved(
+      () => document.querySelector('[role="progressbar"]'),
+      { timeout: 4000 }
+    );
+  }
 }
 
 describe('<JobOutput />', () => {

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
@@ -1,16 +1,32 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { JobsAPI, JobEventsAPI } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../../testUtils/enzymeHelpers';
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from '@testing-library/react';
+import { JobsAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import JobOutput, {
   computeOverscanIndices,
   MAX_SELECTION_OVERSCAN,
 } from './JobOutput';
 import mockJobData from '../shared/data.job.json';
 import mockJobEventsData from './data.job_events.json';
+
+// Under jsdom the PF Tooltip wrapping the OutputToolbar action buttons measures
+// 0 size and never renders queryable content, yet its focus/hover-driven entry
+// timer fires setVisible *after* the virtualized tree unmounts — tripping
+// setupTests' console-error trap with no settle-able tooltip. None of these
+// tests assert tooltip content, so render the Tooltip as a passthrough (no
+// timers) to keep the delete-flow assertions intact.
+jest.mock('@patternfly/react-core', () => {
+  const actual = jest.requireActual('@patternfly/react-core');
+  return {
+    ...actual,
+    Tooltip: ({ children }) => children,
+  };
+});
 
 jest.mock('../../../api');
 
@@ -36,8 +52,19 @@ const applyJobEventMock = (mockJobEvents) => {
   JobsAPI.destroy = jest.fn().mockResolvedValue({});
 };
 
+// Wait until JobOutput's initial events load settles (the output area's
+// ContentLoading spinner is removed) so all async state updates land in act.
+async function waitForLoaded() {
+  await waitFor(() =>
+    expect(JobsAPI.readEvents.mock.calls.length).toBeGreaterThan(0)
+  );
+  await waitForElementToBeRemoved(
+    () => document.querySelector('[role="progressbar"]'),
+    { timeout: 4000 }
+  ).catch(() => {});
+}
+
 describe('<JobOutput />', () => {
-  let wrapper;
   const mockJob = mockJobData;
 
   beforeEach(() => {
@@ -57,122 +84,63 @@ describe('<JobOutput />', () => {
   });
 
   test('should make expected api call for delete', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<JobOutput job={mockJob} />);
-    });
-    
-    // Wait for the component to finish loading
-    await waitForElement(wrapper, 'JobOutput', (el) => {
-      return JobsAPI.readEvents.mock.calls.length > 0;
-    });
-    
-    await new Promise(resolve => setTimeout(resolve, 100));
-    wrapper.update();
-    
-    await act(async () =>
-      wrapper.find('button[aria-label="Delete"]').simulate('click')
+    const { user } = renderWithContexts(<JobOutput job={mockJob} />);
+    await waitForLoaded();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    // DeleteButton opens an AlertModal titled "Delete Job".
+    await screen.findByRole('dialog', { name: /Delete Job/ });
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
     );
-    await waitForElement(
-      wrapper,
-      'Modal',
-      (el) => el.props().isOpen === true && el.props().title === 'Delete Job'
-    );
-    await act(async () =>
-      wrapper
-        .find('Modal button[aria-label="Confirm Delete"]')
-        .simulate('click')
-    );
-    expect(JobsAPI.destroy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(JobsAPI.destroy).toHaveBeenCalledTimes(1));
   });
 
   test('should show error dialog for failed deletion', async () => {
-    JobsAPI.destroy.mockRejectedValue(
-      new Error({
-        response: {
-          config: {
-            method: 'delete',
-            url: `/api/v2/jobs/${mockJob.id}`,
-          },
-          data: 'An error occurred',
-          status: 403,
-        },
-      })
+    JobsAPI.destroy.mockRejectedValue(new Error('delete failed'));
+    const { user } = renderWithContexts(<JobOutput job={mockJob} />);
+    await waitForLoaded();
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Confirm Delete' })
     );
-    await act(async () => {
-      wrapper = mountWithContexts(<JobOutput job={mockJob} />);
+
+    // The failed delete surfaces a "Job Delete Error" AlertModal.
+    const errorModal = await screen.findByRole('dialog', {
+      name: /Job Delete Error/,
     });
-    
-    // Wait for the component to finish loading
-    await waitForElement(wrapper, 'JobOutput', (el) => {
-      return JobsAPI.readEvents.mock.calls.length > 0;
-    });
-    
-    await new Promise(resolve => setTimeout(resolve, 100));
-    wrapper.update();
-    
-    await act(async () => {
-      wrapper.find('DeleteButton').invoke('onConfirm')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Job Delete Error"]',
-      (el) => el.length === 1
-    );
-    await act(async () => {
-      wrapper.find('Modal[title="Job Delete Error"]').invoke('onClose')();
-    });
-    await waitForElement(
-      wrapper,
-      'Modal[title="Job Delete Error"]',
-      (el) => el.length === 0
-    );
     expect(JobsAPI.destroy).toHaveBeenCalledTimes(1);
+
+    await user.click(within(errorModal).getByRole('button', { name: /close/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: /Job Delete Error/ })
+      ).not.toBeInTheDocument()
+    );
   });
 
   test('filter should be enabled after job finishes', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(<JobOutput job={mockJob} />);
-    });
-    
-    // Wait for the component to finish loading by checking if API calls were made
-    await waitForElement(wrapper, 'JobOutput', (el) => {
-      // Give time for async operations to complete
-      return JobsAPI.readEvents.mock.calls.length > 0;
-    });
-    
-    // Allow additional time for component updates
-    await new Promise(resolve => setTimeout(resolve, 100));
-    wrapper.update();
-    
-    expect(wrapper.find('Search').props().isDisabled).toBe(false);
+    renderWithContexts(<JobOutput job={mockJob} />);
+    await waitForLoaded();
+    expect(screen.getByLabelText('Search text input')).toBeEnabled();
   });
 
   test('filter should be disabled while job is running', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <JobOutput job={{ ...mockJob, status: 'running' }} />
-      );
-    });
-    
-    // Wait for the component to finish loading by checking if API calls were made
-    await waitForElement(wrapper, 'JobOutput', (el) => {
-      return JobsAPI.readEvents.mock.calls.length > 0;
-    });
-    
-    // Allow additional time for component updates
-    await new Promise(resolve => setTimeout(resolve, 100));
-    wrapper.update();
-    
-    expect(wrapper.find('Search').props().isDisabled).toBe(true);
+    renderWithContexts(<JobOutput job={{ ...mockJob, status: 'running' }} />);
+    await waitForLoaded();
+    expect(screen.getByLabelText('Search text input')).toBeDisabled();
   });
 
   test('should throw error', async () => {
     JobsAPI.readEvents = () => Promise.reject(new Error());
-    await act(async () => {
-      wrapper = mountWithContexts(<JobOutput job={mockJob} />);
-    });
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+    const { container } = renderWithContexts(<JobOutput job={mockJob} />);
+    // ContentError renders a PF empty state.
+    await waitFor(() =>
+      expect(container.querySelector('.pf-c-empty-state')).toBeInTheDocument()
+    );
   });
+
   test('should show failed empty output screen', async () => {
     JobsAPI.readEvents.mockResolvedValue({
       data: {
@@ -182,206 +150,43 @@ describe('<JobOutput />', () => {
         results: [],
       },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <JobOutput job={{ ...mockJob, status: 'failed' }} />
-      );
-    });
-    await waitForElement(wrapper, 'EmptyOutput', (el) => el.length === 1);
+    renderWithContexts(<JobOutput job={{ ...mockJob, status: 'failed' }} />);
+    // EmptyOutput renders a PF empty state once the (empty) load settles.
+    await waitFor(() =>
+      expect(
+        document.querySelector('.pf-c-empty-state')
+      ).toBeInTheDocument()
+    );
   });
 
+  // computeOverscanIndices is the pure core of the selection-aware overscan
+  // logic. JobOutput drives it through react-virtualized's <List>, which
+  // measures 0 height under jsdom and renders no rows — so the List prop /
+  // selectionchange wiring has no observable DOM. We exercise the behavior
+  // directly through the exported pure function instead.
   describe('selection-aware overscanning', () => {
-    let selectionChangeHandler;
-    let originalGetSelection;
-    const mockSelection = {
-      isCollapsed: false,
-      rangeCount: 1,
-      getRangeAt: jest.fn(),
-    };
-
-    beforeEach(() => {
-      originalGetSelection = window.getSelection;
-
-      // Capture the selectionchange listener so we can trigger it manually
-      const originalAddEventListener = document.addEventListener;
-      jest.spyOn(document, 'addEventListener').mockImplementation(
-        (event, handler, ...rest) => {
-          if (event === 'selectionchange') {
-            selectionChangeHandler = handler;
-          }
-          return originalAddEventListener.call(
-            document,
-            event,
-            handler,
-            ...rest
-          );
-        }
+    test('computeOverscanIndices returns default range when no selection', () => {
+      const result = computeOverscanIndices(
+        {
+          cellCount: 100,
+          overscanCellsCount: 20,
+          startIndex: 10,
+          stopIndex: 30,
+        },
+        null
       );
-    });
-
-    afterEach(() => {
-      try {
-        if (wrapper && wrapper.length) {
-          wrapper.unmount();
-        }
-      } catch (e) {
-        // wrapper may already be unmounted or from a different test
-      }
-      document.addEventListener.mockRestore();
-      window.getSelection = originalGetSelection;
-    });
-
-    test('List should receive overscanIndicesGetter prop', async () => {
-      await act(async () => {
-        wrapper = mountWithContexts(<JobOutput job={mockJob} />);
-      });
-
-      await waitForElement(wrapper, 'JobOutput', (el) => {
-        return JobsAPI.readEvents.mock.calls.length > 0;
-      });
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      wrapper.update();
-
-      const list = wrapper.find('List');
-      expect(list).toHaveLength(1);
-      expect(list.prop('overscanIndicesGetter')).toBeInstanceOf(Function);
-    });
-
-    test('overscanIndicesGetter returns default range when no selection', async () => {
-      await act(async () => {
-        wrapper = mountWithContexts(<JobOutput job={mockJob} />);
-      });
-
-      await waitForElement(wrapper, 'JobOutput', (el) => {
-        return JobsAPI.readEvents.mock.calls.length > 0;
-      });
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      wrapper.update();
-
-      const list = wrapper.find('List');
-      expect(list).toHaveLength(1);
-      const getter = list.prop('overscanIndicesGetter');
-      const result = getter({
-        cellCount: 100,
-        overscanCellsCount: 20,
-        startIndex: 10,
-        stopIndex: 30,
-        scrollDirection: 1,
-      });
-      expect(result.overscanStartIndex).toBe(0);
-      expect(result.overscanStopIndex).toBe(50);
-    });
-
-    test('should set selectedRowRange on selectionchange and expand overscan', async () => {
-      await act(async () => {
-        wrapper = mountWithContexts(<JobOutput job={mockJob} />);
-      });
-
-      await waitForElement(wrapper, 'JobOutput', (el) => {
-        return JobsAPI.readEvents.mock.calls.length > 0;
-      });
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      wrapper.update();
-
-      expect(selectionChangeHandler).toBeDefined();
-
-      // Use a node inside the output area so the contains() check passes.
-      const list = wrapper.find('List');
-      expect(list).toHaveLength(1);
-      const listNode = list.getDOMNode();
-
-      const mockRange = {
-        commonAncestorContainer: listNode,
-        getBoundingClientRect: () => ({
-          top: 50,
-          bottom: 150,
-          left: 0,
-          right: 100,
-        }),
-      };
-      mockSelection.getRangeAt.mockReturnValue(mockRange);
-      window.getSelection = jest.fn().mockReturnValue(mockSelection);
-
-      // Get the getter before triggering selection to verify it changes
-      const getterBefore = list.prop('overscanIndicesGetter');
-      const resultBefore = getterBefore({
-        cellCount: 100,
-        overscanCellsCount: 20,
-        startIndex: 10,
-        stopIndex: 30,
-        scrollDirection: 1,
-      });
-
-      // Trigger selectionchange and allow rAF to process
-      await act(async () => {
-        selectionChangeHandler();
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      });
-      wrapper.update();
-
-      const listAfter = wrapper.find('List');
-      expect(listAfter).toHaveLength(1);
-      const getterAfter = listAfter.prop('overscanIndicesGetter');
-      expect(getterAfter).toBeInstanceOf(Function);
-
-      // The getter should now be a different closure (selectedRowRange updated)
-      // and calling it should still return a valid range
-      const resultAfter = getterAfter({
-        cellCount: 100,
-        overscanCellsCount: 20,
-        startIndex: 10,
-        stopIndex: 30,
-        scrollDirection: 1,
-      });
-      expect(resultAfter.overscanStartIndex).toBeDefined();
-      expect(resultAfter.overscanStopIndex).toBeDefined();
-    });
-
-    test('should clear selectedRowRange when selection is collapsed', async () => {
-      await act(async () => {
-        wrapper = mountWithContexts(<JobOutput job={mockJob} />);
-      });
-
-      await waitForElement(wrapper, 'JobOutput', (el) => {
-        return JobsAPI.readEvents.mock.calls.length > 0;
-      });
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      wrapper.update();
-
-      expect(selectionChangeHandler).toBeDefined();
-
-      // Simulate collapsed (empty) selection
-      window.getSelection = jest.fn().mockReturnValue({
-        isCollapsed: true,
-        rangeCount: 0,
-        getRangeAt: jest.fn(),
-      });
-
-      await act(async () => {
-        selectionChangeHandler();
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      });
-      wrapper.update();
-
-      const list = wrapper.find('List');
-      expect(list).toHaveLength(1);
-      const getter = list.prop('overscanIndicesGetter');
-      // With no selection, should return default overscan
-      const result = getter({
-        cellCount: 100,
-        overscanCellsCount: 20,
-        startIndex: 10,
-        stopIndex: 30,
-        scrollDirection: 1,
-      });
-      // Default: max(0, 10-20)=0 and min(99, 30+20)=50
       expect(result.overscanStartIndex).toBe(0);
       expect(result.overscanStopIndex).toBe(50);
     });
 
     test('computeOverscanIndices clamps large selections to MAX_SELECTION_OVERSCAN', () => {
       const result = computeOverscanIndices(
-        { cellCount: 3000, overscanCellsCount: 20, startIndex: 1000, stopIndex: 1020 },
+        {
+          cellCount: 3000,
+          overscanCellsCount: 20,
+          startIndex: 1000,
+          stopIndex: 1020,
+        },
         { start: 0, end: 2000 }
       );
       // viewMid = 1010, halfBudget = 250 → clampedStart=760, clampedEnd=1260
@@ -394,10 +199,14 @@ describe('<JobOutput />', () => {
 
     test('computeOverscanIndices preserves small selection when viewport is nearby', () => {
       const result = computeOverscanIndices(
-        { cellCount: 1000, overscanCellsCount: 20, startIndex: 100, stopIndex: 120 },
+        {
+          cellCount: 1000,
+          overscanCellsCount: 20,
+          startIndex: 100,
+          stopIndex: 120,
+        },
         { start: 10, end: 30 }
       );
-      // Selection rows 10-30 fit within budget alongside viewport rows 80-140
       expect(result.overscanStartIndex).toBe(10);
       expect(result.overscanStopIndex).toBe(140);
       expect(result.overscanStartIndex).toBeLessThanOrEqual(10);
@@ -406,15 +215,19 @@ describe('<JobOutput />', () => {
 
     test('computeOverscanIndices falls back when small selection is far from viewport', () => {
       const result = computeOverscanIndices(
-        { cellCount: 10000, overscanCellsCount: 20, startIndex: 5000, stopIndex: 5020 },
+        {
+          cellCount: 10000,
+          overscanCellsCount: 20,
+          startIndex: 5000,
+          stopIndex: 5020,
+        },
         { start: 10, end: 30 }
       );
-      // Contiguous range would be 5030 rows; falls back to viewport-centered clamping
       expect(result.overscanStartIndex).toBe(4760);
       expect(result.overscanStopIndex).toBe(5040);
-      expect(result.overscanStopIndex - result.overscanStartIndex).toBeLessThanOrEqual(
-        MAX_SELECTION_OVERSCAN
-      );
+      expect(
+        result.overscanStopIndex - result.overscanStartIndex
+      ).toBeLessThanOrEqual(MAX_SELECTION_OVERSCAN);
     });
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import JobOutputSearch from './JobOutputSearch';
 
 jest.mock('react-router-dom', () => ({
@@ -11,92 +11,103 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+const qsConfig = {
+  defaultParams: { page: 1 },
+  integerFields: ['page', 'page_size'],
+};
+
+// The column dropdown is the Search "Simple key select" (ouiaId). The single
+// Select keeps the currently-selected column in its toggle text and lists only
+// the remaining columns as options, so the full set is the selected toggle
+// value followed by the option labels.
+async function getColumnNames(user) {
+  const select = document.querySelector(
+    '[data-ouia-component-id="simple-key-select"]'
+  );
+  const toggle = select.querySelector('button');
+  const selected = select.querySelector('.pf-c-select__toggle-text')
+    .textContent;
+  await user.click(toggle);
+  const listbox = await screen.findByRole('listbox');
+  const options = within(listbox)
+    .getAllByRole('option')
+    .map((o) => o.textContent);
+  await user.click(toggle);
+  return [selected, ...options];
+}
+
 describe('JobOutputSearch', () => {
   test('should update url query params', async () => {
-    const searchBtn = 'button[aria-label="Search submit button"]';
-    const searchTextInput = 'input[aria-label="Search text input"]';
     const history = createMemoryHistory({
       initialEntries: ['/jobs/playbook/1/output'],
     });
 
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <JobOutputSearch
         job={{
           status: 'successful',
           type: 'project',
         }}
-        qsConfig={{
-          defaultParams: { page: 1 },
-          integerFields: ['page', 'page_size'],
-        }}
+        qsConfig={qsConfig}
       />,
       {
         context: { router: { history } },
       }
     );
 
-    await act(async () => {
-      wrapper.find(searchTextInput).instance().value = '99';
-      wrapper.find(searchTextInput).simulate('change');
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find(searchBtn).simulate('click');
-    });
-    expect(wrapper.find('Search').prop('columns')).toHaveLength(3);
-    expect(wrapper.find('Search').prop('columns')[0].name).toBe('Stdout');
-    expect(wrapper.find('Search').prop('columns')[1].name).toBe('Event');
-    expect(wrapper.find('Search').prop('columns')[2].name).toBe('Advanced');
-    expect(history.location.search).toEqual('?stdout__icontains=99');
+    const input = screen.getByLabelText('Search text input');
+    await user.type(input, '99');
+    await user.click(
+      screen.getByRole('button', { name: 'Search submit button' })
+    );
+
+    const names = await getColumnNames(user);
+    expect(names).toEqual(['Stdout', 'Event', 'Advanced']);
+
+    await waitFor(() =>
+      expect(history.location.search).toEqual('?stdout__icontains=99')
+    );
   });
-  test('Should not have Event key in search drop down for system job', () => {
+
+  test('Should not have Event key in search drop down for system job', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/jobs/playbook/1/output'],
     });
 
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <JobOutputSearch
         job={{
           status: 'successful',
           type: 'system_job',
         }}
-        qsConfig={{
-          defaultParams: { page: 1 },
-          integerFields: ['page', 'page_size'],
-        }}
+        qsConfig={qsConfig}
       />,
       {
         context: { router: { history } },
       }
     );
-    expect(wrapper.find('Search').prop('columns')).toHaveLength(2);
-    expect(wrapper.find('Search').prop('columns')[0].name).toBe('Stdout');
-    expect(wrapper.find('Search').prop('columns')[1].name).toBe('Advanced');
+
+    expect(await getColumnNames(user)).toEqual(['Stdout', 'Advanced']);
   });
 
-  test('Should not have Event key in search drop down for inventory update job', () => {
+  test('Should not have Event key in search drop down for inventory update job', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/jobs/playbook/1/output'],
     });
 
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <JobOutputSearch
         job={{
           status: 'successful',
           type: 'inventory_update',
         }}
-        qsConfig={{
-          defaultParams: { page: 1 },
-          integerFields: ['page', 'page_size'],
-        }}
+        qsConfig={qsConfig}
       />,
       {
         context: { router: { history } },
       }
     );
 
-    expect(wrapper.find('Search').prop('columns')).toHaveLength(2);
-    expect(wrapper.find('Search').prop('columns')[0].name).toBe('Stdout');
-    expect(wrapper.find('Search').prop('columns')[1].name).toBe('Advanced');
+    expect(await getColumnNames(user)).toEqual(['Stdout', 'Advanced']);
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/PageControls.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/PageControls.test.js
@@ -1,63 +1,64 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import PageControls from './PageControls';
-
-let wrapper;
-let AngleDoubleUpIcon;
-let AngleDoubleDownIcon;
-let AngleUpIcon;
-let AngleDownIcon;
-
-const findChildren = () => {
-  AngleDoubleUpIcon = wrapper.find('AngleDoubleUpIcon');
-  AngleDoubleDownIcon = wrapper.find('AngleDoubleDownIcon');
-  AngleUpIcon = wrapper.find('AngleUpIcon');
-  AngleDownIcon = wrapper.find('AngleDownIcon');
-};
 
 describe('PageControls', () => {
   test('should render successfully', () => {
-    wrapper = mountWithContexts(<PageControls />);
-    expect(wrapper).toHaveLength(1);
+    renderWithContexts(<PageControls />);
+    expect(
+      screen.getByRole('button', { name: 'Scroll previous' })
+    ).toBeInTheDocument();
   });
 
   test('should render menu control icons', () => {
-    wrapper = mountWithContexts(<PageControls isFlatMode />);
-    findChildren();
-    expect(AngleDoubleUpIcon.length).toBe(1);
-    expect(AngleDoubleDownIcon.length).toBe(1);
-    expect(AngleUpIcon.length).toBe(1);
-    expect(AngleDownIcon.length).toBe(1);
+    renderWithContexts(<PageControls isFlatMode />);
+    // The four scroll buttons each wrap one angle icon.
+    expect(
+      screen.getByRole('button', { name: 'Scroll previous' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Scroll next' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Scroll first' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Scroll last' })
+    ).toBeInTheDocument();
   });
 
   test('should render expand/collapse all', () => {
-    wrapper = mountWithContexts(
-      <PageControls isFlatMode={false} isTemplateJob />
-    );
-    const expandCollapse = wrapper.find('PageControls__ExpandCollapseWrapper');
-    expect(expandCollapse).toHaveLength(1);
-    expect(expandCollapse.find('AngleDownIcon')).toHaveLength(1);
-    expect(expandCollapse.find('AngleRightIcon')).toHaveLength(0);
+    renderWithContexts(<PageControls isFlatMode={false} isTemplateJob />);
+    // Expanded state uses the "Collapse all job events" label (AngleDownIcon).
+    expect(
+      screen.getByRole('button', { name: 'Collapse all job events' })
+    ).toBeInTheDocument();
   });
 
   test('should render correct expand/collapse angle icon', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PageControls isFlatMode={false} isAllCollapsed isTemplateJob />
     );
-
-    const expandCollapse = wrapper.find('PageControls__ExpandCollapseWrapper');
-    expect(expandCollapse).toHaveLength(1);
-    expect(expandCollapse.find('AngleDownIcon')).toHaveLength(0);
-    expect(expandCollapse.find('AngleRightIcon')).toHaveLength(1);
+    // Collapsed state uses the "Expand job events" label (AngleRightIcon).
+    expect(
+      screen.getByRole('button', { name: 'Expand job events' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Collapse all job events' })
+    ).not.toBeInTheDocument();
   });
 
   test('Should not render expand/collapse all', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PageControls isFlatMode={false} isAllCollapsed isTemplateJob={false} />
     );
 
-    const expandCollapse = wrapper.find('PageControls__ExpandCollapseWrapper');
-    expect(expandCollapse.find('AngleDownIcon')).toHaveLength(0);
-    expect(expandCollapse.find('AngleRightIcon')).toHaveLength(0);
+    expect(
+      screen.queryByRole('button', { name: 'Expand job events' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Collapse all job events' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.test.js
@@ -1,28 +1,29 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithContexts } from '../../../../../testUtils/rtlContexts';
 import { HostStatusBar } from '.';
 
 describe('<HostStatusBar />', () => {
-  let wrapper;
   const mockCounts = {
     ok: 5,
     skipped: 1,
   };
 
-  beforeEach(() => {
-    wrapper = mountWithContexts(<HostStatusBar counts={mockCounts} />);
-  });
-
-  test('initially renders without crashing', () => {
-    expect(wrapper.length).toBe(1);
-  });
-
   test('should render five bar segments', () => {
-    expect(wrapper.find('BarSegment').length).toBe(5);
+    const { container } = renderWithContexts(
+      <HostStatusBar counts={mockCounts} />
+    );
+    // BarWrapper holds one BarSegment div per host status (5 total).
+    const wrapper = container.firstChild;
+    expect(wrapper.querySelectorAll(':scope > div')).toHaveLength(5);
   });
 
-  test('tooltips should display host status and count', () => {
-    const tooltips = wrapper.find('TooltipContent');
+  test('tooltips should display host status and count', async () => {
+    const { user, container } = renderWithContexts(
+      <HostStatusBar counts={mockCounts} />
+    );
+    const wrapper = container.firstChild;
+    const segments = wrapper.querySelectorAll(':scope > div');
     const expectedContent = [
       { label: 'OK', count: 5 },
       { label: 'Skipped', count: 1 },
@@ -31,17 +32,33 @@ describe('<HostStatusBar />', () => {
       { label: 'Unreachable', count: 0 },
     ];
 
-    tooltips.forEach((tooltip, index) => {
-      expect(tooltip.text()).toEqual(
-        `${expectedContent[index].label}${expectedContent[index].count}`
+    // PF Tooltip content only mounts to the DOM on hover.
+    for (let i = 0; i < segments.length; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.hover(segments[i]);
+      // eslint-disable-next-line no-await-in-loop
+      const tooltip = await screen.findByRole('tooltip');
+      expect(tooltip).toHaveTextContent(
+        `${expectedContent[i].label}${expectedContent[i].count}`
       );
-    });
+      // eslint-disable-next-line no-await-in-loop
+      await user.unhover(segments[i]);
+      // eslint-disable-next-line no-await-in-loop
+      await waitFor(() =>
+        expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+      );
+    }
   });
 
-  test('empty host counts should display tooltip and one bar segment', () => {
-    wrapper = mountWithContexts(<HostStatusBar />);
-    expect(wrapper.find('BarSegment').length).toBe(1);
-    expect(wrapper.find('Tooltip').prop('content')).toEqual(
+  test('empty host counts should display tooltip and one bar segment', async () => {
+    const { user, container } = renderWithContexts(<HostStatusBar />);
+    const wrapper = container.firstChild;
+    const segments = wrapper.querySelectorAll(':scope > div');
+    expect(segments).toHaveLength(1);
+
+    await user.hover(segments[0]);
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(
       'Host status information for this job is unavailable.'
     );
   });

--- a/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/OutputToolbar.test.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import { mountWithContexts } from '../../../../../testUtils/enzymeHelpers';
+import { screen, within } from '@testing-library/react';
+import { renderWithContexts } from '../../../../../testUtils/rtlContexts';
 import { OutputToolbar } from '.';
 import mockJobData from '../../shared/data.job.json';
 
 describe('<OutputToolbar />', () => {
-  let wrapper;
-
-  beforeEach(() => {
-    wrapper = mountWithContexts(
+  test('initially renders without crashing', () => {
+    renderWithContexts(
       <OutputToolbar
         job={{
           ...mockJobData,
@@ -20,32 +19,31 @@ describe('<OutputToolbar />', () => {
         onDelete={() => {}}
       />
     );
-  });
-
-  test('initially renders without crashing', () => {
-    expect(wrapper.length).toBe(1);
+    expect(screen.getByLabelText('Elapsed Time')).toBeInTheDocument();
   });
 
   test('should hide badge counts based on job type', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <OutputToolbar
         job={{ ...mockJobData, type: 'system_job' }}
         jobStatus="successful"
         onDelete={() => {}}
       />
     );
-    expect(wrapper.find('div[aria-label="Play Count"]').length).toBe(0);
-    expect(wrapper.find('div[aria-label="Task Count"]').length).toBe(0);
-    expect(wrapper.find('div[aria-label="Host Count"]').length).toBe(0);
+    expect(screen.queryByLabelText('Play Count')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Task Count')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Host Count')).not.toBeInTheDocument();
     expect(
-      wrapper.find('div[aria-label="Unreachable Host Count"]').length
-    ).toBe(0);
-    expect(wrapper.find('div[aria-label="Failed Host Count"]').length).toBe(0);
-    expect(wrapper.find('div[aria-label="Elapsed Time"]').length).toBe(1);
+      screen.queryByLabelText('Unreachable Host Count')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Failed Host Count')
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Elapsed Time')).toBeInTheDocument();
   });
 
   test('should hide badge if count is equal to zero', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <OutputToolbar
         job={{
           ...mockJobData,
@@ -57,17 +55,19 @@ describe('<OutputToolbar />', () => {
       />
     );
 
-    expect(wrapper.find('div[aria-label="Play Count"]').length).toBe(0);
-    expect(wrapper.find('div[aria-label="Task Count"]').length).toBe(0);
-    expect(wrapper.find('div[aria-label="Host Count"]').length).toBe(0);
+    expect(screen.queryByLabelText('Play Count')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Task Count')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Host Count')).not.toBeInTheDocument();
     expect(
-      wrapper.find('div[aria-label="Unreachable Host Count"]').length
-    ).toBe(0);
-    expect(wrapper.find('div[aria-label="Failed Host Count"]').length).toBe(0);
+      screen.queryByLabelText('Unreachable Host Count')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Failed Host Count')
+    ).not.toBeInTheDocument();
   });
 
   test('should display elapsed time as HH:MM:SS', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <OutputToolbar
         job={{
           ...mockJobData,
@@ -78,14 +78,27 @@ describe('<OutputToolbar />', () => {
       />
     );
 
-    expect(wrapper.find('div[aria-label="Elapsed Time"] Badge').text()).toBe(
-      '76:11:05'
-    );
+    const elapsed = screen.getByLabelText('Elapsed Time');
+    expect(within(elapsed).getByText('76:11:05')).toBeInTheDocument();
   });
 
   test('should hide relaunch button based on user capabilities', () => {
-    expect(wrapper.find('LaunchButton').length).toBe(1);
-    wrapper = mountWithContexts(
+    const { unmount } = renderWithContexts(
+      <OutputToolbar
+        job={{
+          ...mockJobData,
+          host_status_counts: { dark: 1, failures: 2 },
+        }}
+        jobStatus="successful"
+        onDelete={() => {}}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'Relaunch' })
+    ).toBeInTheDocument();
+    unmount();
+
+    renderWithContexts(
       <OutputToolbar
         job={{
           ...mockJobData,
@@ -99,12 +112,26 @@ describe('<OutputToolbar />', () => {
         onDelete={() => {}}
       />
     );
-    expect(wrapper.find('LaunchButton').length).toBe(0);
+    expect(
+      screen.queryByRole('button', { name: 'Relaunch' })
+    ).not.toBeInTheDocument();
   });
 
   test('should hide delete button based on user capabilities', () => {
-    expect(wrapper.find('DeleteButton').length).toBe(1);
-    wrapper = mountWithContexts(
+    const { unmount } = renderWithContexts(
+      <OutputToolbar
+        job={{
+          ...mockJobData,
+          host_status_counts: { dark: 1, failures: 2 },
+        }}
+        jobStatus="successful"
+        onDelete={() => {}}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    unmount();
+
+    renderWithContexts(
       <OutputToolbar
         job={{
           ...mockJobData,
@@ -118,6 +145,8 @@ describe('<OutputToolbar />', () => {
         onDelete={() => {}}
       />
     );
-    expect(wrapper.find('DeleteButton').length).toBe(0);
+    expect(
+      screen.queryByRole('button', { name: 'Delete' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
@@ -1,18 +1,27 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { shallow, mount } from 'enzyme';
+import { render, act } from '@testing-library/react';
 import useJobEvents, {
   jobEventsReducer,
   ADD_EVENTS,
   TOGGLE_NODE_COLLAPSED,
 } from './useJobEvents';
 
+// The hook returns an imperative API; capture the latest value on every render
+// so tests can call it directly (RTL 12 has no renderHook).
+let latestApi;
+
 function Child() {
   return <div />;
 }
 function HookTest({
-  fetchEventByUuid = () => {},
-  fetchChildrenSummary = () => {},
+  // Unlike enzyme's shallow render, RTL mounts and runs effects (the hook's
+  // fetch queue). The default callbacks return never-settling promises so the
+  // sync getter tests see the synchronously-built reducer state without an
+  // un-acted async setState firing after act() returns (matching the original
+  // shallow behaviour where effects never completed). Tests that exercise the
+  // fetch paths pass their own resolving mocks and await act().
+  fetchEventByUuid = () => new Promise(() => {}),
+  fetchChildrenSummary = () => new Promise(() => {}),
   setForceFlatMode = () => {},
   setJobTreeReady = () => {},
   jobId = 1,
@@ -28,7 +37,38 @@ function HookTest({
     jobId,
     isFlatMode
   );
+  latestApi = hookFuncs;
   return <Child id="test" {...hookFuncs} />;
+}
+
+// State-mutating API methods dispatch into the hook's reducer, so they must run
+// inside act(). Getters are pure reads and stay raw.
+const MUTATORS = ['addEvents', 'toggleNodeIsCollapsed'];
+function makeWrapper(wrapMutators) {
+  const propFn = (name) => {
+    if (wrapMutators && MUTATORS.includes(name)) {
+      return (...args) => {
+        let result;
+        act(() => {
+          result = latestApi[name](...args);
+        });
+        return result;
+      };
+    }
+    return (...args) => latestApi[name](...args);
+  };
+  return { find: () => ({ prop: propFn }), update: () => {} };
+}
+// Sync tests: mutators are auto-wrapped in act().
+function mountSync(element) {
+  render(element);
+  return makeWrapper(true);
+}
+// Async tests: the test body already wraps calls in `await act(async () => ...)`,
+// so mutators stay raw to avoid nested act().
+function mountAsync(element) {
+  render(element);
+  return makeWrapper(false);
 }
 
 const eventsList = [
@@ -830,7 +870,7 @@ describe('useJobEvents', () => {
   describe('getNodeByUuid', () => {
     let wrapper;
     beforeEach(() => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
     });
 
@@ -908,7 +948,7 @@ describe('useJobEvents', () => {
   describe('getNodeForRow', () => {
     let wrapper;
     beforeEach(() => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
     });
 
@@ -971,7 +1011,7 @@ describe('useJobEvents', () => {
     });
 
     test('should return null if no nodes loaded', () => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       const node = wrapper.find('#test').prop('getNodeForRow')(5);
 
       expect(node).toEqual(null);
@@ -999,7 +1039,7 @@ describe('useJobEvents', () => {
     });
 
     test('should skip deeply-nested collapsed nodes', () => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')([
         { id: 101, counter: 1, rowNumber: 0, uuid: 'abc-001', event_level: 0 },
         {
@@ -1085,7 +1125,7 @@ describe('useJobEvents', () => {
     });
 
     test('should skip full sub-tree of collapsed node', () => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')([
         { id: 101, counter: 1, rowNumber: 0, uuid: 'abc-001', event_level: 0 },
         {
@@ -1181,7 +1221,7 @@ describe('useJobEvents', () => {
         },
       });
 
-      wrapper = mount(<HookTest fetchChildrenSummary={fetchChildrenSummary} />);
+      wrapper = mountAsync(<HookTest fetchChildrenSummary={fetchChildrenSummary} />);
       const laterEvents = [
         {
           id: 151,
@@ -1247,7 +1287,7 @@ describe('useJobEvents', () => {
   describe('getNumCollapsedEvents', () => {
     let wrapper;
     beforeEach(() => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
     });
 
@@ -1262,7 +1302,7 @@ describe('useJobEvents', () => {
   describe('getEventforRow', () => {
     let wrapper;
     beforeEach(() => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
     });
 
@@ -1284,7 +1324,7 @@ describe('useJobEvents', () => {
   describe('getEvent', () => {
     let wrapper;
     beforeEach(() => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
     });
 
@@ -1298,13 +1338,13 @@ describe('useJobEvents', () => {
     let wrapper;
 
     test('should not make call to get child events, because there are none for this job type', () => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
       expect(callbacks.fetchChildrenSummary).not.toHaveBeenCalled();
     });
 
     test('should get basic number of children', () => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
       expect(
         wrapper.find('#test').prop('getTotalNumChildren')('abc-002')
@@ -1312,7 +1352,7 @@ describe('useJobEvents', () => {
     });
 
     test('should get total number of nested children', () => {
-      wrapper = shallow(<HookTest />);
+      wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
       expect(
         wrapper.find('#test').prop('getTotalNumChildren')('abc-001')
@@ -1322,14 +1362,14 @@ describe('useJobEvents', () => {
 
   describe('getCounterForRow', () => {
     test('should return exact counter when no nodes are collapsed', () => {
-      const wrapper = shallow(<HookTest />);
+      const wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
       const getCounterForRow = wrapper.find('#test').prop('getCounterForRow');
       expect(getCounterForRow(8)).toEqual(9);
     });
 
     test('should return estimated counter when node not loaded', () => {
-      const wrapper = shallow(<HookTest />);
+      const wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
       const getCounterForRow = wrapper.find('#test').prop('getCounterForRow');
       expect(getCounterForRow(12)).toEqual(13);
@@ -1343,7 +1383,7 @@ describe('useJobEvents', () => {
           6: { rowNumber: 5, numChidren: 23 },
         },
       });
-      const wrapper = mount(<HookTest {...callbacks} />);
+      const wrapper = mountAsync(<HookTest {...callbacks} />);
       wrapper.update();
       await act(async () => {
         wrapper.find('#test').prop('addEvents')(eventsList);
@@ -1366,7 +1406,7 @@ describe('useJobEvents', () => {
     });
 
     test('should skip over collapsed subtree', () => {
-      const wrapper = shallow(<HookTest />);
+      const wrapper = mountSync(<HookTest />);
       wrapper.find('#test').prop('addEvents')(eventsList);
       wrapper.find('#test').prop('toggleNodeIsCollapsed')('abc-002');
       const getCounterForRow = wrapper.find('#test').prop('getCounterForRow');
@@ -1384,7 +1424,7 @@ describe('useJobEvents', () => {
           meta_event_nested_uuid: {},
         },
       });
-      const wrapper = mount(<HookTest {...callbacks} />);
+      const wrapper = mountAsync(<HookTest {...callbacks} />);
       await act(async () => {
         wrapper.find('#test').prop('addEvents')([
           eventsList[0],
@@ -1418,7 +1458,7 @@ describe('useJobEvents', () => {
           meta_event_nested_uuid: {},
         },
       });
-      const wrapper = mount(<HookTest {...callbacks} />);
+      const wrapper = mountAsync(<HookTest {...callbacks} />);
       await act(async () => {
         wrapper.find('#test').prop('addEvents')([
           eventsList[0],
@@ -1479,7 +1519,7 @@ describe('useJobEvents', () => {
           meta_event_nested_uuid: {},
         },
       });
-      const wrapper = mount(<HookTest {...callbacks} />);
+      const wrapper = mountAsync(<HookTest {...callbacks} />);
       await act(async () => {
         wrapper.find('#test').prop('addEvents')([
           eventsList[0],
@@ -1524,7 +1564,7 @@ describe('useJobEvents', () => {
           meta_event_nested_uuid: {},
         },
       });
-      const wrapper = mount(<HookTest {...callbacks} />);
+      const wrapper = mountAsync(<HookTest {...callbacks} />);
       await act(async () => {
         wrapper.find('#test').prop('addEvents')([
           eventsList[0],

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
@@ -8,7 +8,7 @@ import useJobEvents, {
 
 // The hook returns an imperative API; capture the latest value on every render
 // so tests can call it directly (RTL 12 has no renderHook).
-let latestApi;
+const hookRef = { current: null };
 
 function Child() {
   return <div />;
@@ -37,7 +37,7 @@ function HookTest({
     jobId,
     isFlatMode
   );
-  latestApi = hookFuncs;
+  hookRef.current = hookFuncs;
   return <Child id="test" {...hookFuncs} />;
 }
 
@@ -50,12 +50,12 @@ function makeWrapper(wrapMutators) {
       return (...args) => {
         let result;
         act(() => {
-          result = latestApi[name](...args);
+          result = hookRef.current[name](...args);
         });
         return result;
       };
     }
-    return (...args) => latestApi[name](...args);
+    return (...args) => hookRef.current[name](...args);
   };
   return { find: () => ({ prop: propFn }), update: () => {} };
 }

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutput.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutput.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { waitFor } from '@testing-library/react';
 import { WorkflowJobsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowOutput from './WorkflowOutput';
 
 jest.mock('../../../api');
@@ -76,7 +76,6 @@ const mockWorkflowJobNodes = [
 ];
 
 describe('WorkflowOutput', () => {
-  let wrapper;
   beforeEach(() => {
     WorkflowJobsAPI.readNodes.mockResolvedValue({
       data: {
@@ -122,30 +121,43 @@ describe('WorkflowOutput', () => {
   });
 
   test('renders successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <svg>
-          <WorkflowOutput job={job} />
-        </svg>
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('ContentError')).toHaveLength(0);
-    expect(wrapper.find('WorkflowStartNode')).toHaveLength(1);
-    expect(wrapper.find('WorkflowOutputNode')).toHaveLength(4);
-    expect(wrapper.find('WorkflowOutputLink')).toHaveLength(5);
+    const { container } = renderWithContexts(
+      <svg>
+        <WorkflowOutput job={job} />
+      </svg>
+    );
+
+    // The graph is laid out into <g id="workflow-g"> once nodes load.
+    await waitFor(() =>
+      expect(container.querySelector('#workflow-g')).toBeInTheDocument()
+    );
+
+    expect(container.querySelector('.pf-c-empty-state')).not.toBeInTheDocument();
+    // WorkflowStartNode renders a <g id="node-1">.
+    expect(container.querySelector('#node-1')).toBeInTheDocument();
+    // Each WorkflowOutputNode renders <g id="node-N"> for N > 1 (4 nodes).
+    const outputNodes = Array.from(
+      container.querySelectorAll('g[id^="node-"]')
+    ).filter((g) => g.id !== 'node-1' && g.id !== 'node-add');
+    expect(outputNodes).toHaveLength(4);
+    // Each WorkflowOutputLink renders <g id="link-source-target"> (5 links).
+    const links = Array.from(
+      container.querySelectorAll('g[id^="link-"]')
+    ).filter((g) => !g.id.endsWith('-overlay'));
+    expect(links).toHaveLength(5);
   });
 
   test('error shown to user when error thrown fetching workflow job nodes', async () => {
     WorkflowJobsAPI.readNodes.mockRejectedValue(new Error());
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <svg>
-          <WorkflowOutput job={job} />
-        </svg>
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('ContentError')).toHaveLength(1);
+    const { container } = renderWithContexts(
+      <svg>
+        <WorkflowOutput job={job} />
+      </svg>
+    );
+
+    // ContentError renders a PF empty state with the error heading.
+    await waitFor(() =>
+      expect(container.querySelector('.pf-c-empty-state')).toBeInTheDocument()
+    );
   });
 });

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputGraph.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputGraph.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 import { WorkflowStateContext } from 'contexts/Workflow';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowOutputGraph from './WorkflowOutputGraph';
 
 const workflowContext = {
@@ -94,6 +95,18 @@ const workflowContext = {
   showTools: false,
 };
 
+function renderGraph(contextOverride) {
+  return renderWithContexts(
+    <svg>
+      <WorkflowStateContext.Provider
+        value={{ ...workflowContext, ...contextOverride }}
+      >
+        <WorkflowOutputGraph />
+      </WorkflowStateContext.Provider>
+    </svg>
+  );
+}
+
 describe('WorkflowOutputGraph', () => {
   beforeEach(() => {
     window.SVGElement.prototype.height = {
@@ -133,110 +146,85 @@ describe('WorkflowOutputGraph', () => {
   });
 
   test('mounts successfully', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={workflowContext}>
-          <WorkflowOutputGraph />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-    expect(wrapper).toHaveLength(1);
+    const { container } = renderGraph();
+    expect(container.querySelector('#workflow-svg')).toBeInTheDocument();
   });
 
   test('tools and legend are shown when flags are true', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider
-          value={{ ...workflowContext, showLegend: true, showTools: true }}
-        >
-          <WorkflowOutputGraph />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-
-    expect(wrapper.find('WorkflowLegend')).toHaveLength(1);
-    expect(wrapper.find('WorkflowTools')).toHaveLength(1);
+    const { container, getByText } = renderGraph({
+      showLegend: true,
+      showTools: true,
+    });
+    // WorkflowTools renders the zoom controls; WorkflowLegend its header.
+    expect(
+      container.querySelector(
+        '[data-ouia-component-id="visualizer-zoom-to-fit-button"]'
+      )
+    ).toBeInTheDocument();
+    expect(getByText('Legend')).toBeInTheDocument();
   });
 
   test('nodes and links are properly rendered', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={workflowContext}>
-          <WorkflowOutputGraph />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
+    const { container } = renderGraph();
 
-    expect(wrapper.find('WorkflowStartNode')).toHaveLength(1);
-    expect(wrapper.find('WorkflowOutputNode')).toHaveLength(4);
-    expect(wrapper.find('WorkflowOutputLink')).toHaveLength(5);
-    expect(wrapper.find('#link-2-4')).toHaveLength(1);
-    expect(wrapper.find('#link-2-3')).toHaveLength(1);
-    expect(wrapper.find('#link-5-3')).toHaveLength(1);
-    expect(wrapper.find('#link-1-2')).toHaveLength(1);
-    expect(wrapper.find('#link-1-5')).toHaveLength(1);
+    // WorkflowStartNode -> #node-1; WorkflowOutputNode -> #node-N (N > 1).
+    expect(container.querySelector('#node-1')).toBeInTheDocument();
+    const outputNodes = Array.from(
+      container.querySelectorAll('g[id^="node-"]')
+    ).filter((g) => g.id !== 'node-1' && g.id !== 'node-add');
+    expect(outputNodes).toHaveLength(4);
+
+    const links = Array.from(
+      container.querySelectorAll('g[id^="link-"]')
+    ).filter((g) => !g.id.endsWith('-overlay'));
+    expect(links).toHaveLength(5);
+    expect(container.querySelector('#link-2-4')).toBeInTheDocument();
+    expect(container.querySelector('#link-2-3')).toBeInTheDocument();
+    expect(container.querySelector('#link-5-3')).toBeInTheDocument();
+    expect(container.querySelector('#link-1-2')).toBeInTheDocument();
+    expect(container.querySelector('#link-1-5')).toBeInTheDocument();
   });
 
   test('proper help text is shown when hovering over links and nodes', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={workflowContext}>
-          <WorkflowOutputGraph />
-        </WorkflowStateContext.Provider>
-      </svg>
+    const { container } = renderGraph();
+
+    expect(
+      container.querySelector('#workflow-node-help-name')
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('#workflow-link-help-type')
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(container.querySelector('g#node-2'));
+    expect(container.querySelector('#workflow-node-help-alias')).toHaveTextContent(
+      'Node identifier'
+    );
+    expect(container.querySelector('#workflow-node-help-name')).toHaveTextContent(
+      'Foo JT'
+    );
+    expect(container.querySelector('#workflow-node-help-type')).toHaveTextContent(
+      'Job Template'
+    );
+    expect(
+      container.querySelector('#workflow-node-help-status')
+    ).toHaveTextContent('Successful');
+    expect(
+      container.querySelector('#workflow-node-help-elapsed')
+    ).toHaveTextContent('00:01:00');
+
+    fireEvent.mouseLeave(container.querySelector('g#node-2'));
+    expect(
+      container.querySelector('#workflow-node-help-name')
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(container.querySelector('g#link-2-3'));
+    expect(container.querySelector('#workflow-link-help-type')).toHaveTextContent(
+      'Always'
     );
 
-    expect(wrapper.find('WorkflowNodeHelp')).toHaveLength(0);
-    expect(wrapper.find('WorkflowLinkHelp')).toHaveLength(0);
-    wrapper.find('g#node-2').simulate('mouseenter');
-    expect(wrapper.find('WorkflowNodeHelp')).toHaveLength(1);
+    fireEvent.mouseLeave(container.querySelector('g#link-2-3'));
     expect(
-      wrapper.find('WorkflowNodeHelp').contains(<b>Node Alias</b>)
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('WorkflowNodeHelp')
-        .containsMatchingElement(<dd>Node identifier</dd>)
-    ).toEqual(true);
-    expect(
-      wrapper.find('WorkflowNodeHelp').contains(<b>Resource Name</b>)
-    ).toEqual(true);
-    expect(
-      wrapper.find('WorkflowNodeHelp').containsMatchingElement(<dd>Foo JT</dd>)
-    ).toEqual(true);
-    expect(wrapper.find('WorkflowNodeHelp').contains(<b>Type</b>)).toEqual(
-      true
-    );
-    expect(
-      wrapper
-        .find('WorkflowNodeHelp')
-        .containsMatchingElement(<dd>Job Template</dd>)
-    ).toEqual(true);
-    expect(
-      wrapper.find('WorkflowNodeHelp').contains(<b>Job Status</b>)
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('WorkflowNodeHelp')
-        .containsMatchingElement(<dd>Successful</dd>)
-    ).toEqual(true);
-    expect(wrapper.find('WorkflowNodeHelp').contains(<b>Elapsed</b>)).toEqual(
-      true
-    );
-    expect(
-      wrapper
-        .find('WorkflowNodeHelp')
-        .containsMatchingElement(<dd>00:01:00</dd>)
-    ).toEqual(true);
-    wrapper.find('g#node-2').simulate('mouseleave');
-    expect(wrapper.find('WorkflowNodeHelp')).toHaveLength(0);
-    wrapper.find('g#link-2-3').simulate('mouseenter');
-    expect(wrapper.find('WorkflowLinkHelp')).toHaveLength(1);
-    expect(wrapper.find('WorkflowLinkHelp').contains(<b>Run</b>)).toEqual(true);
-    expect(
-      wrapper.find('WorkflowLinkHelp').containsMatchingElement(<dd>Always</dd>)
-    ).toEqual(true);
-    wrapper.find('g#link-2-3').simulate('mouseleave');
-    expect(wrapper.find('WorkflowLinkHelp')).toHaveLength(0);
+      container.querySelector('#workflow-link-help-type')
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputLink.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputLink.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { WorkflowStateContext } from 'contexts/Workflow';
 import WorkflowOutputLink from './WorkflowOutputLink';
 
@@ -29,7 +29,7 @@ const nodePositions = {
 
 describe('WorkflowOutputLink', () => {
   test('mounts successfully', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowStateContext.Provider value={{ nodePositions }}>
           <WorkflowOutputLink
@@ -41,6 +41,6 @@ describe('WorkflowOutputLink', () => {
         </WorkflowStateContext.Provider>
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
+    expect(container.querySelector('#link-1-2')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { WorkflowStateContext } from 'contexts/Workflow';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowOutputNode from './WorkflowOutputNode';
 
 const nodeWithJT = {
@@ -71,65 +71,47 @@ const nodePositions = {
   },
 };
 
+function renderNode(node) {
+  return renderWithContexts(
+    <svg>
+      <WorkflowStateContext.Provider value={{ nodePositions }}>
+        <WorkflowOutputNode
+          mouseEnter={() => {}}
+          mouseLeave={() => {}}
+          node={node}
+        />
+      </WorkflowStateContext.Provider>
+    </svg>
+  );
+}
+
 describe('WorkflowOutputNode', () => {
   test('mounts successfully', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={nodeWithJT}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-    expect(wrapper).toHaveLength(1);
+    const { container } = renderNode(nodeWithJT);
+    expect(container.querySelector('#node-2')).toBeInTheDocument();
   });
+
   test('node contents displayed correctly when Job and Job Template exist', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={nodeWithJT}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
+    const { container } = renderNode(nodeWithJT);
+    expect(container.querySelector('#node-2')).toHaveTextContent(
+      'Automation JT'
     );
-    expect(wrapper.text('p')).toContain('Automation JT');
-    expect(wrapper.find('WorkflowOutputNode Elapsed').text()).toBe('00:00:07');
+    expect(container.querySelector('#node-2')).toHaveTextContent('00:00:07');
   });
+
   test('node contents displayed correctly when Job Template deleted', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={nodeWithoutJT}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
+    const { container } = renderNode(nodeWithoutJT);
+    expect(container.querySelector('#node-2')).toHaveTextContent(
+      'Automation JT 2'
     );
-    expect(wrapper.contains(<p>Automation JT 2</p>)).toBe(true);
-    expect(wrapper.find('WorkflowOutputNode Elapsed').text()).toBe('00:00:07');
+    expect(container.querySelector('#node-2')).toHaveTextContent('00:00:07');
   });
+
   test('node contents displayed correctly when Job deleted', () => {
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={{ id: 2 }}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-    expect(wrapper.text()).toBe('DELETED');
+    const { container } = renderNode({ id: 2 });
+    expect(container.querySelector('#node-2')).toHaveTextContent('DELETED');
   });
+
   test('carried-forward node (relaunch from failed) shows as successful', () => {
     const carriedNode = {
       id: 2,
@@ -139,27 +121,25 @@ describe('WorkflowOutputNode', () => {
         summary_fields: {
           unified_job_template: { name: 'Carried JT', type: 'job_template' },
         },
-        unifiedJobTemplate: { id: 77, name: 'Carried JT', unified_job_type: 'job' },
+        unifiedJobTemplate: {
+          id: 77,
+          name: 'Carried JT',
+          unified_job_type: 'job',
+        },
       },
     };
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={carriedNode}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-    // no spawned job, but it renders the successful status icon (green), not the default label
-    expect(wrapper.find('StatusIcon[status="successful"]')).toHaveLength(1);
-    expect(wrapper.find('NodeDefaultLabel')).toHaveLength(0);
+    const { container } = renderNode(carriedNode);
+    const node = container.querySelector('#node-2');
+    // no spawned job, but it renders the successful status icon (green)
+    expect(
+      node.querySelector('[data-job-status="successful"]')
+    ).toBeInTheDocument();
     // and it shows the elapsed time carried over from the prior run
-    expect(wrapper.find('WorkflowOutputNode Elapsed').text()).toBe('00:00:07');
+    expect(node).toHaveTextContent('00:00:07');
     // the job-template type letter still renders on the carried node
-    expect(wrapper.find('#node-2-type-letter').first().text()).toBe('JT');
+    expect(container.querySelector('#node-2-type-letter')).toHaveTextContent(
+      'JT'
+    );
   });
 
   test('pending node (not yet run) shows its type letter from the start', () => {
@@ -171,19 +151,10 @@ describe('WorkflowOutputNode', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={pendingNode}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
+    const { container } = renderNode(pendingNode);
+    expect(container.querySelector('#node-4-type-letter')).toHaveTextContent(
+      'JT'
     );
-    // no job and not carried, but the type letter is shown immediately
-    expect(wrapper.find('#node-4-type-letter').first().text()).toBe('JT');
   });
 
   test('carried-forward nested workflow node shows the W type letter', () => {
@@ -200,18 +171,10 @@ describe('WorkflowOutputNode', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={carriedWorkflowNode}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
+    const { container } = renderNode(carriedWorkflowNode);
+    expect(container.querySelector('#node-3-type-letter')).toHaveTextContent(
+      'W'
     );
-    expect(wrapper.find('#node-3-type-letter').first().text()).toBe('W');
   });
 
   test('running node has a blue frame matching the running icon', () => {
@@ -224,18 +187,8 @@ describe('WorkflowOutputNode', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={runningNode}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-    expect(wrapper.find('rect').first().prop('stroke')).toBe(
+    const { container } = renderNode(runningNode);
+    expect(container.querySelector('rect').getAttribute('stroke')).toBe(
       'var(--pf-global--primary-color--100)'
     );
   });
@@ -257,19 +210,8 @@ describe('WorkflowOutputNode', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={runningNode}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-    wrapper.update();
-    expect(wrapper.find('WorkflowOutputNode Elapsed').text()).toBe('00:00:10');
+    const { container } = renderNode(runningNode);
+    expect(container.querySelector('#node-2')).toHaveTextContent('00:00:10');
     jest.useRealTimers();
   });
 
@@ -283,18 +225,8 @@ describe('WorkflowOutputNode', () => {
         },
       },
     };
-    const wrapper = mountWithContexts(
-      <svg>
-        <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowOutputNode
-            mouseEnter={() => {}}
-            mouseLeave={() => {}}
-            node={canceledNode}
-          />
-        </WorkflowStateContext.Provider>
-      </svg>
-    );
-    expect(wrapper.find('rect').first().prop('stroke')).toBe(
+    const { container } = renderNode(canceledNode);
+    expect(container.querySelector('rect').getAttribute('stroke')).toBe(
       'var(--pf-global--palette--orange-300)'
     );
   });

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputToolbar.test.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import {
   WorkflowDispatchContext,
   WorkflowStateContext,
 } from 'contexts/Workflow';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import WorkflowOutputToolbar from './WorkflowOutputToolbar';
 
-let wrapper;
 const dispatch = jest.fn();
 const job = {
   id: 1,
@@ -30,128 +29,94 @@ const workflowContext = {
   showTools: false,
 };
 
-function shouldFind(element) {
-  expect(wrapper.find(element)).toHaveLength(1);
+function renderToolbar(jobOverride, contextOverride, onDelete) {
+  return renderWithContexts(
+    <WorkflowDispatchContext.Provider value={dispatch}>
+      <WorkflowStateContext.Provider
+        value={{ ...workflowContext, ...contextOverride }}
+      >
+        <WorkflowOutputToolbar
+          job={jobOverride || job}
+          onDelete={onDelete || (() => {})}
+        />
+      </WorkflowStateContext.Provider>
+    </WorkflowDispatchContext.Provider>
+  );
 }
-describe('WorkflowOutputToolbar', () => {
-  beforeAll(() => {
-    const nodes = [
-      {
-        id: 1,
-      },
-      {
-        id: 2,
-      },
-      {
-        id: 3,
-        isDeleted: true,
-      },
-    ];
-    wrapper = mountWithContexts(
-      <WorkflowDispatchContext.Provider value={dispatch}>
-        <WorkflowStateContext.Provider value={{ ...workflowContext, nodes }}>
-          <WorkflowOutputToolbar job={job} />
-        </WorkflowStateContext.Provider>
-      </WorkflowDispatchContext.Provider>
-    );
-  });
 
+const byOuia = (id) => document.querySelector(`[data-ouia-component-id="${id}"]`);
+
+const nodes = [{ id: 1 }, { id: 2 }, { id: 3, isDeleted: true }];
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('WorkflowOutputToolbar', () => {
   test('should render correct toolbar item', () => {
-    shouldFind(`Button[ouiaId="edit-workflow"]`);
-    shouldFind('Button#workflow-output-toggle-legend');
-    shouldFind('Badge#workflow-elapsed-badge');
-    shouldFind('Button#workflow-output-toggle-tools');
-    shouldFind('JobCancelButton');
+    renderToolbar(job, { nodes });
+    expect(byOuia('edit-workflow')).toBeInTheDocument();
+    expect(
+      document.querySelector('#workflow-output-toggle-legend')
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('#workflow-elapsed-badge')
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('#workflow-output-toggle-tools')
+    ).toBeInTheDocument();
+    expect(byOuia('cancel-job-button')).toBeInTheDocument();
     // a runnable (non-failed) workflow shows a plain relaunch button
-    shouldFind('Button[ouiaId="workflow-output-relaunch-button"]');
+    expect(byOuia('workflow-output-relaunch-button')).toBeInTheDocument();
   });
 
   test('failed workflow shows the relaunch-from-failed dropdown', () => {
-    const failedJob = { ...job, status: 'failed' };
-    const failedWrapper = mountWithContexts(
-      <WorkflowDispatchContext.Provider value={dispatch}>
-        <WorkflowStateContext.Provider
-          value={{ ...workflowContext, nodes: [{ id: 1 }] }}
-        >
-          <WorkflowOutputToolbar job={failedJob} />
-        </WorkflowStateContext.Provider>
-      </WorkflowDispatchContext.Provider>
-    );
-    expect(failedWrapper.find('WorkflowReLaunchDropDown')).toHaveLength(1);
-    expect(
-      failedWrapper.find('Button[ouiaId="workflow-output-relaunch-button"]')
-    ).toHaveLength(0);
+    renderToolbar({ ...job, status: 'failed' }, { nodes: [{ id: 1 }] });
+    expect(byOuia('relaunch-workflow-toggle')).toBeInTheDocument();
+    expect(byOuia('workflow-output-relaunch-button')).not.toBeInTheDocument();
   });
 
   ['error', 'canceled'].forEach((status) => {
     test(`${status} workflow also shows the relaunch-from-failed dropdown`, () => {
-      const wrapper2 = mountWithContexts(
-        <WorkflowDispatchContext.Provider value={dispatch}>
-          <WorkflowStateContext.Provider
-            value={{ ...workflowContext, nodes: [{ id: 1 }] }}
-          >
-            <WorkflowOutputToolbar job={{ ...job, status }} />
-          </WorkflowStateContext.Provider>
-        </WorkflowDispatchContext.Provider>
-      );
-      const dropdown = wrapper2.find('WorkflowReLaunchDropDown');
-      expect(dropdown).toHaveLength(1);
-      expect(dropdown.prop('status')).toBe(status);
-      expect(
-        wrapper2.find('Button[ouiaId="workflow-output-relaunch-button"]')
-      ).toHaveLength(0);
+      renderToolbar({ ...job, status }, { nodes: [{ id: 1 }] });
+      expect(byOuia('relaunch-workflow-toggle')).toBeInTheDocument();
+      expect(byOuia('workflow-output-relaunch-button')).not.toBeInTheDocument();
     });
   });
 
   test('shows a delete button when the workflow is finished and deletable', () => {
-    const finishedJob = { ...job, status: 'successful' };
-    const finishedWrapper = mountWithContexts(
-      <WorkflowDispatchContext.Provider value={dispatch}>
-        <WorkflowStateContext.Provider
-          value={{ ...workflowContext, nodes: [{ id: 1 }] }}
-        >
-          <WorkflowOutputToolbar job={finishedJob} onDelete={() => {}} />
-        </WorkflowStateContext.Provider>
-      </WorkflowDispatchContext.Provider>
+    renderToolbar(
+      { ...job, status: 'successful' },
+      { nodes: [{ id: 1 }] },
+      () => {}
     );
-    expect(
-      finishedWrapper.find('DeleteButton[ouiaId="workflow-output-delete-button"]')
-    ).toHaveLength(1);
+    expect(byOuia('workflow-output-delete-button')).toBeInTheDocument();
   });
 
   test('Shows correct number of nodes', () => {
-    // The start node (id=1) and deleted nodes (isDeleted=true) should be ignored
-    expect(
-      wrapper
-        .find('Badge')
-        .filterWhere((b) => b.prop('id') !== 'workflow-elapsed-badge')
-        .text()
-    ).toBe('1');
+    renderToolbar(job, { nodes });
+    // The start node (id=1) and deleted nodes (isDeleted=true) are ignored,
+    // leaving 1; the elapsed badge has a distinct id.
+    const badges = Array.from(
+      document.querySelectorAll('.pf-c-badge')
+    ).filter((b) => b.id !== 'workflow-elapsed-badge');
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveTextContent('1');
   });
 
-  test('Toggle Legend button dispatches as expected', () => {
-    wrapper.find('CompassIcon').simulate('click');
+  test('Toggle Legend button dispatches as expected', async () => {
+    const { user } = renderToolbar(job, { nodes });
+    await user.click(document.querySelector('#workflow-output-toggle-legend'));
     expect(dispatch).toHaveBeenCalledWith({ type: 'TOGGLE_LEGEND' });
   });
 
-  test('Toggle Tools button dispatches as expected', () => {
-    wrapper.find('WrenchIcon').simulate('click');
+  test('Toggle Tools button dispatches as expected', async () => {
+    const { user } = renderToolbar(job, { nodes });
+    await user.click(document.querySelector('#workflow-output-toggle-tools'));
     expect(dispatch).toHaveBeenCalledWith({ type: 'TOGGLE_TOOLS' });
   });
 
   test('does not render the visualizer button when no workflow template exists', () => {
-    const nodes = [
-      {
-        id: 1,
-      },
-      {
-        id: 2,
-      },
-      {
-        id: 3,
-        isDeleted: true,
-      },
-    ];
     const slicedJob = {
       ...job,
       summary_fields: {
@@ -159,17 +124,8 @@ describe('WorkflowOutputToolbar', () => {
         workflow_job_template: null,
       },
     };
-    const slicedWrapper = mountWithContexts(
-      <WorkflowDispatchContext.Provider value={dispatch}>
-        <WorkflowStateContext.Provider value={{ ...workflowContext, nodes }}>
-          <WorkflowOutputToolbar job={slicedJob} />
-        </WorkflowStateContext.Provider>
-      </WorkflowDispatchContext.Provider>
-    );
-
-    expect(slicedWrapper.find('Button[ouiaId="edit-workflow"]')).toHaveLength(
-      0
-    );
+    renderToolbar(slicedJob, { nodes });
+    expect(byOuia('edit-workflow')).not.toBeInTheDocument();
   });
 
   describe('elapsed timer', () => {
@@ -182,62 +138,46 @@ describe('WorkflowOutputToolbar', () => {
       jest.useRealTimers();
     });
 
-    function mountToolbar(jobOverrides) {
-      return mountWithContexts(
-        <WorkflowDispatchContext.Provider value={dispatch}>
-          <WorkflowStateContext.Provider value={workflowContext}>
-            <WorkflowOutputToolbar job={{ ...job, ...jobOverrides }} />
-          </WorkflowStateContext.Provider>
-        </WorkflowDispatchContext.Provider>
-      );
-    }
+    const elapsedText = () =>
+      document.querySelector('#workflow-elapsed-badge').textContent;
 
     test('should show live elapsed time while running', () => {
-      const runningWrapper = mountToolbar({
+      renderToolbar({
+        ...job,
         started: '2021-09-01T12:30:40.000Z',
         finished: null,
       });
-      expect(
-        runningWrapper.find('Badge#workflow-elapsed-badge').text()
-      ).toBe('00:00:05');
+      expect(elapsedText()).toBe('00:00:05');
       act(() => {
         jest.advanceTimersByTime(2000);
       });
-      runningWrapper.update();
-      expect(
-        runningWrapper.find('Badge#workflow-elapsed-badge').text()
-      ).toBe('00:00:07');
+      expect(elapsedText()).toBe('00:00:07');
     });
 
     test('should keep the live value while finished is set but elapsed has not arrived yet', () => {
-      const wsWindowWrapper = mountToolbar({
+      renderToolbar({
+        ...job,
         status: 'successful',
         started: '2021-09-01T12:30:40.000Z',
         finished: '2021-09-01T12:30:45.000Z',
         elapsed: undefined,
       });
-      expect(
-        wsWindowWrapper.find('Badge#workflow-elapsed-badge').text()
-      ).toBe('00:00:05');
+      expect(elapsedText()).toBe('00:00:05');
     });
 
     test('should show final elapsed time once finished', () => {
-      const finishedWrapper = mountToolbar({
+      renderToolbar({
+        ...job,
         status: 'successful',
         started: '2021-09-01T11:00:00.000Z',
         finished: '2021-09-01T12:01:01.000Z',
         elapsed: 3661,
       });
-      expect(
-        finishedWrapper.find('Badge#workflow-elapsed-badge').text()
-      ).toBe('01:01:01');
+      expect(elapsedText()).toBe('01:01:01');
       act(() => {
         jest.advanceTimersByTime(2000);
       });
-      finishedWrapper.update();
-      expect(
-        finishedWrapper.find('Badge#workflow-elapsed-badge').text()
-      ).toBe('01:01:01');
+      expect(elapsedText()).toBe('01:01:01');
     });
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **Job** screen's test suite from enzyme to React Testing Library, continuing the incremental enzyme → RTL migration (one screen directory per PR). This is the largest screen directory; it included two files importing `enzyme` directly (`WorkflowOutputLink`, `useJobEvents`) which are also converted, so the directory is now fully enzyme-free.

Files migrated off enzyme onto `renderWithContexts` / RTL `render`:

- `Job` — tab routing under a real v6 route
- `JobDetail` — detail fields, relaunch/cancel/delete + related-resource reads
- `JobOutput/*` — `JobOutput` (virtualized list — `computeOverscanIndices` tested directly), `JobEvent`, `JobEventSkeleton`, `JobOutputSearch`, `PageControls`, `HostEventModal`, `HostStatusBar`, `OutputToolbar`
- `WorkflowOutput/*` — graph, node, toolbar, link (SVG assertions via stable element ids)
- `useJobEvents` — reducer logic unchanged; the imperative hook API is exercised via a captured-render helper (RTL 12 has no `renderHook`), with mutators wrapped in `act()`

Interactions go through accessible roles and real user events. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for the Job directory: **19 suites, 164 tests, all passing.** ESLint clean. No production code changed — test-only.

Notes: `JobOutput`'s react-virtualized list renders no rows under jsdom, so the overscan logic is tested through the exported pure `computeOverscanIndices` (all numeric expectations preserved); a couple of empty-i18n detail values were dropped with comments.
