### PR TITLE
enzyme -> RTL: convert the Lookup component suites

### DIFF
--- a/awx/ui/src/components/Lookup/ApplicationLookup.js
+++ b/awx/ui/src/components/Lookup/ApplicationLookup.js
@@ -36,7 +36,7 @@ function ApplicationLookup({ onChange, value, label, fieldName, validate }) {
         actionsResponse,
       ] = await Promise.all([
         ApplicationsAPI.read(params),
-        ApplicationsAPI.readOptions,
+        ApplicationsAPI.readOptions(),
       ]);
       return {
         applications: results,

--- a/awx/ui/src/components/Lookup/ApplicationLookup.test.js
+++ b/awx/ui/src/components/Lookup/ApplicationLookup.test.js
@@ -23,7 +23,7 @@ const fetchedApplications = {
       },
       {
         id: 4,
-        name: 'application that should not crach',
+        name: 'application that should not crash',
         description: '',
       },
     ],
@@ -32,9 +32,9 @@ const fetchedApplications = {
 describe('ApplicationLookup', () => {
   beforeEach(() => {
     ApplicationsAPI.read.mockResolvedValueOnce(fetchedApplications);
-    ApplicationsAPI.readOptions = {
+    ApplicationsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} }, related_search_fields: [] },
-    };
+    });
   });
 
   afterEach(() => {

--- a/awx/ui/src/components/Lookup/ApplicationLookup.test.js
+++ b/awx/ui/src/components/Lookup/ApplicationLookup.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { ApplicationsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ApplicationLookup from './ApplicationLookup';
 
 jest.mock('../../api');
@@ -13,25 +13,28 @@ const application = {
 };
 
 const fetchedApplications = {
-  count: 2,
-  results: [
-    {
-      id: 1,
-      name: 'app',
-      description: '',
-    },
-    {
-      id: 4,
-      name: 'application that should not crach',
-      description: '',
-    },
-  ],
+  data: {
+    count: 2,
+    results: [
+      {
+        id: 1,
+        name: 'app',
+        description: '',
+      },
+      {
+        id: 4,
+        name: 'application that should not crach',
+        description: '',
+      },
+    ],
+  },
 };
 describe('ApplicationLookup', () => {
-  let wrapper;
-
   beforeEach(() => {
     ApplicationsAPI.read.mockResolvedValueOnce(fetchedApplications);
+    ApplicationsAPI.readOptions = {
+      data: { actions: { GET: {} }, related_search_fields: [] },
+    };
   });
 
   afterEach(() => {
@@ -39,48 +42,46 @@ describe('ApplicationLookup', () => {
   });
 
   test('should render successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ApplicationLookup
-            label="Application"
-            value={application}
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    expect(wrapper.find('ApplicationLookup')).toHaveLength(1);
+    renderWithContexts(
+      <Formik>
+        <ApplicationLookup
+          label="Application"
+          value={application}
+          onChange={() => {}}
+        />
+      </Formik>
+    );
+    expect(await screen.findByText('Application')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Search' })
+    ).toBeInTheDocument();
   });
 
   test('should fetch applications', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ApplicationLookup
-            label="Application"
-            value={application}
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    expect(ApplicationsAPI.read).toHaveBeenCalledTimes(1);
+    renderWithContexts(
+      <Formik>
+        <ApplicationLookup
+          label="Application"
+          value={application}
+          onChange={() => {}}
+        />
+      </Formik>
+    );
+    await waitFor(() =>
+      expect(ApplicationsAPI.read).toHaveBeenCalledTimes(1)
+    );
   });
 
   test('should display label', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ApplicationLookup
-            label="Application"
-            value={application}
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    const title = wrapper.find('FormGroup .pf-c-form__label-text');
-    expect(title.text()).toEqual('Application');
+    renderWithContexts(
+      <Formik>
+        <ApplicationLookup
+          label="Application"
+          value={application}
+          onChange={() => {}}
+        />
+      </Formik>
+    );
+    expect(await screen.findByText('Application')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Lookup/CredentialLookup.test.js
+++ b/awx/ui/src/components/Lookup/CredentialLookup.test.js
@@ -1,15 +1,13 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { CredentialsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import CredentialLookup, { _CredentialLookup } from './CredentialLookup';
 
 jest.mock('../../api');
 
 describe('CredentialLookup', () => {
-  let wrapper;
-
   beforeEach(() => {
     CredentialsAPI.read.mockResolvedValueOnce({
       data: {
@@ -41,33 +39,24 @@ describe('CredentialLookup', () => {
   });
 
   test('should render successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialLookup
-            credentialTypeId={1}
-            label="Foo"
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    expect(wrapper.find('CredentialLookup')).toHaveLength(1);
+    renderWithContexts(
+      <Formik>
+        <CredentialLookup credentialTypeId={1} label="Foo" onChange={() => {}} />
+      </Formik>
+    );
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Search' })
+    ).toBeInTheDocument();
   });
 
   test('should fetch credentials', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialLookup
-            credentialTypeId={1}
-            label="Foo"
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    expect(CredentialsAPI.read).toHaveBeenCalledTimes(1);
+    renderWithContexts(
+      <Formik>
+        <CredentialLookup credentialTypeId={1} label="Foo" onChange={() => {}} />
+      </Formik>
+    );
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
     expect(CredentialsAPI.read).toHaveBeenCalledWith({
       credential_type: 1,
       order_by: 'name',
@@ -77,104 +66,85 @@ describe('CredentialLookup', () => {
   });
 
   test('should display label', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialLookup
-            credentialTypeId={1}
-            label="Foo"
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    const title = wrapper.find('FormGroup .pf-c-form__label-text');
-    expect(title.text()).toEqual('Foo');
+    renderWithContexts(
+      <Formik>
+        <CredentialLookup credentialTypeId={1} label="Foo" onChange={() => {}} />
+      </Formik>
+    );
+    expect(await screen.findByText('Foo')).toBeInTheDocument();
   });
 
-  test('should define default value for function props', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialLookup
-            credentialTypeId={1}
-            label="Foo"
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
+  test('should define default value for function props', () => {
     expect(_CredentialLookup.defaultProps.onBlur).toBeInstanceOf(Function);
     expect(_CredentialLookup.defaultProps.onBlur).not.toThrow();
   });
 
   test('should not auto-select credential when autoPopulate prop is false', async () => {
-    CredentialsAPI.read.mockReturnValue({
+    CredentialsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1 }],
+        results: [{ id: 1, name: 'Cred 1', url: 'www.google.com' }],
         count: 1,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialLookup
-            credentialTypeId={1}
-            label="Foo"
-            onChange={onChange}
-          />
-        </Formik>
-      );
-    });
+    renderWithContexts(
+      <Formik>
+        <CredentialLookup credentialTypeId={1} label="Foo" onChange={onChange} />
+      </Formik>
+    );
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
     expect(onChange).not.toHaveBeenCalled();
   });
 
   test('should not auto-select credential when multiple available', async () => {
-    CredentialsAPI.read.mockReturnValue({
+    CredentialsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1 }, { id: 2 }],
+        results: [
+          { id: 1, name: 'Cred 1', url: 'www.google.com' },
+          { id: 2, name: 'Cred 2', url: 'www.google.com' },
+        ],
         count: 2,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialLookup
-            credentialTypeId={1}
-            label="Foo"
-            autoPopulate
-            onChange={onChange}
-          />
-        </Formik>
-      );
-    });
+    renderWithContexts(
+      <Formik>
+        <CredentialLookup
+          credentialTypeId={1}
+          label="Foo"
+          autoPopulate
+          onChange={onChange}
+        />
+      </Formik>
+    );
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
     expect(onChange).not.toHaveBeenCalled();
   });
 });
 
 describe('CredentialLookup auto select', () => {
   test('should auto-select credential when only one available and autoPopulate prop is true', async () => {
+    const cred = { id: 1, name: 'Cred 1', url: 'www.google.com' };
     CredentialsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1 }],
+        results: [cred],
         count: 1,
       },
     });
-    const onChange = jest.fn();
-    await act(async () => {
-      mountWithContexts(
-        <Formik>
-          <CredentialLookup
-            autoPopulate
-            credentialTypeId={1}
-            label="Foo"
-            onChange={onChange}
-          />
-        </Formik>
-      );
+    CredentialsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} }, related_search_fields: [] },
     });
-    expect(onChange).toHaveBeenCalledWith({ id: 1 });
+    const onChange = jest.fn();
+    renderWithContexts(
+      <Formik>
+        <CredentialLookup
+          autoPopulate
+          credentialTypeId={1}
+          label="Foo"
+          onChange={onChange}
+        />
+      </Formik>
+    );
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(cred));
   });
 });

