### PR TITLE
enzyme -> RTL: convert the AppContainer component suites

### DIFF
--- a/awx/ui/src/components/AppContainer/AppContainer.test.js
+++ b/awx/ui/src/components/AppContainer/AppContainer.test.js
@@ -157,7 +157,9 @@ describe('<AppContainer />', () => {
     // check about modal content (raw textContent preserves the double spaces
     // of the speech bubble that toHaveTextContent would collapse)
     const dialog = await screen.findByRole('dialog');
-    expect(dialog.querySelector('pre').textContent).toContain('<  AWX 222  >');
+    expect(dialog.querySelector('pre').textContent).toContain(
+      `<  AWX ${version}  >`
+    );
 
     // close the about modal
     await user.click(within(dialog).getByRole('button', { name: 'Close Dialog' }));

--- a/awx/ui/src/components/AppContainer/AppContainer.test.js
+++ b/awx/ui/src/components/AppContainer/AppContainer.test.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { MeAPI, RootAPI } from 'api';
 import { useAuthorizedPath } from 'contexts/Config';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts, settleTooltips } from '../../../testUtils/rtlContexts';
 import AppContainer from './AppContainer';
 
 jest.mock('../../api');
@@ -51,59 +48,13 @@ describe('<AppContainer />', () => {
       },
     ];
 
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AppContainer navRouteConfig={routeConfig}>
-          {routeConfig.map(({ groupId }) => (
-            <div key={groupId} id={groupId} />
-          ))}
-        </AppContainer>,
-        {
-          context: {
-            config: {
-              analytics_status: 'detailed',
-              ansible_version: null,
-              version: '9000',
-              me: { is_superuser: true },
-              toJSON: () => '/config/',
-              license_info: {
-                valid_key: true,
-              },
-            },
-          },
-        }
-      );
-    });
-    wrapper.update();
-
-    // page components
-    expect(wrapper.length).toBe(1);
-    expect(wrapper.find('PageHeader').length).toBe(1);
-    expect(wrapper.find('PageSidebar').length).toBe(1);
-
-    // sidebar groups and route links
-    expect(wrapper.find('NavExpandableGroup').length).toBe(2);
-    expect(wrapper.find('a[href="/foo"]').length).toBe(1);
-    expect(wrapper.find('a[href="/bar"]').length).toBe(1);
-    expect(wrapper.find('a[href="/fiz"]').length).toBe(1);
-
-    expect(wrapper.find('#group_one').length).toBe(1);
-    expect(wrapper.find('#group_two').length).toBe(1);
-
-    expect(global.pendo.initialize).toHaveBeenCalledTimes(1);
-  });
-
-  test('Pendo not initialized when key is missing', async () => {
-    RootAPI.readAssetVariables.mockResolvedValue({
-      data: {
-        BRAND_NAME: 'AWX',
-        PENDO_API_KEY: '',
-      },
-    });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<AppContainer />, {
+    const { container } = renderWithContexts(
+      <AppContainer navRouteConfig={routeConfig}>
+        {routeConfig.map(({ groupId }) => (
+          <div key={groupId} id={groupId} />
+        ))}
+      </AppContainer>,
+      {
         context: {
           config: {
             analytics_status: 'detailed',
@@ -116,86 +67,124 @@ describe('<AppContainer />', () => {
             },
           },
         },
-      });
+      }
+    );
+
+    // page header and sidebar navigation. PF's managed sidebar starts
+    // collapsed (aria-hidden) so the nav is queried from the container rather
+    // than by accessibility role.
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(
+      container.querySelector('nav[aria-label="Navigation"]')
+    ).toBeInTheDocument();
+
+    // sidebar groups (NavExpandableGroup, 2 expandable groups) and route links
+    expect(
+      container.querySelectorAll('.pf-c-nav__item.pf-m-expandable')
+    ).toHaveLength(2);
+    expect(screen.getByText('Group One')).toBeInTheDocument();
+    expect(screen.getByText('Group Two')).toBeInTheDocument();
+    expect(container.querySelector('a[href="/foo"]')).toBeInTheDocument();
+    expect(container.querySelector('a[href="/bar"]')).toBeInTheDocument();
+    expect(container.querySelector('a[href="/fiz"]')).toBeInTheDocument();
+
+    // children rendered (isReady)
+    expect(container.querySelector('#group_one')).toBeInTheDocument();
+    expect(container.querySelector('#group_two')).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(global.pendo.initialize).toHaveBeenCalledTimes(1)
+    );
+  });
+
+  test('Pendo not initialized when key is missing', async () => {
+    RootAPI.readAssetVariables.mockResolvedValue({
+      data: {
+        BRAND_NAME: 'AWX',
+        PENDO_API_KEY: '',
+      },
     });
-    wrapper.update();
+    renderWithContexts(<AppContainer />, {
+      context: {
+        config: {
+          analytics_status: 'detailed',
+          ansible_version: null,
+          version: '9000',
+          me: { is_superuser: true },
+          toJSON: () => '/config/',
+          license_info: {
+            valid_key: true,
+          },
+        },
+      },
+    });
+    // give the pendo identity effect a chance to run before asserting it didn't
+    await waitFor(() => expect(RootAPI.readAssetVariables).toHaveBeenCalled());
     expect(global.pendo.initialize).toHaveBeenCalledTimes(0);
   });
 
   test('Pendo not initialized when status is analytics off', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<AppContainer />, {
-        context: {
-          config: {
-            analytics_status: 'off',
-            ansible_version: null,
-            version: '9000',
-            me: { is_superuser: true },
-            toJSON: () => '/config/',
-            license_info: {
-              valid_key: true,
-            },
+    renderWithContexts(<AppContainer />, {
+      context: {
+        config: {
+          analytics_status: 'off',
+          ansible_version: null,
+          version: '9000',
+          me: { is_superuser: true },
+          toJSON: () => '/config/',
+          license_info: {
+            valid_key: true,
           },
         },
-      });
+      },
     });
-    wrapper.update();
+    // analytics off short-circuits before readAssetVariables; allow effects to flush
+    await waitFor(() => expect(screen.getByRole('banner')).toBeInTheDocument());
     expect(global.pendo.initialize).toHaveBeenCalledTimes(0);
   });
 
   test('opening the about modal renders prefetched config data', async () => {
-    const aboutDropdown = 'Dropdown QuestionCircleIcon';
-    const aboutButton = 'DropdownItem li button';
-    const aboutModalContent = 'AboutModalBoxContent';
-    const aboutModalClose = 'button[aria-label="Close Dialog"]';
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<AppContainer />, {
-        context: { config: { version } },
-      });
+    const { user } = renderWithContexts(<AppContainer />, {
+      context: { config: { version } },
     });
 
-    // open about dropdown menu
-    await waitForElement(wrapper, aboutDropdown);
-    wrapper.find(aboutDropdown).simulate('click');
+    // open the help/about dropdown menu
+    await user.click(await screen.findByRole('button', { name: 'Info' }));
 
-    // open about modal
-    (
-      await waitForElement(wrapper, aboutButton, (el) => !el.props().disabled)
-    ).simulate('click');
+    // open the about modal
+    await user.click(await screen.findByText('About'));
 
-    // check about modal content
-    const content = await waitForElement(wrapper, aboutModalContent);
-    expect(content.find('pre').text()).toContain(`<  AWX ${version}  >`);
+    // check about modal content (raw textContent preserves the double spaces
+    // of the speech bubble that toHaveTextContent would collapse)
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.querySelector('pre').textContent).toContain('<  AWX 222  >');
 
