### PR TITLE
enzyme -> RTL: convert the LaunchPrompt component suites

### DIFF
--- a/awx/ui/src/components/LaunchPrompt/LaunchPrompt.test.js
+++ b/awx/ui/src/components/LaunchPrompt/LaunchPrompt.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, isElementOfType } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import {
   ExecutionEnvironmentsAPI,
   InstanceGroupsAPI,
@@ -8,19 +8,8 @@ import {
   CredentialTypesAPI,
   JobTemplatesAPI,
 } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import LaunchPrompt from './LaunchPrompt';
-import InventoryStep from './steps/InventoryStep';
-import CredentialsStep from './steps/CredentialsStep';
-import CredentialPasswordsStep from './steps/CredentialPasswordsStep';
-import OtherPromptsStep from './steps/OtherPromptsStep';
-import PreviewStep from './steps/PreviewStep';
-import ExecutionEnvironmentStep from './steps/ExecutionEnvironmentStep';
-import InstanceGroupsStep from './steps/InstanceGroupsStep';
-import SurveyStep from './steps/SurveyStep';
 
 jest.mock('../../api/models/Inventories');
 jest.mock('../../api/models/ExecutionEnvironments');
@@ -49,6 +38,25 @@ const resource = {
   },
 };
 const noop = () => {};
+
+// The wizard renders every included step's name as <div id="...-step"> in the
+// left-hand nav. It mounts in a PF Modal portal (under document.body, not the
+// render container), so query the document and collect ids in DOM order to
+// assert the step set without reaching into component internals.
+async function getStepIds() {
+  return waitFor(() => {
+    // de-dupe: each step name renders both in the collapsed toggle and the
+    // nav list, so collect unique ids in first-seen (DOM) order.
+    const seen = [];
+    document.querySelectorAll('[id$="-step"]').forEach((el) => {
+      if (!seen.includes(el.id)) {
+        seen.push(el.id);
+      }
+    });
+    expect(seen.length).toBeGreaterThan(0);
+    return seen;
+  });
+}
 
 describe('LaunchPrompt', () => {
   beforeEach(() => {
@@ -187,274 +195,222 @@ describe('LaunchPrompt', () => {
   afterEach(() => jest.clearAllMocks());
 
   test('should render Wizard with all steps', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LaunchPrompt
-          launchConfig={{
-            ...config,
-            ask_inventory_on_launch: true,
-            ask_credential_on_launch: true,
-            ask_scm_branch_on_launch: true,
-            ask_execution_environment_on_launch: true,
-            ask_instance_groups_on_launch: true,
-            survey_enabled: true,
-            passwords_needed_to_start: ['ssh_password'],
-            defaults: {
-              credentials: [
-                {
-                  id: 1,
-                  name: 'cred that prompts',
-                  passwords_needed: ['ssh_password'],
-                  credential_type: 1,
-                },
-              ],
-            },
-          }}
-          resource={{
-            ...resource,
-            summary_fields: {
-              credentials: [
-                {
-                  id: 5,
-                  name: 'cred that prompts',
-                  credential_type: 1,
-                  inputs: {
-                    password: 'ASK',
-                  },
-                },
-              ],
-            },
-          }}
-          resourceDefaultCredentials={[
-            {
-              id: 5,
-              name: 'cred that prompts',
-              credential_type: 1,
-              inputs: {
-                password: 'ASK',
-              },
-            },
-          ]}
-          onLaunch={noop}
-          onCancel={noop}
-          surveyConfig={{
-            name: '',
-            description: '',
-            spec: [
+    renderWithContexts(
+      <LaunchPrompt
+        launchConfig={{
+          ...config,
+          ask_inventory_on_launch: true,
+          ask_credential_on_launch: true,
+          ask_scm_branch_on_launch: true,
+          ask_execution_environment_on_launch: true,
+          ask_instance_groups_on_launch: true,
+          survey_enabled: true,
+          passwords_needed_to_start: ['ssh_password'],
+          defaults: {
+            credentials: [
               {
-                choices: '',
-                default: '',
-                max: 1024,
-                min: 0,
-                new_question: false,
-                question_description: '',
-                question_name: 'foo',
-                required: true,
-                type: 'text',
-                variable: 'foo',
+                id: 1,
+                name: 'cred that prompts',
+                passwords_needed: ['ssh_password'],
+                credential_type: 1,
               },
             ],
-          }}
-        />
-      );
-    });
-    const wizard = await waitForElement(wrapper, 'Wizard');
-    const steps = wizard.prop('steps');
-
-    expect(steps).toHaveLength(8);
-    
-    // Test step names by checking the id prop instead of translated children
-    expect(steps[0].name.props.id).toEqual('inventory-step');
-    expect(steps[1].name.props.id).toEqual('credentials-step');
-    expect(steps[2].name.props.id).toEqual('credential-passwords-step');
-    expect(steps[3].name.props.id).toEqual('execution-environment-step');
-    expect(steps[4].name.props.id).toEqual('instance-groups-step');
-    expect(steps[5].name.props.id).toEqual('other-prompts-step');
-    expect(steps[6].name.props.id).toEqual('survey-step');
-    expect(steps[7].name.props.id).toEqual('preview-step');
-    expect(wizard.find('WizardHeader').prop('title')).toBe('Launch | Foobar');
-    expect(wizard.find('WizardHeader').prop('description')).toBe(
-      'Foo Description'
+          },
+        }}
+        resource={{
+          ...resource,
+          summary_fields: {
+            credentials: [
+              {
+                id: 5,
+                name: 'cred that prompts',
+                credential_type: 1,
+                inputs: {
+                  password: 'ASK',
+                },
+              },
+            ],
+          },
+        }}
+        resourceDefaultCredentials={[
+          {
+            id: 5,
+            name: 'cred that prompts',
+            credential_type: 1,
+            inputs: {
+              password: 'ASK',
+            },
+          },
+        ]}
+        onLaunch={noop}
+        onCancel={noop}
+        surveyConfig={{
+          name: '',
+          description: '',
+          spec: [
+            {
+              choices: '',
+              default: '',
+              max: 1024,
+              min: 0,
+              new_question: false,
+              question_description: '',
+              question_name: 'foo',
+              required: true,
+              type: 'text',
+              variable: 'foo',
+            },
+          ],
+        }}
+      />
     );
+
+    const ids = await getStepIds();
+    expect(ids).toEqual([
+      'inventory-step',
+      'credentials-step',
+      'credential-passwords-step',
+      'execution-environment-step',
+      'instance-groups-step',
+      'other-prompts-step',
+      'survey-step',
+      'preview-step',
+    ]);
+    expect(screen.getByText('Launch | Foobar')).toBeInTheDocument();
+    expect(screen.getByText('Foo Description')).toBeInTheDocument();
   });
 
   test('should add inventory step', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LaunchPrompt
-          launchConfig={{
-            ...config,
-            ask_inventory_on_launch: true,
-          }}
-          resource={resource}
-          onLaunch={noop}
-          onCancel={noop}
-        />
-      );
-    });
-    const wizard = await waitForElement(wrapper, 'Wizard');
-    const steps = wizard.prop('steps');
+    renderWithContexts(
+      <LaunchPrompt
+        launchConfig={{
+          ...config,
+          ask_inventory_on_launch: true,
+        }}
+        resource={resource}
+        onLaunch={noop}
+        onCancel={noop}
+      />
+    );
 
-    expect(steps).toHaveLength(2);
-    expect(steps[0].name.props.id).toEqual('inventory-step');
-    expect(isElementOfType(steps[0].component, InventoryStep)).toEqual(true);
-    expect(isElementOfType(steps[1].component, PreviewStep)).toEqual(true);
+    const ids = await getStepIds();
+    expect(ids).toEqual(['inventory-step', 'preview-step']);
   });
 
   test('should add credentials step', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LaunchPrompt
-          launchConfig={{
-            ...config,
-            ask_credential_on_launch: true,
-          }}
-          resource={resource}
-          onLaunch={noop}
-          onCancel={noop}
-          resourceDefaultCredentials={[
-            {
-              id: 5,
-              name: 'cred that prompts',
-              credential_type: 1,
-              inputs: {
-                password: 'ASK',
-              },
+    renderWithContexts(
+      <LaunchPrompt
+        launchConfig={{
+          ...config,
+          ask_credential_on_launch: true,
+        }}
+        resource={resource}
+        onLaunch={noop}
+        onCancel={noop}
+        resourceDefaultCredentials={[
+          {
+            id: 5,
+            name: 'cred that prompts',
+            credential_type: 1,
+            inputs: {
+              password: 'ASK',
             },
-          ]}
-        />
-      );
-    });
-    const wizard = await waitForElement(wrapper, 'Wizard');
-    const steps = wizard.prop('steps');
+          },
+        ]}
+      />
+    );
 