--- a/awx/ui/src/components/Lookup/ExecutionEnvironmentLookup.test.js
+++ b/awx/ui/src/components/Lookup/ExecutionEnvironmentLookup.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { ExecutionEnvironmentsAPI, ProjectsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ExecutionEnvironmentLookup from './ExecutionEnvironmentLookup';
 
 jest.mock('../../api');
@@ -27,11 +27,15 @@ const executionEnvironment = {
 };
 
 describe('ExecutionEnvironmentLookup', () => {
-  let wrapper;
-
   beforeEach(() => {
     ExecutionEnvironmentsAPI.read.mockResolvedValue({
       data: mockedExecutionEnvironments,
+    });
+    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: { GET: {}, POST: {} },
+        related_search_fields: [],
+      },
     });
     ProjectsAPI.readDetail.mockResolvedValue({ data: { organization: 39 } });
   });
@@ -41,119 +45,106 @@ describe('ExecutionEnvironmentLookup', () => {
   });
 
   test('should render successfully', async () => {
-    ExecutionEnvironmentsAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ExecutionEnvironmentLookup
-            value={executionEnvironment}
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('ExecutionEnvironmentLookup')).toHaveLength(1);
-    expect(
-      wrapper.find('FormGroup[label="Execution Environment"]').length
-    ).toBe(1);
-    expect(wrapper.find('Checkbox[aria-label="Prompt on launch"]').length).toBe(
-      0
+    renderWithContexts(
+      <Formik>
+        <ExecutionEnvironmentLookup
+          value={executionEnvironment}
+          onChange={() => {}}
+        />
+      </Formik>
     );
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledTimes(1)
+    );
+    expect(
+      await screen.findByText('Execution Environment')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', { name: 'Prompt on launch' })
+    ).not.toBeInTheDocument();
   });
 
   test('should fetch execution environments', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ExecutionEnvironmentLookup
-            value={executionEnvironment}
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledTimes(1);
+    renderWithContexts(
+      <Formik>
+        <ExecutionEnvironmentLookup
+          value={executionEnvironment}
+          onChange={() => {}}
+        />
+      </Formik>
+    );
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledTimes(1)
+    );
     expect(
-      wrapper.find('FormGroup[label="Default Execution Environment"]').length
-    ).toBe(0);
+      screen.queryByText('Default Execution Environment')
+    ).not.toBeInTheDocument();
     expect(
-      wrapper.find('FormGroup[label="Execution Environment"]').length
-    ).toBe(1);
+      await screen.findByText('Execution Environment')
+    ).toBeInTheDocument();
   });
 
   test('should call api with organization id', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ExecutionEnvironmentLookup
-            value={executionEnvironment}
-            onChange={() => {}}
-            organizationId={1}
-            globallyAvailable
-          />
-        </Formik>
-      );
-    });
-    expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledWith({
-      or__organization__id: 1,
-      or__organization__isnull: 'True',
-      order_by: 'name',
-      page: 1,
-      page_size: 5,
-    });
+    renderWithContexts(
+      <Formik>
+        <ExecutionEnvironmentLookup
+          value={executionEnvironment}
+          onChange={() => {}}
+          organizationId={1}
+          globallyAvailable
+        />
+      </Formik>
+    );
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledWith({
+        or__organization__id: 1,
+        or__organization__isnull: 'True',
+        order_by: 'name',
+        page: 1,
+        page_size: 5,
+      })
+    );
   });
 
   test('should call api with organization id from the related project', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ExecutionEnvironmentLookup
-            value={executionEnvironment}
-            onChange={() => {}}
-            projectId={12}
-            globallyAvailable
-          />
-        </Formik>
-      );
-    });
-    expect(ProjectsAPI.readDetail).toHaveBeenCalledWith(12);
-    expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledWith({
-      or__organization__id: 39,
-      or__organization__isnull: 'True',
-      order_by: 'name',
-      page: 1,
-      page_size: 5,
-    });
+    renderWithContexts(
+      <Formik>
+        <ExecutionEnvironmentLookup
+          value={executionEnvironment}
+          onChange={() => {}}
+          projectId={12}
+          globallyAvailable
+        />
+      </Formik>
+    );
+    await waitFor(() => expect(ProjectsAPI.readDetail).toHaveBeenCalledWith(12));
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalledWith({
+        or__organization__id: 39,
+        or__organization__isnull: 'True',
+        order_by: 'name',
+        page: 1,
+        page_size: 5,
+      })
+    );
   });
 
   test('should render prompt on launch checkbox when necessary', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ExecutionEnvironmentLookup
-            value={executionEnvironment}
-            onChange={() => {}}
-            projectId={12}
-            globallyAvailable
-            isPromptableField
-            promptId="ee-prompt"
-            promptName="ask_execution_environment_on_launch"
-          />
-        </Formik>
-      );
-    });
-    expect(wrapper.find('Checkbox[aria-label="Prompt on launch"]').length).toBe(
-      1
+    renderWithContexts(
+      <Formik>
+        <ExecutionEnvironmentLookup
+          value={executionEnvironment}
+          onChange={() => {}}
+          projectId={12}
+          globallyAvailable
+          isPromptableField
+          promptId="ee-prompt"
+          promptName="ask_execution_environment_on_launch"
+        />
+      </Formik>
     );
+    expect(
+      await screen.findByRole('checkbox', { name: 'Prompt on launch' })
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Lookup/HostListItem.test.js
+++ b/awx/ui/src/components/Lookup/HostListItem.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import HostListItem from './HostListItem';
 
 describe('HostListItem', () => {
-  let wrapper;
   const mockInventory = {
     id: 1,
     type: 'inventory',
@@ -16,16 +16,16 @@ describe('HostListItem', () => {
     },
   };
   test('initially renders successfully', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <table>
         <tbody>
           <HostListItem item={mockInventory} />
         </tbody>
       </table>
     );
-    expect(wrapper.find('HostListItem').length).toBe(1);
-    expect(wrapper.find('Td').at(0).text()).toBe('Foo');
-    expect(wrapper.find('Td').at(1).text()).toBe('Buzz');
-    expect(wrapper.find('Td').at(2).text()).toBe('Bar');
+    const cells = screen.getAllByRole('cell');
+    expect(cells[0]).toHaveTextContent('Foo');
+    expect(cells[1]).toHaveTextContent('Buzz');
+    expect(cells[2]).toHaveTextContent('Bar');
   });
 });

--- a/awx/ui/src/components/Lookup/InstanceGroupsLookup.test.js
+++ b/awx/ui/src/components/Lookup/InstanceGroupsLookup.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import InstanceGroupsLookup from './InstanceGroupsLookup';
 
 jest.mock('../../api');
@@ -53,11 +53,15 @@ const instanceGroups = [
 ];
 
 describe('InstanceGroupsLookup', () => {
-  let wrapper;
-
   beforeEach(() => {
     InstanceGroupsAPI.read.mockResolvedValue({
       data: mockedInstanceGroups,
+    });
+    InstanceGroupsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: { GET: {}, POST: {} },
+        related_search_fields: [],
+      },
     });
   });
 
