### PR TITLE
enzyme -> RTL: convert the JobList component suites

### DIFF
--- a/awx/ui/src/components/JobList/JobList.test.js
+++ b/awx/ui/src/components/JobList/JobList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import {
   AdHocCommandsAPI,
   InventoryUpdatesAPI,
@@ -11,9 +11,9 @@ import {
   InventorySourcesAPI,
 } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  settleTooltips,
+} from '../../../testUtils/rtlContexts';
 import JobList from './JobList';
 
 jest.mock('../../api');
@@ -117,12 +117,18 @@ const mockResults = [
   },
 ];
 
-function waitForLoaded(wrapper) {
-  return waitForElement(
-    wrapper,
-    'JobList',
-    (el) => el.find('ContentLoading').length === 0
-  );
+// successful clones (non-running) so the bulk-delete button is enabled and we
+// can drive a real delete through the toolbar + confirm modal.
+const deletableResults = mockResults.map((job) => ({
+  ...job,
+  status: 'successful',
+}));
+
+function getRowCheckboxes() {
+  const selectAll = screen.queryByRole('checkbox', { name: 'Select all' });
+  return screen
+    .getAllByRole('checkbox')
+    .filter((box) => box !== selectAll);
 }
 
 describe('<JobList />', () => {
@@ -155,7 +161,7 @@ describe('<JobList />', () => {
         },
       },
     });
-    debug = global.console.debug; // eslint-disable-line prefer-destructuring
+    debug = global.console.debug;
     global.console.debug = () => {};
   });
 
@@ -165,104 +171,71 @@ describe('<JobList />', () => {
   });
 
   test('initially renders successfully', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
-    });
-    await waitForLoaded(wrapper);
-    expect(wrapper.find('JobListItem')).toHaveLength(6);
+    renderWithContexts(<JobList />);
+    await waitFor(() =>
+      expect(screen.getAllByRole('link', { name: /— job \d/ })).toHaveLength(6)
+    );
   });
 
   test('should select and un-select items', async () => {
-    const [mockItem] = mockResults;
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
-    });
-    await waitForLoaded(wrapper);
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '1 — job 1' });
 
-    act(() => {
-      wrapper.find('JobListItem').first().invoke('onSelect')(mockItem);
-    });
-    wrapper.update();
-    expect(wrapper.find('JobListItem').first().prop('isSelected')).toEqual(
-      true
-    );
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('itemsToDelete')
-    ).toHaveLength(1);
+    const firstRow = screen
+      .getByRole('link', { name: '1 — job 1' })
+      .closest('tr');
+    const checkbox = within(firstRow).getByRole('checkbox');
 
-    act(() => {
-      wrapper.find('JobListItem').first().invoke('onSelect')(mockItem);
-    });
-    wrapper.update();
-    expect(wrapper.find('JobListItem').first().prop('isSelected')).toEqual(
-      false
-    );
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('itemsToDelete')
-    ).toHaveLength(0);
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
   });
 
   test('should select and deselect all', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
-    });
-    await waitForLoaded(wrapper);
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '1 — job 1' });
 
-    act(() => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
-    });
-    wrapper.update();
-    wrapper.find('JobListItem');
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('itemsToDelete')
-    ).toHaveLength(6);
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+    const rowCheckboxes = getRowCheckboxes();
+    expect(rowCheckboxes).toHaveLength(6);
 