-    expect(steps).toHaveLength(3);
-    expect(steps[0].name.props.id).toEqual('credentials-step');
-    expect(isElementOfType(steps[0].component, CredentialsStep)).toEqual(true);
-    expect(
-      isElementOfType(steps[1].component, CredentialPasswordsStep)
-    ).toEqual(true);
-    expect(isElementOfType(steps[2].component, PreviewStep)).toEqual(true);
+    const ids = await getStepIds();
+    expect(ids).toEqual([
+      'credentials-step',
+      'credential-passwords-step',
+      'preview-step',
+    ]);
   });
 
   test('should add execution environment step', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LaunchPrompt
-          launchConfig={{
-            ...config,
-            ask_execution_environment_on_launch: true,
-          }}
-          resource={resource}
-          onLaunch={noop}
-          onCancel={noop}
-        />
-      );
-    });
-    const wizard = await waitForElement(wrapper, 'Wizard');
-    const steps = wizard.prop('steps');
+    renderWithContexts(
+      <LaunchPrompt
+        launchConfig={{
+          ...config,
+          ask_execution_environment_on_launch: true,
+        }}
+        resource={resource}
+        onLaunch={noop}
+        onCancel={noop}
+      />
+    );
 
-    expect(steps).toHaveLength(2);
-    expect(steps[0].name.props.id).toEqual('execution-environment-step');
-    expect(
-      isElementOfType(steps[0].component, ExecutionEnvironmentStep)
-    ).toEqual(true);
-    expect(isElementOfType(steps[1].component, PreviewStep)).toEqual(true);
+    const ids = await getStepIds();
+    expect(ids).toEqual(['execution-environment-step', 'preview-step']);
   });
 
   test('should add instance groups step', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LaunchPrompt
-          launchConfig={{
-            ...config,
-            ask_instance_groups_on_launch: true,
-          }}
-          resource={resource}
-          onLaunch={noop}
-          onCancel={noop}
-        />
-      );
-    });
-    const wizard = await waitForElement(wrapper, 'Wizard');
-    const steps = wizard.prop('steps');
-
-    expect(steps).toHaveLength(2);
-    expect(steps[0].name.props.id).toEqual('instance-groups-step');
-    expect(isElementOfType(steps[0].component, InstanceGroupsStep)).toEqual(
-      true
+    renderWithContexts(
+      <LaunchPrompt
+        launchConfig={{
+          ...config,
+          ask_instance_groups_on_launch: true,
+        }}
+        resource={resource}
+        onLaunch={noop}
+        onCancel={noop}
+      />
     );
-    expect(isElementOfType(steps[1].component, PreviewStep)).toEqual(true);
+
+    const ids = await getStepIds();
+    expect(ids).toEqual(['instance-groups-step', 'preview-step']);
   });
 
   test('should add other prompts step', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LaunchPrompt
-          launchConfig={{
-            ...config,
-            ask_verbosity_on_launch: true,
-          }}
-          resource={resource}
-          onLaunch={noop}
-          onCancel={noop}
-        />
-      );
-    });
-    const wizard = await waitForElement(wrapper, 'Wizard');
-    const steps = wizard.prop('steps');
+    renderWithContexts(
+      <LaunchPrompt
+        launchConfig={{
+          ...config,
+          ask_verbosity_on_launch: true,
+        }}
+        resource={resource}
+        onLaunch={noop}
+        onCancel={noop}
+      />
+    );
 
-    expect(steps).toHaveLength(2);
-    expect(steps[0].name.props.id).toEqual('other-prompts-step');
-    expect(isElementOfType(steps[0].component, OtherPromptsStep)).toEqual(true);
-    expect(isElementOfType(steps[1].component, PreviewStep)).toEqual(true);
+    const ids = await getStepIds();
+    expect(ids).toEqual(['other-prompts-step', 'preview-step']);
   });
 
   test('should add survey step', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <LaunchPrompt
-          launchConfig={{
-            ...config,
-            survey_enabled: true,
-          }}
-          resource={resource}
-          onLaunch={noop}
-          onCancel={noop}
-          surveyConfig={{
-            name: '',
-            description: '',
-            spec: [
-              {
-                choices: '',
-                default: '',
-                max: 1024,
-                min: 0,
-                new_question: false,
-                question_description: '',
-                question_name: 'foo',
-                required: true,
-                type: 'text',
-                variable: 'foo',
-              },
-            ],
-          }}
-        />
-      );
-    });
-    const wizard = await waitForElement(wrapper, 'Wizard');
-    const steps = wizard.prop('steps');
+    renderWithContexts(
+      <LaunchPrompt
+        launchConfig={{
+          ...config,
+          survey_enabled: true,
+        }}
+        resource={resource}
+        onLaunch={noop}
+        onCancel={noop}
+        surveyConfig={{
+          name: '',
+          description: '',
+          spec: [
+            {
+              choices: '',
+              default: '',
+              max: 1024,
+              min: 0,
+              new_question: false,
+              question_description: '',
+              question_name: 'foo',
+              required: true,
+              type: 'text',
+              variable: 'foo',
+            },
+          ],
+        }}
+      />
+    );
 
