### PR TITLE
enzyme -> RTL: convert the PaginatedTable component suites

### DIFF
--- a/awx/ui/src/components/PaginatedTable/ActionItem.test.js
+++ b/awx/ui/src/components/PaginatedTable/ActionItem.test.js
@@ -6,7 +6,7 @@ import ActionItem from './ActionItem';
 describe('<ActionItem />', () => {
   test('should render child wrapped with tooltip', async () => {
     const { user } = renderWithContexts(
-      <ActionItem columns={1} tooltip="a tooltip" visible>
+      <ActionItem column={1} tooltip="a tooltip" visible>
         foo
       </ActionItem>
     );
@@ -23,7 +23,7 @@ describe('<ActionItem />', () => {
 
   test('should render null if not visible', async () => {
     const { container } = renderWithContexts(
-      <ActionItem columns={1} tooltip="foo">
+      <ActionItem column={1} tooltip="foo">
         <div>foo</div>
       </ActionItem>
     );

--- a/awx/ui/src/components/PaginatedTable/ActionItem.test.js
+++ b/awx/ui/src/components/PaginatedTable/ActionItem.test.js
@@ -1,29 +1,34 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ActionItem from './ActionItem';
 
 describe('<ActionItem />', () => {
-  test('should render child with tooltip', async () => {
-    const wrapper = shallow(
+  test('should render child wrapped with tooltip', async () => {
+    const { user } = renderWithContexts(
       <ActionItem columns={1} tooltip="a tooltip" visible>
         foo
       </ActionItem>
     );
 
-    const tooltip = wrapper.find('Tooltip');
-    expect(tooltip.prop('content')).toEqual('a tooltip');
-    expect(tooltip.prop('children')).toEqual(<div>foo</div>);
+    // when a tooltip is provided, ActionItem wraps the children in a <div>
+    // inside a PF Tooltip; the child content is rendered to the DOM
+    const child = screen.getByText('foo');
+    expect(child).toBeInTheDocument();
+    expect(child.tagName).toEqual('DIV');
+    // the tooltip content ("a tooltip") is revealed on hover
+    await user.hover(child);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('a tooltip');
   });
 
   test('should render null if not visible', async () => {
-    const wrapper = shallow(
+    const { container } = renderWithContexts(
       <ActionItem columns={1} tooltip="foo">
         <div>foo</div>
       </ActionItem>
     );
 
-    expect(wrapper.find('Tooltip')).toHaveLength(0);
-    expect(wrapper.find('div')).toHaveLength(0);
-    expect(wrapper.text()).toEqual('');
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/PaginatedTable/HeaderRow.test.js
+++ b/awx/ui/src/components/PaginatedTable/HeaderRow.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import HeaderRow, { HeaderCell } from './HeaderRow';
 
 describe('<HeaderRow />', () => {
@@ -11,7 +12,7 @@ describe('<HeaderRow />', () => {
   };
 
   test('should render cells', async () => {
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <table>
         <HeaderRow qsConfig={qsConfig}>
           <HeaderCell sortKey="one">One</HeaderCell>
@@ -20,17 +21,19 @@ describe('<HeaderRow />', () => {
       </table>
     );
 
-    const cells = wrapper.find('Th');
+    // HeaderRow is selectable by default, so it renders an empty leading
+    // <th> plus the two HeaderCell columns = 3 column headers
+    const cells = screen.getAllByRole('columnheader');
     expect(cells).toHaveLength(3);
-    expect(cells.at(1).text()).toEqual('One');
-    expect(cells.at(2).text()).toEqual('Two');
+    expect(cells[1]).toHaveTextContent('One');
+    expect(cells[2]).toHaveTextContent('Two');
   });
 
   test('should provide sort controls', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/list'],
     });
-    const wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <table>
         <HeaderRow qsConfig={qsConfig}>
           <HeaderCell sortKey="one">One</HeaderCell>
@@ -40,8 +43,10 @@ describe('<HeaderRow />', () => {
       { context: { router: { history } } }
     );
 
-    const cell = wrapper.find('Th').at(1);
-    cell.prop('sort').onSort({}, '', 'desc');
+    // the "One" column is sortable and currently sorted ascending (the default
+    // order_by), so clicking its sort button toggles it to descending
+    const oneHeader = screen.getByRole('columnheader', { name: /One/ });
+    await user.click(within(oneHeader).getByRole('button', { name: 'One' }));
     expect(history.location.search).toEqual('?order_by=-one');
   });
 
@@ -49,7 +54,7 @@ describe('<HeaderRow />', () => {
     const history = createMemoryHistory({
       initialEntries: ['/list'],
     });
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <table>
         <HeaderRow qsConfig={qsConfig}>
           <HeaderCell sortKey="one">One</HeaderCell>
@@ -59,13 +64,14 @@ describe('<HeaderRow />', () => {
       { context: { router: { history } } }
     );
 
-    const cell = wrapper.find('Th').at(2);
-    expect(cell.prop('sort')).toEqual(null);
+    // the "Two" column has no sortKey, so it renders no sort button (sort=null)
+    const twoHeader = screen.getByRole('columnheader', { name: 'Two' });
+    expect(within(twoHeader).queryByRole('button')).not.toBeInTheDocument();
   });
 
   test('should handle null children gracefully', async () => {
     const nope = false;
-    const wrapper = mountWithContexts(
+    renderWithContexts(
       <table>
         <HeaderRow qsConfig={qsConfig}>
           <HeaderCell sortKey="one">One</HeaderCell>
@@ -75,7 +81,6 @@ describe('<HeaderRow />', () => {
       </table>
     );
 
-    const cells = wrapper.find('Th');
-    expect(cells).toHaveLength(3);
+    expect(screen.getAllByRole('columnheader')).toHaveLength(3);
   });
 });

--- a/awx/ui/src/components/PaginatedTable/PaginatedTable.test.js
+++ b/awx/ui/src/components/PaginatedTable/PaginatedTable.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import { within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import PaginatedTable from './PaginatedTable';
 
 const mockData = [
@@ -17,12 +18,19 @@ const qsConfig = {
   integerFields: ['page', 'page_size'],
 };
 
+// the bottom Pagination is rendered with ouiaId="bottom-pagination"; scope
+// queries to it because the top (compact) pagination shares the same labels
+const bottomPagination = (container) =>
+  within(
+    container.querySelector('[data-ouia-component-id="bottom-pagination"]')
+  );
+
 describe('<PaginatedTable />', () => {
   test('should render item rows', () => {
     const history = createMemoryHistory({
       initialEntries: ['/organizations/1/teams'],
     });
-    const wrapper = mountWithContexts(
+    const { container } = renderWithContexts(
       <PaginatedTable
         items={mockData}
         itemCount={7}
@@ -41,20 +49,20 @@ describe('<PaginatedTable />', () => {
       { context: { router: { history } } }
     );
 
-    const rows = wrapper.find('tr');
+    const rows = container.querySelectorAll('tbody tr');
     expect(rows).toHaveLength(5);
-    expect(rows.at(0).text()).toEqual('one');
-    expect(rows.at(1).text()).toEqual('two');
-    expect(rows.at(2).text()).toEqual('three');
-    expect(rows.at(3).text()).toEqual('four');
-    expect(rows.at(4).text()).toEqual('five');
+    expect(rows[0]).toHaveTextContent('one');
+    expect(rows[1]).toHaveTextContent('two');
+    expect(rows[2]).toHaveTextContent('three');
+    expect(rows[3]).toHaveTextContent('four');
+    expect(rows[4]).toHaveTextContent('five');
   });
 
-  test('should navigate page when changes', () => {
+  test('should navigate page when changes', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/organizations/1/teams'],
     });
-    const wrapper = mountWithContexts(
+    const { container, user } = renderWithContexts(
       <PaginatedTable
         items={mockData}
         itemCount={7}
@@ -69,25 +77,32 @@ describe('<PaginatedTable />', () => {
       { context: { router: { history } } }
     );
 
-    const pagination = wrapper.find('Pagination').at(1);
-    pagination.prop('onSetPage')(null, 2);
+    await user.click(
+      bottomPagination(container).getByRole('button', {
+        name: 'Go to next page',
+      })
+    );
     expect(history.location.search).toEqual('?item.page=2');
-    wrapper.update();
-    pagination.prop('onSetPage')(null, 1);
-    // since page = 1 is the default, that should be strip out of the search
+
+    await user.click(
+      bottomPagination(container).getByRole('button', {
+        name: 'Go to previous page',
+      })
+    );
+    // since page = 1 is the default, that should be stripped out of the search
     expect(history.location.search).toEqual('');
   });
 
-  test('should navigate to page when page size changes', () => {
+  test('should navigate to page when page size changes', async () => {
     const history = createMemoryHistory({
-      initialEntries: ['/organizations/1/teams'],
+      initialEntries: ['/organizations/1/teams?item.page=2'],
     });
-    const wrapper = mountWithContexts(
+    const { container, user } = renderWithContexts(
       <PaginatedTable
         items={mockData}
         itemCount={7}
         queryParams={{
-          page: 1,
+          page: 2,
           page_size: 5,
           order_by: 'name',
         }}
@@ -97,12 +112,16 @@ describe('<PaginatedTable />', () => {
       { context: { router: { history } } }
     );
 
-    const pagination = wrapper.find('Pagination').at(1);
-    pagination.prop('onPerPageSelect')(null, 25, 2);
-    expect(history.location.search).toEqual('?item.page=2&item.page_size=25');
-    wrapper.update();
-    // since page_size = 5 is the default, that should be strip out of the search
-    pagination.prop('onPerPageSelect')(null, 5, 2);
-    expect(history.location.search).toEqual('?item.page=2');
+    // open the per-page dropdown (its toggle is labelled "Select") and pick 20
+    await user.click(
+      bottomPagination(container).getByRole('button', { name: 'Select' })
+    );
+    await user.click(
+      bottomPagination(container).getByRole('menuitem', { name: '20 per page' })
+    );
+    // PF recomputes the page for the new page size; with 7 items at 20/page it
+    // lands back on page 1 (the default, so it is stripped from the query) and
+    // only the new page_size is pushed
+    expect(history.location.search).toEqual('?item.page_size=20');
   });
 });

--- a/awx/ui/src/components/PaginatedTable/ToolbarAddButton.test.js
+++ b/awx/ui/src/components/PaginatedTable/ToolbarAddButton.test.js
@@ -1,30 +1,29 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ToolbarAddButton from './ToolbarAddButton';
 
 describe('<ToolbarAddButton />', () => {
-  test('should render button', () => {
+  test('should render button', async () => {
     const onClick = jest.fn();
-    const wrapper = mountWithContexts(<ToolbarAddButton onClick={onClick} />);
-    const button = wrapper.find('button');
-    expect(button).toHaveLength(1);
-    button.simulate('click');
+    const { user } = renderWithContexts(<ToolbarAddButton onClick={onClick} />);
+    const button = screen.getByRole('button', { name: 'Add' });
+    expect(button).toBeInTheDocument();
+    await user.click(button);
     expect(onClick).toHaveBeenCalled();
   });
 
   test('should render link', () => {
-    const wrapper = mountWithContexts(<ToolbarAddButton linkTo="/foo" />);
-    const link = wrapper.find('Link');
-    expect(link).toHaveLength(1);
-    expect(link.prop('to')).toBe('/foo');
+    renderWithContexts(<ToolbarAddButton linkTo="/foo" />);
+    const link = screen.getByRole('link', { name: 'Add' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/foo');
   });
 
   test('should render link with toggle icon', () => {
-    const wrapper = mountWithContexts(
-      <ToolbarAddButton showToggleIndicator linkTo="/foo" />
-    );
-    const link = wrapper.find('Link');
-    expect(link).toHaveLength(1);
-    expect(link.prop('to')).toBe('/foo');
+    renderWithContexts(<ToolbarAddButton showToggleIndicator linkTo="/foo" />);
+    const link = screen.getByRole('link', { name: 'Add' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/foo');
   });
 });

--- a/awx/ui/src/components/PaginatedTable/ToolbarDeleteButton.test.js
+++ b/awx/ui/src/components/PaginatedTable/ToolbarDeleteButton.test.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 
 import { CredentialsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import ToolbarDeleteButton from './ToolbarDeleteButton';
 
 jest.mock('../../api');
@@ -28,7 +25,6 @@ const itemC = {
 
 describe('<ToolbarDeleteButton />', () => {
   let deleteDetailsRequests;
-  let wrapper;
   beforeEach(() => {
     deleteDetailsRequests = [
       {
@@ -43,77 +39,72 @@ describe('<ToolbarDeleteButton />', () => {
   });
 
   test('should render button', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <ToolbarDeleteButton onDelete={() => {}} itemsToDelete={[]} />
     );
-    expect(wrapper.find('button')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
 
   test('should open confirmation modal', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ToolbarDeleteButton
-          onDelete={() => {}}
-          itemsToDelete={[itemA]}
-          deleteDetailsRequests={deleteDetailsRequests}
-          deleteMessage="Delete this?"
-          warningMessage="Are you sure to want to delete this"
-        />
-      );
-    });
+    const { user } = renderWithContexts(
+      <ToolbarDeleteButton
+        onDelete={() => {}}
+        itemsToDelete={[itemA]}
+        deleteDetailsRequests={deleteDetailsRequests}
+        deleteMessage="Delete this?"
+        warningMessage="Are you sure to want to delete this"
+      />
+    );
 
-    expect(wrapper.find('Modal')).toHaveLength(0);
-    await act(async () => {
-      wrapper.find('button').prop('onClick')();
-    });
-    await waitForElement(wrapper, 'Modal', (el) => el.length > 0);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    const modal = await screen.findByRole('dialog');
     expect(CredentialsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('Modal')).toHaveLength(1);
+    expect(modal).toBeInTheDocument();
+    // the delete-details badge is rendered with this aria-label
     expect(
-      wrapper.find('div[aria-label="Workflow Job Template Node: 1"]')
-    ).toHaveLength(1);
+      screen.getByLabelText('Workflow Job Template Node: 1')
+    ).toBeInTheDocument();
     expect(
-      wrapper.find('Button[aria-label="confirm delete"]').prop('isDisabled')
-    ).toBe(false);
-    expect(wrapper.find('div[aria-label="Delete this?"]')).toHaveLength(1);
+      screen.getByRole('button', { name: 'confirm delete' })
+    ).not.toBeDisabled();
+    expect(screen.getByLabelText('Delete this?')).toBeInTheDocument();
   });
 
   test('should open confirmation with enabled delete button modal', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ToolbarDeleteButton
-          onDelete={() => {}}
-          itemsToDelete={[
-            {
-              name: 'foo',
-              id: 1,
-              type: 'credential_type',
-              summary_fields: { user_capabilities: { delete: true } },
-            },
-            {
-              name: 'bar',
-              id: 2,
-              type: 'credential_type',
-              summary_fields: { user_capabilities: { delete: true } },
-            },
-          ]}
-          deleteDetailsRequests={deleteDetailsRequests}
-          deleteMessage="Delete this?"
-          warningMessage="Are you sure to want to delete this"
-        />
-      );
-    });
+    const { user } = renderWithContexts(
+      <ToolbarDeleteButton
+        onDelete={() => {}}
+        itemsToDelete={[
+          {
+            name: 'foo',
+            id: 1,
+            type: 'credential_type',
+            summary_fields: { user_capabilities: { delete: true } },
+          },
+          {
+            name: 'bar',
+            id: 2,
+            type: 'credential_type',
+            summary_fields: { user_capabilities: { delete: true } },
+          },
+        ]}
+        deleteDetailsRequests={deleteDetailsRequests}
+        deleteMessage="Delete this?"
+        warningMessage="Are you sure to want to delete this"
+      />
+    );
 
-    expect(wrapper.find('Modal')).toHaveLength(0);
-    await act(async () => {
-      wrapper.find('button').prop('onClick')();
-    });
-    await waitForElement(wrapper, 'Modal', (el) => el.length > 0);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    // multiple items skip the per-item delete details request
     expect(CredentialsAPI.read).not.toHaveBeenCalled();
-    expect(wrapper.find('Modal')).toHaveLength(1);
     expect(
-      wrapper.find('Button[aria-label="confirm delete"]').prop('isDisabled')
-    ).toBe(false);
+      screen.getByRole('button', { name: 'confirm delete' })
+    ).not.toBeDisabled();
   });
 
   test('should disable confirm delete button', async () => {
@@ -123,37 +114,33 @@ describe('<ToolbarDeleteButton />', () => {
         request: CredentialsAPI.read.mockResolvedValue({ data: { count: 3 } }),
       },
     ];
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ToolbarDeleteButton
-          onDelete={() => {}}
-          itemsToDelete={[
-            {
-              name: 'foo',
-              id: 1,
-              type: 'credential_type',
-              summary_fields: { user_capabilities: { delete: true } },
-            },
-          ]}
-          deleteDetailsRequests={request}
-          deleteMessage="Delete this?"
-          warningMessage="Are you sure to want to delete this"
-        />
-      );
-    });
+    const { user } = renderWithContexts(
+      <ToolbarDeleteButton
+        onDelete={() => {}}
+        itemsToDelete={[
+          {
+            name: 'foo',
+            id: 1,
+            type: 'credential_type',
+            summary_fields: { user_capabilities: { delete: true } },
+          },
+        ]}
+        deleteDetailsRequests={request}
+        deleteMessage="Delete this?"
+        warningMessage="Are you sure to want to delete this"
+      />
+    );
 
-    expect(wrapper.find('Modal')).toHaveLength(0);
-    await act(async () => {
-      wrapper.find('button').prop('onClick')();
-    });
-    await waitForElement(wrapper, 'Modal', (el) => el.length > 0);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(CredentialsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('Modal')).toHaveLength(1);
-
+    // single credential_type item with delete details disables confirm
     expect(
-      wrapper.find('Button[aria-label="confirm delete"]').prop('isDisabled')
-    ).toBe(true);
-    expect(wrapper.find('div[aria-label="Delete this?"]')).toHaveLength(1);
+      screen.getByRole('button', { name: 'confirm delete' })
+    ).toBeDisabled();
+    expect(screen.getByLabelText('Delete this?')).toBeInTheDocument();
   });
 
   test('should open delete error modal', async () => {
@@ -175,65 +162,66 @@ describe('<ToolbarDeleteButton />', () => {
       },
     ];
 
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <ToolbarDeleteButton
-          onDelete={() => {}}
-          itemsToDelete={[itemA]}
-          deleteDetailsRequests={request}
-          deleteMessage="Delete this?"
-          warningMessage="Are you sure to want to delete this"
-        />
-      );
-    });
+    const { user } = renderWithContexts(
+      <ToolbarDeleteButton
+        onDelete={() => {}}
+        itemsToDelete={[itemA]}
+        deleteDetailsRequests={request}
+        deleteMessage="Delete this?"
+        warningMessage="Are you sure to want to delete this"
+      />
+    );
 
-    expect(wrapper.find('Modal')).toHaveLength(0);
-    await act(async () => wrapper.find('button').simulate('click'));
-    await waitForElement(wrapper, 'Modal', (el) => el.length > 0);
-    expect(CredentialsAPI.read).toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
 
-    wrapper.update();
-
-    expect(wrapper.find('AlertModal[title="Error!"]')).toHaveLength(1);
+    await waitFor(() => expect(CredentialsAPI.read).toHaveBeenCalled());
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 
-  test('should invoke onDelete prop', () => {
+  test('should invoke onDelete prop', async () => {
     const onDelete = jest.fn();
-    wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <ToolbarDeleteButton onDelete={onDelete} itemsToDelete={[itemA]} />
     );
-    wrapper.find('button').simulate('click');
-    wrapper.update();
-    wrapper
-      .find('ModalBoxFooter button[aria-label="confirm delete"]')
-      .simulate('click');
-    wrapper.update();
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
     expect(onDelete).toHaveBeenCalled();
-    expect(wrapper.find('Modal')).toHaveLength(0);
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    );
   });
 
   test('should disable button when no delete permissions', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <ToolbarDeleteButton onDelete={() => {}} itemsToDelete={[itemB]} />
     );
-    expect(wrapper.find('button[disabled]')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
   });
 
-  test('should render tooltip', () => {
-    wrapper = mountWithContexts(
+  test('should render tooltip', async () => {
+    const { user } = renderWithContexts(
       <ToolbarDeleteButton onDelete={() => {}} itemsToDelete={[itemA]} />
     );
-    expect(wrapper.find('Tooltip')).toHaveLength(1);
-    expect(wrapper.find('Tooltip').prop('content')).toEqual('Delete');
+    // tooltip content is revealed on hover
+    const button = screen.getByRole('button', { name: 'Delete' });
+    await user.hover(button);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Delete');
+    await user.unhover(button);
   });
 
-  test('should render tooltip for username', () => {
-    wrapper = mountWithContexts(
+  test('should render tooltip for username', async () => {
+    const { user } = renderWithContexts(
       <ToolbarDeleteButton onDelete={() => {}} itemsToDelete={[itemC]} />
     );
-    expect(wrapper.find('Tooltip')).toHaveLength(1);
-    expect(wrapper.find('Tooltip').prop('content').props.children).toEqual(
+    // disabled button is wrapped in a div; hover the wrapper to show tooltip
+    const button = screen.getByRole('button', { name: 'Delete' });
+    await user.hover(button);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
       'You do not have permission to delete Items: Foo'
     );
+    await user.unhover(button);
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **PaginatedTable** component test suite (`components/PaginatedTable`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `PaginatedTable`, `HeaderRow`, `ActionItem`, `ToolbarAddButton`, `ToolbarDeleteButton`.

Column sort, pagination (next/prev/per-page), and the delete-confirm flow are driven through the real PF controls and asserted via the resulting history/query string and modal flow (rather than inspecting React props). Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/PaginatedTable`: **6 suites, 22 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