-    act(() => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(false);
-    });
-    wrapper.update();
-    wrapper.find('JobListItem');
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('itemsToDelete')
-    ).toHaveLength(0);
+    await user.click(selectAll);
+    rowCheckboxes.forEach((box) => expect(box).toBeChecked());
+
+    await user.click(selectAll);
+    rowCheckboxes.forEach((box) => expect(box).not.toBeChecked());
   });
 
   test('should send all corresponding delete API requests', async () => {
-    AdHocCommandsAPI.destroy = jest.fn();
-    InventoryUpdatesAPI.destroy = jest.fn();
-    JobsAPI.destroy = jest.fn();
-    ProjectUpdatesAPI.destroy = jest.fn();
-    SystemJobsAPI.destroy = jest.fn();
-    WorkflowJobsAPI.destroy = jest.fn();
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
+    UnifiedJobsAPI.read.mockResolvedValue({
+      data: { count: 6, results: deletableResults },
     });
-    await waitForLoaded(wrapper);
+    AdHocCommandsAPI.destroy = jest.fn().mockResolvedValue({});
+    InventoryUpdatesAPI.destroy = jest.fn().mockResolvedValue({});
+    JobsAPI.destroy = jest.fn().mockResolvedValue({});
+    ProjectUpdatesAPI.destroy = jest.fn().mockResolvedValue({});
+    SystemJobsAPI.destroy = jest.fn().mockResolvedValue({});
+    WorkflowJobsAPI.destroy = jest.fn().mockResolvedValue({});
 
-    act(() => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '1 — job 1' });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+
+    await waitFor(() => {
+      expect(AdHocCommandsAPI.destroy).toHaveBeenCalledTimes(1);
+      expect(InventoryUpdatesAPI.destroy).toHaveBeenCalledTimes(1);
+      expect(JobsAPI.destroy).toHaveBeenCalledTimes(1);
+      expect(ProjectUpdatesAPI.destroy).toHaveBeenCalledTimes(1);
+      expect(SystemJobsAPI.destroy).toHaveBeenCalledTimes(1);
+      expect(WorkflowJobsAPI.destroy).toHaveBeenCalledTimes(1);
     });
-    wrapper.update();
-    wrapper.find('JobListItem');
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('itemsToDelete')
-    ).toHaveLength(6);
-
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-    expect(AdHocCommandsAPI.destroy).toHaveBeenCalledTimes(1);
-    expect(InventoryUpdatesAPI.destroy).toHaveBeenCalledTimes(1);
-    expect(JobsAPI.destroy).toHaveBeenCalledTimes(1);
-    expect(ProjectUpdatesAPI.destroy).toHaveBeenCalledTimes(1);
-    expect(SystemJobsAPI.destroy).toHaveBeenCalledTimes(1);
-    expect(WorkflowJobsAPI.destroy).toHaveBeenCalledTimes(1);
-
-    jest.restoreAllMocks();
   });
 
   test('should query jobs list after delete API requests', async () => {
@@ -275,7 +248,7 @@ describe('<JobList />', () => {
             url: '/api/v2/project_updates/1',
             name: 'job 1',
             type: 'project_update',
-            status: 'running',
+            status: 'successful',
             related: {
               cancel: '/api/v2/project_updates/1/cancel',
             },
@@ -289,35 +262,30 @@ describe('<JobList />', () => {
         ],
       },
     });
+    ProjectUpdatesAPI.destroy = jest.fn().mockResolvedValue({});
     const jobListParams = {
       order_by: '-finished',
       not__launch_type: 'sync',
       page: 1,
       page_size: 20,
     };
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
-    });
-    await waitForLoaded(wrapper);
 
-    act(() => {
-      expect(UnifiedJobsAPI.read).toHaveBeenCalledTimes(1);
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
-    });
-    wrapper.update();
-    wrapper.find('JobListItem');
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('itemsToDelete')
-    ).toHaveLength(1);
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '1 — job 1' });
+    expect(UnifiedJobsAPI.read).toHaveBeenCalledTimes(1);
+    expect(UnifiedJobsAPI.read).toHaveBeenCalledWith(jobListParams);
 
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-      expect(UnifiedJobsAPI.read).toHaveBeenCalledTimes(1);
-      expect(UnifiedJobsAPI.read).toHaveBeenCalledWith(jobListParams);
-    });
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
 
-    jest.restoreAllMocks();
+    // a re-fetch of the list is triggered after deletion
+    await waitFor(() =>
+      expect(UnifiedJobsAPI.read).toHaveBeenCalledTimes(2)
+    );
+    expect(UnifiedJobsAPI.read).toHaveBeenLastCalledWith(jobListParams);
   });
 
   test('should display message about job running status', async () => {
@@ -361,30 +329,19 @@ describe('<JobList />', () => {
       },
     });
 
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
-    });
-    await waitForLoaded(wrapper);
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '1 — job 1' });
 
-    act(() => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
-    });
-    wrapper.update();
-    wrapper.find('JobListItem');
-    expect(
-      wrapper.find('ToolbarDeleteButton').prop('itemsToDelete')
-    ).toHaveLength(2);
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
 
