### PR TITLE
enzyme -> RTL: convert the PromptDetail component suites

### DIFF
--- a/awx/ui/src/components/PromptDetail/PromptDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptDetail.test.js
@@ -8,6 +8,17 @@ import mockTemplate from './data.job_template.json';
 
 import PromptDetail from './PromptDetail';
 
+// Render the (otherwise Ace-backed) CodeEditor as plain text so VariablesDetail's
+// computed value is assertable under jsdom.
+jest.mock('components/CodeEditor/CodeEditor', () => {
+  const ReactMock = require('react');
+  return {
+    __esModule: true,
+    default: ({ value }) =>
+      ReactMock.createElement('div', { 'data-testid': 'code-editor' }, value),
+  };
+});
+
 const mockPromptLaunch = {
   ask_credential_on_launch: true,
   ask_diff_mode_on_launch: true,
@@ -65,7 +76,9 @@ describe('PromptDetail', () => {
       );
 
       // No overrides -> no "Prompted Values" section
-      expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
+      expect(
+        screen.queryByRole('heading', { name: 'Prompted Values' })
+      ).not.toBeInTheDocument();
 
       assertDetail('Name', 'Mock JT');
       assertDetail('Description', 'Mock JT Description');
@@ -84,8 +97,9 @@ describe('PromptDetail', () => {
         screen.getByText('Job Slicing').nextElementSibling
       ).toHaveTextContent('1');
 
-      // Variables uses react-ace (empty under jsdom); assert the surrounding label
+      // Variables renders the extra_vars through the (mocked) CodeEditor
       expect(screen.getByText('Variables')).toBeInTheDocument();
+      expect(screen.getByTestId('code-editor')).toHaveTextContent('foo: bar');
 
       // Labels chips
       expect(screen.getByText('L_91o2')).toBeInTheDocument();
@@ -119,7 +133,9 @@ describe('PromptDetail', () => {
     test('should not render promptable overrides section', () => {
       renderWithContexts(<PromptDetail resource={mockTemplate} />);
       // No launchConfig prompt data + no overrides -> no "Prompted Values" section
-      expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
+      expect(
+        screen.queryByRole('heading', { name: 'Prompted Values' })
+      ).not.toBeInTheDocument();
       expect(
         screen.queryByLabelText('Prompt Overrides')
       ).not.toBeInTheDocument();
@@ -168,8 +184,8 @@ describe('PromptDetail', () => {
       );
 
       expect(
-        screen.getByRole('heading', { level: 2 })
-      ).toHaveTextContent('Prompted Values');
+        screen.getByRole('heading', { name: 'Prompted Values' })
+      ).toBeInTheDocument();
       assertDetail('Name', 'Mock JT');
       assertDetail('Description', 'Mock JT Description');
       assertDetail('Type', 'Job Template');
@@ -183,8 +199,11 @@ describe('PromptDetail', () => {
       assertDetail('Forks', '2');
       assertDetail('Job Slicing', '2');
 
-      // Variables uses react-ace (empty under jsdom); assert the surrounding label
+      // Variables renders the overridden extra_vars through the (mocked) CodeEditor
       expect(screen.getByText('Variables')).toBeInTheDocument();
+      const codeEditor = screen.getByTestId('code-editor');
+      expect(codeEditor).toHaveTextContent('one: two');
+      expect(codeEditor).toHaveTextContent('bar: baz');
 
       // Labels chips
       const labelsTerm = screen.getByText('Labels');

--- a/awx/ui/src/components/PromptDetail/PromptDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptDetail.test.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../testUtils/rtlContexts';
 import mockTemplate from './data.job_template.json';
 
 import PromptDetail from './PromptDetail';
@@ -55,35 +59,14 @@ const mockPromptLaunch = {
 
 describe('PromptDetail', () => {
   describe('With prompt values', () => {
-    let wrapper;
-
-    beforeAll(() => {
-      wrapper = mountWithContexts(
+    test('should render expected details', () => {
+      renderWithContexts(
         <PromptDetail launchConfig={mockPromptLaunch} resource={mockTemplate} />
       );
-    });
 
-    test('should render successfully', () => {
-      expect(wrapper.find('PromptDetail').length).toBe(1);
-    });
+      // No overrides -> no "Prompted Values" section
+      expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
 
-    test('should render expected details', () => {
-      function assertDetail(label, value) {
-        const detail = wrapper.find(`Detail[label="${label}"]`);
-        // Skip text assertions for Verbosity and Job Slicing due to Lingui v5 translation issues
-        // causing empty dt/dd elements despite Detail component existing
-        if (label === 'Verbosity' || label === 'Job Slicing') {
-          // Only check existence if the detail is found
-          if (detail.length > 0) {
-            expect(detail.length).toBeGreaterThanOrEqual(1);
-          }
-          return;
-        }
-        expect(detail.find('dt').text()).toBe(label);
-        expect(detail.find('dd').text()).toBe(value);
-      }
-
-      expect(wrapper.find('PromptDetail h2')).toHaveLength(0);
       assertDetail('Name', 'Mock JT');
       assertDetail('Description', 'Mock JT Description');
       assertDetail('Type', 'Job Template');
@@ -91,84 +74,59 @@ describe('PromptDetail', () => {
       assertDetail('Inventory', 'Demo Inventory');
       assertDetail('Source Control Branch', 'Foo branch');
       assertDetail('Limit', 'localhost');
-      assertDetail('Verbosity', '3 (Debug)');
+      // Verbosity Detail renders empty under jsdom (Lingui macro yields no text),
+      // so the row is absent — original suite skipped its text assertion too.
       assertDetail('Show Changes', 'Off');
       assertDetail('Timeout', '1 min 40 sec');
       assertDetail('Forks', '1');
-      assertDetail('Job Slicing', '1');
-      expect(wrapper.find('VariablesDetail').prop('value')).toEqual(
-        '---foo: bar'
+      // ' Job Slicing' label has a leading space; getByText normalizes whitespace
+      expect(
+        screen.getByText('Job Slicing').nextElementSibling
+      ).toHaveTextContent('1');
+
+      // Variables uses react-ace (empty under jsdom); assert the surrounding label
+      expect(screen.getByText('Variables')).toBeInTheDocument();
+
+      // Labels chips
+      expect(screen.getByText('L_91o2')).toBeInTheDocument();
+      expect(screen.getByText('L_91o3')).toBeInTheDocument();
+
+      // Credentials chips
+      const credentialsTerm = screen.getByText('Credentials');
+      expect(credentialsTerm.nextElementSibling).toHaveTextContent(
+        'SSH: Credential 1'
       );
-      expect(
-        wrapper
-          .find('Detail[label="Labels"]')
-          .containsAllMatchingElements([
-            <span>L_91o2</span>,
-            <span>L_91o3</span>,
-          ])
-      ).toEqual(true);
-      expect(
-        wrapper
-          .find('Detail[label="Credentials"]')
-          .containsAllMatchingElements([
-            <span>
-              <strong>SSH:</strong>Credential 1
-            </span>,
-            <span>
-              <strong>Awx:</strong>Credential 2
-            </span>,
-          ])
-      ).toEqual(true);
-      expect(
-        wrapper
-          .find('Detail[label="Job Tags"]')
-          .containsAnyMatchingElements([<span>T_100</span>, <span>T_200</span>])
-      ).toEqual(true);
-      expect(
-        wrapper
-          .find('Detail[label="Skip Tags"]')
-          .containsAllMatchingElements([<span>S_100</span>, <span>S_200</span>])
-      ).toEqual(true);
+      expect(credentialsTerm.nextElementSibling).toHaveTextContent(
+        'Awx: Credential 2'
+      );
+
+      // Job Tags / Skip Tags chips
+      expect(screen.getByText('T_100')).toBeInTheDocument();
+      expect(screen.getByText('T_200')).toBeInTheDocument();
+      expect(screen.getByText('S_100')).toBeInTheDocument();
+      expect(screen.getByText('S_200')).toBeInTheDocument();
     });
   });
 
   describe('Without prompt values', () => {
-    let wrapper;
-    beforeAll(() => {
-      wrapper = mountWithContexts(<PromptDetail resource={mockTemplate} />);
-    });
-
     test('should render basic detail values', () => {
-      expect(wrapper.find(`Detail[label="Name"]`).length).toBe(1);
-      expect(wrapper.find(`Detail[label="Description"]`).length).toBe(1);
-      expect(wrapper.find(`Detail[label="Type"]`).length).toBe(1);
+      renderWithContexts(<PromptDetail resource={mockTemplate} />);
+      assertDetail('Name', 'Mock JT');
+      assertDetail('Description', 'Mock JT Description');
+      assertDetail('Type', 'Job Template');
     });
 
-    test('should not render promptable details', () => {
-      const overrideDetails = wrapper.find(
-        'DetailList[aria-label="Prompt Overrides"]'
-      );
-      function assertNoDetail(label) {
-        expect(overrideDetails.find(`Detail[label="${label}"]`).length).toBe(0);
-      }
-      [
-        'Job Type',
-        'Credential',
-        'Inventory',
-        'Source Control Branch',
-        'Limit',
-        'Verbosity',
-        'Job Tags',
-        'Skip Tags',
-        'Diff Mode',
-      ].forEach((label) => assertNoDetail(label));
-      expect(overrideDetails.find('PromptDetail h2').length).toBe(0);
-      expect(overrideDetails.find('VariablesDetail').length).toBe(0);
+    test('should not render promptable overrides section', () => {
+      renderWithContexts(<PromptDetail resource={mockTemplate} />);
+      // No launchConfig prompt data + no overrides -> no "Prompted Values" section
+      expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
+      expect(
+        screen.queryByLabelText('Prompt Overrides')
+      ).not.toBeInTheDocument();
     });
   });
 
   describe('with overrides', () => {
-    let wrapper;
     const overrides = {
       extra_vars: '---one: two\nbar: baz',
       inventory: {
@@ -197,8 +155,8 @@ describe('PromptDetail', () => {
       ],
     };
 
-    beforeAll(() => {
-      wrapper = mountWithContexts(
+    test('should render overridden details', () => {
+      renderWithContexts(
         <PromptDetail
           launchConfig={mockPromptLaunch}
           resource={{
@@ -208,22 +166,10 @@ describe('PromptDetail', () => {
           overrides={overrides}
         />
       );
-    });
 
-    test('should render overridden details', () => {
-      function assertDetail(label, value) {
-        const detail = wrapper.find(`Detail[label="${label}"]`);
-        // Skip text assertions for Verbosity and Job Slicing due to Lingui v5 translation issues
-        // causing empty dt/dd elements despite Detail component existing
-        if (label === 'Verbosity' || label === 'Job Slicing') {
-          expect(detail.length).toBeGreaterThanOrEqual(1);
-          return;
-        }
-        expect(detail.find('dt').text()).toBe(label);
-        expect(detail.find('dd').text()).toBe(value);
-      }
-
-      expect(wrapper.find('PromptDetail h2').text()).toBe('Prompted Values');
+      expect(
+        screen.getByRole('heading', { level: 2 })
+      ).toHaveTextContent('Prompted Values');
       assertDetail('Name', 'Mock JT');
       assertDetail('Description', 'Mock JT Description');
       assertDetail('Type', 'Job Template');
@@ -231,41 +177,39 @@ describe('PromptDetail', () => {
       assertDetail('Inventory', 'Override inventory');
       assertDetail('Source Control Branch', 'Bar branch');
       assertDetail('Limit', 'otherlimit');
-      assertDetail('Verbosity', '0 (Normal)');
+      // Verbosity Detail renders empty under jsdom (see note above)
       assertDetail('Show Changes', 'On');
       assertDetail('Timeout', '2 min 40 sec');
       assertDetail('Forks', '2');
       assertDetail('Job Slicing', '2');
-      expect(wrapper.find('VariablesDetail').prop('value')).toEqual(
-        '---one: two\nbar: baz'
+
+      // Variables uses react-ace (empty under jsdom); assert the surrounding label
+      expect(screen.getByText('Variables')).toBeInTheDocument();
+
+      // Labels chips
+      const labelsTerm = screen.getByText('Labels');
+      expect(labelsTerm.nextElementSibling).toHaveTextContent('foo');
+      expect(labelsTerm.nextElementSibling).toHaveTextContent('bar');
+
+      // Credentials chips
+      const credentialsTerm = screen.getByText('Credentials');
+      expect(credentialsTerm.nextElementSibling).toHaveTextContent(
+        'SSH: Credential 1'
       );
-      expect(
-        wrapper
-          .find('Detail[label="Labels"]')
-          .containsAllMatchingElements([<span>foo</span>, <span>bar</span>])
-      ).toEqual(true);
-      expect(
-        wrapper
-          .find('Detail[label="Credentials"]')
-          .containsAllMatchingElements([
-            <span>
-              <strong>SSH:</strong>Credential 1
-            </span>,
-            <span>
-              <strong>Awx:</strong>Credential 2
-            </span>,
-          ])
-      ).toEqual(true);
-      expect(
-        wrapper
-          .find('Detail[label="Job Tags"]')
-          .containsAnyMatchingElements([<span>foo</span>, <span>bar</span>])
-      ).toEqual(true);
-      expect(
-        wrapper
-          .find('Detail[label="Skip Tags"]')
-          .containsAllMatchingElements([<span>baz</span>, <span>boo</span>])
-      ).toEqual(true);
+      expect(credentialsTerm.nextElementSibling).toHaveTextContent(
+        'Awx: Credential 2'
+      );
+
+      // Job Tags / Skip Tags chips
+      const jobTagsTerm = screen.getByText('Job Tags');
+      expect(jobTagsTerm.nextElementSibling).toHaveTextContent('foo');
+      expect(jobTagsTerm.nextElementSibling).toHaveTextContent('bar');
+      const skipTagsTerm = screen.getByText('Skip Tags');
+      expect(skipTagsTerm.nextElementSibling).toHaveTextContent('baz');
+      expect(skipTagsTerm.nextElementSibling).toHaveTextContent('boo');
+
+      // Instance Groups chip
+      expect(screen.getByText('controlplane')).toBeInTheDocument();
     });
   });
 });

--- a/awx/ui/src/components/PromptDetail/PromptInventorySourceDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptInventorySourceDetail.test.js
@@ -1,92 +1,65 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import PromptInventorySourceDetail from './PromptInventorySourceDetail';
 import mockInvSource from './data.inventory_source.json';
 
 describe('PromptInventorySourceDetail', () => {
-  let wrapper;
-
-  beforeAll(() => {
-    wrapper = mountWithContexts(
+  test('should render expected details', () => {
+    renderWithContexts(
       <PromptInventorySourceDetail resource={mockInvSource} />
     );
-  });
 
-  test('should render successfully', () => {
-    expect(wrapper.find('PromptInventorySourceDetail')).toHaveLength(1);
-  });
+    // Key content rendered across the detail rows
+    expect(screen.getByText('Demo Inventory')).toBeInTheDocument();
+    expect(screen.getByText('scm')).toBeInTheDocument();
+    expect(screen.getByText('Mock Project')).toBeInTheDocument();
+    expect(screen.getByText('2 Seconds')).toBeInTheDocument();
 
-  test('should render expected details', () => {
-    // Test that we can find the rendered text content without complex selectors
-    const htmlContent = wrapper.html();
-    
-    // Check for key content that should be rendered
-    expect(htmlContent).toContain('Demo Inventory');
-    expect(htmlContent).toContain('scm'); 
-    expect(htmlContent).toContain('Mock Project');
-    expect(htmlContent).toContain('foo');
-    expect(htmlContent).toContain('2 Seconds');
-    
-    // Check that Detail components are rendered
-    expect(wrapper.find('Detail').length).toBeGreaterThan(5);
-    
-    // Test specific elements that we know work
-    expect(
-      wrapper
-        .find('Detail[label="Regions"]')
-        .containsAllMatchingElements([
-          <span>us-east-1</span>,
-          <span>us-east-2</span>,
-        ])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Instance Filters"]')
-        .containsAllMatchingElements([
-          <span>filter1</span>,
-          <span>filter2</span>,
-          <span>filter3</span>,
-        ])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Only Group By"]')
-        .containsAllMatchingElements([
-          <span>group1</span>,
-          <span>group2</span>,
-          <span>group3</span>,
-        ])
-    ).toEqual(true);
-    expect(wrapper.find('CredentialChip').text()).toBe('Cloud: mock cred');
-    expect(wrapper.find('VariablesDetail').prop('value')).toEqual(
-      '---\nfoo: bar'
+    // Regions chips
+    expect(screen.getByText('us-east-1')).toBeInTheDocument();
+    expect(screen.getByText('us-east-2')).toBeInTheDocument();
+    // Instance Filters chips
+    expect(screen.getByText('filter1')).toBeInTheDocument();
+    expect(screen.getByText('filter2')).toBeInTheDocument();
+    expect(screen.getByText('filter3')).toBeInTheDocument();
+    // Only Group By chips
+    expect(screen.getByText('group1')).toBeInTheDocument();
+    expect(screen.getByText('group2')).toBeInTheDocument();
+    expect(screen.getByText('group3')).toBeInTheDocument();
+
+    // Credential chip
+    const credentialTerm = screen.getByText('Credential');
+    expect(credentialTerm.nextElementSibling).toHaveTextContent(
+      'Cloud: mock cred'
     );
+
+    // Variables uses react-ace (empty under jsdom); assert the surrounding label
+    expect(screen.getByText('Source Variables')).toBeInTheDocument();
+
+    // Enabled Options renders one <li> per enabled flag
     expect(
-      wrapper
-        .find('Detail[label="Enabled Options"]')
-        .containsAllMatchingElements([
-          <li>
-            Overwrite local groups and hosts from remote inventory source
-          </li>,
-          <li>Overwrite local variables from remote inventory source</li>,
-          <li>Update on launch</li>,
-        ])
-    ).toEqual(true);
+      screen.getByText(
+        'Overwrite local groups and hosts from remote inventory source'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Overwrite local variables from remote inventory source')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Update on launch')).toBeInTheDocument();
   });
 
   test('should render "Deleted" details', () => {
     delete mockInvSource.summary_fields.organization;
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptInventorySourceDetail resource={mockInvSource} />
     );
-    
-    // Check that "Deleted" text appears in the HTML content
-    const htmlContent = wrapper.html();
-    expect(htmlContent).toContain('Deleted');
+
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
   });
 
   test('should not load Credentials', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptInventorySourceDetail
         resource={{
           ...mockInvSource,
@@ -96,7 +69,7 @@ describe('PromptInventorySourceDetail', () => {
         }}
       />
     );
-    const credentials_detail = wrapper.find(`Detail[label="Credential"]`).at(0);
-    expect(credentials_detail.prop('isEmpty')).toEqual(true);
+    // isEmpty Credential Detail renders nothing, so the label is absent
+    expect(screen.queryByText('Credential')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/PromptDetail/PromptInventorySourceDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptInventorySourceDetail.test.js
@@ -1,8 +1,22 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { renderWithContexts } from '../../../testUtils/rtlContexts';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../testUtils/rtlContexts';
 import PromptInventorySourceDetail from './PromptInventorySourceDetail';
 import mockInvSource from './data.inventory_source.json';
+
+// Render the (otherwise Ace-backed) CodeEditor as plain text so VariablesDetail's
+// computed value is assertable under jsdom.
+jest.mock('components/CodeEditor/CodeEditor', () => {
+  const ReactMock = require('react');
+  return {
+    __esModule: true,
+    default: ({ value }) =>
+      ReactMock.createElement('div', { 'data-testid': 'code-editor' }, value),
+  };
+});
 
 describe('PromptInventorySourceDetail', () => {
   test('should render expected details', () => {
@@ -15,6 +29,7 @@ describe('PromptInventorySourceDetail', () => {
     expect(screen.getByText('scm')).toBeInTheDocument();
     expect(screen.getByText('Mock Project')).toBeInTheDocument();
     expect(screen.getByText('2 Seconds')).toBeInTheDocument();
+    assertDetail('Inventory File', 'foo');
 
     // Regions chips
     expect(screen.getByText('us-east-1')).toBeInTheDocument();
@@ -34,8 +49,9 @@ describe('PromptInventorySourceDetail', () => {
       'Cloud: mock cred'
     );
 
-    // Variables uses react-ace (empty under jsdom); assert the surrounding label
+    // Source Variables renders the source_vars through the (mocked) CodeEditor
     expect(screen.getByText('Source Variables')).toBeInTheDocument();
+    expect(screen.getByTestId('code-editor')).toHaveTextContent('foo: bar');
 
     // Enabled Options renders one <li> per enabled flag
     expect(
@@ -50,9 +66,13 @@ describe('PromptInventorySourceDetail', () => {
   });
 
   test('should render "Deleted" details', () => {
-    delete mockInvSource.summary_fields.organization;
+    const deletedInvSource = {
+      ...mockInvSource,
+      summary_fields: { ...mockInvSource.summary_fields },
+    };
+    delete deletedInvSource.summary_fields.organization;
     renderWithContexts(
-      <PromptInventorySourceDetail resource={mockInvSource} />
+      <PromptInventorySourceDetail resource={deletedInvSource} />
     );
 
     expect(screen.getByText('Deleted')).toBeInTheDocument();
@@ -64,6 +84,7 @@ describe('PromptInventorySourceDetail', () => {
         resource={{
           ...mockInvSource,
           summary_fields: {
+            ...mockInvSource.summary_fields,
             credentials: [],
           },
         }}

--- a/awx/ui/src/components/PromptDetail/PromptJobTemplateDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptJobTemplateDetail.test.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../testUtils/rtlContexts';
 import PromptJobTemplateDetail from './PromptJobTemplateDetail';
 import mockData from './data.job_template.json';
 
@@ -18,102 +22,79 @@ const mockJT = {
   ],
 };
 
-function assertDetail(wrapper, label, value) {
-  const detail = wrapper.find(`Detail[label="${label}"]`);
-  expect(detail.find('dt').text()).toBe(label);
-  expect(detail.find('dd').text()).toBe(value);
-}
-
 describe('PromptJobTemplateDetail', () => {
-  let wrapper;
-
-  beforeAll(() => {
-    wrapper = mountWithContexts(<PromptJobTemplateDetail resource={mockJT} />);
-  });
-
-  test('should render successfully', () => {
-    expect(wrapper.find('PromptJobTemplateDetail')).toHaveLength(1);
-  });
-
   test('should render expected details', () => {
-    assertDetail(wrapper, 'Job Type', 'Run');
-    assertDetail(wrapper, 'Inventory', 'Demo Inventory');
-    const link = wrapper.find('Detail[label="Inventory"]');
-    expect(link.find('Link').prop('to')).toBe(
-      '/inventories/inventory/1/details'
+    renderWithContexts(<PromptJobTemplateDetail resource={mockJT} />);
+
+    assertDetail('Job Type', 'Run');
+    assertDetail('Inventory', 'Demo Inventory');
+    // Inventory value is a Link to the inventory details page
+    const inventoryTerm = screen.getByText('Inventory');
+    expect(
+      inventoryTerm.nextElementSibling.querySelector('a')
+    ).toHaveAttribute('href', '/inventories/inventory/1/details');
+    assertDetail('Project', 'Mock Project');
+    assertDetail('Source Control Branch', 'Foo branch');
+    assertDetail('Playbook', 'ping.yml');
+    assertDetail('Forks', '2');
+    assertDetail('Limit', 'alpha:beta');
+    // Verbosity Detail renders empty under jsdom (Lingui macro returns no text),
+    // so the row is not present in the DOM — matching the original suite which
+    // skipped its text assertion.
+    assertDetail('Show Changes', 'Off');
+    // ' Job Slicing' label has a leading space; getByText normalizes whitespace
+    expect(
+      screen.getByText('Job Slicing').nextElementSibling
+    ).toHaveTextContent('1');
+    assertDetail('Host Config Key', 'a1b2c3');
+    assertDetail('Webhook Service', 'Github');
+    assertDetail('Webhook Key', 'PiM3n2');
+
+    // Two recent jobs render two Sparkline job links
+    expect(
+      screen.getByRole('link', { name: 'View job 12' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'View job 13' })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Webhook URL').nextElementSibling
+    ).toHaveTextContent('/api/v2/job_templates/7/github/');
+    expect(
+      screen.getByText('Provisioning Callback URL').nextElementSibling
+    ).toHaveTextContent('/api/v2/job_templates/7/callback/');
+
+    expect(
+      screen.getByText('Webhook Credential').nextElementSibling
+    ).toHaveTextContent('Github Token: GitHub Cred');
+
+    const credentialsTerm = screen.getByText('Credentials');
+    expect(credentialsTerm.nextElementSibling).toHaveTextContent(
+      'SSH: Credential 1'
     );
-    assertDetail(wrapper, 'Project', 'Mock Project');
-    assertDetail(wrapper, 'Source Control Branch', 'Foo branch');
-    assertDetail(wrapper, 'Playbook', 'ping.yml');
-    assertDetail(wrapper, 'Forks', '2');
-    assertDetail(wrapper, 'Limit', 'alpha:beta');
-    // Verbosity has rendering issues - skip for now
-    // assertDetail(wrapper, 'Verbosity', '3 (Debug)');
-    assertDetail(wrapper, 'Show Changes', 'Off');
-    assertDetail(wrapper, ' Job Slicing', '1');
-    assertDetail(wrapper, 'Host Config Key', 'a1b2c3');
-    assertDetail(wrapper, 'Webhook Service', 'Github');
-    assertDetail(wrapper, 'Webhook Key', 'PiM3n2');
-    expect(wrapper.find('StatusIcon')).toHaveLength(2);
-    expect(wrapper.find('Detail[label="Webhook URL"]').find('dd').text()).toEqual(
-      expect.stringContaining('/api/v2/job_templates/7/github/')
+    expect(credentialsTerm.nextElementSibling).toHaveTextContent(
+      'Awx: Credential 2'
     );
-    expect(
-      wrapper.find('Detail[label="Provisioning Callback URL"]').find('dd').text()
-    ).toEqual(expect.stringContaining('/api/v2/job_templates/7/callback/'));
-    expect(
-      wrapper
-        .find('Detail[label="Webhook Credential"]')
-        .containsAllMatchingElements([
-          <span>
-            <strong>Github Token:</strong>GitHub Cred
-          </span>,
-        ])
-    ).toEqual(true);
-    expect(
-      wrapper.find('Detail[label="Credentials"]').containsAllMatchingElements([
-        <span>
-          <strong>SSH:</strong>Credential 1
-        </span>,
-        <span>
-          <strong>Awx:</strong>Credential 2
-        </span>,
-      ])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Labels"]')
-        .containsAllMatchingElements([<span>L_91o2</span>, <span>L_91o3</span>])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Instance Groups"]')
-        .containsAllMatchingElements([<span>ig1</span>, <span>ig2</span>])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Job Tags"]')
-        .containsAllMatchingElements([<span>T_100</span>, <span>T_200</span>])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Skip Tags"]')
-        .containsAllMatchingElements([<span>S_100</span>, <span>S_200</span>])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Enabled Options"]')
-        .containsAllMatchingElements([
-          <li>Privilege Escalation</li>,
-          <li>Provisioning Callbacks</li>,
-          <li>Concurrent Jobs</li>,
-          <li>Fact Storage</li>,
-          <li>Webhooks</li>,
-        ])
-    ).toEqual(true);
-    expect(wrapper.find('VariablesDetail').prop('value')).toEqual(
-      '---foo: bar'
-    );
+
+    expect(screen.getByText('L_91o2')).toBeInTheDocument();
+    expect(screen.getByText('L_91o3')).toBeInTheDocument();
+    expect(screen.getByText('ig1')).toBeInTheDocument();
+    expect(screen.getByText('ig2')).toBeInTheDocument();
+    expect(screen.getByText('T_100')).toBeInTheDocument();
+    expect(screen.getByText('T_200')).toBeInTheDocument();
+    expect(screen.getByText('S_100')).toBeInTheDocument();
+    expect(screen.getByText('S_200')).toBeInTheDocument();
+
+    // Enabled Options renders one <li> per enabled flag
+    expect(screen.getByText('Privilege Escalation')).toBeInTheDocument();
+    expect(screen.getByText('Provisioning Callbacks')).toBeInTheDocument();
+    expect(screen.getByText('Concurrent Jobs')).toBeInTheDocument();
+    expect(screen.getByText('Fact Storage')).toBeInTheDocument();
+    expect(screen.getByText('Webhooks')).toBeInTheDocument();
+
+    // Variables uses react-ace (empty under jsdom); assert the surrounding label
+    expect(screen.getByText('Variables')).toBeInTheDocument();
   });
 
   test('should render "Deleted" details', () => {
@@ -121,15 +102,15 @@ describe('PromptJobTemplateDetail', () => {
     delete mockJT.summary_fields.organization;
     delete mockJT.summary_fields.project;
 
-    wrapper = mountWithContexts(<PromptJobTemplateDetail resource={mockJT} />);
+    renderWithContexts(<PromptJobTemplateDetail resource={mockJT} />);
 
-    assertDetail(wrapper, 'Inventory', 'Deleted');
-    assertDetail(wrapper, 'Organization', 'Deleted');
-    assertDetail(wrapper, 'Project', 'Deleted');
+    assertDetail('Inventory', 'Deleted');
+    assertDetail('Organization', 'Deleted');
+    assertDetail('Project', 'Deleted');
   });
 
   test('should not load Activity', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptJobTemplateDetail
         resource={{
           ...mockJT,
@@ -139,12 +120,11 @@ describe('PromptJobTemplateDetail', () => {
         }}
       />
     );
-    const activity_detail = wrapper.find(`Detail[label="Activity"]`).at(0);
-    expect(activity_detail.prop('isEmpty')).toEqual(true);
+    expect(screen.queryByText('Activity')).not.toBeInTheDocument();
   });
 
   test('should not load Credentials', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptJobTemplateDetail
         resource={{
           ...mockJT,
@@ -154,14 +134,11 @@ describe('PromptJobTemplateDetail', () => {
         }}
       />
     );
-    const credentials_detail = wrapper
-      .find(`Detail[label="Credentials"]`)
-      .at(0);
-    expect(credentials_detail.prop('isEmpty')).toEqual(true);
+    expect(screen.queryByText('Credentials')).not.toBeInTheDocument();
   });
 
   test('should not load Labels', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptJobTemplateDetail
         resource={{
           ...mockJT,
@@ -173,12 +150,11 @@ describe('PromptJobTemplateDetail', () => {
         }}
       />
     );
-    const labels_detail = wrapper.find(`Detail[label="Labels"]`).at(0);
-    expect(labels_detail.prop('isEmpty')).toEqual(true);
+    expect(screen.queryByText('Labels')).not.toBeInTheDocument();
   });
 
   test('should not load Instance Groups', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptJobTemplateDetail
         resource={{
           ...mockJT,
@@ -186,14 +162,11 @@ describe('PromptJobTemplateDetail', () => {
         }}
       />
     );
-    const instance_groups_detail = wrapper
-      .find(`Detail[label="Instance Groups"]`)
-      .at(0);
-    expect(instance_groups_detail.prop('isEmpty')).toEqual(true);
+    expect(screen.queryByText('Instance Groups')).not.toBeInTheDocument();
   });
 
   test('should not load Job Tags', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptJobTemplateDetail
         resource={{
           ...mockJT,
@@ -201,11 +174,11 @@ describe('PromptJobTemplateDetail', () => {
         }}
       />
     );
-    expect(wrapper.find('Detail[label="Job Tags"]').length).toBe(0);
+    expect(screen.queryByText('Job Tags')).not.toBeInTheDocument();
   });
 
   test('should not load Skip Tags', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptJobTemplateDetail
         resource={{
           ...mockJT,
@@ -213,6 +186,6 @@ describe('PromptJobTemplateDetail', () => {
         }}
       />
     );
-    expect(wrapper.find('Detail[label="Skip Tags"]').length).toBe(0);
+    expect(screen.queryByText('Skip Tags')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/PromptDetail/PromptJobTemplateDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptJobTemplateDetail.test.js
@@ -7,6 +7,17 @@ import {
 import PromptJobTemplateDetail from './PromptJobTemplateDetail';
 import mockData from './data.job_template.json';
 
+// Render the (otherwise Ace-backed) CodeEditor as plain text so VariablesDetail's
+// computed value is assertable under jsdom.
+jest.mock('components/CodeEditor/CodeEditor', () => {
+  const ReactMock = require('react');
+  return {
+    __esModule: true,
+    default: ({ value }) =>
+      ReactMock.createElement('div', { 'data-testid': 'code-editor' }, value),
+  };
+});
+
 const mockJT = {
   ...mockData,
   webhook_key: 'PiM3n2',
@@ -93,16 +104,21 @@ describe('PromptJobTemplateDetail', () => {
     expect(screen.getByText('Fact Storage')).toBeInTheDocument();
     expect(screen.getByText('Webhooks')).toBeInTheDocument();
 
-    // Variables uses react-ace (empty under jsdom); assert the surrounding label
+    // Variables renders the extra_vars through the (mocked) CodeEditor
     expect(screen.getByText('Variables')).toBeInTheDocument();
+    expect(screen.getByTestId('code-editor')).toHaveTextContent('foo: bar');
   });
 
   test('should render "Deleted" details', () => {
-    delete mockJT.summary_fields.inventory;
-    delete mockJT.summary_fields.organization;
-    delete mockJT.summary_fields.project;
+    const deletedJT = {
+      ...mockJT,
+      summary_fields: { ...mockJT.summary_fields },
+    };
+    delete deletedJT.summary_fields.inventory;
+    delete deletedJT.summary_fields.organization;
+    delete deletedJT.summary_fields.project;
 
-    renderWithContexts(<PromptJobTemplateDetail resource={mockJT} />);
+    renderWithContexts(<PromptJobTemplateDetail resource={deletedJT} />);
 
     assertDetail('Inventory', 'Deleted');
     assertDetail('Organization', 'Deleted');
@@ -115,6 +131,7 @@ describe('PromptJobTemplateDetail', () => {
         resource={{
           ...mockJT,
           summary_fields: {
+            ...mockJT.summary_fields,
             recent_jobs: [],
           },
         }}
@@ -129,6 +146,7 @@ describe('PromptJobTemplateDetail', () => {
         resource={{
           ...mockJT,
           summary_fields: {
+            ...mockJT.summary_fields,
             credentials: [],
           },
         }}

--- a/awx/ui/src/components/PromptDetail/PromptProjectDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptProjectDetail.test.js
@@ -55,8 +55,12 @@ describe('PromptProjectDetail', () => {
   });
 
   test('should render "Deleted" details', () => {
-    delete mockProject.summary_fields.organization;
-    renderWithContexts(<PromptProjectDetail resource={mockProject} />, {
+    const deletedProject = {
+      ...mockProject,
+      summary_fields: { ...mockProject.summary_fields },
+    };
+    delete deletedProject.summary_fields.organization;
+    renderWithContexts(<PromptProjectDetail resource={deletedProject} />, {
       context: { config },
     });
     assertDetail('Organization', 'Deleted');

--- a/awx/ui/src/components/PromptDetail/PromptProjectDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptProjectDetail.test.js
@@ -1,21 +1,19 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../testUtils/rtlContexts';
 import PromptProjectDetail from './PromptProjectDetail';
 import mockProject from './data.project.json';
 
-function assertDetail(wrapper, label, value) {
-  expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-  expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
-}
-
 describe('PromptProjectDetail', () => {
-  let wrapper;
   const config = {
     project_base_dir: 'dir/foo/bar',
   };
 
-  beforeAll(() => {
-    wrapper = mountWithContexts(
+  test('should render expected details', () => {
+    renderWithContexts(
       <PromptProjectDetail
         resource={{ ...mockProject, scm_track_submodules: true }}
       />,
@@ -23,54 +21,44 @@ describe('PromptProjectDetail', () => {
         context: { config },
       }
     );
-  });
 
-  test('should render successfully', () => {
-    expect(wrapper.find('PromptProjectDetail')).toHaveLength(1);
-  });
-
-  test('should render expected details', () => {
-    assertDetail(wrapper, 'Source Control Type', 'Git');
+    assertDetail('Source Control Type', 'Git');
     assertDetail(
-      wrapper,
       'Source Control URL',
       'https://github.com/ansible/ansible-tower-samples'
     );
-    assertDetail(wrapper, 'Source Control Branch', 'foo');
-    assertDetail(wrapper, 'Source Control Refspec', 'refs/');
-    assertDetail(wrapper, 'Cache Timeout', '3 Seconds');
-    assertDetail(wrapper, 'Project Base Path', 'dir/foo/bar');
-    assertDetail(wrapper, 'Playbook Directory', '_6__demo_project');
-    assertDetail(wrapper, 'Source Control Credential', 'Scm: mock scm');
-    const executionEnvironment = wrapper.find('ExecutionEnvironmentDetail');
-    expect(executionEnvironment).toHaveLength(1);
-    expect(executionEnvironment.find('dt').text()).toEqual(
-      'Default Execution Environment'
-    );
-    expect(executionEnvironment.find('dd').text()).toEqual(
+    assertDetail('Source Control Branch', 'foo');
+    assertDetail('Source Control Refspec', 'refs/');
+    assertDetail('Cache Timeout', '3 Seconds');
+    assertDetail('Project Base Path', 'dir/foo/bar');
+    assertDetail('Playbook Directory', '_6__demo_project');
+    assertDetail('Source Control Credential', 'Scm: mock scm');
+    assertDetail(
+      'Default Execution Environment',
       mockProject.summary_fields.default_environment.name
     );
+
+    // Enabled Options renders one <li> per enabled flag
     expect(
-      wrapper
-        .find('Detail[label="Enabled Options"]')
-        .containsAllMatchingElements([
-          <li>Discard local changes before syncing</li>,
-          <li>Delete the project before syncing</li>,
-          <li>Track submodules latest commit on branch</li>,
-          <li>Update revision on job launch</li>,
-          <li>Allow branch override</li>,
-        ])
-    ).toEqual(true);
+      screen.getByText('Discard local changes before syncing')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Delete the project before syncing')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Track submodules latest commit on branch')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Update revision on job launch')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Allow branch override')).toBeInTheDocument();
   });
 
   test('should render "Deleted" details', () => {
     delete mockProject.summary_fields.organization;
-    wrapper = mountWithContexts(
-      <PromptProjectDetail resource={mockProject} />,
-      {
-        context: { config },
-      }
-    );
-    assertDetail(wrapper, 'Organization', 'Deleted');
+    renderWithContexts(<PromptProjectDetail resource={mockProject} />, {
+      context: { config },
+    });
+    assertDetail('Organization', 'Deleted');
   });
 });

--- a/awx/ui/src/components/PromptDetail/PromptWFJobTemplateDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptWFJobTemplateDetail.test.js
@@ -1,5 +1,9 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../testUtils/rtlContexts';
 import PromptWFJobTemplateDetail from './PromptWFJobTemplateDetail';
 import mockData from './data.workflow_template.json';
 
@@ -9,62 +13,44 @@ const mockWF = {
 };
 
 describe('PromptWFJobTemplateDetail', () => {
-  let wrapper;
-
-  beforeAll(() => {
-    wrapper = mountWithContexts(
-      <PromptWFJobTemplateDetail resource={mockWF} />
-    );
-  });
-
-  test('should render successfully', () => {
-    expect(wrapper.find('PromptWFJobTemplateDetail')).toHaveLength(1);
-  });
-
   test('should render expected details', () => {
-    function assertDetail(label, value) {
-      expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-      expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
-    }
+    renderWithContexts(<PromptWFJobTemplateDetail resource={mockWF} />);
 
-    expect(wrapper.find('StatusIcon')).toHaveLength(1);
+    // Activity row renders a Sparkline (one job link for the single recent job)
+    expect(
+      screen.getByRole('link', { name: 'View job 226' })
+    ).toBeInTheDocument();
     assertDetail('Inventory', 'Mock Smart Inv');
     assertDetail('Source Control Branch', '/bar/');
     assertDetail('Limit', 'hosts1,hosts2');
     assertDetail('Webhook Service', 'Github');
     assertDetail('Webhook Key', 'Pim3mRXT0');
-    expect(wrapper.find('Detail[label="Webhook URL"] dd').text()).toEqual(
-      expect.stringContaining('/api/v2/workflow_job_templates/47/github/')
+
+    const webhookUrlTerm = screen.getByText('Webhook URL');
+    expect(webhookUrlTerm.nextElementSibling).toHaveTextContent(
+      '/api/v2/workflow_job_templates/47/github/'
     );
-    expect(
-      wrapper
-        .find('Detail[label="Enabled Options"]')
-        .containsAllMatchingElements([
-          <li>Concurrent Jobs</li>,
-          <li>Webhooks</li>,
-        ])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Webhook Credential"]')
-        .containsAllMatchingElements([
-          <span>
-            <strong>Github Token:</strong>github
-          </span>,
-        ])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Labels"]')
-        .containsAllMatchingElements([<span>L_10o0</span>, <span>L_20o0</span>])
-    ).toEqual(true);
-    expect(wrapper.find('VariablesDetail').prop('value')).toEqual(
-      '---\nmock: data'
+
+    // Enabled Options renders one <li> per enabled flag
+    expect(screen.getByText('Concurrent Jobs')).toBeInTheDocument();
+    expect(screen.getByText('Webhooks')).toBeInTheDocument();
+
+    // Webhook Credential chip
+    const webhookCredTerm = screen.getByText('Webhook Credential');
+    expect(webhookCredTerm.nextElementSibling).toHaveTextContent(
+      'Github Token: github'
     );
+
+    // Labels chips
+    expect(screen.getByText('L_10o0')).toBeInTheDocument();
+    expect(screen.getByText('L_20o0')).toBeInTheDocument();
+
+    // Variables uses react-ace (empty under jsdom); assert the surrounding label
+    expect(screen.getByText('Variables')).toBeInTheDocument();
   });
 
   test('should not load Activity', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptWFJobTemplateDetail
         resource={{
           ...mockWF,
@@ -74,12 +60,12 @@ describe('PromptWFJobTemplateDetail', () => {
         }}
       />
     );
-    const activity_detail = wrapper.find(`Detail[label="Activity"]`).at(0);
-    expect(activity_detail.prop('isEmpty')).toEqual(true);
+    // isEmpty Activity Detail renders nothing, so the label is absent
+    expect(screen.queryByText('Activity')).not.toBeInTheDocument();
   });
 
   test('should not load Labels', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <PromptWFJobTemplateDetail
         resource={{
           ...mockWF,
@@ -91,7 +77,7 @@ describe('PromptWFJobTemplateDetail', () => {
         }}
       />
     );
-    const labels_detail = wrapper.find(`Detail[label="Labels"]`).at(0);
-    expect(labels_detail.prop('isEmpty')).toEqual(true);
+    // isEmpty Labels Detail renders nothing, so the label is absent
+    expect(screen.queryByText('Labels')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/PromptDetail/PromptWFJobTemplateDetail.test.js
+++ b/awx/ui/src/components/PromptDetail/PromptWFJobTemplateDetail.test.js
@@ -7,6 +7,17 @@ import {
 import PromptWFJobTemplateDetail from './PromptWFJobTemplateDetail';
 import mockData from './data.workflow_template.json';
 
+// Render the (otherwise Ace-backed) CodeEditor as plain text so VariablesDetail's
+// computed value is assertable under jsdom.
+jest.mock('components/CodeEditor/CodeEditor', () => {
+  const ReactMock = require('react');
+  return {
+    __esModule: true,
+    default: ({ value }) =>
+      ReactMock.createElement('div', { 'data-testid': 'code-editor' }, value),
+  };
+});
+
 const mockWF = {
   ...mockData,
   webhook_key: 'Pim3mRXT0',
@@ -45,8 +56,9 @@ describe('PromptWFJobTemplateDetail', () => {
     expect(screen.getByText('L_10o0')).toBeInTheDocument();
     expect(screen.getByText('L_20o0')).toBeInTheDocument();
 
-    // Variables uses react-ace (empty under jsdom); assert the surrounding label
+    // Variables renders the extra_vars through the (mocked) CodeEditor
     expect(screen.getByText('Variables')).toBeInTheDocument();
+    expect(screen.getByTestId('code-editor')).toHaveTextContent('mock: data');
   });
 
   test('should not load Activity', () => {
@@ -55,6 +67,7 @@ describe('PromptWFJobTemplateDetail', () => {
         resource={{
           ...mockWF,
           summary_fields: {
+            ...mockWF.summary_fields,
             recent_jobs: [],
           },
         }}
@@ -70,6 +83,7 @@ describe('PromptWFJobTemplateDetail', () => {
         resource={{
           ...mockWF,
           summary_fields: {
+            ...mockWF.summary_fields,
             labels: {
               results: [],
             },


### PR DESCRIPTION
##### SUMMARY

Converts the **PromptDetail** component test suite (`components/PromptDetail`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `PromptDetail` and the per-resource detail variants — `PromptJobTemplateDetail`, `PromptWFJobTemplateDetail`, `PromptInventorySourceDetail`, `PromptProjectDetail`.

Prompt-override detail rows and credential/label chips are asserted via `assertDetail`/`getByText`; empty `Detail` rows (which render `null`) are asserted as absent. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/PromptDetail`: **5 suites, 20 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only. (Redundant mount-only "renders successfully" tests were folded into the detail-render tests since RTL renders fresh per test — no coverage dropped.)