-    // close about modal
-    wrapper.find(aboutModalClose).simulate('click');
-    expect(wrapper.find(aboutModalContent)).toHaveLength(0);
+    // close the about modal
+    await user.click(within(dialog).getByRole('button', { name: 'Close Dialog' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    );
+    await settleTooltips();
   });
 
   test('logout makes expected call to api client', async () => {
-    const userMenuButton = 'UserIcon';
-    const logoutButton = '#logout-button button';
     const logout = jest.fn();
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<AppContainer />, {
-        context: {
-          session: {
-            logout,
-          },
+    const { user } = renderWithContexts(<AppContainer />, {
+      context: {
+        session: {
+          logout,
         },
-      });
+      },
     });
+
     // open the user menu
-    expect(wrapper.find(logoutButton)).toHaveLength(0);
-    wrapper.find(userMenuButton).simulate('click');
-    expect(wrapper.find(logoutButton)).toHaveLength(1);
+    const userToggle = document.querySelector(
+      '[data-ouia-component-id="toolbar-user-dropdown-toggle"]'
+    );
+    await user.click(userToggle);
 
     // logout
-    wrapper.find(logoutButton).simulate('click');
+    await user.click(await screen.findByText('Logout'));
     expect(logout).toHaveBeenCalledTimes(1);
   });
 });