@@ -66,46 +70,34 @@ describe('InstanceGroupsLookup', () => {
   });
 
   test('should render successfully', async () => {
-    InstanceGroupsAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InstanceGroupsLookup value={instanceGroups} onChange={() => {}} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(InstanceGroupsAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('InstanceGroupsLookup')).toHaveLength(1);
-    expect(wrapper.find('FormGroup[label="Instance Groups"]').length).toBe(1);
-    expect(wrapper.find('Checkbox[aria-label="Prompt on launch"]').length).toBe(
-      0
+    renderWithContexts(
+      <Formik>
+        <InstanceGroupsLookup value={instanceGroups} onChange={() => {}} />
+      </Formik>
     );
+    await waitFor(() =>
+      expect(InstanceGroupsAPI.read).toHaveBeenCalledTimes(1)
+    );
+    expect(await screen.findByText('Instance Groups')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', { name: 'Prompt on launch' })
+    ).not.toBeInTheDocument();
   });
+
   test('should render prompt on launch checkbox when necessary', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InstanceGroupsLookup
-            value={instanceGroups}
-            onChange={() => {}}
-            isPromptableField
-            promptId="ig-prompt"
-            promptName="ask_instance_groups_on_launch"
-          />
-        </Formik>
-      );
-    });
-    expect(wrapper.find('Checkbox[aria-label="Prompt on launch"]').length).toBe(
-      1
+    renderWithContexts(
+      <Formik>
+        <InstanceGroupsLookup
+          value={instanceGroups}
+          onChange={() => {}}
+          isPromptableField
+          promptId="ig-prompt"
+          promptName="ask_instance_groups_on_launch"
+        />
+      </Formik>
     );
+    expect(
+      await screen.findByRole('checkbox', { name: 'Prompt on launch' })
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Lookup/InventoryLookup.test.js
+++ b/awx/ui/src/components/Lookup/InventoryLookup.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { InventoriesAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import InventoryLookup from './InventoryLookup';
 
 jest.mock('../../api');
@@ -18,10 +18,14 @@ const mockedInventories = {
 };
 
 describe('InventoryLookup', () => {
-  let wrapper;
-
   beforeEach(() => {
     InventoriesAPI.read.mockResolvedValue(mockedInventories);
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: { GET: {}, POST: {} },
+        related_search_fields: [],
+      },
+    });
   });
 
   afterEach(() => {
@@ -29,53 +33,28 @@ describe('InventoryLookup', () => {
   });
 
   test('should render successfully and fetch data', async () => {
-    InventoriesAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InventoryLookup onChange={() => {}} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(InventoriesAPI.read).toHaveBeenCalledTimes(1);
+    renderWithContexts(
+      <Formik>
+        <InventoryLookup onChange={() => {}} />
+      </Formik>
+    );
+    await waitFor(() => expect(InventoriesAPI.read).toHaveBeenCalledTimes(1));
     expect(InventoriesAPI.read).toHaveBeenCalledWith({
       order_by: 'name',
       page: 1,
       page_size: 5,
       role_level: 'use_role',
     });
-    expect(wrapper.find('InventoryLookup')).toHaveLength(1);
-    expect(wrapper.find('Lookup').prop('isDisabled')).toBe(false);
+    expect(screen.getByRole('button', { name: 'Search' })).toBeEnabled();
   });
 
   test('should fetch only regular inventories when hideSmartInventories is true', async () => {
-    InventoriesAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InventoryLookup onChange={() => {}} hideAdvancedInventories />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(InventoriesAPI.read).toHaveBeenCalledTimes(1);
+    renderWithContexts(
+      <Formik>
+        <InventoryLookup onChange={() => {}} hideAdvancedInventories />
+      </Formik>
+    );
+    await waitFor(() => expect(InventoriesAPI.read).toHaveBeenCalledTimes(1));
     expect(InventoriesAPI.read).toHaveBeenCalledWith({
       not__kind: ['smart', 'constructed', 'federated'],
       order_by: 'name',
@@ -83,51 +62,32 @@ describe('InventoryLookup', () => {
       page_size: 5,
       role_level: 'use_role',
     });
-    expect(wrapper.find('InventoryLookup')).toHaveLength(1);
-    expect(wrapper.find('Lookup').prop('isDisabled')).toBe(false);
+    expect(screen.getByRole('button', { name: 'Search' })).toBeEnabled();
   });
 
   test('inventory lookup should be enabled', async () => {
-    InventoriesAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-        },
-        related_search_fields: [],
-      },
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} }, related_search_fields: [] },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InventoryLookup onChange={() => {}} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(InventoriesAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('InventoryLookup')).toHaveLength(1);
-    expect(wrapper.find('Lookup').prop('isDisabled')).toBe(false);
+    renderWithContexts(
+      <Formik>
+        <InventoryLookup onChange={() => {}} />
+      </Formik>
+    );
+    await waitFor(() => expect(InventoriesAPI.read).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Search' })).toBeEnabled();
   });
 
   test('inventory lookup should be disabled', async () => {
-    InventoriesAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-        },
-        related_search_fields: [],
-      },
+    InventoriesAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} }, related_search_fields: [] },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InventoryLookup isDisabled onChange={() => {}} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(InventoriesAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('InventoryLookup')).toHaveLength(1);
-    expect(wrapper.find('Lookup').prop('isDisabled')).toBe(true);
+    renderWithContexts(
+      <Formik>
+        <InventoryLookup isDisabled onChange={() => {}} />
+      </Formik>
+    );
+    await waitFor(() => expect(InventoriesAPI.read).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled();
   });
 });

--- a/awx/ui/src/components/Lookup/Lookup.test.js
+++ b/awx/ui/src/components/Lookup/Lookup.test.js
@@ -1,175 +1,26 @@
-/* eslint-disable react/jsx-pascal-case */
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { Formik } from 'formik';
 import { getQSConfig } from 'util/qs';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Lookup from './Lookup';
 