-    expect(steps).toHaveLength(2);
-    expect(steps[0].name.props.id).toEqual('survey-step');
-    expect(isElementOfType(steps[0].component, SurveyStep)).toEqual(true);
-    expect(isElementOfType(steps[1].component, PreviewStep)).toEqual(true);
+    const ids = await getStepIds();
+    expect(ids).toEqual(['survey-step', 'preview-step']);
   });
 });

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialPasswordsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialPasswordsStep.test.js
@@ -99,8 +99,8 @@ describe('CredentialPasswordsStep', () => {
         >
           <CredentialPasswordsStep
             launchConfig={{
+              ask_credential_on_launch: true,
               defaults: {
-                ask_credential_on_launch: true,
                 credentials: [
                   {
                     id: 1,

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialPasswordsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialPasswordsStep.test.js
@@ -1,603 +1,486 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { Formik } from 'formik';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import CredentialPasswordsStep from './CredentialPasswordsStep';
 
+// The PasswordField id lands on the rendered <input>, so query inputs by id
+// from the container rather than getByLabelText (the FormGroup labelIcon
+// breaks the label/input association).
 describe('CredentialPasswordsStep', () => {
+  function assertPasswordFields(
+    container,
+    { ssh, passphrase, become, vaultIds = [] }
+  ) {
+    expect(!!container.querySelector('#launch-ssh-password')).toBe(ssh);
+    expect(!!container.querySelector('#launch-private-key-passphrase')).toBe(
+      passphrase
+    );
+    expect(
+      !!container.querySelector('#launch-privilege-escalation-password')
+    ).toBe(become);
+    const vaultFields = container.querySelectorAll(
+      '[id^="launch-vault-password-"]'
+    );
+    expect(vaultFields).toHaveLength(vaultIds.length);
+    vaultIds.forEach((vaultId) => {
+      expect(
+        container.querySelector(`#launch-vault-password-${vaultId}`)
+      ).not.toBeNull();
+    });
+  }
+
   describe('JT default credentials (no credential replacement) and creds are promptable', () => {
-    test('should render ssh password field when JT has default machine cred', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [
-                    {
-                      id: 1,
-                      passwords_needed: ['ssh_password'],
-                    },
-                  ],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render become password field when JT has default machine cred', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [
-                    {
-                      id: 1,
-                      passwords_needed: ['become_password'],
-                    },
-                  ],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render private key passphrase field when JT has default machine cred', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                defaults: {
-                  ask_credential_on_launch: true,
-                  credentials: [
-                    {
-                      id: 1,
-                      passwords_needed: ['ssh_key_unlock'],
-                    },
-                  ],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render vault password field when JT has default vault cred', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [
-                    {
-                      id: 1,
-                      passwords_needed: ['vault_password.1'],
-                    },
-                  ],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-vault-password-1')
-      ).toHaveLength(1);
-    });
-    test('should render all password field when JT has default vault cred and machine cred', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                },
-                {
-                  id: 2,
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [
-                    {
-                      id: 1,
-                      passwords_needed: [
-                        'ssh_password',
-                        'become_password',
-                        'ssh_key_unlock',
-                      ],
-                    },
-                    {
-                      id: 2,
-                      passwords_needed: ['vault_password.1'],
-                    },
-                  ],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-vault-password-1')
-      ).toHaveLength(1);
-    });
-  });
-  describe('Credentials have been replaced and creds are promptable', () => {
-    test('should render ssh password field when replacement machine cred prompts for it', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                  inputs: {
-                    password: 'ASK',
-                    become_password: null,
-                    ssh_key_unlock: null,
-                    vault_password: null,
+    test('should render ssh password field when JT has default machine cred', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [{ id: 1 }],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [
+                  {
+                    id: 1,
+                    passwords_needed: ['ssh_password'],
                   },
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render become password field when replacement machine cred prompts for it', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                  inputs: {
-                    password: null,
-                    become_password: 'ASK',
-                    ssh_key_unlock: null,
-                    vault_password: null,
-                  },
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render private key passphrase field when replacement machine cred prompts for it', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                  inputs: {
-                    password: null,
-                    become_password: null,
-                    ssh_key_unlock: 'ASK',
-                    vault_password: null,
-                  },
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render vault password field when replacement vault cred prompts for it', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                  inputs: {
-                    password: null,
-                    become_password: null,
-                    ssh_key_unlock: null,
-                    vault_password: 'ASK',
-                    vault_id: 'foobar',
-                  },
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-vault-password-foobar')
-      ).toHaveLength(1);
-    });
-    test('should render all password fields when replacement vault and machine creds prompt for it', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik
-            initialValues={{
-              credentials: [
-                {
-                  id: 1,
-                  inputs: {
-                    password: 'ASK',
-                    become_password: 'ASK',
-                    ssh_key_unlock: 'ASK',
-                  },
-                },
-                {
-                  id: 2,
-                  inputs: {
-                    password: null,
-                    become_password: null,
-                    ssh_key_unlock: null,
-                    vault_password: 'ASK',
-                    vault_id: 'foobar',
-                  },
-                },
-              ],
-            }}
-          >
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: true,
-                defaults: {
-                  credentials: [],
-                },
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-vault-password-foobar')
-      ).toHaveLength(1);
-    });
-  });
-  describe('Credentials have been replaced and creds are not promptable', () => {
-    test('should render ssh password field when required', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik initialValues={{}}>
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: false,
-                passwords_needed_to_start: ['ssh_password'],
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render become password field when required', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik initialValues={{}}>
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: false,
-                passwords_needed_to_start: ['become_password'],
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render private key passphrase field when required', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik initialValues={{}}>
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: false,
-                passwords_needed_to_start: ['ssh_key_unlock'],
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(0);
-    });
-    test('should render vault password field when required', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik initialValues={{}}>
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: false,
-                passwords_needed_to_start: ['vault_password.foobar'],
-              }}
-            />
-          </Formik>
-        );
-      });
-
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(0);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-vault-password-foobar')
-      ).toHaveLength(1);
-    });
-    test('should render all password fields when required', async () => {
-      let wrapper;
-      await act(async () => {
-        wrapper = mountWithContexts(
-          <Formik initialValues={{}}>
-            <CredentialPasswordsStep
-              launchConfig={{
-                ask_credential_on_launch: false,
-                passwords_needed_to_start: [
-                  'ssh_password',
-                  'become_password',
-                  'ssh_key_unlock',
-                  'vault_password.foobar',
                 ],
-              }}
-            />
-          </Formik>
-        );
-      });
+              },
+            }}
+          />
+        </Formik>
+      );
 
