### PR TITLE
enzyme -> RTL: convert the Workflow visualizer component suites

### DIFF
--- a/awx/ui/src/components/Workflow/WorkflowActionTooltip.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowActionTooltip.test.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import WorkflowActionTooltip from './WorkflowActionTooltip';
 
 describe('WorkflowActionTooltip', () => {
   test('successfully mounts', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowActionTooltip actions={[]} pointX={0} pointY={0} />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
+    expect(container.querySelector('foreignObject')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowActionTooltipItem.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowActionTooltipItem.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import WorkflowActionTooltipItem from './WorkflowActionTooltipItem';
 
 describe('WorkflowActionTooltipItem', () => {
   test('successfully mounts', () => {
-    const wrapper = mount(<WorkflowActionTooltipItem id="node" />);
-    expect(wrapper).toHaveLength(1);
+    const { container } = render(<WorkflowActionTooltipItem id="node" />);
+    expect(container.querySelector('#node')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowHelp.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowHelp.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import WorkflowHelp from './WorkflowHelp';
 
 describe('WorkflowHelp', () => {
   test('successfully mounts', () => {
-    const wrapper = mount(<WorkflowHelp />);
-    expect(wrapper).toHaveLength(1);
+    render(<WorkflowHelp>Help content</WorkflowHelp>);
+    expect(screen.getByText('Help content')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowLegend.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowLegend.test.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowLegend from './WorkflowLegend';
 
 describe('WorkflowLegend', () => {
   test('renders the expected content', () => {
-    const wrapper = mountWithContexts(<WorkflowLegend onClose={() => {}} />);
-    expect(wrapper).toHaveLength(1);
+    renderWithContexts(<WorkflowLegend onClose={() => {}} />);
+    expect(screen.getByText('Legend')).toBeInTheDocument();
+    expect(screen.getByText('Job Template')).toBeInTheDocument();
+    expect(screen.getByText('Always')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowLinkHelp.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowLinkHelp.test.js
@@ -1,31 +1,39 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowLinkHelp from './WorkflowLinkHelp';
 
 describe('WorkflowLinkHelp', () => {
   test('successfully mounts', () => {
-    const wrapper = mountWithContexts(<WorkflowLinkHelp link={{}} />);
-    expect(wrapper).toHaveLength(1);
+    const { container } = renderWithContexts(<WorkflowLinkHelp link={{}} />);
+    expect(
+      container.querySelector('#workflow-link-help-type')
+    ).toBeInTheDocument();
   });
   test('renders the expected content for an on success link', () => {
     const link = {
       linkType: 'success',
     };
-    const wrapper = mountWithContexts(<WorkflowLinkHelp link={link} />);
-    expect(wrapper.find('#workflow-link-help-type').text()).toBe('On Success');
+    const { container } = renderWithContexts(<WorkflowLinkHelp link={link} />);
+    expect(
+      container.querySelector('#workflow-link-help-type')
+    ).toHaveTextContent('On Success');
   });
   test('renders the expected content for an on failure link', () => {
     const link = {
       linkType: 'failure',
     };
-    const wrapper = mountWithContexts(<WorkflowLinkHelp link={link} />);
-    expect(wrapper.find('#workflow-link-help-type').text()).toBe('On Failure');
+    const { container } = renderWithContexts(<WorkflowLinkHelp link={link} />);
+    expect(
+      container.querySelector('#workflow-link-help-type')
+    ).toHaveTextContent('On Failure');
   });
   test('renders the expected content for an always link', () => {
     const link = {
       linkType: 'always',
     };
-    const wrapper = mountWithContexts(<WorkflowLinkHelp link={link} />);
-    expect(wrapper.find('#workflow-link-help-type').text()).toBe('Always');
+    const { container } = renderWithContexts(<WorkflowLinkHelp link={link} />);
+    expect(
+      container.querySelector('#workflow-link-help-type')
+    ).toHaveTextContent('Always');
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowNodeHelp.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeHelp.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowNodeHelp from './WorkflowNodeHelp';
 
 const node = {
@@ -26,17 +26,21 @@ const node = {
 
 describe('WorkflowNodeHelp', () => {
   test('renders the expected content for a completed job template job', () => {
-    const wrapper = mountWithContexts(<WorkflowNodeHelp node={node} />);
-    expect(wrapper.find('#workflow-node-help-alias').text()).toBe('Foo');
-    expect(wrapper.find('#workflow-node-help-name').text()).toBe(
-      'Foo Job Template'
-    );
-    expect(wrapper.find('#workflow-node-help-type').text()).toBe(
-      'Job Template'
-    );
-    expect(wrapper.find('#workflow-node-help-status').text()).toBe(
-      'Successful'
-    );
-    expect(wrapper.find('#workflow-node-help-elapsed').text()).toBe('02:30:00');
+    const { container } = renderWithContexts(<WorkflowNodeHelp node={node} />);
+    expect(
+      container.querySelector('#workflow-node-help-alias')
+    ).toHaveTextContent('Foo');
+    expect(
+      container.querySelector('#workflow-node-help-name')
+    ).toHaveTextContent('Foo Job Template');
+    expect(
+      container.querySelector('#workflow-node-help-type')
+    ).toHaveTextContent('Job Template');
+    expect(
+      container.querySelector('#workflow-node-help-status')
+    ).toHaveTextContent('Successful');
+    expect(
+      container.querySelector('#workflow-node-help-elapsed')
+    ).toHaveTextContent('02:30:00');
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowNodeTypeLetter.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeTypeLetter.test.js
@@ -1,44 +1,40 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { PauseIcon } from '@patternfly/react-icons';
+import { render } from '@testing-library/react';
 import WorkflowNodeTypeLetter from './WorkflowNodeTypeLetter';
 
 describe('WorkflowNodeTypeLetter', () => {
   test('renders JT when type=job_template', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{ fullUnifiedJobTemplate: { type: 'job_template' } }}
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('JT');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('JT');
   });
   test('renders JT when unified_job_type=job', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{ fullUnifiedJobTemplate: { unified_job_type: 'job' } }}
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('JT');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('JT');
   });
   test('renders P when type=project', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{ fullUnifiedJobTemplate: { type: 'project' } }}
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('P');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('P');
   });
   test('renders P when unified_job_type=project_update', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{
@@ -47,22 +43,20 @@ describe('WorkflowNodeTypeLetter', () => {
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('P');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('P');
   });
   test('renders I when type=inventory_source', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{ fullUnifiedJobTemplate: { type: 'inventory_source' } }}
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('I');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('I');
   });
   test('renders I when unified_job_type=inventory_update', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{
@@ -71,22 +65,20 @@ describe('WorkflowNodeTypeLetter', () => {
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('I');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('I');
   });
   test('renders W when type=workflow_job_template', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{ fullUnifiedJobTemplate: { type: 'workflow_job_template' } }}
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('W');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('W');
   });
   test('renders W when unified_job_type=workflow_job', () => {
-    const wrapper = mount(
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{
@@ -95,11 +87,10 @@ describe('WorkflowNodeTypeLetter', () => {
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.text()).toBe('W');
+    expect(container.querySelector('foreignObject')).toHaveTextContent('W');
   });
-  test('renders puse icon when type=workflow_approval_template', () => {
-    const wrapper = mount(
+  test('renders pause icon when type=workflow_approval_template', () => {
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{
@@ -108,11 +99,10 @@ describe('WorkflowNodeTypeLetter', () => {
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.containsMatchingElement(<PauseIcon />));
+    expect(container.querySelector('svg')).toBeInTheDocument();
   });
-  test('renders W when unified_job_type=workflow_approval', () => {
-    const wrapper = mount(
+  test('renders pause icon when unified_job_type=workflow_approval', () => {
+    const { container } = render(
       <svg>
         <WorkflowNodeTypeLetter
           node={{
@@ -121,7 +111,6 @@ describe('WorkflowNodeTypeLetter', () => {
         />
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
-    expect(wrapper.containsMatchingElement(<PauseIcon />));
+    expect(container.querySelector('svg')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowNodeTypeLetter.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeTypeLetter.test.js
@@ -99,7 +99,9 @@ describe('WorkflowNodeTypeLetter', () => {
         />
       </svg>
     );
-    expect(container.querySelector('svg')).toBeInTheDocument();
+    // the pause icon is an <svg> rendered inside the component's foreignObject;
+    // the outer wrapper <svg> would match either way, so scope to foreignObject
+    expect(container.querySelector('foreignObject svg')).toBeInTheDocument();
   });
   test('renders pause icon when unified_job_type=workflow_approval', () => {
     const { container } = render(
@@ -111,6 +113,8 @@ describe('WorkflowNodeTypeLetter', () => {
         />
       </svg>
     );
-    expect(container.querySelector('svg')).toBeInTheDocument();
+    // the pause icon is an <svg> rendered inside the component's foreignObject;
+    // the outer wrapper <svg> would match either way, so scope to foreignObject
+    expect(container.querySelector('foreignObject svg')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowStartNode.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowStartNode.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-
+import { fireEvent, waitFor } from '@testing-library/react';
 import { WorkflowStateContext } from 'contexts/Workflow';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowStartNode from './WorkflowStartNode';
 
 const nodePositions = {
@@ -13,7 +13,7 @@ const nodePositions = {
 
 describe('WorkflowStartNode', () => {
   test('mounts successfully', () => {
-    const wrapper = mountWithContexts(
+    const { container } = renderWithContexts(
       <svg>
         <WorkflowStateContext.Provider value={{ nodePositions }}>
           <WorkflowStartNode
@@ -23,23 +23,25 @@ describe('WorkflowStartNode', () => {
         </WorkflowStateContext.Provider>
       </svg>
     );
-    expect(wrapper).toHaveLength(1);
+    expect(container.querySelector('#node-1')).toBeInTheDocument();
   });
-  test('tooltip shown on hover', () => {
-    const wrapper = mountWithContexts(
+  test('tooltip shown on hover', async () => {
+    const { container } = renderWithContexts(
       <svg>
         <WorkflowStateContext.Provider value={{ nodePositions }}>
-          <WorkflowStartNode
-            nodePositions={nodePositions}
-            showActionTooltip
-          />
+          <WorkflowStartNode nodePositions={nodePositions} showActionTooltip />
         </WorkflowStateContext.Provider>
       </svg>
     );
-    expect(wrapper.find('WorkflowActionTooltip')).toHaveLength(0);
-    wrapper.find('WorkflowStartNode').simulate('mouseenter');
-    expect(wrapper.find('WorkflowActionTooltip')).toHaveLength(1);
-    wrapper.find('WorkflowStartNode').simulate('mouseleave');
-    expect(wrapper.find('WorkflowActionTooltip')).toHaveLength(0);
+    const startNode = container.querySelector('#node-1');
+    expect(container.querySelector('#node-add')).not.toBeInTheDocument();
+    fireEvent.mouseEnter(startNode);
+    await waitFor(() =>
+      expect(container.querySelector('#node-add')).toBeInTheDocument()
+    );
+    fireEvent.mouseLeave(startNode);
+    await waitFor(() =>
+      expect(container.querySelector('#node-add')).not.toBeInTheDocument()
+    );
   });
 });

--- a/awx/ui/src/components/Workflow/WorkflowTools.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowTools.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowTools from './WorkflowTools';
 
 describe('WorkflowTools', () => {
   test('renders the expected content', () => {
-    const wrapper = mountWithContexts(
+    const { container } = renderWithContexts(
       <WorkflowTools
         onClose={() => {}}
         onFitGraph={() => {}}
@@ -14,12 +14,14 @@ describe('WorkflowTools', () => {
         zoomPercentage={100}
       />
     );
-    expect(wrapper).toHaveLength(1);
+    expect(
+      container.querySelector('[data-ouia-component-id="visualizer-zoom-in-button"]')
+    ).toBeInTheDocument();
   });
-  test('clicking zoom/pan buttons passes callback correct values', () => {
+  test('clicking zoom/pan buttons passes callback correct values', async () => {
     const pan = jest.fn();
     const zoomChange = jest.fn();
-    const wrapper = mountWithContexts(
+    const { container, user } = renderWithContexts(
       <WorkflowTools
         onClose={() => {}}
         onFitGraph={() => {}}
@@ -29,17 +31,19 @@ describe('WorkflowTools', () => {
         zoomPercentage={95.7}
       />
     );
-    wrapper.find('PlusIcon').simulate('click');
+    const byOuia = (id) =>
+      container.querySelector(`[data-ouia-component-id="${id}"]`);
+    await user.click(byOuia('visualizer-zoom-in-button'));
     expect(zoomChange).toHaveBeenCalledWith(1.1);
-    wrapper.find('MinusIcon').simulate('click');
+    await user.click(byOuia('visualizer-zoom-out-button'));
     expect(zoomChange).toHaveBeenCalledWith(0.8);
-    wrapper.find('CaretLeftIcon').simulate('click');
+    await user.click(byOuia('visualizer-pan-left-button'));
     expect(pan).toHaveBeenCalledWith('left');
-    wrapper.find('CaretUpIcon').simulate('click');
+    await user.click(byOuia('visualizer-pan-up-button'));
     expect(pan).toHaveBeenCalledWith('up');
-    wrapper.find('CaretRightIcon').simulate('click');
+    await user.click(byOuia('visualizer-pan-right-button'));
     expect(pan).toHaveBeenCalledWith('right');
-    wrapper.find('CaretDownIcon').simulate('click');
+    await user.click(byOuia('visualizer-pan-down-button'));
     expect(pan).toHaveBeenCalledWith('down');
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the shared **Workflow visualizer** component test suite (`components/Workflow`) from enzyme to React Testing Library, as part of the incremental enzyme → RTL migration (now moving from screens into shared components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `WorkflowActionTooltip(+Item)`, `WorkflowHelp`, `WorkflowNodeHelp`, `WorkflowLinkHelp`, `WorkflowNodeTypeLetter`, `WorkflowLegend`, `WorkflowStartNode`, `WorkflowTools`.

SVG primitives have no ARIA roles, so content is asserted via stable element ids / `foreignObject` selectors and `getByText`; the visualizer toolbar buttons are selected by their `data-ouia-component-id`. A couple of dead enzyme assertions (a `containsMatchingElement` call missing its `expect`, a `toHaveLength(1)` no-op) were upgraded to real DOM assertions. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/Workflow`: **11 suites, 60 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