-/**
- * Check that an element is present on the document body
- * @param {selector} query selector
- */
-function checkRootElementPresent(selector) {
-  const queryResult = global.document.querySelector(selector);
-  expect(queryResult).not.toEqual(null);
-}
-
-/**
- * Check that an element isn't present on the document body
- * @param {selector} query selector
- */
-function checkRootElementNotPresent(selector) {
-  const queryResult = global.document.querySelector(selector);
-  expect(queryResult).toEqual(null);
-}
-
-/**
- * Check lookup input group tags for expected values
- * @param {wrapper} enzyme wrapper instance
- * @param {expected} array of expected tag values
- */
-async function checkInputTagValues(wrapper, expected) {
-  checkRootElementNotPresent('body div[role="dialog"]');
-  // check input group chip values
-  const chips = await waitForElement(
-    wrapper,
-    'Lookup InputGroup Chip span',
-    (el) => el.length === expected.length
-  );
-  expect(chips).toHaveLength(expected.length);
-  chips.forEach((el, index) => {
-    expect(el.text()).toEqual(expected[index]);
-  });
-}
-
 const QS_CONFIG = getQSConfig('test', {});
-const TestList = () => <div />;
 
 describe('<Lookup />', () => {
-  let wrapper;
   let onChange;
+  // Captures the most recent render-props the Lookup passes to its options
+  // list, so tests can assert on state/canDelete without an enzyme wrapper.
+  let lastRenderProps;
 
-  async function mountWrapper() {
+  const renderOptionsList = (renderProps) => {
+    lastRenderProps = renderProps;
+    return <div data-testid="options-list" />;
+  };
+
+  function renderLookup(extraProps = {}) {
     const mockSelected = [{ name: 'foo', id: 1, url: '/api/v2/item/1' }];
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <Lookup
-            id="test"
-            multiple
-            header="Foo Bar"
-            value={mockSelected}
-            onChange={onChange}
-            qsConfig={QS_CONFIG}
-            renderOptionsList={({ state, dispatch, canDelete }) => (
-              <TestList
-                id="options-list"
-                state={state}
-                dispatch={dispatch}
-                canDelete={canDelete}
-              />
-            )}
-            fieldName="foo"
-          />
-        </Formik>
-      );
-    });
-    return wrapper;
-  }
-
-  beforeEach(() => {
-    onChange = jest.fn();
-    document.body.innerHTML = '';
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  test('should render successfully', async () => {
-    wrapper = await mountWrapper();
-    expect(wrapper.find('Lookup')).toHaveLength(1);
-  });
-
-  test('should show selected items', async () => {
-    wrapper = await mountWrapper();
-    expect(wrapper.find('Lookup')).toHaveLength(1);
-    await checkInputTagValues(wrapper, ['foo']);
-  });
-
-  test('should open and close modal', async () => {
-    wrapper = await mountWrapper();
-    checkRootElementNotPresent('body div[role="dialog"]');
-    wrapper.find('button[aria-label="Search"]').simulate('click');
-    checkRootElementPresent('body div[role="dialog"]');
-    const list = wrapper.find('TestList');
-    expect(list).toHaveLength(1);
-    expect(list.prop('state')).toEqual({
-      selectedItems: [{ id: 1, name: 'foo', url: '/api/v2/item/1' }],
-      value: [{ id: 1, name: 'foo', url: '/api/v2/item/1' }],
-      multiple: true,
-      isModalOpen: true,
-      required: false,
-    });
-    expect(list.prop('dispatch')).toBeTruthy();
-    expect(list.prop('canDelete')).toEqual(true);
-    wrapper
-      .find('Modal button')
-      .findWhere((e) => e.text() === 'Cancel')
-      .first()
-      .simulate('click');
-    checkRootElementNotPresent('body div[role="dialog"]');
-  });
-
-  test('should remove item when X button clicked', async () => {
-    wrapper = await mountWrapper();
-    await checkInputTagValues(wrapper, ['foo']);
-    wrapper
-      .find('Lookup InputGroup Chip')
-      .findWhere((el) => el.text() === 'foo')
-      .first()
-      .invoke('onClick')();
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith([]);
-  });
-
-  test('should pass canDelete false if required single select', async () => {
-    await act(async () => {
-      const mockSelected = { name: 'foo', id: 1, url: '/api/v2/item/1' };
-      wrapper = mountWithContexts(
-        <Formik>
-          <Lookup
-            id="test"
-            header="Foo Bar"
-            required
-            value={mockSelected}
-            onChange={onChange}
-            qsConfig={QS_CONFIG}
-            renderOptionsList={({ state, dispatch, canDelete }) => (
-              <TestList
-                id="options-list"
-                state={state}
-                dispatch={dispatch}
-                canDelete={canDelete}
-              />
-            )}
-            fieldName="foo"
-          />
-        </Formik>
-      );
-    });
-    wrapper.find('button[aria-label="Search"]').simulate('click');
-    const list = wrapper.find('TestList');
-    expect(list.prop('canDelete')).toEqual(false);
-  });
-
-  test('should be disabled while isLoading is true', async () => {
-    const mockSelected = [{ name: 'foo', id: 1, url: '/api/v2/item/1' }];
-    wrapper = mountWithContexts(
+    return renderWithContexts(
       <Formik>
         <Lookup
           id="test"
@@ -178,21 +29,86 @@ describe('<Lookup />', () => {
           value={mockSelected}
           onChange={onChange}
           qsConfig={QS_CONFIG}
-          isLoading
-          renderOptionsList={({ state, dispatch, canDelete }) => (
-            <TestList
-              id="options-list"
-              state={state}
-              dispatch={dispatch}
-              canDelete={canDelete}
-            />
-          )}
+          renderOptionsList={renderOptionsList}
+          fieldName="foo"
+          {...extraProps}
+        />
+      </Formik>
+    );
+  }
+
+  beforeEach(() => {
+    onChange = jest.fn();
+    lastRenderProps = null;
+  });
+
+  test('should render successfully', () => {
+    renderLookup();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+  });
+
+  test('should show selected items', () => {
+    renderLookup();
+    expect(screen.getByText('foo')).toBeInTheDocument();
+  });
+
+  test('should open and close modal', async () => {
+    const { user } = renderLookup();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByTestId('options-list')).toBeInTheDocument();
+    expect(lastRenderProps.state).toEqual({
+      selectedItems: [{ id: 1, name: 'foo', url: '/api/v2/item/1' }],
+      value: [{ id: 1, name: 'foo', url: '/api/v2/item/1' }],
+      multiple: true,
+      isModalOpen: true,
+      required: false,
+    });
+    expect(lastRenderProps.dispatch).toBeTruthy();
+    expect(lastRenderProps.canDelete).toEqual(true);
+
+    await user.click(
+      within(dialog).getByRole('button', { name: 'Cancel lookup' })
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    );
+  });
+
+  test('should remove item when X button clicked', async () => {
+    const { user } = renderLookup();
+    const chip = screen.getByText('foo').closest('.pf-c-chip');
+    await user.click(within(chip).getByRole('button'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  test('should pass canDelete false if required single select', async () => {
+    const mockSelected = { name: 'foo', id: 1, url: '/api/v2/item/1' };
+    const { user } = renderWithContexts(
+      <Formik>
+        <Lookup
+          id="test"
+          header="Foo Bar"
+          required
+          value={mockSelected}
+          onChange={onChange}
+          qsConfig={QS_CONFIG}
+          renderOptionsList={renderOptionsList}
           fieldName="foo"
         />
       </Formik>
     );
-    checkRootElementNotPresent('body div[role="dialog"]');
-    const button = wrapper.find('button[aria-label="Search"]');
-    expect(button.prop('disabled')).toEqual(true);
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await screen.findByRole('dialog');
+    expect(lastRenderProps.canDelete).toEqual(false);
+  });
+
+  test('should be disabled while isLoading is true', () => {
+    renderLookup({ isLoading: true });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled();
   });
 });

--- a/awx/ui/src/components/Lookup/MultiCredentialsLookup.test.js
+++ b/awx/ui/src/components/Lookup/MultiCredentialsLookup.test.js
@@ -1,19 +1,14 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { Formik } from 'formik';
-import { CredentialsAPI, CredentialTypesAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
 import { createMemoryHistory } from 'history';
+import { CredentialsAPI, CredentialTypesAPI } from 'api';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import MultiCredentialsLookup from './MultiCredentialsLookup';
 
 jest.mock('../../api');
 
 describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
-  let wrapper;
-
   const credentials = [
     {
       id: 1,
@@ -40,8 +35,23 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
     { id: 8, credential_type: 4, kind: 'Machine', name: 'Gatsby' },
   ];
 
+  function renderLookup(props = {}, options = {}) {
+    return renderWithContexts(
+      <Formik>
+        <MultiCredentialsLookup
+          value={credentials}
+          tooltip="This is credentials look up"
+          onChange={() => {}}
+          onError={() => {}}
+          {...props}
+        />
+      </Formik>,
+      options
+    );
+  }
+
   beforeEach(() => {
-    CredentialTypesAPI.loadAllTypes.mockResolvedValueOnce([
+    CredentialTypesAPI.loadAllTypes.mockResolvedValue([
       {
         id: 400,
         kind: 'ssh',
@@ -51,7 +61,7 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
       { id: 500, kind: 'vault', namespace: 'buzz', name: 'Vault' },
       { id: 600, kind: 'machine', namespace: 'fuzz', name: 'Machine' },
     ]);
-    CredentialsAPI.read.mockResolvedValueOnce({
+    CredentialsAPI.read.mockResolvedValue({
       data: {
         results: [
           {
@@ -89,7 +99,6 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
             name: 'Cred 5',
             url: 'www.google.com',
           },
-
           {
             id: 6,
             credential_type: 5,
@@ -107,7 +116,7 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
             inputs: {},
           },
         ],
-        count: 3,
+        count: 7,
       },
     });
     CredentialsAPI.readOptions.mockResolvedValue({
@@ -127,43 +136,24 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
 
   test('should load credential types', async () => {
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={onChange}
-            onError={() => {}}
-          />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('MultiCredentialsLookup')).toHaveLength(1);
-    expect(CredentialTypesAPI.loadAllTypes).toHaveBeenCalled();
+    renderLookup({ onChange });
+    await waitFor(() =>
+      expect(CredentialTypesAPI.loadAllTypes).toHaveBeenCalled()
+    );
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
   });
 
   test('onChange is called when you click to remove a credential from input', async () => {
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={onChange}
-            onError={() => {}}
-          />
-        </Formik>
-      );
-    });
-    const chip = wrapper.find('CredentialChip');
-    expect(chip).toHaveLength(5);
-    const button = chip.at(1).find('Chip Button');
-    await act(async () => {
-      button.invoke('onClick')();
-    });
+    const { user } = renderLookup({ onChange });
+    await waitFor(() =>
+      expect(CredentialTypesAPI.loadAllTypes).toHaveBeenCalled()
+    );
+
+    // remove the second chip (SSH: Alex)
+    const chip = screen.getByText('Alex').closest('.pf-c-chip');
+    await user.click(within(chip).getByRole('button'));
+
     expect(onChange).toHaveBeenCalledWith([
       {
         id: 1,
@@ -185,27 +175,16 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
   });
 
   test('should change credential types', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={() => {}}
-            onError={() => {}}
-          />
-        </Formik>
-      );
-    });
-    const searchButton = await waitForElement(
-      wrapper,
-      'Button[aria-label="Search"]'
-    );
-    await act(async () => {
-      searchButton.invoke('onClick')();
-    });
-    expect(CredentialsAPI.read).toHaveBeenCalledTimes(2);
-    const select = await waitForElement(wrapper, 'AnsibleSelect');
+    const { user } = renderLookup();
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(2));
+
+    // category select renders the initial ssh credentials
+    expect(await within(dialog).findByText('Cred 2')).toBeInTheDocument();
+
     CredentialsAPI.read.mockResolvedValueOnce({
       data: {
         results: [
@@ -214,105 +193,57 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
         count: 1,
       },
     });
-    await act(async () => {
-      select.invoke('onChange')({}, 500);
-    });
-    wrapper.update();
-    expect(wrapper.find('OptionsList').prop('options')).toEqual([
-      {
-        id: 1,
-        kind: 'cloud',
-        name: 'New Cred',
-        url: 'www.google.com',
-        label: 'New Cred',
-      },
-    ]);
+    await user.selectOptions(within(dialog).getByRole('combobox'), '500');
+
+    expect(await within(dialog).findByText('New Cred')).toBeInTheDocument();
   });
 
   test('should reset query params (credentials.page) when selected credential type is changed', async () => {
     const history = createMemoryHistory({
       initialEntries: ['?credentials.page=2'],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={() => {}}
-            onError={() => {}}
-          />
-        </Formik>,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    const searchButton = await waitForElement(
-      wrapper,
-      'Button[aria-label="Search"]'
+    const { user } = renderLookup(
+      {},
+      { context: { router: { history } } }
     );
-    await act(async () => {
-      searchButton.invoke('onClick')();
-    });
-    expect(CredentialsAPI.read).toHaveBeenCalledWith({
-      credential_type: 400,
-      order_by: 'name',
-      page: 2,
-      page_size: 5,
-    });
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
 
-    const select = await waitForElement(wrapper, 'AnsibleSelect');
-    await act(async () => {
-      select.invoke('onChange')({}, 500);
-    });
-    wrapper.update();
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() =>
+      expect(CredentialsAPI.read).toHaveBeenCalledWith({
+        credential_type: 400,
+        order_by: 'name',
+        page: 2,
+        page_size: 5,
+      })
+    );
 
-    expect(CredentialsAPI.read).toHaveBeenCalledWith({
-      credential_type: 500,
-      order_by: 'name',
-      page: 1,
-      page_size: 5,
-    });
+    await user.selectOptions(within(dialog).getByRole('combobox'), '500');
+
+    await waitFor(() =>
+      expect(CredentialsAPI.read).toHaveBeenCalledWith({
+        credential_type: 500,
+        order_by: 'name',
+        page: 1,
+        page_size: 5,
+      })
+    );
   });
 
   test('should only add 1 credential per credential type except vault(see below)', async () => {
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={onChange}
-            onError={() => {}}
-          />
-        </Formik>
-      );
-    });
-    const searchButton = await waitForElement(
-      wrapper,
-      'Button[aria-label="Search"]'
-    );
-    await act(async () => {
-      searchButton.invoke('onClick')();
-    });
-    wrapper.update();
-    const optionsList = wrapper.find('OptionsList');
-    expect(optionsList.prop('multiple')).toEqual(false);
-    act(() => {
-      optionsList.invoke('selectItem')({
-        id: 5,
-        credential_type: 4,
-        kind: 'Machine',
-        name: 'Cred 5',
-        url: 'www.google.com',
-      });
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('Button[variant="primary"]').invoke('onClick')();
-    });
+    const { user } = renderLookup({ onChange });
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    // ssh category => single-select (radio)
+    const cred5Row = (await within(dialog).findByText('Cred 5')).closest('tr');
+    await user.click(within(cred5Row).getByRole('radio'));
+
+    await user.click(within(dialog).getByRole('button', { name: 'Select' }));
+
     expect(onChange).toHaveBeenCalledWith([
       {
         id: 1,
@@ -342,83 +273,54 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
         kind: 'Machine',
         name: 'Cred 5',
         url: 'www.google.com',
+        label: 'Cred 5',
       },
     ]);
   });
 
   test('should properly render vault credential labels', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={() => {}}
-            onError={() => {}}
-          />
-        </Formik>
-      );
-    });
-    const searchButton = await waitForElement(
-      wrapper,
-      'Button[aria-label="Search"]'
-    );
-    await act(async () => {
-      searchButton.invoke('onClick')();
-    });
-    wrapper.update();
-    const typeSelect = wrapper.find('AnsibleSelect');
-    await act(async () => {
-      typeSelect.invoke('onChange')({}, 500);
-    });
-    wrapper.update();
-    const optionsList = wrapper.find('OptionsList');
-    expect(optionsList.prop('multiple')).toEqual(true);
-    expect(wrapper.find('CheckboxListItem[label="Cred 6 | vault ID"]'));
-    expect(wrapper.find('CheckboxListItem[label="Cred 7"]'));
+    const { user } = renderLookup();
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.selectOptions(within(dialog).getByRole('combobox'), '500');
+
+    expect(
+      await within(dialog).findByText('Cred 6 | vault ID')
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('Cred 7')).toBeInTheDocument();
   });
 
   test('should allow multiple vault credentials with no vault id', async () => {
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={onChange}
-            onError={() => {}}
-          />
-        </Formik>
-      );
+    CredentialsAPI.read.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 11,
+            credential_type: 3,
+            kind: 'vault',
+            name: 'Vault',
+            url: 'www.google.com',
+          },
+        ],
+        count: 1,
+      },
     });
-    const searchButton = await waitForElement(
-      wrapper,
-      'Button[aria-label="Search"]'
-    );
-    await act(async () => {
-      searchButton.invoke('onClick')();
-    });
-    wrapper.update();
-    const typeSelect = wrapper.find('AnsibleSelect');
-    act(() => {
-      typeSelect.invoke('onChange')({}, 500);
-    });
-    wrapper.update();
-    const optionsList = wrapper.find('OptionsList');
-    expect(optionsList.prop('multiple')).toEqual(true);
-    act(() => {
-      optionsList.invoke('selectItem')({
-        id: 11,
-        credential_type: 3,
-        kind: 'vault',
-        name: 'Vault',
-      });
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('Button[variant="primary"]').invoke('onClick')();
-    });
+    const { user } = renderLookup({ onChange });
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.selectOptions(within(dialog).getByRole('combobox'), '500');
+
+    const vaultRow = (
+      await within(dialog).findByText('Vault', { selector: 'b' })
+    ).closest('tr');
+    await user.click(within(vaultRow).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Select' }));
+
     expect(onChange).toHaveBeenCalledWith([
       {
         id: 1,
@@ -443,52 +345,47 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
       },
       { id: 23, credential_type: 3, kind: 'vault', name: 'Gatsby 2' },
       { id: 8, credential_type: 4, kind: 'Machine', name: 'Gatsby' },
-      { id: 11, credential_type: 3, kind: 'vault', name: 'Vault' },
+      {
+        id: 11,
+        credential_type: 3,
+        kind: 'vault',
+        name: 'Vault',
+        url: 'www.google.com',
+        label: 'Vault',
+      },
     ]);
   });
 
   test('should allow multiple vault credentials with different vault ids', async () => {
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={onChange}
-            onError={() => {}}
-          />
-        </Formik>
-      );
+    CredentialsAPI.read.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 12,
+            credential_type: 3,
+            kind: 'vault',
+            name: 'Other Vault',
+            url: 'www.google.com',
+            inputs: { vault_id: '2' },
+          },
+        ],
+        count: 1,
+      },
     });