-      expect(wrapper.find('PasswordField#launch-ssh-password')).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-private-key-passphrase')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-privilege-escalation-password')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField[id^="launch-vault-password-"]')
-      ).toHaveLength(1);
-      expect(
-        wrapper.find('PasswordField#launch-vault-password-foobar')
-      ).toHaveLength(1);
+      assertPasswordFields(container, {
+        ssh: true,
+        passphrase: false,
+        become: false,
+      });
+    });
+
+    test('should render become password field when JT has default machine cred', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [{ id: 1 }],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [
+                  {
+                    id: 1,
+                    passwords_needed: ['become_password'],
+                  },
+                ],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: false,
+        become: true,
+      });
+    });
+
+    test('should render private key passphrase field when JT has default machine cred', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [{ id: 1 }],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              defaults: {
+                ask_credential_on_launch: true,
+                credentials: [
+                  {
+                    id: 1,
+                    passwords_needed: ['ssh_key_unlock'],
+                  },
+                ],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: true,
+        become: false,
+      });
+    });
+
+    test('should render vault password field when JT has default vault cred', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [{ id: 1 }],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [
+                  {
+                    id: 1,
+                    passwords_needed: ['vault_password.1'],
+                  },
+                ],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: false,
+        become: false,
+        vaultIds: ['1'],
+      });
+    });
+
+    test('should render all password field when JT has default vault cred and machine cred', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [{ id: 1 }, { id: 2 }],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [
+                  {
+                    id: 1,
+                    passwords_needed: [
+                      'ssh_password',
+                      'become_password',
+                      'ssh_key_unlock',
+                    ],
+                  },
+                  {
+                    id: 2,
+                    passwords_needed: ['vault_password.1'],
+                  },
+                ],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: true,
+        passphrase: true,
+        become: true,
+        vaultIds: ['1'],
+      });
+    });
+  });
+
+  describe('Credentials have been replaced and creds are promptable', () => {
+    test('should render ssh password field when replacement machine cred prompts for it', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [
+              {
+                id: 1,
+                inputs: {
+                  password: 'ASK',
+                  become_password: null,
+                  ssh_key_unlock: null,
+                  vault_password: null,
+                },
+              },
+            ],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: true,
+        passphrase: false,
+        become: false,
+      });
+    });
+
+    test('should render become password field when replacement machine cred prompts for it', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [
+              {
+                id: 1,
+                inputs: {
+                  password: null,
+                  become_password: 'ASK',
+                  ssh_key_unlock: null,
+                  vault_password: null,
+                },
+              },
+            ],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: false,
+        become: true,
+      });
+    });
+
+    test('should render private key passphrase field when replacement machine cred prompts for it', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [
+              {
+                id: 1,
+                inputs: {
+                  password: null,
+                  become_password: null,
+                  ssh_key_unlock: 'ASK',
+                  vault_password: null,
+                },
+              },
+            ],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: true,
+        become: false,
+      });
+    });
+
+    test('should render vault password field when replacement vault cred prompts for it', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [
+              {
+                id: 1,
+                inputs: {
+                  password: null,
+                  become_password: null,
+                  ssh_key_unlock: null,
+                  vault_password: 'ASK',
+                  vault_id: 'foobar',
+                },
+              },
+            ],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: false,
+        become: false,
+        vaultIds: ['foobar'],
+      });
+    });
+
+    test('should render all password fields when replacement vault and machine creds prompt for it', () => {
+      const { container } = renderWithContexts(
+        <Formik
+          initialValues={{
+            credentials: [
+              {
+                id: 1,
+                inputs: {
+                  password: 'ASK',
+                  become_password: 'ASK',
+                  ssh_key_unlock: 'ASK',
+                },
+              },
+              {
+                id: 2,
+                inputs: {
+                  password: null,
+                  become_password: null,
+                  ssh_key_unlock: null,
+                  vault_password: 'ASK',
+                  vault_id: 'foobar',
+                },
+              },
+            ],
+          }}
+        >
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: true,
+              defaults: {
+                credentials: [],
+              },
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: true,
+        passphrase: true,
+        become: true,
+        vaultIds: ['foobar'],
+      });
+    });
+  });
+
+  describe('Credentials have been replaced and creds are not promptable', () => {
+    test('should render ssh password field when required', () => {
+      const { container } = renderWithContexts(
+        <Formik initialValues={{}}>
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: false,
+              passwords_needed_to_start: ['ssh_password'],
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: true,
+        passphrase: false,
+        become: false,
+      });
+    });
+
+    test('should render become password field when required', () => {
+      const { container } = renderWithContexts(
+        <Formik initialValues={{}}>
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: false,
+              passwords_needed_to_start: ['become_password'],
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: false,
+        become: true,
+      });
+    });
+
+    test('should render private key passphrase field when required', () => {
+      const { container } = renderWithContexts(
+        <Formik initialValues={{}}>
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: false,
+              passwords_needed_to_start: ['ssh_key_unlock'],
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: true,
+        become: false,
+      });
+    });
+
+    test('should render vault password field when required', () => {
+      const { container } = renderWithContexts(
+        <Formik initialValues={{}}>
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: false,
+              passwords_needed_to_start: ['vault_password.foobar'],
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: false,
+        passphrase: false,
+        become: false,
+        vaultIds: ['foobar'],
+      });
+    });
+
+    test('should render all password fields when required', () => {
+      const { container } = renderWithContexts(
+        <Formik initialValues={{}}>
+          <CredentialPasswordsStep
+            launchConfig={{
+              ask_credential_on_launch: false,
+              passwords_needed_to_start: [
+                'ssh_password',
+                'become_password',
+                'ssh_key_unlock',
+                'vault_password.foobar',
+              ],
+            }}
+          />
+        </Formik>
+      );
+
+      assertPasswordFields(container, {
+        ssh: true,
+        passphrase: true,
+        become: true,
+        vaultIds: ['foobar'],
+      });
     });
   });
 });

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
@@ -163,7 +163,9 @@ describe('CredentialsStep', () => {
     );
 
     const select = await findCategorySelect(container);
-    await user.selectOptions(select, 'Vault');
+    // the native <select> option values are credential type ids, so select
+    // by the Vault type id (3) rather than its label
+    await user.selectOptions(select, '3');
 
     await waitFor(() =>
       expect(CredentialsAPI.read).toHaveBeenCalledWith({
@@ -200,7 +202,9 @@ describe('CredentialsStep', () => {
     );
 
     const select = await findCategorySelect(container);
-    await user.selectOptions(select, 'Vault');
+    // the native <select> option values are credential type ids, so select
+    // by the Vault type id (3) rather than its label
+    await user.selectOptions(select, '3');
 
     await waitFor(() =>
       expect(CredentialsAPI.read).toHaveBeenCalledWith({
@@ -341,7 +345,9 @@ describe('CredentialsStep', () => {
     expect(alert).toHaveTextContent('Vault | foo');
 
     const select = await findCategorySelect(container);
-    await user.selectOptions(select, 'Vault');
+    // the native <select> option values are credential type ids, so select
+    // by the Vault type id (3) rather than its label
+    await user.selectOptions(select, '3');
 
     const checkbox = await waitFor(() => {
       const el = container.querySelector('#check-action-item-33 input');

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
-import { CredentialsAPI, CredentialTypesAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import { createMemoryHistory } from 'history';
+import { CredentialsAPI, CredentialTypesAPI } from 'api';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import CredentialsStep from './CredentialsStep';
 
 jest.mock('../../../api/models/CredentialTypes');
@@ -101,6 +101,16 @@ const credentials = [
   },
 ];
 
+// The credential-type AnsibleSelect renders a native <select> with a generic
+// "Select Input" aria-label, so locate it by its stable id.
+async function findCategorySelect(container) {
+  return waitFor(() => {
+    const el = container.querySelector('select#multiCredentialsLookUp-select');
+    expect(el).not.toBeNull();
+    return el;
+  });
+}
+
 describe('CredentialsStep', () => {
   beforeEach(() => {
     CredentialTypesAPI.loadAllTypes.mockResolvedValue(types);
@@ -121,112 +131,109 @@ describe('CredentialsStep', () => {
     });
   });
 
-  test('should load credentials', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialsStep allowCredentialsWithPasswords />
-        </Formik>
-      );
-    });
-    wrapper.update();
+  afterEach(() => jest.clearAllMocks());
 
-    expect(CredentialsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('OptionsList').prop('options')).toEqual(credentials);
+  test('should load credentials', async () => {
+    renderWithContexts(
+      <Formik>
+        <CredentialsStep allowCredentialsWithPasswords />
+      </Formik>
+    );
+
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalled());
+    expect(await screen.findByText('Cred 1')).toBeInTheDocument();
+    expect(screen.getByText('Cred 2')).toBeInTheDocument();
+    expect(screen.getByText('Cred 5')).toBeInTheDocument();
   });
 
   test('should load credentials for selected type', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialsStep allowCredentialsWithPasswords />
-        </Formik>
-      );
-    });
-    wrapper.update();
+    const { user, container } = renderWithContexts(
+      <Formik>
+        <CredentialsStep allowCredentialsWithPasswords />
+      </Formik>
+    );
 
-    expect(CredentialsAPI.read).toHaveBeenCalledWith({
-      credential_type: 1,
-      order_by: 'name',
-      page: 1,
-      page_size: 5,
-    });
+    await waitFor(() =>
+      expect(CredentialsAPI.read).toHaveBeenCalledWith({
+        credential_type: 1,
+        order_by: 'name',
+        page: 1,
+        page_size: 5,
+      })
+    );
 
-    await act(async () => {
-      wrapper.find('AnsibleSelect').invoke('onChange')({}, 3);
-    });
-    expect(CredentialsAPI.read).toHaveBeenCalledWith({
-      credential_type: 3,
-      order_by: 'name',
-      page: 1,
-      page_size: 5,
-    });
+    const select = await findCategorySelect(container);
+    await user.selectOptions(select, 'Vault');
+
+    await waitFor(() =>
+      expect(CredentialsAPI.read).toHaveBeenCalledWith({
+        credential_type: 3,
+        order_by: 'name',
+        page: 1,
+        page_size: 5,
+      })
+    );
   });
 
   test('should reset query params (credential.page) when selected credential type is changed', async () => {
-    let wrapper;
     const history = createMemoryHistory({
       initialEntries: [
         '?credential.page=2&credential.page_size=5&credential.order_by=name',
       ],
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <CredentialsStep allowCredentialsWithPasswords />
-        </Formik>,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    wrapper.update();
+    const { user, container } = renderWithContexts(
+      <Formik>
+        <CredentialsStep allowCredentialsWithPasswords />
+      </Formik>,
+      {
+        context: { router: { history } },
+      }
+    );
 
-    expect(CredentialsAPI.read).toHaveBeenCalledWith({
-      credential_type: 1,
-      order_by: 'name',
-      page: 2,
-      page_size: 5,
-    });
+    await waitFor(() =>
+      expect(CredentialsAPI.read).toHaveBeenCalledWith({
+        credential_type: 1,
+        order_by: 'name',
+        page: 2,
+        page_size: 5,
+      })
+    );
 
-    await act(async () => {
-      wrapper.find('AnsibleSelect').invoke('onChange')({}, 3);
-    });
-    expect(CredentialsAPI.read).toHaveBeenCalledWith({
-      credential_type: 3,
-      order_by: 'name',
-      page: 1,
-      page_size: 5,
-    });
+    const select = await findCategorySelect(container);
+    await user.selectOptions(select, 'Vault');
+
+    await waitFor(() =>
+      expect(CredentialsAPI.read).toHaveBeenCalledWith({
+        credential_type: 3,
+        order_by: 'name',
+        page: 1,
+        page_size: 5,
+      })
+    );
   });
 
   test("error should be shown when a credential that prompts for passwords is selected on a step that doesn't allow it", async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik
-          initialValues={{
-            credentials: [],
-          }}
-        >
-          <CredentialsStep allowCredentialsWithPasswords={false} />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(0);
-    await act(async () => {
-      wrapper.find('td#check-action-item-2').find('input').simulate('click');
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(1);
-    expect(wrapper.find('Alert').text().includes('Cred 2')).toBe(true);
+    const { user, container } = renderWithContexts(
+      <Formik
+        initialValues={{
+          credentials: [],
+        }}
+      >
+        <CredentialsStep allowCredentialsWithPasswords={false} />
+      </Formik>
+    );
+
+    await screen.findByText('Cred 2');
+    expect(screen.queryByText(/require passwords on launch/)).toBeNull();
+
+    const checkbox = container.querySelector('#check-action-item-2 input');
+    await user.click(checkbox);
+
+    const alert = await screen.findByText(/require passwords on launch/);
+    expect(alert).toHaveTextContent('Cred 2');
   });
 
   test('error should be toggled when default machine credential is removed and then replaced', async () => {
-    let wrapper;
     const selectedCredentials = [
       {
         id: 5,
@@ -242,38 +249,40 @@ describe('CredentialsStep', () => {
         },
       },
     ];
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik
-          initialValues={{
-            credentials: selectedCredentials,
-          }}
-        >
-          <CredentialsStep
-            allowCredentialsWithPasswords={false}
-            defaultCredentials={selectedCredentials}
-          />
-        </Formik>
-      );
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(0);
-    expect(wrapper.find('CredentialChip').length).toBe(1);
-    await act(async () => {
-      wrapper.find('button#remove_credential-chip-5').simulate('click');
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(1);
-    expect(wrapper.find('Alert').text().includes('Machine')).toBe(true);
-    await act(async () => {
-      wrapper.find('td#check-action-item-5').find('input').simulate('click');
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(0);
+    const { user, container } = renderWithContexts(
+      <Formik
+        initialValues={{
+          credentials: selectedCredentials,
+        }}
+      >
+        <CredentialsStep
+          allowCredentialsWithPasswords={false}
+          defaultCredentials={selectedCredentials}
+        />
+      </Formik>
+    );
+
+    await screen.findByText('Cred 2');
+    expect(screen.queryByText(/must be replaced/)).toBeNull();
+
+    const removeChip = container.querySelector(
+      'button#remove_credential-chip-5'
+    );
+    expect(removeChip).not.toBeNull();
+    await user.click(removeChip);
+
+    const alert = await screen.findByText(/must be replaced/);
+    expect(alert).toHaveTextContent('Machine');
+
+    const checkbox = container.querySelector('#check-action-item-5 input');
+    await user.click(checkbox);
+
+    await waitFor(() =>
+      expect(screen.queryByText(/must be replaced/)).toBeNull()
+    );
   });
 
   test('error should be toggled when default vault credential is removed and then replaced', async () => {
-    let wrapper;
     const selectedCredentials = [
       {
         id: 33,
@@ -306,38 +315,43 @@ describe('CredentialsStep', () => {
         },
       },
     ];
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik
-          initialValues={{
-            credentials: selectedCredentials,
-          }}
-        >
-          <CredentialsStep
-            allowCredentialsWithPasswords={false}
-            defaultCredentials={selectedCredentials}
-          />
-        </Formik>
-      );
+    const { user, container } = renderWithContexts(
+      <Formik
+        initialValues={{
+          credentials: selectedCredentials,
+        }}
+      >
+        <CredentialsStep
+          allowCredentialsWithPasswords={false}
+          defaultCredentials={selectedCredentials}
+        />
+      </Formik>
+    );
+
+    await screen.findByText('Cred 1');
+    expect(screen.queryByText(/must be replaced/)).toBeNull();
+
+    const removeChip = container.querySelector(
+      'button#remove_credential-chip-33'
+    );
+    expect(removeChip).not.toBeNull();
+    await user.click(removeChip);
+
+    const alert = await screen.findByText(/must be replaced/);
+    expect(alert).toHaveTextContent('Vault | foo');
+
+    const select = await findCategorySelect(container);
+    await user.selectOptions(select, 'Vault');
+
+    const checkbox = await waitFor(() => {
+      const el = container.querySelector('#check-action-item-33 input');
+      expect(el).not.toBeNull();
+      return el;
     });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(0);
-    expect(wrapper.find('CredentialChip').length).toBe(2);
-    await act(async () => {
-      wrapper.find('button#remove_credential-chip-33').simulate('click');
-    });
-    wrapper.update();
-    expect(wrapper.find('CredentialChip').length).toBe(1);
-    expect(wrapper.find('Alert').length).toBe(1);
-    expect(wrapper.find('Alert').text().includes('Vault | foo')).toBe(true);
-    await act(async () => {
-      wrapper.find('AnsibleSelect').invoke('onChange')({}, 3);
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('td#check-action-item-33').find('input').simulate('click');
-    });
-    wrapper.update();
-    expect(wrapper.find('Alert').length).toBe(0);
+    await user.click(checkbox);
+
+    await waitFor(() =>
+      expect(screen.queryByText(/must be replaced/)).toBeNull()
+    );
   });
 });

--- a/awx/ui/src/components/LaunchPrompt/steps/ExecutionEnvironmentStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/ExecutionEnvironmentStep.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { ExecutionEnvironmentsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import ExecutionEnvironmentStep from './ExecutionEnvironmentStep';
 
 jest.mock('../../../api/models/ExecutionEnvironments');
@@ -33,20 +33,20 @@ describe('ExecutionEnvironmentStep', () => {
     });
   });
 
-  test('should load execution environments', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <ExecutionEnvironmentStep />
-        </Formik>
-      );
-    });
-    wrapper.update();
+  afterEach(() => jest.clearAllMocks());
 
-    expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('OptionsList').prop('options')).toEqual(
-      execution_environments
+  test('should load execution environments', async () => {
+    renderWithContexts(
+      <Formik>
+        <ExecutionEnvironmentStep />
+      </Formik>
     );
+
+    await waitFor(() =>
+      expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalled()
+    );
+    expect(await screen.findByText('ee one')).toBeInTheDocument();
+    expect(screen.getByText('ee two')).toBeInTheDocument();
+    expect(screen.getByText('ee three')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/LaunchPrompt/steps/InstanceGroupsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/InstanceGroupsStep.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { InstanceGroupsAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import InstanceGroupsStep from './InstanceGroupsStep';
 
 jest.mock('../../../api/models/InstanceGroups');
@@ -33,20 +33,18 @@ describe('InstanceGroupsStep', () => {
     });
   });
 
-  test('should load instance groups', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ instance_groups: [] }}>
-          <InstanceGroupsStep />
-        </Formik>
-      );
-    });
-    wrapper.update();
+  afterEach(() => jest.clearAllMocks());
 
-    expect(InstanceGroupsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('OptionsList').prop('options')).toEqual(
-      instance_groups
+  test('should load instance groups', async () => {
+    renderWithContexts(
+      <Formik initialValues={{ instance_groups: [] }}>
+        <InstanceGroupsStep />
+      </Formik>
     );
+
+    await waitFor(() => expect(InstanceGroupsAPI.read).toHaveBeenCalled());
+    expect(await screen.findByText('ig one')).toBeInTheDocument();
+    expect(screen.getByText('ig two')).toBeInTheDocument();
+    expect(screen.getByText('ig three')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/LaunchPrompt/steps/InventoryStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/InventoryStep.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { InventoriesAPI } from 'api';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import InventoryStep from './InventoryStep';
 
 jest.mock('../../../api/models/Inventories');
@@ -33,34 +33,30 @@ describe('InventoryStep', () => {
     });
   });
 
-  test('should load inventories', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InventoryStep />
-        </Formik>
-      );
-    });
-    wrapper.update();
+  afterEach(() => jest.clearAllMocks());
 
-    expect(InventoriesAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('OptionsList').prop('options')).toEqual(inventories);
+  test('should load inventories', async () => {
+    renderWithContexts(
+      <Formik>
+        <InventoryStep />
+      </Formik>
+    );
+
+    await waitFor(() => expect(InventoriesAPI.read).toHaveBeenCalled());
+    expect(await screen.findByText('inv one')).toBeInTheDocument();
+    expect(screen.getByText('inv two')).toBeInTheDocument();
+    expect(screen.getByText('inv three')).toBeInTheDocument();
   });
 
   test('should show warning message when one is passed in', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <InventoryStep
-            warningMessage={<div id="test-warning-message">TEST</div>}
-          />
-        </Formik>
-      );
-    });
-    wrapper.update();
+    renderWithContexts(
+      <Formik>
+        <InventoryStep
+          warningMessage={<div id="test-warning-message">TEST</div>}
+        />
+      </Formik>
+    );
 
-    expect(wrapper.find('div#test-warning-message').length).toBe(1);
+    expect(await screen.findByText('TEST')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/LaunchPrompt/steps/OtherPromptsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/OtherPromptsStep.test.js
@@ -1,240 +1,174 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
 import { Formik } from 'formik';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import OtherPromptsStep from './OtherPromptsStep';
 
+const jobTemplateData = {
+  job_template_data: {
+    name: 'Demo Job Template',
+    id: 1,
+    description: '',
+  },
+};
+
 describe('OtherPromptsStep', () => {
-  test('should render job type field', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ job_type: 'run' }}>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_job_type_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('JobTypeField')).toHaveLength(1);
-    expect(
-      wrapper.find('JobTypeField AnsibleSelect').prop('data')
-    ).toHaveLength(3);
-    expect(wrapper.find('JobTypeField AnsibleSelect').prop('value')).toEqual(
-      'run'
+  // FormField/FormGroup labelIcon (the tooltip) breaks the label/input
+  // association, so query inputs and selects by id from the container.
+  test('should render job type field', () => {
+    const { container } = renderWithContexts(
+      <Formik initialValues={{ job_type: 'run' }}>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_job_type_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
     );
+
+    const select = container.querySelector('select#prompt-job-type');
+    expect(select).not.toBeNull();
+    expect(select.options).toHaveLength(3);
+    expect(select.value).toEqual('run');
   });
 
-  test('should render limit field', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_limit_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('FormField#prompt-limit')).toHaveLength(1);
-    expect(wrapper.find('FormField#prompt-limit input').prop('name')).toEqual(
-      'limit'
+  test('should render limit field', () => {
+    const { container } = renderWithContexts(
+      <Formik>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_limit_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
     );
+
+    const input = container.querySelector('input#prompt-limit');
+    expect(input).not.toBeNull();
+    expect(input).toHaveAttribute('name', 'limit');
   });
 
-  test('should render timeout field', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_timeout_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('FormField#prompt-timeout')).toHaveLength(1);
-    expect(wrapper.find('FormField#prompt-timeout input').prop('name')).toEqual(
-      'timeout'
+  test('should render timeout field', () => {
+    const { container } = renderWithContexts(
+      <Formik>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_timeout_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
     );
+
+    const input = container.querySelector('input#prompt-timeout');
+    expect(input).not.toBeNull();
+    expect(input).toHaveAttribute('name', 'timeout');
   });
 
-  test('should render forks field', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_forks_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('FormField#prompt-forks')).toHaveLength(1);
-    expect(wrapper.find('FormField#prompt-forks input').prop('name')).toEqual(
-      'forks'
+  test('should render forks field', () => {
+    const { container } = renderWithContexts(
+      <Formik>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_forks_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
     );
+
+    const input = container.querySelector('input#prompt-forks');
+    expect(input).not.toBeNull();
+    expect(input).toHaveAttribute('name', 'forks');
   });
 
-  test('should render job slicing field', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_job_slice_count_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('FormField#prompt-job-slicing')).toHaveLength(1);
-    expect(
-      wrapper.find('FormField#prompt-job-slicing input').prop('name')
-    ).toEqual('job_slice_count');
-  });
-
-  test('should render source control branch field', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_scm_branch_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('FormField#prompt-scm-branch')).toHaveLength(1);
-    expect(
-      wrapper.find('FormField#prompt-scm-branch input').prop('name')
-    ).toEqual('scm_branch');
-  });
-
-  test('should render verbosity field', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ verbosity: '' }}>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_verbosity_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('VerbosityField')).toHaveLength(1);
-    expect(
-      wrapper.find('VerbosityField AnsibleSelect').prop('data')
-    ).toHaveLength(6);
-  });
-
-  test('should render show changes toggle', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ diff_mode: true }}>
-          <OtherPromptsStep
-            launchConfig={{
-              ask_diff_mode_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
-
-    expect(wrapper.find('ShowChangesToggle')).toHaveLength(1);
-    expect(wrapper.find('ShowChangesToggle Switch').prop('isChecked')).toEqual(
-      true
+  test('should render job slicing field', () => {
+    const { container } = renderWithContexts(
+      <Formik>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_job_slice_count_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
     );
+
+    const input = container.querySelector('input#prompt-job-slicing');
+    expect(input).not.toBeNull();
+    expect(input).toHaveAttribute('name', 'job_slice_count');
   });
 
-  test('should pass mode and onModeChange to VariablesField', async () => {
-    let wrapper;
-    const onModeChange = jest.fn();
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ extra_vars: '{}' }}>
-          <OtherPromptsStep
-            variablesMode="javascript"
-            onVarModeChange={onModeChange}
-            launchConfig={{
-              ask_variables_on_launch: true,
-              job_template_data: {
-                name: 'Demo Job Template',
-                id: 1,
-                description: '',
-              },
-            }}
-          />
-        </Formik>
-      );
-    });
+  test('should render source control branch field', () => {
+    const { container } = renderWithContexts(
+      <Formik>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_scm_branch_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
+    );
 
-    expect(wrapper.find('VariablesField').prop('initialMode')).toEqual(
-      'javascript'
+    const input = container.querySelector('input#prompt-scm-branch');
+    expect(input).not.toBeNull();
+    expect(input).toHaveAttribute('name', 'scm_branch');
+  });
+
+  test('should render verbosity field', () => {
+    const { container } = renderWithContexts(
+      <Formik initialValues={{ verbosity: '' }}>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_verbosity_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
     );
-    expect(wrapper.find('VariablesField').prop('onModeChange')).toEqual(
-      onModeChange
+
+    const select = container.querySelector('select#prompt-verbosity');
+    expect(select).not.toBeNull();
+    expect(select.options).toHaveLength(6);
+  });
+
+  test('should render show changes toggle', () => {
+    renderWithContexts(
+      <Formik initialValues={{ diff_mode: true }}>
+        <OtherPromptsStep
+          launchConfig={{
+            ask_diff_mode_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
     );
+
+    const toggle = screen.getByRole('checkbox', { name: 'On' });
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toBeChecked();
+  });
+
+  test('should render variables field', async () => {
+    // react-ace renders empty under jsdom, so assert the surrounding label.
+    // VariablesField does an async Formik update on mount; findBy settles it
+    // inside act so the console-error trap stays quiet.
+    renderWithContexts(
+      <Formik initialValues={{ extra_vars: '{}' }}>
+        <OtherPromptsStep
+          variablesMode="javascript"
+          onVarModeChange={jest.fn()}
+          launchConfig={{
+            ask_variables_on_launch: true,
+            ...jobTemplateData,
+          }}
+        />
+      </Formik>
+    );
+
+    expect(await screen.findByText('Variables')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/LaunchPrompt/steps/PreviewStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/PreviewStep.test.js
@@ -1,8 +1,19 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen } from '@testing-library/react';
 import { Formik } from 'formik';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import PreviewStep from './PreviewStep';
+
+// PromptDetail is a large read-only detail renderer; this suite only cares
+// about the resource/overrides PreviewStep computes and forwards, so mock it
+// and surface the props it receives into the DOM for assertion.
+jest.mock('../../PromptDetail', () => ({ resource, overrides }) => (
+  <div
+    data-testid="prompt-detail"
+    data-resource={JSON.stringify(resource)}
+    data-overrides={JSON.stringify(overrides)}
+  />
+));
 
 const resource = {
   id: 1,
@@ -28,130 +39,117 @@ const formErrors = {
   inventory: 'An inventory must be selected',
 };
 
-describe('PreviewStep', () => {
-  test('should render PromptDetail', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ limit: '4', survey_foo: 'abc' }}>
-          <PreviewStep
-            resource={resource}
-            launchConfig={{
-              ask_limit_on_launch: true,
-              survey_enabled: true,
-            }}
-            surveyConfig={survey}
-            formErrors={formErrors}
-          />
-        </Formik>
-      );
-    });
+function getPromptDetail() {
+  return screen.getByTestId('prompt-detail');
+}
 
-    const detail = wrapper.find('PromptDetail');
-    expect(detail).toHaveLength(1);
-    expect(detail.prop('resource')).toEqual(resource);
-    expect(detail.prop('overrides')).toEqual({
+describe('PreviewStep', () => {
+  test('should render PromptDetail', () => {
+    renderWithContexts(
+      <Formik initialValues={{ limit: '4', survey_foo: 'abc' }}>
+        <PreviewStep
+          resource={resource}
+          launchConfig={{
+            ask_limit_on_launch: true,
+            survey_enabled: true,
+          }}
+          surveyConfig={survey}
+          formErrors={formErrors}
+        />
+      </Formik>
+    );
+
+    const detail = getPromptDetail();
+    expect(JSON.parse(detail.dataset.resource)).toEqual(resource);
+    expect(JSON.parse(detail.dataset.overrides)).toEqual({
       extra_vars: 'foo: abc\n',
       limit: '4',
       survey_foo: 'abc',
     });
   });
 
-  test('should render PromptDetail without survey', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ limit: '4' }}>
-          <PreviewStep
-            resource={resource}
-            launchConfig={{
-              ask_limit_on_launch: true,
-            }}
-            formErrors={formErrors}
-          />
-        </Formik>
-      );
-    });
+  test('should render PromptDetail without survey', () => {
+    renderWithContexts(
+      <Formik initialValues={{ limit: '4' }}>
+        <PreviewStep
+          resource={resource}
+          launchConfig={{
+            ask_limit_on_launch: true,
+          }}
+          formErrors={formErrors}
+        />
+      </Formik>
+    );
 
-    const detail = wrapper.find('PromptDetail');
-    expect(detail).toHaveLength(1);
-    expect(detail.prop('resource')).toEqual(resource);
-    expect(detail.prop('overrides')).toEqual({
+    const detail = getPromptDetail();
+    expect(JSON.parse(detail.dataset.resource)).toEqual(resource);
+    expect(JSON.parse(detail.dataset.overrides)).toEqual({
       limit: '4',
     });
   });
-  test('should handle extra vars with survey', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ extra_vars: 'one: 1', survey_foo: 'abc' }}>
-          <PreviewStep
-            resource={resource}
-            launchConfig={{
-              ask_variables_on_launch: true,
-              survey_enabled: true,
-            }}
-            surveyConfig={survey}
-            formErrors={formErrors}
-          />
-        </Formik>
-      );
-    });
 
-    const detail = wrapper.find('PromptDetail');
-    expect(detail).toHaveLength(1);
-    expect(detail.prop('resource')).toEqual(resource);
-    expect(detail.prop('overrides')).toEqual({
+  test('should handle extra vars with survey', () => {
+    renderWithContexts(
+      <Formik initialValues={{ extra_vars: 'one: 1', survey_foo: 'abc' }}>
+        <PreviewStep
+          resource={resource}
+          launchConfig={{
+            ask_variables_on_launch: true,
+            survey_enabled: true,
+          }}
+          surveyConfig={survey}
+          formErrors={formErrors}
+        />
+      </Formik>
+    );
+
+    const detail = getPromptDetail();
+    expect(JSON.parse(detail.dataset.resource)).toEqual(resource);
+    expect(JSON.parse(detail.dataset.overrides)).toEqual({
       extra_vars: 'one: 1\nfoo: abc\n',
       survey_foo: 'abc',
     });
   });
-  test('should handle extra vars without survey', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ extra_vars: 'one: 1' }}>
-          <PreviewStep
-            resource={resource}
-            launchConfig={{
-              ask_variables_on_launch: true,
-            }}
-            formErrors={formErrors}
-          />
-        </Formik>
-      );
-    });
 
-    const detail = wrapper.find('PromptDetail');
-    expect(detail).toHaveLength(1);
-    expect(detail.prop('resource')).toEqual(resource);
-    expect(detail.prop('overrides')).toEqual({
+  test('should handle extra vars without survey', () => {
+    renderWithContexts(
+      <Formik initialValues={{ extra_vars: 'one: 1' }}>
+        <PreviewStep
+          resource={resource}
+          launchConfig={{
+            ask_variables_on_launch: true,
+          }}
+          formErrors={formErrors}
+        />
+      </Formik>
+    );
+
+    const detail = getPromptDetail();
+    expect(JSON.parse(detail.dataset.resource)).toEqual(resource);
+    expect(JSON.parse(detail.dataset.overrides)).toEqual({
       extra_vars: 'one: 1\n',
     });
   });
-  test('should remove survey with empty array value', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik
-          initialValues={{ extra_vars: 'one: 1' }}
-          values={{ extra_vars: 'one: 1', survey_foo: [] }}
-        >
-          <PreviewStep
-            resource={resource}
-            launchConfig={{
-              ask_variables_on_launch: true,
-            }}
-            formErrors={formErrors}
-          />
-        </Formik>
-      );
-    });
 
-    const detail = wrapper.find('PromptDetail');
-    expect(detail).toHaveLength(1);
-    expect(detail.prop('resource')).toEqual(resource);
-    expect(detail.prop('overrides')).toEqual({
+  test('should remove survey with empty array value', () => {
+    renderWithContexts(
+      <Formik
+        initialValues={{ extra_vars: 'one: 1' }}
+        values={{ extra_vars: 'one: 1', survey_foo: [] }}
+      >
+        <PreviewStep
+          resource={resource}
+          launchConfig={{
+            ask_variables_on_launch: true,
+          }}
+          formErrors={formErrors}
+        />
+      </Formik>
+    );
+
+    const detail = getPromptDetail();
+    expect(JSON.parse(detail.dataset.resource)).toEqual(resource);
+    expect(JSON.parse(detail.dataset.overrides)).toEqual({
       extra_vars: 'one: 1\n',
     });
   });

--- a/awx/ui/src/components/LaunchPrompt/steps/SurveyStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/SurveyStep.test.js
@@ -1,88 +1,58 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, within } from '@testing-library/react';
 import { Formik } from 'formik';
-import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import SurveyStep from './SurveyStep';
+
+function makeConfig(choices) {
+  return {
+    name: 'survey',
+    description: '',
+    spec: [
+      {
+        question_name: 'q1',
+        question_description: '',
+        required: true,
+        type: 'multiplechoice',
+        variable: 'q1',
+        min: null,
+        max: null,
+        default: '',
+        choices,
+      },
+    ],
+  };
+}
+
+async function openAndAssertOptions(user) {
+  // The typeahead toggle is the button inside the PF Select.
+  const toggle = screen.getByRole('button', { name: 'Options menu' });
+  await user.click(toggle);
+
+  const listbox = screen.getByRole('listbox');
+  ['1', '2', '3', '4', '5', '6'].forEach((value) => {
+    expect(within(listbox).getByText(value)).toBeInTheDocument();
+  });
+}
 
 describe('SurveyStep', () => {
   test('should handle choices as a string', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ job_type: 'run' }}>
-          <SurveyStep
-            surveyConfig={{
-              name: 'survey',
-              description: '',
-              spec: [
-                {
-                  question_name: 'q1',
-                  question_description: '',
-                  required: true,
-                  type: 'multiplechoice',
-                  variable: 'q1',
-                  min: null,
-                  max: null,
-                  default: '',
-                  choices: '1\n2\n3\n4\n5\n6',
-                },
-              ],
-            }}
-          />
-        </Formik>
-      );
-    });
+    const { user } = renderWithContexts(
+      <Formik initialValues={{ job_type: 'run' }}>
+        <SurveyStep surveyConfig={makeConfig('1\n2\n3\n4\n5\n6')} />
+      </Formik>
+    );
 
-    await act(async () => {
-      wrapper.find('SelectToggle').simulate('click');
-    });
-    wrapper.update();
-    const selectOptions = wrapper.find('SelectOption');
-    expect(selectOptions.at(0).prop('value')).toEqual('1');
-    expect(selectOptions.at(1).prop('value')).toEqual('2');
-    expect(selectOptions.at(2).prop('value')).toEqual('3');
-    expect(selectOptions.at(3).prop('value')).toEqual('4');
-    expect(selectOptions.at(4).prop('value')).toEqual('5');
-    expect(selectOptions.at(5).prop('value')).toEqual('6');
+    await openAndAssertOptions(user);
   });