--- a/awx/ui/src/components/AppContainer/BrandLogo.test.js
+++ b/awx/ui/src/components/AppContainer/BrandLogo.test.js
@@ -1,22 +1,12 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import BrandLogo from './BrandLogo';
-
-let logoWrapper;
-let brandLogoElem;
-let imgElem;
-
-const findChildren = () => {
-  brandLogoElem = logoWrapper.find('BrandLogo');
-  imgElem = logoWrapper.find('img');
-};
 
 describe('<BrandLogo />', () => {
   test('initially renders without crashing', () => {
-    logoWrapper = mountWithContexts(<BrandLogo />);
-    findChildren();
-    expect(logoWrapper.length).toBe(1);
-    expect(brandLogoElem.length).toBe(1);
-    expect(imgElem.length).toBe(1);
+    const { container } = renderWithContexts(<BrandLogo alt="brand logo" />);
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('alt', 'brand logo');
   });
 });

--- a/awx/ui/src/components/AppContainer/NavExpandableGroup.test.js
+++ b/awx/ui/src/components/AppContainer/NavExpandableGroup.test.js
@@ -47,7 +47,7 @@ describe('NavExpandableGroup', () => {
     expect(fiz).not.toHaveAttribute('aria-current', 'page');
   });
 
-  test('when location is /foo/1/bar/fiz isActive returns false', () => {
+  test('when location is /foo/1/bar/fiz the Foo group stays active (prefix match)', () => {
     renderGroup('/foo/1/bar/fiz');
 
     const foo = screen.getByRole('link', { name: 'Foo' });

--- a/awx/ui/src/components/AppContainer/NavExpandableGroup.test.js
+++ b/awx/ui/src/components/AppContainer/NavExpandableGroup.test.js
@@ -1,120 +1,77 @@
 import React from 'react';
+import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
 import { Nav } from '@patternfly/react-core';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import NavExpandableGroup from './NavExpandableGroup';
 
+const routes = [
+  { path: '/foo', title: 'Foo' },
+  { path: '/bar', title: 'Bar' },
+  { path: '/fiz', title: 'Fiz' },
+];
+
+function renderGroup(initialEntry) {
+  return renderWithContexts(
+    <Nav aria-label="Test Navigation">
+      <NavExpandableGroup groupId="test" groupTitle="Test" routes={routes} />
+    </Nav>,
+    {
+      context: {
+        router: {
+          history: createMemoryHistory({ initialEntries: [initialEntry] }),
+        },
+      },
+    }
+  );
+}
+
+// PF NavItem renders the active link with aria-current="page" (the DOM
+// equivalent of the enzyme NavItem isActive prop), and each Link renders an
+// <a> whose href is the route path (the DOM equivalent of Link `to`).
 describe('NavExpandableGroup', () => {
   test('initialization and render', () => {
-    const component = mountWithContexts(
-      <Nav aria-label="Test Navigation">
-          <NavExpandableGroup
-            groupId="test"
-            groupTitle="Test"
-            routes={[
-              { path: '/foo', title: 'Foo' },
-              { path: '/bar', title: 'Bar' },
-              { path: '/fiz', title: 'Fiz' },
-            ]}
-          />
-        </Nav>,
-      {
-        context: {
-          router: { history: createMemoryHistory({ initialEntries: ['/foo'] }) },
-        },
-      }
-    ).find('NavExpandableGroup');
+    renderGroup('/foo');
 
-    expect(component.find('NavItem').length).toEqual(3);
-    let link = component.find('NavItem').at(0);
-    expect(component.find('NavItem').at(0).prop('isActive')).toBeTruthy();
-    expect(link.find('Link').prop('to')).toBe('/foo');
+    const foo = screen.getByRole('link', { name: 'Foo' });
+    const bar = screen.getByRole('link', { name: 'Bar' });
+    const fiz = screen.getByRole('link', { name: 'Fiz' });
 
-    link = component.find('NavItem').at(1);
-    expect(link.prop('isActive')).toBeFalsy();
-    expect(link.find('Link').prop('to')).toBe('/bar');
+    expect(foo).toHaveAttribute('href', '/foo');
+    expect(bar).toHaveAttribute('href', '/bar');
+    expect(fiz).toHaveAttribute('href', '/fiz');
 
-    link = component.find('NavItem').at(2);
-    expect(link.prop('isActive')).toBeFalsy();
-    expect(link.find('Link').prop('to')).toBe('/fiz');
+    expect(foo).toHaveAttribute('aria-current', 'page');
+    expect(bar).not.toHaveAttribute('aria-current', 'page');
+    expect(fiz).not.toHaveAttribute('aria-current', 'page');
   });
 
   test('when location is /foo/1/bar/fiz isActive returns false', () => {
-    const component = mountWithContexts(
-      <Nav aria-label="Test Navigation">
-          <NavExpandableGroup
-            groupId="test"
-            groupTitle="Test"
-            routes={[
-              { path: '/foo', title: 'Foo' },
-              { path: '/bar', title: 'Bar' },
-              { path: '/fiz', title: 'Fiz' },
-            ]}
-          />
-        </Nav>,
-      {
-        context: {
-          router: { history: createMemoryHistory({ initialEntries: ['/foo/1/bar/fiz'] }) },
-        },
-      }
-    ).find('NavExpandableGroup');
+    renderGroup('/foo/1/bar/fiz');
 
-    expect(component.find('NavItem').length).toEqual(3);
-    const link = component.find('NavItem').at(0);
-    expect(component.find('NavItem').at(0).prop('isActive')).toBeTruthy();
-    expect(link.find('Link').prop('to')).toBe('/foo');
+    const foo = screen.getByRole('link', { name: 'Foo' });
+    expect(screen.getAllByRole('link')).toHaveLength(3);
+    expect(foo).toHaveAttribute('href', '/foo');
+    // matchPath without exact still matches /foo as a prefix of /foo/1/bar/fiz
+    expect(foo).toHaveAttribute('aria-current', 'page');
   });
 
   test('when location is /fo isActive returns false', () => {
-    const component = mountWithContexts(
-      <Nav aria-label="Test Navigation">
-          <NavExpandableGroup
-            groupId="test"
-            groupTitle="Test"
-            routes={[
-              { path: '/foo', title: 'Foo' },
-              { path: '/bar', title: 'Bar' },
-              { path: '/fiz', title: 'Fiz' },
-            ]}
-          />
-        </Nav>,
-      {
-        context: {
-          router: { history: createMemoryHistory({ initialEntries: ['/fo'] }) },
-        },
-      }
-    ).find('NavExpandableGroup');
+    renderGroup('/fo');
 
-    expect(component.find('NavItem').length).toEqual(3);
-    const link = component.find('NavItem').at(0);
-    expect(component.find('NavItem').at(0).prop('isActive')).toBeFalsy();
-    expect(link.find('Link').prop('to')).toBe('/foo');
+    const foo = screen.getByRole('link', { name: 'Foo' });
+    expect(screen.getAllByRole('link')).toHaveLength(3);
+    expect(foo).toHaveAttribute('href', '/foo');
+    expect(foo).not.toHaveAttribute('aria-current', 'page');
   });
 
   test('when location is /foo isActive returns true', () => {
-    const component = mountWithContexts(
-      <Nav aria-label="Test Navigation">
-          <NavExpandableGroup
-            groupId="test"
-            groupTitle="Test"
-            routes={[
-              { path: '/foo', title: 'Foo' },
-              { path: '/bar', title: 'Bar' },
-              { path: '/fiz', title: 'Fiz' },
-            ]}
-          />
-        </Nav>,
-      {
-        context: {
-          router: { history: createMemoryHistory({ initialEntries: ['/foo'] }) },
-        },
-      }
-    ).find('NavExpandableGroup');
+    renderGroup('/foo');
 
-    expect(component.find('NavItem').length).toEqual(3);
-    const link = component.find('NavItem').at(0);
-    expect(component.find('NavItem').at(0).prop('isActive')).toBeTruthy();
-    expect(link.find('Link').prop('to')).toBe('/foo');
+    const foo = screen.getByRole('link', { name: 'Foo' });
+    expect(screen.getAllByRole('link')).toHaveLength(3);
+    expect(foo).toHaveAttribute('href', '/foo');
+    expect(foo).toHaveAttribute('aria-current', 'page');
   });
 });

--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.test.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.test.js
@@ -1,66 +1,82 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { WorkflowApprovalsAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import PageHeaderToolbar from './PageHeaderToolbar';
 
 jest.mock('../../api');
 
-let wrapper;
-
 describe('PageHeaderToolbar', () => {
-  const pageHelpDropdownSelector = 'Dropdown QuestionCircleIcon';
-  const pageUserDropdownSelector = 'Dropdown UserIcon';
   const onAboutClick = jest.fn();
   const onLogoutClick = jest.fn();
 
-  test('expected content is rendered on initialization', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <PageHeaderToolbar
-          onAboutClick={onAboutClick}
-          onLogoutClick={onLogoutClick}
-        />
-      );
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
+  test('expected content is rendered on initialization', async () => {
+    const { container } = renderWithContexts(
+      <PageHeaderToolbar
+        onAboutClick={onAboutClick}
+        onLogoutClick={onLogoutClick}
+      />
+    );
+
+    // help dropdown toggle (aria-label Info) and user dropdown toggle. Wait
+    // for the on-mount approvals request to settle so its setState lands inside
+    // act before asserting.
+    expect(await screen.findByRole('button', { name: 'Info' })).toBeInTheDocument();
     expect(
-      wrapper.find(
-        'Link[to="/workflow_approvals?workflow_approvals.status=pending"]'
+      container.querySelector(
+        'a[href="/workflow_approvals?workflow_approvals.status=pending"]'
       )
-    ).toHaveLength(1);
-    expect(wrapper.find(pageHelpDropdownSelector)).toHaveLength(1);
-    expect(wrapper.find(pageUserDropdownSelector)).toHaveLength(1);
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '[data-ouia-component-id="toolbar-user-dropdown-toggle"]'
+      )
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(WorkflowApprovalsAPI.read).toHaveBeenCalled()
+    );
   });
 
   test('dropdowns have expected items and callbacks', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <PageHeaderToolbar
-          onAboutClick={onAboutClick}
-          onLogoutClick={onLogoutClick}
-          loggedInUser={{ id: 1 }}
-        />
-      );
-    });
-    expect(wrapper.find('DropdownItem')).toHaveLength(0);
-    wrapper.find(pageHelpDropdownSelector).simulate('click');
-    expect(wrapper.find('DropdownItem')).toHaveLength(2);
+    const { user } = renderWithContexts(
+      <PageHeaderToolbar
+        onAboutClick={onAboutClick}
+        onLogoutClick={onLogoutClick}
+        loggedInUser={{ id: 1 }}
+      />
+    );
+    // wait for the on-mount approvals request to settle
+    await screen.findByRole('button', { name: 'Info' });
 
-    const about = wrapper.find('DropdownItem[ouiaId="about-dropdown-item"]');
-    about.simulate('click');
+    // help dropdown items are not rendered until the toggle is clicked
+    expect(screen.queryByText('About')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Info' }));
+    expect(screen.getByText('Help')).toBeInTheDocument();
+    expect(screen.getByText('About')).toBeInTheDocument();
+
+    // clicking About fires the callback
+    await user.click(screen.getByText('About'));
     expect(onAboutClick).toHaveBeenCalled();
 
-    expect(wrapper.find('DropdownItem')).toHaveLength(0);
-    wrapper.find(pageUserDropdownSelector).simulate('click');
-    wrapper.update();
-    expect(
-      wrapper.find('DropdownItem[aria-label="User details"]').prop('href')
-    ).toBe('#/users/1/details');
-    expect(wrapper.find('DropdownItem')).toHaveLength(2);
+    // open the user dropdown (item carries aria-label "User details")
+    const userToggle = document.querySelector(
+      '[data-ouia-component-id="toolbar-user-dropdown-toggle"]'
+    );
+    await user.click(userToggle);
 
-    const logout = wrapper.find('DropdownItem li button');
-    logout.simulate('click');
+    // PF DropdownItem renders the item with role="menuitem" (the anchor's
+    // href is the DOM equivalent of the enzyme DropdownItem href prop check)
+    const userDetails = await screen.findByRole('menuitem', {
+      name: 'User details',
+    });
+    expect(userDetails).toHaveAttribute('href', '#/users/1/details');
+
+    // clicking Logout fires the callback
+    await user.click(screen.getByRole('menuitem', { name: 'Logout' }));
     expect(onLogoutClick).toHaveBeenCalled();
   });
 
@@ -70,17 +86,18 @@ describe('PageHeaderToolbar', () => {
         count: 20,
       },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <PageHeaderToolbar
-          onAboutClick={onAboutClick}
-          onLogoutClick={onLogoutClick}
-        />
-      );
-    });
+    const { container } = renderWithContexts(
+      <PageHeaderToolbar
+        onAboutClick={onAboutClick}
+        onLogoutClick={onLogoutClick}
+      />
+    );
 
-    expect(
-      wrapper.find('NotificationBadge#toolbar-workflow-approval-badge').text()
-    ).toEqual('20');
+    await waitFor(() => {
+      const badge = container.querySelector(
+        '#toolbar-workflow-approval-badge'
+      );
+      expect(within(badge).getByText('20')).toBeInTheDocument();
+    });
   });
 });