-    const searchButton = await waitForElement(
-      wrapper,
-      'Button[aria-label="Search"]'
-    );
-    await act(async () => {
-      searchButton.invoke('onClick')();
-    });
-    wrapper.update();
-    const typeSelect = wrapper.find('AnsibleSelect');
-    act(() => {
-      typeSelect.invoke('onChange')({}, 500);
-    });
-    wrapper.update();
-    const optionsList = wrapper.find('OptionsList');
-    expect(optionsList.prop('multiple')).toEqual(true);
-    act(() => {
-      optionsList.invoke('selectItem')({
-        id: 12,
-        credential_type: 3,
-        kind: 'vault',
-        name: 'Other Vault',
-        vault_id: '2',
-      });
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('Button[variant="primary"]').invoke('onClick')();
-    });
+    const { user } = renderLookup({ onChange });
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.selectOptions(within(dialog).getByRole('combobox'), '500');
+
+    const vaultRow = (
+      await within(dialog).findByText('Other Vault | 2')
+    ).closest('tr');
+    await user.click(within(vaultRow).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Select' }));
+
     expect(onChange).toHaveBeenCalledWith([
       {
         id: 1,
@@ -518,53 +415,43 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
         credential_type: 3,
         kind: 'vault',
         name: 'Other Vault',
-        vault_id: '2',
+        url: 'www.google.com',
+        inputs: { vault_id: '2' },
+        label: 'Other Vault | 2',
       },
     ]);
   });
 
   test('should not select multiple vault credentials with same vault id', async () => {
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <MultiCredentialsLookup
-            value={credentials}
-            tooltip="This is credentials look up"
-            onChange={onChange}
-            onError={() => {}}
-          />
-        </Formik>
-      );
+    CredentialsAPI.read.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 13,
+            credential_type: 3,
+            kind: 'vault',
+            name: 'Vault Cred with Same Vault Id',
+            url: 'www.google.com',
+            inputs: { vault_id: '1' },
+          },
+        ],
+        count: 1,
+      },
     });