-  test('should handle choices as an array', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={{ job_type: 'run' }}>
-          <SurveyStep
-            surveyConfig={{
-              name: 'survey',
-              description: '',
-              spec: [
-                {
-                  question_name: 'q1',
-                  question_description: '',
-                  required: true,
-                  type: 'multiplechoice',
-                  variable: 'q1',
-                  min: null,
-                  max: null,
-                  default: '',
-                  choices: ['1', '2', '3', '4', '5', '6'],
-                },
-              ],
-            }}
-          />
-        </Formik>
-      );
-    });
 
-    await act(async () => {
-      wrapper.find('SelectToggle').simulate('click');
-    });
-    wrapper.update();
-    const selectOptions = wrapper.find('SelectOption');
-    expect(selectOptions.at(0).prop('value')).toEqual('1');
-    expect(selectOptions.at(1).prop('value')).toEqual('2');
-    expect(selectOptions.at(2).prop('value')).toEqual('3');
-    expect(selectOptions.at(3).prop('value')).toEqual('4');
-    expect(selectOptions.at(4).prop('value')).toEqual('5');
-    expect(selectOptions.at(5).prop('value')).toEqual('6');
+  test('should handle choices as an array', async () => {
+    const { user } = renderWithContexts(
+      <Formik initialValues={{ job_type: 'run' }}>
+        <SurveyStep surveyConfig={makeConfig(['1', '2', '3', '4', '5', '6'])} />
+      </Formik>
+    );
+
+    await openAndAssertOptions(user);
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **LaunchPrompt** component test suite (`components/LaunchPrompt`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `LaunchPrompt` (the launch wizard) and its steps — Inventory, Credentials, CredentialPasswords, OtherPrompts, Preview, Survey, ExecutionEnvironment, InstanceGroups.

The PF Wizard mounts in a Modal portal under `document.body` (not the render container), so wizard nav/steps are asserted there. Step forms are driven through real selects/checkboxes; `PromptDetail` overrides are surfaced via a mock for the preview step. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/LaunchPrompt`: **9 suites, 48 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