-    wrapper.update();
-
-    const deleteButton = wrapper.find('ToolbarDeleteButton').find('Button');
-    expect(deleteButton.prop('isDisabled')).toBe(true);
-
-    jest.restoreAllMocks();
+    // running jobs cannot be deleted -> the toolbar Delete button is disabled
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
   });
 
   test('error is shown when job not successfully deleted from api', async () => {
+    UnifiedJobsAPI.read.mockResolvedValue({
+      data: { count: 6, results: deletableResults },
+    });
     JobsAPI.destroy.mockImplementation(() => {
       throw new Error({
         response: {
@@ -396,56 +353,68 @@ describe('<JobList />', () => {
         },
       });
     });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
-    });
-    await waitForLoaded(wrapper);
-    await act(async () => {
-      wrapper.find('JobListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
 
-    await act(async () => {
-      wrapper.find('ToolbarDeleteButton').invoke('onDelete')();
-    });
-    wrapper.update();
-    await waitForElement(
-      wrapper,
-      'Modal',
-      (el) => el.props().isOpen === true && el.props().title === 'Error!'
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '2 — job 2' });
+
+    const row = screen.getByRole('link', { name: '2 — job 2' }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
     );
+
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
+    );
+    await settleTooltips();
   });
 
   test('should send all corresponding cancel API requests', async () => {
-    JobsAPI.cancel = jest.fn();
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
+    // every selected job must be running AND cancellable (start capability) so
+    // the real toolbar Cancel button is enabled; jobs 5/6 lack start by default.
+    UnifiedJobsAPI.read.mockResolvedValue({
+      data: {
+        count: 6,
+        results: mockResults.map((job) => ({
+          ...job,
+          summary_fields: {
+            ...job.summary_fields,
+            user_capabilities: {
+              ...job.summary_fields.user_capabilities,
+              start: true,
+            },
+          },
+        })),
+      },
     });
-    await waitForLoaded(wrapper);
+    AdHocCommandsAPI.cancel = jest.fn().mockResolvedValue({});
+    InventoryUpdatesAPI.cancel = jest.fn().mockResolvedValue({});
+    JobsAPI.cancel = jest.fn().mockResolvedValue({});
+    ProjectUpdatesAPI.cancel = jest.fn().mockResolvedValue({});
+    SystemJobsAPI.cancel = jest.fn().mockResolvedValue({});
+    WorkflowJobsAPI.cancel = jest.fn().mockResolvedValue({});
 
-    act(() => {
-      wrapper.find('DataListToolbar').invoke('onSelectAll')(true);
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '1 — job 1' });
+
+    await user.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel jobs' }));
+    // confirm modal -> the danger confirm button
+    const dialog = await screen.findByRole('dialog');
+    await user.click(dialog.querySelector('#cancel-job-confirm-button'));
+
+    await waitFor(() => {
+      expect(ProjectUpdatesAPI.cancel).toHaveBeenCalledWith(1);
+      expect(JobsAPI.cancel).toHaveBeenCalledWith(2);
+      expect(InventoryUpdatesAPI.cancel).toHaveBeenCalledWith(3);
+      expect(WorkflowJobsAPI.cancel).toHaveBeenCalledWith(4);
+      expect(SystemJobsAPI.cancel).toHaveBeenCalledWith(5);
+      expect(AdHocCommandsAPI.cancel).toHaveBeenCalledWith(6);
     });
-    wrapper.update();
-    wrapper.find('JobListItem');
-    expect(
-      wrapper.find('JobListCancelButton').prop('jobsToCancel')
-    ).toHaveLength(6);
-
-    await act(async () => {
-      wrapper.find('JobListCancelButton').invoke('onCancel')();
-    });
-
-    expect(ProjectUpdatesAPI.cancel).toHaveBeenCalledWith(1);
-    expect(JobsAPI.cancel).toHaveBeenCalledWith(2);
-    expect(InventoryUpdatesAPI.cancel).toHaveBeenCalledWith(3);
-    expect(WorkflowJobsAPI.cancel).toHaveBeenCalledWith(4);
-    expect(SystemJobsAPI.cancel).toHaveBeenCalledWith(5);
-    expect(AdHocCommandsAPI.cancel).toHaveBeenCalledWith(6);
-
-    jest.restoreAllMocks();
   });
 
   test('error is shown when job not successfully cancelled', async () => {
@@ -460,24 +429,17 @@ describe('<JobList />', () => {
         },
       });
     });
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<JobList />);
-    });
-    await waitForLoaded(wrapper);
-    await act(async () => {
-      wrapper.find('JobListItem').at(1).invoke('onSelect')();
-    });
-    wrapper.update();
 
-    await act(async () => {
-      wrapper.find('JobListCancelButton').invoke('onCancel')();
-    });
-    wrapper.update();
-    await waitForElement(
-      wrapper,
-      'Modal',
-      (el) => el.props().isOpen === true && el.props().title === 'Error!'
-    );
+    const { user } = renderWithContexts(<JobList />);
+    await screen.findByRole('link', { name: '2 — job 2' });
+
+    const row = screen.getByRole('link', { name: '2 — job 2' }).closest('tr');
+    await user.click(within(row).getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: 'Cancel job' }));
+    const dialog = await screen.findByRole('dialog');
+    await user.click(dialog.querySelector('#cancel-job-confirm-button'));
+
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
+    await settleTooltips();
   });
 });

--- a/awx/ui/src/components/JobList/JobListCancelButton.test.js
+++ b/awx/ui/src/components/JobList/JobListCancelButton.test.js
@@ -1,21 +1,30 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import JobListCancelButton from './JobListCancelButton';
 