-    const searchButton = await waitForElement(
-      wrapper,
-      'Button[aria-label="Search"]'
-    );
-    await act(async () => {
-      searchButton.invoke('onClick')();
-    });
-    wrapper.update();
-    const typeSelect = wrapper.find('AnsibleSelect');
-    act(() => {
-      typeSelect.invoke('onChange')({}, 500);
-    });
-    wrapper.update();
-    const optionsList = wrapper.find('OptionsList');
-    expect(optionsList.prop('multiple')).toEqual(true);
-    act(() => {
-      optionsList.invoke('selectItem')({
-        id: 13,
-        credential_type: 3,
-        kind: 'vault',
-        name: 'Vault Cred with Same Vault Id',
-        inputs: { vault_id: '1' },
-      });
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('Button[variant="primary"]').invoke('onClick')();
-    });
+    const { user } = renderLookup({ onChange });
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.selectOptions(within(dialog).getByRole('combobox'), '500');
+
+    const vaultRow = (
+      await within(dialog).findByText('Vault Cred with Same Vault Id | 1')
+    ).closest('tr');
+    await user.click(within(vaultRow).getByRole('checkbox'));
+    await user.click(within(dialog).getByRole('button', { name: 'Select' }));
+
     expect(onChange).toHaveBeenCalledWith([
       {
         id: 1,
@@ -587,7 +474,9 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
         credential_type: 3,
         kind: 'vault',
         name: 'Vault Cred with Same Vault Id',
+        url: 'www.google.com',
         inputs: { vault_id: '1' },
+        label: 'Vault Cred with Same Vault Id | 1',
       },
     ]);
   });