--- a/awx/ui/src/components/AppContainer/useWsPendingApprovalCount.test.js
+++ b/awx/ui/src/components/AppContainer/useWsPendingApprovalCount.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act, screen } from '@testing-library/react';
 import WS from 'jest-websocket-mock';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import useWsPendingApprovalCount from './useWsPendingApprovalCount';
 
 // Mock useThrottle to return the value immediately without throttling
@@ -10,26 +10,25 @@ jest.mock('../../hooks/useThrottle', () => ({
   default: jest.fn((val) => val),
 }));
 
-function TestInner() {
-  return <div />;
+function TestInner({ count }) {
+  return <div data-testid="count">{count}</div>;
 }
 function Test({ initialCount, fetchApprovalsCount }) {
   const updatedWorkflowApprovals = useWsPendingApprovalCount(
     initialCount,
     fetchApprovalsCount
   );
-  return <TestInner initialCount={updatedWorkflowApprovals} />;
+  return <TestInner count={updatedWorkflowApprovals} />;
 }
 
 describe('useWsPendingApprovalCount hook', () => {
   let debug;
-  let wrapper;
   beforeEach(() => {
     /*
       Jest mock timers don't play well with jest-websocket-mock,
       so we'll stub out throttling to resolve immediately
     */
-    debug = global.console.debug; // eslint-disable-line prefer-destructuring
+    debug = global.console.debug;
     global.console.debug = () => {};
   });
 
@@ -39,11 +38,11 @@ describe('useWsPendingApprovalCount hook', () => {
   });
 
   test('should return workflow approval pending count', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <Test initialCount={2} fetchApprovalsCount={() => {}} />
     );
 
-    expect(wrapper.find('TestInner').prop('initialCount')).toEqual(2);
+    expect(screen.getByTestId('count')).toHaveTextContent('2');
   });
 
   test('should establish websocket connection', async () => {
@@ -51,7 +50,7 @@ describe('useWsPendingApprovalCount hook', () => {
     const mockServer = new WS('ws://localhost/websocket/');
 
     await act(async () => {
-      wrapper = mountWithContexts(
+      renderWithContexts(
         <Test initialCount={2} fetchApprovalsCount={() => {}} />
       );
     });
@@ -72,15 +71,15 @@ describe('useWsPendingApprovalCount hook', () => {
     global.document.cookie = 'csrftoken=abc123';
     const mockServer = new WS('ws://localhost/websocket/');
     const fetchApprovalsCount = jest.fn(() => []);
-    
+
     await act(async () => {
-      wrapper = await mountWithContexts(
+      renderWithContexts(
         <Test initialCount={2} fetchApprovalsCount={fetchApprovalsCount} />
       );
     });
 
     await mockServer.connected;
-    
+
     // Send the websocket message
     act(() => {
       mockServer.send(
@@ -91,14 +90,12 @@ describe('useWsPendingApprovalCount hook', () => {
         })
       );
     });
-    
-    wrapper.update();
 
     // TODO: This test has timing issues with the throttling mechanism and websocket mocking
     // The hook correctly receives the websocket message but the throttled fetch doesn't trigger
     // in the test environment. This is a known issue with jest-websocket-mock and useThrottle.
     // For now, we just verify the component renders and websocket connects properly.
-    expect(wrapper.find('TestInner')).toHaveLength(1);
+    expect(screen.getByTestId('count')).toBeInTheDocument();
     // expect(fetchApprovalsCount).toHaveBeenCalledTimes(1); // TODO: Fix timing issue
   });
 
@@ -107,7 +104,7 @@ describe('useWsPendingApprovalCount hook', () => {
     const mockServer = new WS('ws://localhost/websocket/');
     const fetchApprovalsCount = jest.fn(() => []);
     await act(async () => {
-      wrapper = await mountWithContexts(
+      renderWithContexts(
         <Test initialCount={2} fetchApprovalsCount={fetchApprovalsCount} />
       );
     });


### PR DESCRIPTION
##### SUMMARY

Converts the **AppContainer** component test suite (`components/AppContainer`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `BrandLogo`, `NavExpandableGroup`, `PageHeaderToolbar`, the `AppContainer` shell, and `useWsPendingApprovalCount`.

Navigation, the help/user dropdowns, and the About modal are driven through their real toggles; active nav is asserted via `aria-current`, menu items via `role="menuitem"` + `href`, logout via the session mock, and the approval badge via its element text. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/AppContainer`: **5 suites, 17 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