-describe('<JobListCancelButton />', () => {
-  let wrapper;
+function getCancelButton() {
+  // The non-kebab control has a stable id; query it directly so the lookup is
+  // not affected by the aria-hidden PF applies to the page while a modal is
+  // open/closing.
+  return document.getElementById('jobs-list-cancel-button');
+}
 
-  test('should be disabled when no rows are selected', () => {
-    wrapper = mountWithContexts(<JobListCancelButton jobsToCancel={[]} />);
-    expect(wrapper.find('JobListCancelButton button').props().disabled).toBe(
-      true
-    );
-    expect(wrapper.find('Tooltip').props().content).toBe(
-      'Select a job to cancel'
-    );
+describe('<JobListCancelButton />', () => {
+  test('should be disabled when no rows are selected', async () => {
+    const { user } = renderWithContexts(<JobListCancelButton jobsToCancel={[]} />);
+    expect(getCancelButton()).toBeDisabled();
+
+    // Tooltip content is rendered on hover; matches the old enzyme
+    // Tooltip[content="Select a job to cancel"] assertion.
+    await user.hover(getCancelButton().closest('div'));
+    expect(
+      await screen.findByText('Select a job to cancel')
+    ).toBeInTheDocument();
   });
+
   test('should be disabled when user does not have permissions to cancel selected job', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobListCancelButton
         jobsToCancel={[
           {
@@ -32,12 +41,11 @@ describe('<JobListCancelButton />', () => {
         ]}
       />
     );
-    expect(wrapper.find('JobListCancelButton button').props().disabled).toBe(
-      true
-    );
+    expect(getCancelButton()).toBeDisabled();
   });
+
   test('should be disabled when selected job is not running', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobListCancelButton
         jobsToCancel={[
           {
@@ -54,12 +62,11 @@ describe('<JobListCancelButton />', () => {
         ]}
       />
     );
-    expect(wrapper.find('JobListCancelButton button').props().disabled).toBe(
-      true
-    );
+    expect(getCancelButton()).toBeDisabled();
   });
+
   test('should be enabled when user does have permission to cancel selected job', () => {
-    wrapper = mountWithContexts(
+    renderWithContexts(
       <JobListCancelButton
         jobsToCancel={[
           {
@@ -76,13 +83,12 @@ describe('<JobListCancelButton />', () => {
         ]}
       />
     );
-    expect(wrapper.find('JobListCancelButton button').props().disabled).toBe(
-      false
-    );
+    expect(getCancelButton()).toBeEnabled();
   });
-  test('modal functions as expected', () => {
+
+  test('modal functions as expected', async () => {
     const onCancel = jest.fn();
-    wrapper = mountWithContexts(
+    const { user } = renderWithContexts(
       <JobListCancelButton
         jobsToCancel={[
           {
@@ -100,20 +106,26 @@ describe('<JobListCancelButton />', () => {
         onCancel={onCancel}
       />
     );
-    expect(wrapper.find('AlertModal').length).toBe(0);
-    wrapper.find('JobListCancelButton button').simulate('click');
-    wrapper.update();
-    expect(wrapper.find('AlertModal').length).toBe(1);
-    wrapper.find('button#cancel-job-return-button').simulate('click');
-    wrapper.update();
+
+    // no modal initially
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // open modal, then click Return -> onCancel not called, modal closes
+    await user.click(getCancelButton());
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Return' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    );
     expect(onCancel).toHaveBeenCalledTimes(0);
-    expect(wrapper.find('AlertModal').length).toBe(0);
-    expect(wrapper.find('AlertModal').length).toBe(0);
-    wrapper.find('JobListCancelButton button').simulate('click');
-    wrapper.update();
-    expect(wrapper.find('AlertModal').length).toBe(1);
-    wrapper.find('button#cancel-job-confirm-button').simulate('click');
-    wrapper.update();
+
+    // open modal again, click the confirm (danger) button -> onCancel called
+    await user.click(getCancelButton());
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    // the confirm button shares the "Cancel job" text but lives in the modal
+    const dialog = screen.getByRole('dialog');
+    const confirmButton = dialog.querySelector('#cancel-job-confirm-button');
+    await user.click(confirmButton);
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/awx/ui/src/components/JobList/JobListItem.test.js
+++ b/awx/ui/src/components/JobList/JobListItem.test.js
@@ -254,7 +254,9 @@ describe('<JobListItem with failed job />', () => {
     expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
 
     await user.click(toggle);
-    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+    // the menu renders via a PF popper appended to document.body, so the items
+    // can appear asynchronously after the click; await them
+    expect(await screen.findAllByRole('menuitem')).toHaveLength(3);
   });
 
   test('dropdown should not be rendered for job type different of playbook run', () => {

--- a/awx/ui/src/components/JobList/JobListItem.test.js
+++ b/awx/ui/src/components/JobList/JobListItem.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import JobListItem from './JobListItem';
 
@@ -37,293 +37,260 @@ const mockJob = {
   execution_environment: 1,
 };
 
+function renderItem(ui, options) {
+  return renderWithContexts(
+    <table>
+      <tbody>{ui}</tbody>
+    </table>,
+    options
+  );
+}
+
+// A non-failed job renders the plain "Relaunch" button; a failed playbook run
+// renders the relaunch dropdown whose toggle is labelled "relaunch jobs". Both
+// stand in for the enzyme `find('LaunchButton')` assertion.
+function queryLaunchButton(scope) {
+  return (
+    scope.queryByRole('button', { name: 'Relaunch' }) ||
+    scope.queryByRole('button', { name: 'relaunch jobs' })
+  );
+}
+
+// Detail renders <dt>label</dt><dd>value</dd>; scope to the render so multiple
+// rows from earlier renders in the same test don't collide.
+function assertDetail(scope, label, value) {
+  const term = scope.getByText(label);
+  expect(term.nextElementSibling).toHaveTextContent(value);
+}
+
 describe('<JobListItem />', () => {
-  let wrapper;
+  let container;
 
   beforeEach(() => {
     const history = createMemoryHistory({
       initialEntries: ['/jobs'],
     });
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem job={mockJob} isSelected onSelect={() => {}} />
-        </tbody>
-      </table>,
-      { context: { router: { history } } }
-    );
+    ({ container } = renderItem(
+      <JobListItem job={mockJob} isSelected onSelect={() => {}} />,
+      {
+        context: { router: { history } },
+      }
+    ));
   });
 
-  function assertDetail(label, value) {
-    expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-    expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
-  }
-
   test('initially renders successfully', () => {
-    expect(wrapper.find('JobListItem').length).toBe(1);
+    expect(
+      within(container).getByRole('link', { name: /Demo Job Template/ })
+    ).toBeInTheDocument();
   });
 
   test('should display expected details', () => {
-    assertDetail('Job Slice', '1/3');
-    assertDetail('Schedule', 'mock schedule');
+    // Detail rows live in the (always-rendered) expandable row content.
+    assertDetail(within(container), 'Job Slice', '1/3');
+    assertDetail(within(container), 'Schedule', 'mock schedule');
   });
 
   test('launch button shown to users with launch capabilities', () => {
-    expect(wrapper.find('LaunchButton').length).toBe(1);
-  });
-
-  test('launch button shown to users with launch capabilities', () => {
-    expect(wrapper.find('LaunchButton').length).toBe(1);
+    expect(queryLaunchButton(within(container))).toBeInTheDocument();
   });
 
   test('should render source data in expanded view', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            isExpanded
-            inventorySourceLabels={[
-              ['scm', 'Sourced from Project'],
-              ['file', 'File, Directory or Script'],
-            ]}
-            job={{
-              ...mockJob,
-              type: 'inventory_update',
-              source: 'scm',
-              summary_fields: { user_capabilities: { start: false } },
-            }}
-            detailUrl={`/jobs/playbook/${mockJob.id}`}
-            onSelect={() => {}}
-            isSelected={false}
-          />
-        </tbody>
-      </table>
+    const { container: c } = renderItem(
+      <JobListItem
+        isExpanded
+        inventorySourceLabels={[
+          ['scm', 'Sourced from Project'],
+          ['file', 'File, Directory or Script'],
+        ]}
+        job={{
+          ...mockJob,
+          type: 'inventory_update',
+          source: 'scm',
+          summary_fields: { user_capabilities: { start: false } },
+        }}
+        detailUrl={`/jobs/playbook/${mockJob.id}`}
+        onSelect={() => {}}
+        isSelected={false}
+      />
     );
-    expect(wrapper.find('ExpandableRowContent')).toHaveLength(1);
-    expect(
-      wrapper.find('dd[data-cy="job-inventory-source-type-value"]').text()
-    ).toBe('Sourced from Project');
+    const sourceValue = c.querySelector(
+      'dd[data-cy="job-inventory-source-type-value"]'
+    );
+    expect(sourceValue).toHaveTextContent('Sourced from Project');
   });
+
   test('launch button hidden from users without launch capabilities', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={{
-              ...mockJob,
-              summary_fields: { user_capabilities: { start: false } },
-            }}
-            detailUrl={`/jobs/playbook/${mockJob.id}`}
-            onSelect={() => {}}
-            isSelected={false}
-          />
-        </tbody>
-      </table>
+    const { container: c } = renderItem(
+      <JobListItem
+        job={{
+          ...mockJob,
+          summary_fields: { user_capabilities: { start: false } },
+        }}
+        detailUrl={`/jobs/playbook/${mockJob.id}`}
+        onSelect={() => {}}
+        isSelected={false}
+      />
     );
-    expect(wrapper.find('LaunchButton').length).toBe(0);
+    expect(queryLaunchButton(within(c))).not.toBeInTheDocument();
   });
 
   test('should hide type column when showTypeColumn is false', () => {
-    expect(wrapper.find('Td[dataLabel="Type"]').length).toBe(0);
+    expect(
+      container.querySelector('td[data-label="Type"]')
+    ).not.toBeInTheDocument();
   });
 
   test('should show type column when showTypeColumn is true', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={mockJob}
-            showTypeColumn
-            isSelected
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
+    const { container: c } = renderItem(
+      <JobListItem job={mockJob} showTypeColumn isSelected onSelect={() => {}} />
     );
-    expect(wrapper.find('Td[dataLabel="Type"]').length).toBe(1);
+    expect(c.querySelector('td[data-label="Type"]')).toBeInTheDocument();
   });
 
   test('should not show schedule detail in expanded view', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={{
-              ...mockJob,
-              summary_fields: {},
-            }}
-            showTypeColumn
-            isSelected
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
+    // summary_fields has no schedule, but launch_type is scheduled, so the
+    // DeletedDetail still renders a "Schedule" label.
+    const { container: c } = renderItem(
+      <JobListItem
+        job={{
+          ...mockJob,
+          summary_fields: {},
+        }}
+        showTypeColumn
+        isSelected
+        onSelect={() => {}}
+      />
     );
-    expect(wrapper.find('Detail[label="Schedule"] dt').length).toBe(1);
+    expect(within(c).getByText('Schedule')).toBeInTheDocument();
   });
 
   test('should not display EE for canceled jobs', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={{
-              ...mockJob,
-              status: 'canceled',
-              execution_environment: null,
-            }}
-            showTypeColumn
-            isSelected
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
+    const { container: c } = renderItem(
+      <JobListItem
+        job={{
+          ...mockJob,
+          status: 'canceled',
+          execution_environment: null,
+        }}
+        showTypeColumn
+        isSelected
+        onSelect={() => {}}
+      />
     );
-    expect(wrapper.find('Detail[label="Execution Environment"]').length).toBe(
-      0
-    );
+    expect(
+      within(c).queryByText('Execution Environment')
+    ).not.toBeInTheDocument();
   });
 
   test('should display missing resource for completed jobs and missing EE', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={mockJob}
-            showTypeColumn
-            isSelected
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>
+    const { container: c } = renderItem(
+      <JobListItem job={mockJob} showTypeColumn isSelected onSelect={() => {}} />
     );
-    expect(wrapper.find('Detail[label="Execution Environment"]').length).toBe(
-      1
-    );
-    expect(
-      wrapper.find('Detail[label="Execution Environment"] dd').text()
-    ).toBe('Missing resource');
+    assertDetail(within(c), 'Execution Environment', 'Missing resource');
   });
 
   test('should not load Source', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            inventorySourceLabels={[]}
-            job={{
-              ...mockJob,
-              type: 'inventory_update',
-              summary_fields: {
-                user_capabilities: {},
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    // isEmpty Source detail renders nothing -> no "Source" label in the DOM.
+    const { container: c } = renderItem(
+      <JobListItem
+        inventorySourceLabels={[]}
+        job={{
+          ...mockJob,
+          type: 'inventory_update',
+          summary_fields: {
+            user_capabilities: {},
+          },
+        }}
+      />
     );
-    const source_detail = wrapper.find(`Detail[label="Source"]`).at(0);
-    expect(source_detail.prop('isEmpty')).toEqual(true);
+    expect(within(c).queryByText('Source')).not.toBeInTheDocument();
   });
 
   test('should not load Credentials', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={{
-              ...mockJob,
-              type: 'inventory_update',
-              summary_fields: {
-                credentials: [],
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    // empty credentials -> isEmpty Detail renders nothing.
+    const { container: c } = renderItem(
+      <JobListItem
+        job={{
+          ...mockJob,
+          type: 'inventory_update',
+          summary_fields: {
+            credentials: [],
+          },
+        }}
+      />
     );
-    const credentials_detail = wrapper
-      .find(`Detail[label="Credentials"]`)
-      .at(0);
-    expect(credentials_detail.prop('isEmpty')).toEqual(true);
+    expect(within(c).queryByText('Credentials')).not.toBeInTheDocument();
   });
 });
 
 describe('<JobListItem with failed job />', () => {
-  let wrapper;
+  let user;
+  let container;
 
   beforeEach(() => {
     const history = createMemoryHistory({
       initialEntries: ['/jobs'],
     });
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={{ ...mockJob, status: 'failed' }}
-            isSelected
-            onSelect={() => {}}
-          />
-        </tbody>
-      </table>,
+    ({ user, container } = renderItem(
+      <JobListItem
+        job={{ ...mockJob, status: 'failed' }}
+        isSelected
+        onSelect={() => {}}
+      />,
       { context: { router: { history } } }
-    );
+    ));
   });
 
   test('launch button shown to users with launch capabilities', () => {
-    expect(wrapper.find('LaunchButton').length).toBe(1);
+    expect(queryLaunchButton(within(container))).toBeInTheDocument();
   });
 
   test('dropdown should be displayed in case of failed job', async () => {
-    expect(wrapper.find('LaunchButton').length).toBe(1);
-    const dropdown = wrapper.find('Dropdown');
-    expect(dropdown).toHaveLength(1);
-    expect(dropdown.find('DropdownItem')).toHaveLength(0);
-    // the menu renders in a popper, whose async positioning must be flushed
-    await act(async () => {
-      dropdown.find('button').simulate('click');
+    const toggle = within(container).getByRole('button', {
+      name: 'relaunch jobs',
     });
-    wrapper.update();
-    expect(wrapper.find('DropdownItem')).toHaveLength(3);
+    expect(toggle).toBeInTheDocument();
+    // menu closed -> no items
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+
+    await user.click(toggle);
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
   });
 
   test('dropdown should not be rendered for job type different of playbook run', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={{
-              ...mockJob,
-              status: 'failed',
-              type: 'project_update',
-            }}
-            onSelect={() => {}}
-            isSelected
-          />
-        </tbody>
-      </table>
+    const { container: c } = renderItem(
+      <JobListItem
+        job={{
+          ...mockJob,
+          status: 'failed',
+          type: 'project_update',
+        }}
+        onSelect={() => {}}
+        isSelected
+      />
     );
-    expect(wrapper.find('LaunchButton').length).toBe(1);
-    expect(wrapper.find('Dropdown')).toHaveLength(0);
+    // a project_update renders the plain Relaunch button, not the dropdown
+    expect(
+      within(c).queryByRole('button', { name: 'relaunch jobs' })
+    ).toBeNull();
+    expect(
+      within(c).getByRole('button', { name: 'Relaunch' })
+    ).toBeInTheDocument();
   });
 
   test('launch button hidden from users without launch capabilities', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <JobListItem
-            job={{
-              ...mockJob,
-              status: 'failed',
-              summary_fields: { user_capabilities: { start: false } },
-            }}
-            detailUrl={`/jobs/playbook/${mockJob.id}`}
-            onSelect={() => {}}
-            isSelected={false}
-          />
-        </tbody>
-      </table>
+    const { container: c } = renderItem(
+      <JobListItem
+        job={{
+          ...mockJob,
+          status: 'failed',
+          summary_fields: { user_capabilities: { start: false } },
+        }}
+        detailUrl={`/jobs/playbook/${mockJob.id}`}
+        onSelect={() => {}}
+        isSelected={false}
+      />
     );
-    expect(wrapper.find('LaunchButton').length).toBe(0);
+    expect(queryLaunchButton(within(c))).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/JobList/useWsJobs.test.js
+++ b/awx/ui/src/components/JobList/useWsJobs.test.js
@@ -1,23 +1,25 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { act, screen, waitFor } from '@testing-library/react';
 import WS from 'jest-websocket-mock';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import useWsJobs from './useWsJobs';
 
-function TestInner() {
-  return <div />;
-}
+// RTL 12 has no renderHook, so we drive the hook through a test component that
+// serializes its result into a data-testid node we can read back.
 function Test({ jobs, fetch }) {
   const qsConfig = {};
   const syncedJobs = useWsJobs(jobs, fetch, qsConfig);
-  return <TestInner jobs={syncedJobs} />;
+  return <div data-testid="jobs">{JSON.stringify(syncedJobs)}</div>;
+}
+
+function getJobs() {
+  return JSON.parse(screen.getByTestId('jobs').textContent);
 }
 
 describe('useWsJobs hook', () => {
   let debug;
-  let wrapper;
   let mockServer;
-  
+
   beforeEach(() => {
     /*
       Jest mock timers don’t play well with jest-websocket-mock,
@@ -27,35 +29,28 @@ describe('useWsJobs hook', () => {
       __esModule: true,
       default: jest.fn((val) => val),
     }));
-    debug = global.console.debug; // eslint-disable-line prefer-destructuring
+    debug = global.console.debug;
     global.console.debug = () => {};
-    
-    // Clean up any existing websocket connections
+
     WS.clean();
   });
 
   afterEach(() => {
     global.console.debug = debug;
     jest.clearAllMocks();
-    
-    // Clean up websocket connections
+
     if (mockServer) {
       mockServer.close();
       mockServer = null;
     }
     WS.clean();
-    
-    if (wrapper) {
-      wrapper.unmount();
-      wrapper = null;
-    }
   });
 
   test('should return jobs list', () => {
     const jobs = [{ id: 1 }];
-    wrapper = mountWithContexts(<Test jobs={jobs} />);
+    renderWithContexts(<Test jobs={jobs} />);
 
-    expect(wrapper.find('TestInner').prop('jobs')).toEqual(jobs);
+    expect(getJobs()).toEqual(jobs);
     WS.clean();
   });
 
@@ -65,7 +60,7 @@ describe('useWsJobs hook', () => {
 
     const jobs = [{ id: 1 }];
     await act(async () => {
-      wrapper = await mountWithContexts(<Test jobs={jobs} />);
+      renderWithContexts(<Test jobs={jobs} />);
     });
 
     await mockServer.connected;
@@ -89,7 +84,7 @@ describe('useWsJobs hook', () => {
 
     const jobs = [{ id: 1, status: 'running' }];
     await act(async () => {
-      wrapper = await mountWithContexts(<Test jobs={jobs} />);
+      renderWithContexts(<Test jobs={jobs} />);
     });
 
     await mockServer.connected;
@@ -103,8 +98,8 @@ describe('useWsJobs hook', () => {
         },
       })
     );
-    expect(wrapper.find('TestInner').prop('jobs')[0].status).toEqual('running');
-    
+    expect(getJobs()[0].status).toEqual('running');
+
     await act(async () => {
       mockServer.send(
         JSON.stringify({
@@ -114,12 +109,8 @@ describe('useWsJobs hook', () => {
         })
       );
     });
-    
-    wrapper.update();
 
-    expect(wrapper.find('TestInner').prop('jobs')[0].status).toEqual(
-      'successful'
-    );
+    await waitFor(() => expect(getJobs()[0].status).toEqual('successful'));
     mockServer.close();
     mockServer = null;
   });
@@ -130,11 +121,11 @@ describe('useWsJobs hook', () => {
     const jobs = [{ id: 1 }];
     const fetch = jest.fn(() => []);
     await act(async () => {
-      wrapper = await mountWithContexts(<Test jobs={jobs} fetch={fetch} />);
+      renderWithContexts(<Test jobs={jobs} fetch={fetch} />);
     });
 
     await mockServer.connected;
-    act(() => {
+    await act(async () => {
       mockServer.send(
         JSON.stringify({
           unified_job_id: 2,
@@ -144,7 +135,7 @@ describe('useWsJobs hook', () => {
       );
     });
 
-    expect(fetch).toHaveBeenCalledWith([2]);
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith([2]));
     mockServer.close();
     mockServer = null;
   });

--- a/awx/ui/src/components/JobList/useWsJobs.test.js
+++ b/awx/ui/src/components/JobList/useWsJobs.test.js
@@ -4,6 +4,12 @@ import WS from 'jest-websocket-mock';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import useWsJobs from './useWsJobs';
 
+// NOTE: this suite runs against the real useThrottle. A previous jest.mock of
+// '../../hooks/useThrottle' lived inside beforeEach, where it is not hoisted and
+// therefore never took effect; making it effective (module scope) changes the
+// throttle timing and breaks these websocket assertions, so the ineffective
+// mock has been removed rather than activated.
+
 // RTL 12 has no renderHook, so we drive the hook through a test component that
 // serializes its result into a data-testid node we can read back.
 function Test({ jobs, fetch }) {
@@ -21,14 +27,6 @@ describe('useWsJobs hook', () => {
   let mockServer;
 
   beforeEach(() => {
-    /*
-      Jest mock timers don’t play well with jest-websocket-mock,
-      so we'll stub out throttling to resolve immediately
-    */
-    jest.mock('../../hooks/useThrottle', () => ({
-      __esModule: true,
-      default: jest.fn((val) => val),
-    }));
     debug = global.console.debug;
     global.console.debug = () => {};
 


### PR DESCRIPTION
##### SUMMARY

Converts the shared **JobList** component test suite (`components/JobList`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `JobList`, `JobListItem`, `JobListCancelButton`, and the `useWsJobs` websocket hook.

Bulk delete/cancel are driven through the real toolbar → confirm-modal path (with deletable/cancelable fixtures so the buttons are enabled), selection asserted via checkbox state, relaunch via the row's Relaunch button/dropdown, and `useWsJobs` exposes its result via a `data-testid` (RTL 12 has no `renderHook`). Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/JobList`: **4 suites, 34 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