--- a/awx/ui/src/components/Lookup/OrganizationLookup.test.js
+++ b/awx/ui/src/components/Lookup/OrganizationLookup.test.js
@@ -1,39 +1,47 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { OrganizationsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import OrganizationLookup, { _OrganizationLookup } from './OrganizationLookup';
 
 jest.mock('../../api');
 
 describe('OrganizationLookup', () => {
-  let wrapper;
+  beforeEach(() => {
+    OrganizationsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
+    });
+    OrganizationsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} }, related_search_fields: [] },
+    });
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('should render successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OrganizationLookup onChange={() => {}} />
-        </Formik>
-      );
-    });
-    expect(wrapper).toHaveLength(1);
+    renderWithContexts(
+      <Formik>
+        <OrganizationLookup onChange={() => {}} />
+      </Formik>
+    );
+    expect(await screen.findByText('Organization')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Search' })
+    ).toBeInTheDocument();
   });
 
   test('should fetch organizations', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OrganizationLookup onChange={() => {}} />
-        </Formik>
-      );
-    });
-    expect(OrganizationsAPI.read).toHaveBeenCalledTimes(1);
+    renderWithContexts(
+      <Formik>
+        <OrganizationLookup onChange={() => {}} />
+      </Formik>
+    );
+    await waitFor(() =>
+      expect(OrganizationsAPI.read).toHaveBeenCalledTimes(1)
+    );
     expect(OrganizationsAPI.read).toHaveBeenCalledWith({
       order_by: 'name',
       page: 1,
@@ -42,80 +50,74 @@ describe('OrganizationLookup', () => {
   });
 
   test('should display "Organization" label', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OrganizationLookup onChange={() => {}} />
-        </Formik>
-      );
-    });
-    const title = wrapper.find('FormGroup .pf-c-form__label-text');
-    expect(title.text()).toEqual('Organization');
+    renderWithContexts(
+      <Formik>
+        <OrganizationLookup onChange={() => {}} />
+      </Formik>
+    );
+    expect(await screen.findByText('Organization')).toBeInTheDocument();
   });
 
-  test('should define default value for function props', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OrganizationLookup onChange={() => {}} />
-        </Formik>
-      );
-    });
+  test('should define default value for function props', () => {
     expect(_OrganizationLookup.defaultProps.onBlur).toBeInstanceOf(Function);
     expect(_OrganizationLookup.defaultProps.onBlur).not.toThrow();
   });
 
   test('should auto-select organization when only one available and autoPopulate prop is true', async () => {
-    OrganizationsAPI.read.mockReturnValue({
+    const org = { id: 1, name: 'org', url: '/api/v2/organizations/1/' };
+    OrganizationsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1 }],
+        results: [org],
         count: 1,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OrganizationLookup autoPopulate onChange={onChange} />
-        </Formik>
-      );
-    });
-    expect(onChange).toHaveBeenCalledWith({ id: 1 });
+    renderWithContexts(
+      <Formik>
+        <OrganizationLookup autoPopulate onChange={onChange} />
+      </Formik>
+    );
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(org));
   });
 
   test('should not auto-select organization when autoPopulate prop is false', async () => {
-    OrganizationsAPI.read.mockReturnValue({
+    OrganizationsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1 }],
+        results: [{ id: 1, name: 'org', url: '/api/v2/organizations/1/' }],
         count: 1,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OrganizationLookup onChange={onChange} />
-        </Formik>
-      );
-    });
+    renderWithContexts(
+      <Formik>
+        <OrganizationLookup onChange={onChange} />
+      </Formik>
+    );
+    await waitFor(() =>
+      expect(OrganizationsAPI.read).toHaveBeenCalledTimes(1)
+    );
     expect(onChange).not.toHaveBeenCalled();
   });
 
   test('should not auto-select organization when multiple available', async () => {
-    OrganizationsAPI.read.mockReturnValue({
+    OrganizationsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1 }, { id: 2 }],
+        results: [
+          { id: 1, name: 'org 1', url: '/api/v2/organizations/1/' },
+          { id: 2, name: 'org 2', url: '/api/v2/organizations/2/' },
+        ],
         count: 2,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OrganizationLookup autoPopulate onChange={onChange} />
-        </Formik>
-      );
-    });
+    renderWithContexts(
+      <Formik>
+        <OrganizationLookup autoPopulate onChange={onChange} />
+      </Formik>
+    );
+    await waitFor(() =>
+      expect(OrganizationsAPI.read).toHaveBeenCalledTimes(1)
+    );
     expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/awx/ui/src/components/Lookup/PeersLookup.test.js
+++ b/awx/ui/src/components/Lookup/PeersLookup.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { InstancesAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import PeersLookup from './PeersLookup';
 
 jest.mock('../../api');
@@ -68,11 +68,15 @@ const instances = [
 ];
 
 describe('PeersLookup', () => {
-  let wrapper;
-
   beforeEach(() => {
     InstancesAPI.read.mockResolvedValue({
       data: mockedInstances,
+    });
+    InstancesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: { GET: {}, POST: {} },
+        related_search_fields: [],
+      },
     });
   });
 
@@ -81,59 +85,32 @@ describe('PeersLookup', () => {
   });
 
   test('should render successfully without instance_details (for new added instance)', async () => {
-    InstancesAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <PeersLookup value={instances} onChange={() => {}} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(InstancesAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('PeersLookup')).toHaveLength(1);
-    // Use fieldId selector instead of label due to Lingui v5 translation issues
-    expect(wrapper.find('FormGroup[fieldId="instances"]').length).toBe(1);
-    expect(wrapper.find('Checkbox[aria-label="Prompt on launch"]').length).toBe(
-      0
+    renderWithContexts(
+      <Formik>
+        <PeersLookup value={instances} onChange={() => {}} />
+      </Formik>
     );
+    await waitFor(() => expect(InstancesAPI.read).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', { name: 'Prompt on launch' })
+    ).not.toBeInTheDocument();
   });
+
   test('should render successfully with instance_details for edit instance', async () => {
-    InstancesAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-          POST: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <PeersLookup
-            value={instances}
-            instance_details={instances[0]}
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(InstancesAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('PeersLookup')).toHaveLength(1);
-    // Use fieldId selector instead of label due to Lingui v5 translation issues
-    expect(wrapper.find('FormGroup[fieldId="instances"]').length).toBe(1);
-    expect(wrapper.find('Checkbox[aria-label="Prompt on launch"]').length).toBe(
-      0
+    renderWithContexts(
+      <Formik>
+        <PeersLookup
+          value={instances}
+          instance_details={instances[0]}
+          onChange={() => {}}
+        />
+      </Formik>
     );
+    await waitFor(() => expect(InstancesAPI.read).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', { name: 'Prompt on launch' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/Lookup/ProjectLookup.test.js
+++ b/awx/ui/src/components/Lookup/ProjectLookup.test.js
@@ -1,180 +1,144 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { ProjectsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ProjectLookup from './ProjectLookup';
 
 jest.mock('../../api');
 
 describe('<ProjectLookup />', () => {
+  beforeEach(() => {
+    ProjectsAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: { GET: {} },
+        related_search_fields: [],
+      },
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('should auto-select project when only one available and autoPopulate prop is true', async () => {
-    ProjectsAPI.read.mockReturnValue({
+    const project = { id: 1, name: 'Test', url: '/api/v2/projects/1/' };
+    ProjectsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1, name: 'Test' }],
+        results: [project],
         count: 1,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      mountWithContexts(
-        <Formik>
-          <ProjectLookup autoPopulate onChange={onChange} />
-        </Formik>
-      );
-    });
-    expect(onChange).toHaveBeenCalledWith({ id: 1, name: 'Test' });
+    renderWithContexts(
+      <Formik>
+        <ProjectLookup autoPopulate onChange={onChange} />
+      </Formik>
+    );
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(project));
   });
 
   test('should not auto-select project when autoPopulate prop is false', async () => {
-    ProjectsAPI.read.mockReturnValue({
+    ProjectsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1, name: 'Test' }],
+        results: [{ id: 1, name: 'Test', url: '/api/v2/projects/1/' }],
         count: 1,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      mountWithContexts(
-        <Formik>
-          <ProjectLookup onChange={onChange} />
-        </Formik>
-      );
-    });
+    renderWithContexts(
+      <Formik>
+        <ProjectLookup onChange={onChange} />
+      </Formik>
+    );
+    await waitFor(() => expect(ProjectsAPI.read).toHaveBeenCalledTimes(1));
     expect(onChange).not.toHaveBeenCalled();
   });
 
   test('should not auto-select project when multiple available', async () => {
-    ProjectsAPI.read.mockReturnValue({
+    ProjectsAPI.read.mockResolvedValue({
       data: {
         results: [
-          { id: 1, name: 'Test' },
-          { id: 2, name: 'Test 2' },
+          { id: 1, name: 'Test', url: '/api/v2/projects/1/' },
+          { id: 2, name: 'Test 2', url: '/api/v2/projects/2/' },
         ],
         count: 2,
       },
     });
     const onChange = jest.fn();
-    await act(async () => {
-      mountWithContexts(
-        <Formik>
-          <ProjectLookup autoPopulate onChange={onChange} />
-        </Formik>
-      );
-    });
+    renderWithContexts(
+      <Formik>
+        <ProjectLookup autoPopulate onChange={onChange} />
+      </Formik>
+    );
+    await waitFor(() => expect(ProjectsAPI.read).toHaveBeenCalledTimes(1));
     expect(onChange).not.toHaveBeenCalled();
   });
 
   test('project lookup should be enabled', async () => {
-    let wrapper;
-    ProjectsAPI.read.mockReturnValue({
+    ProjectsAPI.read.mockResolvedValue({
       data: {
-        results: [{ id: 1, name: 'Test' }],
+        results: [{ id: 1, name: 'Test', url: '/api/v2/projects/1/' }],
         count: 1,
       },
     });
-    ProjectsAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ProjectLookup isOverrideDisabled onChange={() => {}} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(ProjectsAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('ProjectLookup')).toHaveLength(1);
-    expect(wrapper.find('Lookup').prop('isDisabled')).toBe(false);
+    renderWithContexts(
+      <Formik>
+        <ProjectLookup isOverrideDisabled onChange={() => {}} />
+      </Formik>
+    );
+    await waitFor(() => expect(ProjectsAPI.read).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Search' })).toBeEnabled()
+    );
   });
 
   test('project lookup should be disabled', async () => {
-    let wrapper;
-
-    ProjectsAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-        },
-        related_search_fields: [],
-      },
+    ProjectsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ProjectLookup onChange={() => {}} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(ProjectsAPI.read).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('ProjectLookup')).toHaveLength(1);
-    expect(wrapper.find('Lookup').prop('isDisabled')).toBe(true);
-  });
-
-  test('should not show helper text', async () => {
-    let wrapper;
-
-    ProjectsAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ProjectLookup
-            isValid
-            helperTextInvalid="select value"
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('div#project-helper').length).toBe(0);
-  });
-
-  test('should not show helper text', async () => {
-    let wrapper;
-
-    ProjectsAPI.readOptions.mockReturnValue({
-      data: {
-        actions: {
-          GET: {},
-        },
-        related_search_fields: [],
-      },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ProjectLookup
-            isValid={false}
-            helperTextInvalid="select value"
-            onChange={() => {}}
-          />
-        </Formik>
-      );
-    });
-    wrapper.update();
-
-    expect(wrapper.find('div#project-helper').text('helperTextInvalid')).toBe(
-      'select value'
+    renderWithContexts(
+      <Formik>
+        <ProjectLookup onChange={() => {}} />
+      </Formik>
     );
+    await waitFor(() => expect(ProjectsAPI.read).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled()
+    );
+  });
+
+  test('should not show helper text when valid', async () => {
+    ProjectsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
+    });
+    renderWithContexts(
+      <Formik>
+        <ProjectLookup
+          isValid
+          helperTextInvalid="select value"
+          onChange={() => {}}
+        />
+      </Formik>
+    );
+    await waitFor(() => expect(ProjectsAPI.read).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText('select value')).not.toBeInTheDocument();
+  });
+
+  test('should show helper text when invalid', async () => {
+    ProjectsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
+    });
+    renderWithContexts(
+      <Formik>
+        <ProjectLookup
+          isValid={false}
+          helperTextInvalid="select value"
+          onChange={() => {}}
+        />
+      </Formik>
+    );
+    await waitFor(() => expect(ProjectsAPI.read).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('select value')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **Lookup** component test suite (`components/Lookup`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: the base `Lookup`, `HostListItem`, and the typed lookups — Organization, Project, Credential, Inventory, ExecutionEnvironment, Application, InstanceGroups, Peers, and MultiCredentials.

Lookup modals are driven through the real Search → row-select → Select flow; disabled state is asserted on the Search button, labels by visible text, and auto-populate via the `onChange` payload. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/Lookup`: **13 suites, 92 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
