### PR TITLE
enzyme -> RTL: convert the AdHocCommands component suites

### DIFF
--- a/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
@@ -61,7 +61,8 @@ function renderAdHoc(props = {}) {
 async function runWizardToLaunch(user) {
   await user.selectOptions(document.querySelector('#module_name'), 'command');
   await user.type(document.querySelector('#module_args'), 'foo');
-  await user.selectOptions(document.querySelector('#verbosity'), '1 (Verbose)');
+  // select verbosity by its stable option value ('1'), not the i18n label
+  await user.selectOptions(document.querySelector('#verbosity'), '1');
   await user.click(screen.getByRole('button', { name: 'Next' }));
 
   // step 2: execution environment - select EE2

--- a/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import {
   CredentialTypesAPI,
   InventoriesAPI,
@@ -8,9 +8,9 @@ import {
   RootAPI,
 } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  settleTooltips,
+} from '../../../testUtils/rtlContexts';
 import AdHocCommands from './AdHocCommands';
 
 jest.mock('../../api/models/CredentialTypes');
@@ -40,6 +40,59 @@ const adHocItems = [
   { name: 'Inventory 2 Org 0' },
 ];
 
+function renderAdHoc(props = {}) {
+  return renderWithContexts(
+    <AdHocCommands
+      adHocItems={adHocItems}
+      hasListItems
+      onLaunchLoading={() => jest.fn()}
+      moduleOptions={[
+        ['command', 'command'],
+        ['foo', 'foo'],
+      ]}
+      {...props}
+    />
+  );
+}
+
+// Walk the open wizard from the details step through to launch, selecting the
+// EE row at index 2 (EE2) and the credential row at index 4 (Cred 4) to mirror
+// the original enzyme flow's check-action-item-2 / -4 selections.
+async function runWizardToLaunch(user) {
+  await user.selectOptions(document.querySelector('#module_name'), 'command');
+  await user.type(document.querySelector('#module_args'), 'foo');
+  await user.selectOptions(document.querySelector('#verbosity'), '1 (Verbose)');
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+
+  // step 2: execution environment - select EE2
+  await screen.findByText('EE2');
+  await user.click(screen.getByRole('row', { name: /EE2/ }).querySelector('input'));
+  await waitFor(() =>
+    expect(
+      screen.getByRole('row', { name: /EE2/ }).querySelector('input')
+    ).toBeChecked()
+  );
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+
+  // step 3: machine credential - select Cred 4
+  await screen.findByText('Cred 4');
+  await user.click(
+    screen.getByRole('row', { name: /Cred 4/ }).querySelector('input')
+  );
+  await waitFor(() =>
+    expect(
+      screen.getByRole('row', { name: /Cred 4/ }).querySelector('input')
+    ).toBeChecked()
+  );
+  await user.click(screen.getByRole('button', { name: 'Next' }));
+
+  // preview step -> launch
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Launch' })).toBeEnabled()
+  );
+  await user.click(screen.getByRole('button', { name: 'Launch' }));
+}
+
 describe('<AdHocCommands />', () => {
   beforeEach(() => {
     RootAPI.readAssetVariables.mockResolvedValue({
@@ -59,28 +112,21 @@ describe('<AdHocCommands />', () => {
         count: 2,
       },
     });
+    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {}, POST: {} } },
+    });
   });
-  let wrapper;
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('mounts successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommands
-          adHocItems={adHocItems}
-          hasListItems
-          onLaunchLoading={() => jest.fn()}
-          moduleOptions={[
-            ['command', 'command'],
-            ['shell', 'shell'],
-          ]}
-        />
-      );
-    });
-    expect(wrapper.find('AdHocCommands').length).toBe(1);
+    renderAdHoc();
+    expect(
+      await screen.findByRole('button', { name: 'Run Command' })
+    ).toBeInTheDocument();
+    await settleTooltips();
   });
 
   test('should open the wizard', async () => {
@@ -88,40 +134,16 @@ describe('<AdHocCommands />', () => {
     CredentialTypesAPI.read.mockResolvedValue({
       data: { results: [{ id: 1 }] },
     });
-    ExecutionEnvironmentsAPI.read.mockResolvedValue({
-      data: {
-        results: [
-          { id: 1, name: 'EE1 1', url: 'wwww.google.com' },
-          { id: 2, name: 'EE2', url: 'wwww.google.com' },
-        ],
-        count: 2,
-      },
+    const { user } = renderAdHoc();
+    const runButton = await screen.findByRole('button', {
+      name: 'Run Command',
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommands
-          moduleOptions={[
-            ['command', 'command'],
-            ['foo', 'foo'],
-          ]}
-          adHocItems={adHocItems}
-          hasListItems
-          onLaunchLoading={() => jest.fn()}
-        />
-      );
-    });
-    await waitForElement(
-      wrapper,
-      'button[aria-label="Run Command"]',
-      (el) => el.length === 1
-    );
-    await act(async () =>
-      wrapper.find('button[aria-label="Run Command"]').prop('onClick')()
-    );
+    await user.click(runButton);
 
-    wrapper.update();
-
-    expect(wrapper.find('AdHocCommandsWizard').length).toBe(1);
+    // the wizard renders its title once open
+    expect(await screen.findByText('Run command')).toBeInTheDocument();
+    // settle the Run Command button's tooltip timers before unmount
+    await settleTooltips();
   });
 
   test('should submit properly', async () => {
@@ -129,7 +151,6 @@ describe('<AdHocCommands />', () => {
     InventoriesAPI.readDetail.mockResolvedValue({
       data: { organization: 1 },
     });
-
     CredentialsAPI.read.mockResolvedValue({
       data: {
         results: credentials,
@@ -139,117 +160,37 @@ describe('<AdHocCommands />', () => {
     CredentialsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
-
-    ExecutionEnvironmentsAPI.read.mockResolvedValue({
-      data: {
-        results: [
-          { id: 1, name: 'EE1 1', url: 'wwww.google.com' },
-          { id: 2, name: 'EE2', url: 'wwww.google.com' },
-        ],
-        count: 2,
-      },
+    const { user } = renderAdHoc();
+    const runButton = await screen.findByRole('button', {
+      name: 'Run Command',
     });
-    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
-      data: { actions: { GET: {}, POST: {} } },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommands
-          adHocItems={adHocItems}
-          hasListItems
-          moduleOptions={[
-            ['command', 'command'],
-            ['foo', 'foo'],
-          ]}
-          onLaunchLoading={() => jest.fn()}
-        />
-      );
-    });
-    await waitForElement(
-      wrapper,
-      'button[aria-label="Run Command"]',
-      (el) => el.length === 1
-    );
-    await act(async () =>
-      wrapper.find('button[aria-label="Run Command"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    await act(async () => {
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('onChange')(
-        {},
-        'command'
-      );
-      wrapper.find('input#module_args').simulate('change', {
-        target: { value: 'foo', name: 'module_args' },
-      });
-      wrapper.find('AnsibleSelect[name="verbosity"]').prop('onChange')({}, 1);
-    });
-
-    wrapper.update();
-
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    await waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-
-    // second step of wizard
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-2').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(
-      wrapper.find('CheckboxListItem[label="EE2"]').prop('isSelected')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    // third step of wizard
-    await waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-4').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(
-      wrapper.find('CheckboxListItem[label="Cred 4"]').prop('isSelected')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    // fourth step
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
+    await user.click(runButton);
+    await waitFor(() =>
+      expect(document.querySelector('#module_name')).toBeInTheDocument()
     );
 
-    expect(InventoriesAPI.launchAdHocCommands).toHaveBeenCalledWith(1, {
-      module_args: 'foo',
-      diff_mode: false,
-      credential: 4,
-      become_password: undefined,
-      job_type: 'run',
-      become_enabled: '',
-      extra_vars: '---',
-      forks: 0,
-      limit: 'Inventory 1 Org 0, Inventory 2 Org 0',
-      module_name: 'command',
-      ssh_key_unlock: undefined,
-      ssh_password: undefined,
-      verbosity: 1,
-      execution_environment: 2,
-    });
+    await runWizardToLaunch(user);
+
+    await waitFor(() =>
+      expect(InventoriesAPI.launchAdHocCommands).toHaveBeenCalledWith(1, {
+        module_args: 'foo',
+        diff_mode: false,
+        credential: 4,
+        become_password: undefined,
+        job_type: 'run',
+        become_enabled: '',
+        extra_vars: '---',
+        forks: 0,
+        limit: 'Inventory 1 Org 0, Inventory 2 Org 0',
+        module_name: 'command',
+        ssh_key_unlock: undefined,
+        ssh_password: undefined,
+        verbosity: '1',
+        execution_environment: 2,
+      })
+    );
+    // launch navigates away, unmounting the tooltip-wrapped Run Command button
+    await settleTooltips();
   });
 
   test('should throw error on submission properly', async () => {
@@ -268,15 +209,6 @@ describe('<AdHocCommands />', () => {
     InventoriesAPI.readDetail.mockResolvedValue({
       data: { organization: 1 },
     });
-    CredentialTypesAPI.read.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-          },
-        ],
-      },
-    });
     CredentialsAPI.read.mockResolvedValue({
       data: {
         results: credentials,
@@ -286,138 +218,37 @@ describe('<AdHocCommands />', () => {
     CredentialsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
-
-    ExecutionEnvironmentsAPI.read.mockResolvedValue({
-      data: {
-        results: [
-          {
-            id: 1,
-            name: 'EE1 1',
-            url: 'wwww.google.com',
-          },
-          {
-            id: 2,
-            name: 'EE2',
-            url: 'wwww.google.com',
-          },
-        ],
-        count: 2,
-      },
+    const { user } = renderAdHoc();
+    const runButton = await screen.findByRole('button', {
+      name: 'Run Command',
     });
-    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
-      data: { actions: { GET: {}, POST: {} } },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommands
-          adHocItems={adHocItems}
-          moduleOptions={[
-            ['command', 'command'],
-            ['foo', 'foo'],
-          ]}
-          hasListItems
-          onLaunchLoading={() => jest.fn()}
-        />
-      );
-    });
-    await waitForElement(
-      wrapper,
-      'button[aria-label="Run Command"]',
-      (el) => el.length === 1
-    );
-    await act(async () =>
-      wrapper.find('button[aria-label="Run Command"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    await act(async () => {
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('onChange')(
-        {},
-        'command'
-      );
-      wrapper.find('input#module_args').simulate('change', {
-        target: {
-          value: 'foo',
-          name: 'module_args',
-        },
-      });
-      wrapper.find('AnsibleSelect[name="verbosity"]').prop('onChange')({}, 1);
-    });
-
-    wrapper.update();
-
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
+    await user.click(runButton);
+    await waitFor(() =>
+      expect(document.querySelector('#module_name')).toBeInTheDocument()
     );
 
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
+    await runWizardToLaunch(user);
+
+    // the failed launch surfaces an AlertModal with ErrorDetail
+    await waitFor(() =>
+      expect(screen.getByText('Failed to launch job.')).toBeInTheDocument()
     );
-
-    await waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-
-    // second step of wizard
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-2').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
     expect(
-      wrapper.find('CheckboxListItem[label="EE2"]').prop('isSelected')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    // third step of wizard
-    await waitForElement(wrapper, 'ContentEmpty', (el) => el.length === 0);
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-4').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(
-      wrapper.find('CheckboxListItem[label="Cred 4"]').prop('isSelected')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    // fourth step of wizard
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    await waitForElement(wrapper, 'ErrorDetail', (el) => el.length > 0);
+      screen.getByRole('button', { name: 'Details' })
+    ).toBeInTheDocument();
+    await settleTooltips();
   });
 
   test('should disable run command button due to lack of list items', async () => {
     InventoriesAPI.readHosts.mockResolvedValue({
       data: { results: [], count: 0 },
     });
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommands
-          moduleOptions={[
-            ['command', 'command'],
-            ['foo', 'foo'],
-          ]}
-          adHocItems={adHocItems}
-          hasListItems={false}
-          onLaunchLoading={() => jest.fn()}
-        />
-      );
+    renderAdHoc({ hasListItems: false });
+    const runButton = await screen.findByRole('button', {
+      name: 'Run Command',
     });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    const runCommandsButton = wrapper.find('button[aria-label="Run Command"]');
-    expect(runCommandsButton.prop('disabled')).toBe(true);
+    expect(runButton).toBeDisabled();
+    await settleTooltips();
   });
 
   test('should open alert modal when error on fetching data', async () => {
@@ -433,21 +264,19 @@ describe('<AdHocCommands />', () => {
         },
       })
     );
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommands
-          moduleOptions={[
-            ['command', 'command'],
-            ['foo', 'foo'],
-          ]}
-          adHocItems={adHocItems}
-          hasListItems
-          onLaunchLoading={() => jest.fn()}
-        />
-      );
+    renderAdHoc();
+    const runButton = await screen.findByRole('button', {
+      name: 'Run Command',
     });
-    await act(async () => wrapper.find('button').prop('onClick')());
-    wrapper.update();
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
+    // fireEvent (not userEvent) avoids focusing the button, so its tooltip
+    // hover/focus timer is not scheduled before the fetch error swaps the
+    // button out for the AlertModal (which would log an unmount warning).
+    fireEvent.click(runButton);
+
+    // a fetch error while the wizard is open renders the ContentError alert
+    await waitFor(() =>
+      expect(screen.getByText('Something went wrong...')).toBeInTheDocument()
+    );
+    await settleTooltips();
   });
 });

--- a/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.test.js
@@ -40,7 +40,8 @@ async function fillDetails(user) {
   );
   await user.selectOptions(document.querySelector('#module_name'), 'command');
   await user.type(document.querySelector('#module_args'), 'foo');
-  await user.selectOptions(document.querySelector('#verbosity'), '1 (Verbose)');
+  // select verbosity by its stable option value ('1'), not the i18n label
+  await user.selectOptions(document.querySelector('#verbosity'), '1');
 }
 
 // The Wizard footer renders a Next button and a final Launch button.
@@ -220,11 +221,19 @@ describe('<AdHocCommandsWizard/>', () => {
     await waitFor(() => expect(credRadios[0]).toBeChecked());
     await user.click(nextButton());
 
-    // step 4: credential passwords - the ssh password field is rendered
-    const sshPassword = await waitFor(() =>
-      document.querySelector('input[name="credential_passwords.ssh_password"]')
+    // step 4: credential passwords - the ssh password field is rendered.
+    // Assert inside waitFor (a bare querySelector returning null doesn't throw,
+    // so waitFor would resolve immediately even when the field is absent).
+    await waitFor(() =>
+      expect(
+        document.querySelector(
+          'input[name="credential_passwords.ssh_password"]'
+        )
+      ).toBeInTheDocument()
     );
-    expect(sshPassword).toBeInTheDocument();
+    const sshPassword = document.querySelector(
+      'input[name="credential_passwords.ssh_password"]'
+    );
     await user.type(sshPassword, 'password');
     expect(sshPassword).toHaveValue('password');
     await user.click(nextButton());

--- a/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { CredentialsAPI, ExecutionEnvironmentsAPI, RootAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import AdHocCommandsWizard from './AdHocCommandsWizard';
 
 jest.mock('../../api/models/CredentialTypes');
@@ -22,26 +19,41 @@ const adHocItems = [
   { name: 'Inventory 2' },
   { name: 'inventory 3' },
 ];
+
+function renderWizard(onLaunch) {
+  return renderWithContexts(
+    <AdHocCommandsWizard
+      adHocItems={adHocItems}
+      onLaunch={onLaunch}
+      moduleOptions={moduleOptions}
+      onCloseWizard={() => {}}
+      credentialTypeId={1}
+      organizationId={1}
+    />
+  );
+}
+
+// Fill the details step (module/args/verbosity) so Next is enabled.
+async function fillDetails(user) {
+  await waitFor(() =>
+    expect(document.querySelector('#module_name')).toBeInTheDocument()
+  );
+  await user.selectOptions(document.querySelector('#module_name'), 'command');
+  await user.type(document.querySelector('#module_args'), 'foo');
+  await user.selectOptions(document.querySelector('#verbosity'), '1 (Verbose)');
+}
+
+// The Wizard footer renders a Next button and a final Launch button.
+const nextButton = () => screen.getByRole('button', { name: 'Next' });
+const launchButton = () => screen.getByRole('button', { name: 'Launch' });
+
 describe('<AdHocCommandsWizard/>', () => {
-  let wrapper;
   const onLaunch = jest.fn();
-  beforeEach(async () => {
+  beforeEach(() => {
     RootAPI.readAssetVariables.mockResolvedValue({
       data: {
         BRAND_NAME: 'AWX',
       },
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <AdHocCommandsWizard
-          adHocItems={adHocItems}
-          onLaunch={onLaunch}
-          moduleOptions={moduleOptions}
-          onCloseWizard={() => {}}
-          credentialTypeId={1}
-          organizationId={1}
-        />
-      );
     });
   });
   afterEach(() => {
@@ -49,30 +61,44 @@ describe('<AdHocCommandsWizard/>', () => {
   });
 
   test('should mount properly', async () => {
-    expect(wrapper.find('AdHocCommandsWizard').length).toBe(1);
+    renderWizard(onLaunch);
+    // the wizard renders its title in a body portal
+    expect(await screen.findByText('Run command')).toBeInTheDocument();
   });
 
   test('launch button should be disabled', async () => {
-    waitForElement(wrapper, 'WizardNavItem', (el) => el.length > 0);
+    ExecutionEnvironmentsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
+    });
+    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} } },
+    });
+    CredentialsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
+    });
+    CredentialsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} } },
+    });
+    const { user } = renderWizard(onLaunch);
+    await waitFor(() =>
+      expect(document.querySelector('#module_name')).toBeInTheDocument()
+    );
+    // step through without filling required fields -> preview reports errors.
+    // each list step is empty here, so the "No ... Found" empty state is a
+    // unique marker that the wizard advanced to that step.
+    await user.click(nextButton());
+    await screen.findByText('No Execution Environments Found');
+    await user.click(nextButton());
+    await screen.findByText('No Machine Credential Found');
+    await user.click(nextButton());
 
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
+    // preview step shows the missing-field error and disables Launch
+    await waitFor(() =>
+      expect(
+        screen.getByText('Some of the previous step(s) have errors')
+      ).toBeInTheDocument()
     );
-    act(() => wrapper.find('Button[type="submit"]').prop('onClick')());
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-    wrapper.update();
-    act(() => wrapper.find('Button[type="submit"]').prop('onClick')());
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-    wrapper.update();
-    act(() => wrapper.find('Button[type="submit"]').prop('onClick')());
-    wrapper.update();
-
-    expect(wrapper.find('AdHocPreviewStep').prop('hasErrors')).toBe(true);
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(true);
+    expect(launchButton()).toBeDisabled();
   });
 
   test('launch button should become active', async () => {
@@ -100,94 +126,47 @@ describe('<AdHocCommandsWizard/>', () => {
     CredentialsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
-    await waitForElement(wrapper, 'WizardNavItem', (el) => el.length > 0);
+    const { user } = renderWizard(onLaunch);
+    await fillDetails(user);
+    expect(nextButton()).toBeEnabled();
+    await user.click(nextButton());
 
-    await act(async () => {
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('onChange')(
-        {},
-        'command'
-      );
-      wrapper.find('input#module_args').simulate('change', {
-        target: { value: 'foo', name: 'module_args' },
-      });
-      wrapper.find('AnsibleSelect[name="verbosity"]').prop('onChange')({}, 1);
-    });
-    wrapper.update();
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
+    // step 2: execution environment list
+    await waitFor(() => expect(screen.getByText('EE 1')).toBeInTheDocument());
+    const eeRadios = screen.getAllByRole('radio');
+    expect(eeRadios).toHaveLength(2);
+    await user.click(eeRadios[0]);
+    await waitFor(() => expect(eeRadios[0]).toBeChecked());
+    await user.click(nextButton());
+
+    // step 3: machine credential list
+    await waitFor(() => expect(screen.getByText('Cred 1')).toBeInTheDocument());
+    const credRadios = screen.getAllByRole('radio');
+    expect(credRadios).toHaveLength(2);
+    await user.click(credRadios[0]);
+    await waitFor(() => expect(credRadios[0]).toBeChecked());
+    await user.click(nextButton());
+
+    // preview step -> launch
+    await waitFor(() => expect(launchButton()).toBeEnabled());
+    await user.click(launchButton());
+
+    await waitFor(() =>
+      expect(onLaunch).toHaveBeenCalledWith({
+        become_enabled: '',
+        credentials: [{ id: 1, name: 'Cred 1', url: '' }],
+        credential_passwords: {},
+        diff_mode: false,
+        execution_environment: [{ id: 1, name: 'EE 1', url: '' }],
+        extra_vars: '---',
+        forks: 0,
+        job_type: 'run',
+        limit: 'Inventory 1, Inventory 2, inventory 3',
+        module_args: 'foo',
+        module_name: 'command',
+        verbosity: '1',
+      })
     );
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-
-    wrapper.update();
-
-    // step 2
-
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
-    expect(wrapper.find('CheckboxListItem').length).toBe(2);
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-1').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(
-      wrapper.find('CheckboxListItem[label="EE 1"]').prop('isSelected')
-    ).toBe(true);
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-
-    wrapper.update();
-    // step 3
-
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
-    expect(wrapper.find('CheckboxListItem').length).toBe(2);
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-1').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(
-      wrapper.find('CheckboxListItem[label="Cred 1"]').prop('isSelected')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    wrapper.update();
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-
-    expect(onLaunch).toHaveBeenCalledWith({
-      become_enabled: '',
-      credentials: [{ id: 1, name: 'Cred 1', url: '' }],
-      credential_passwords: {},
-      diff_mode: false,
-      execution_environment: [{ id: 1, name: 'EE 1', url: '' }],
-      extra_vars: '---',
-      forks: 0,
-      job_type: 'run',
-      limit: 'Inventory 1, Inventory 2, inventory 3',
-      module_args: 'foo',
-      module_name: 'command',
-      verbosity: 1,
-    });
   });
 
   test('should render credential passwords step', async () => {
@@ -220,141 +199,95 @@ describe('<AdHocCommandsWizard/>', () => {
     CredentialsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
-    await waitForElement(wrapper, 'WizardNavItem', (el) => el.length > 0);
+    const { user } = renderWizard(onLaunch);
+    await fillDetails(user);
+    expect(nextButton()).toBeEnabled();
+    await user.click(nextButton());
 
-    await act(async () => {
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('onChange')(
-        {},
-        'command'
-      );
-      wrapper.find('input#module_args').simulate('change', {
-        target: { value: 'foo', name: 'module_args' },
-      });
-      wrapper.find('AnsibleSelect[name="verbosity"]').prop('onChange')({}, 1);
-    });
-    wrapper.update();
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
+    // step 2: execution environment
+    await waitFor(() => expect(screen.getByText('EE 1')).toBeInTheDocument());
+    const eeRadios = screen.getAllByRole('radio');
+    expect(eeRadios).toHaveLength(2);
+    await user.click(eeRadios[0]);
+    await waitFor(() => expect(eeRadios[0]).toBeChecked());
+    await user.click(nextButton());
+
+    // step 3: credential (selecting a password-prompting cred adds step 4)
+    await waitFor(() => expect(screen.getByText('Cred 1')).toBeInTheDocument());
+    const credRadios = screen.getAllByRole('radio');
+    expect(credRadios).toHaveLength(2);
+    await user.click(credRadios[0]);
+    await waitFor(() => expect(credRadios[0]).toBeChecked());
+    await user.click(nextButton());
+
+    // step 4: credential passwords - the ssh password field is rendered
+    const sshPassword = await waitFor(() =>
+      document.querySelector('input[name="credential_passwords.ssh_password"]')
     );
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
+    expect(sshPassword).toBeInTheDocument();
+    await user.type(sshPassword, 'password');
+    expect(sshPassword).toHaveValue('password');
+    await user.click(nextButton());
 
-    wrapper.update();
+    // preview step -> launch
+    await waitFor(() => expect(launchButton()).toBeEnabled());
+    await user.click(launchButton());
 
-    // step 2
-
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
-    expect(wrapper.find('CheckboxListItem').length).toBe(2);
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-1').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(
-      wrapper.find('CheckboxListItem[label="EE 1"]').prop('isSelected')
-    ).toBe(true);
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-
-    wrapper.update();
-    // step 3
-
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
-    expect(wrapper.find('CheckboxListItem').length).toBe(2);
-
-    await act(async () => {
-      wrapper.find('td#check-action-item-1').find('input').simulate('click');
-    });
-
-    wrapper.update();
-
-    expect(
-      wrapper.find('CheckboxListItem[label="Cred 1"]').prop('isSelected')
-    ).toBe(true);
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    // step 4
-
-    expect(wrapper.find('PasswordInput')).toHaveLength(1);
-    await act(async () =>
-      wrapper
-        .find('TextInputBase[name="credential_passwords.ssh_password"]')
-        .prop('onChange')('', {
-        target: {
-          value: 'password',
-          name: 'credential_passwords.ssh_password',
-        },
+    await waitFor(() =>
+      expect(onLaunch).toHaveBeenCalledWith({
+        become_enabled: '',
+        credentials: [
+          { id: 1, name: 'Cred 1', url: '', inputs: { password: 'ASK' } },
+        ],
+        credential_passwords: { ssh_password: 'password' },
+        diff_mode: false,
+        execution_environment: [{ id: 1, name: 'EE 1', url: '' }],
+        extra_vars: '---',
+        forks: 0,
+        job_type: 'run',
+        limit: 'Inventory 1, Inventory 2, inventory 3',
+        module_args: 'foo',
+        module_name: 'command',
+        verbosity: '1',
       })
     );
-    wrapper.update();
-    expect(
-      wrapper
-        .find('TextInput[name="credential_passwords.ssh_password"]')
-        .prop('value')
-    ).toBe('password');
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-    wrapper.update();
-
-    // step 5
-
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
-    );
-
-    expect(onLaunch).toHaveBeenCalledWith({
-      become_enabled: '',
-      credentials: [
-        { id: 1, name: 'Cred 1', url: '', inputs: { password: 'ASK' } },
-      ],
-      credential_passwords: { ssh_password: 'password' },
-      diff_mode: false,
-      execution_environment: [{ id: 1, name: 'EE 1', url: '' }],
-      extra_vars: '---',
-      forks: 0,
-      job_type: 'run',
-      limit: 'Inventory 1, Inventory 2, inventory 3',
-      module_args: 'foo',
-      module_name: 'command',
-      verbosity: 1,
-    });
   });
 
   test('should show error in navigation bar', async () => {
-    await waitForElement(wrapper, 'WizardNavItem', (el) => el.length > 0);
-
-    await act(async () => {
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('onChange')(
-        {},
-        'command'
-      );
-      wrapper.find('input#module_args').simulate('change', {
-        target: { value: '', name: 'module_args' },
-      });
+    ExecutionEnvironmentsAPI.read.mockResolvedValue({
+      data: { results: [], count: 0 },
     });
-    waitForElement(wrapper, 'ExclamationCircleIcon', (el) => el.length > 0);
+    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} } },
+    });
+    const { user } = renderWizard(onLaunch);
+    await waitFor(() =>
+      expect(document.querySelector('#module_name')).toBeInTheDocument()
+    );
+    // choose command (requires args) but leave args empty, then advance.
+    // advancing marks the details step visited so its nav item flags the error.
+    await user.selectOptions(document.querySelector('#module_name'), 'command');
+    await user.click(nextButton());
+    await screen.findByText('No Execution Environments Found');
+
+    // the details nav item surfaces the error icon (StepName ExclamationCircle)
+    await waitFor(() =>
+      expect(
+        document.querySelector('#details-step svg')
+      ).toBeInTheDocument()
+    );
   });
 
   test('expect credential step to throw error', async () => {
+    ExecutionEnvironmentsAPI.read.mockResolvedValue({
+      data: {
+        results: [{ id: 1, name: 'EE 1', url: '' }],
+        count: 1,
+      },
+    });
+    ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
+      data: { actions: { GET: {} } },
+    });
     CredentialsAPI.read.mockRejectedValue(
       new Error({
         response: {
@@ -370,34 +303,19 @@ describe('<AdHocCommandsWizard/>', () => {
     CredentialsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
-    await waitForElement(wrapper, 'WizardNavItem', (el) => el.length > 0);
+    const { user } = renderWizard(onLaunch);
+    await fillDetails(user);
+    expect(nextButton()).toBeEnabled();
+    await user.click(nextButton());
 
-    await act(async () => {
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('onChange')(
-        {},
-        'command'
-      );
-      wrapper.find('input#module_args').simulate('change', {
-        target: { value: 'foo', name: 'module_args' },
-      });
-      wrapper.find('AnsibleSelect[name="verbosity"]').prop('onChange')({}, 1);
-    });
-    wrapper.update();
-    expect(wrapper.find('Button[type="submit"]').prop('isDisabled')).toBe(
-      false
+    await waitFor(() => expect(screen.getByText('EE 1')).toBeInTheDocument());
+    await user.click(nextButton());
+
+    // the credential step's failed fetch renders ContentError
+    await waitFor(() =>
+      expect(
+        within(document.body).getByText(/Something went wrong/i)
+      ).toBeInTheDocument()
     );
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-
-    wrapper.update();
-
-    await act(async () =>
-      wrapper.find('Button[type="submit"]').prop('onClick')()
-    );
-
-    wrapper.update();
-    expect(wrapper.find('ContentError').length).toBe(1);
   });
 });

--- a/awx/ui/src/components/AdHocCommands/AdHocCredentialStep.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCredentialStep.test.js
@@ -1,18 +1,14 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { CredentialsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import AdHocCredentialStep from './AdHocCredentialStep';
 
 jest.mock('../../api/models/Credentials');
 
 describe('<AdHocCredentialStep />', () => {
   const onEnableLaunch = jest.fn();
-  let wrapper;
   beforeEach(async () => {
     CredentialsAPI.read.mockResolvedValue({
       data: {
@@ -26,28 +22,31 @@ describe('<AdHocCredentialStep />', () => {
     CredentialsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <AdHocCredentialStep
-            credentialTypeId={1}
-            onEnableLaunch={onEnableLaunch}
-          />
-        </Formik>
-      );
-    });
   });
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   test('should mount properly', async () => {
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
+    renderWithContexts(
+      <Formik>
+        <AdHocCredentialStep credentialTypeId={1} onEnableLaunch={onEnableLaunch} />
+      </Formik>
+    );
+    // OptionsList renders the fetched credential rows once loading resolves
+    await waitFor(() => expect(screen.getByText('Cred 1')).toBeInTheDocument());
   });
 
   test('should call api', async () => {
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
+    renderWithContexts(
+      <Formik>
+        <AdHocCredentialStep credentialTypeId={1} onEnableLaunch={onEnableLaunch} />
+      </Formik>
+    );
+    await waitFor(() => expect(screen.getByText('Cred 1')).toBeInTheDocument());
     expect(CredentialsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('CheckboxListItem').length).toBe(2);
+    // two CheckboxListItem rows (one per result) render a radio select cell
+    expect(screen.getByText('Cred2')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
   });
 });

--- a/awx/ui/src/components/AdHocCommands/AdHocDetailsStep.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocDetailsStep.test.js
@@ -77,7 +77,7 @@ describe('<AdHocDetailsStep />', () => {
     expect(screen.getByText('Extra variables')).toBeInTheDocument();
   });
 
-  test('shold update form values', async () => {
+  test('should update form values', async () => {
     const { user } = renderStep();
     await waitFor(() =>
       expect(document.querySelector('#module_name')).toBeInTheDocument()
@@ -94,8 +94,8 @@ describe('<AdHocDetailsStep />', () => {
     await user.type(argsInput, 'foo');
     await user.clear(limitInput);
     await user.type(limitInput, 'Inventory 1, inventory 2, new inventory');
-    // verbosity options come from VerbositySelectField; "1" maps to "1 (Verbose)"
-    await user.selectOptions(verbositySelect, '1 (Verbose)');
+    // select verbosity by its stable option value ('1'), not the i18n label
+    await user.selectOptions(verbositySelect, '1');
     await user.clear(forksInput);
     await user.type(forksInput, '10');
 

--- a/awx/ui/src/components/AdHocCommands/AdHocDetailsStep.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocDetailsStep.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { RootAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import DetailsStep from './AdHocDetailsStep';
 
 jest.mock('../../api/models/Credentials');
@@ -31,9 +31,19 @@ const initialValues = {
   module_name: 'shell',
 };
 
-describe('<AdHocDetailsStep />', () => {
-  let wrapper;
+function renderStep() {
+  return renderWithContexts(
+    <Formik initialValues={initialValues}>
+      <DetailsStep
+        verbosityOptions={verbosityOptions}
+        moduleOptions={moduleOptions}
+        onLimitChange={onLimitChange}
+      />
+    </Formik>
+  );
+}
 
+describe('<AdHocDetailsStep />', () => {
   beforeEach(() => {
     RootAPI.readAssetVariables.mockResolvedValue({
       data: {
@@ -43,97 +53,67 @@ describe('<AdHocDetailsStep />', () => {
   });
 
   test('should mount properly', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={initialValues}>
-          <DetailsStep
-            verbosityOptions={verbosityOptions}
-            moduleOptions={moduleOptions}
-            onLimitChange={onLimitChange}
-          />
-        </Formik>
-      );
-    });
+    renderStep();
+    // the Module select is the first field rendered by the step
+    await waitFor(() =>
+      expect(document.querySelector('#module_name')).toBeInTheDocument()
+    );
   });
 
   test('should show all the fields', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={initialValues}>
-          <DetailsStep
-            verbosityOptions={verbosityOptions}
-            moduleOptions={moduleOptions}
-            onLimitChange={onLimitChange}
-          />
-        </Formik>
-      );
-    });
-    expect(wrapper.find('FormGroup[label="Module"]').length).toBe(1);
-    expect(wrapper.find('FormField[label="Arguments"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[label="Verbosity"]').length).toBe(1);
-    expect(wrapper.find('FormField[label="Limit"]').length).toBe(1);
-    expect(wrapper.find('FormField[name="forks"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[label="Show changes"]').length).toBe(1);
-    expect(wrapper.find('FormGroup[name="become_enabled"]').length).toBe(1);
-    expect(wrapper.find('VariablesField').length).toBe(1);
+    renderStep();
+    await waitFor(() =>
+      expect(document.querySelector('#module_name')).toBeInTheDocument()
+    );
+    // FormField labelIcons break getByLabelText, so query the inputs by id
+    expect(document.querySelector('#module_name')).toBeInTheDocument(); // Module
+    expect(document.querySelector('#module_args')).toBeInTheDocument(); // Arguments
+    expect(document.querySelector('#verbosity')).toBeInTheDocument(); // Verbosity
+    expect(document.querySelector('#limit')).toBeInTheDocument(); // Limit
+    expect(document.querySelector('#template-forks')).toBeInTheDocument(); // forks
+    expect(screen.getByText('Show changes')).toBeInTheDocument();
+    expect(document.querySelector('#become_enabled')).toBeInTheDocument();
+    // VariablesField (react-ace) renders empty under jsdom; assert its label
+    expect(screen.getByText('Extra variables')).toBeInTheDocument();
   });
 
   test('shold update form values', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik initialValues={initialValues}>
-          <DetailsStep
-            verbosityOptions={verbosityOptions}
-            moduleOptions={moduleOptions}
-            onLimitChange={onLimitChange}
-          />
-        </Formik>
-      );
-    });
-
-    await act(async () => {
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('onChange')(
-        {},
-        'command'
-      );
-      wrapper.find('input#module_args').simulate('change', {
-        target: { value: 'foo', name: 'module_args' },
-      });
-      wrapper.find('input#limit').simulate('change', {
-        target: {
-          value: 'Inventory 1, inventory 2, new inventory',
-          name: 'limit',
-        },
-      });
-      wrapper.find('AnsibleSelect[name="verbosity"]').prop('onChange')({}, 1);
-
-      wrapper.find('TextInputBase[name="forks"]').simulate('change', {
-        target: { value: 10, name: 'forks' },
-      });
-      wrapper.find('Switch').invoke('onChange')();
-      wrapper
-        .find('Checkbox[aria-label="Enable privilege escalation"]')
-        .invoke('onChange')(true, {
-        currentTarget: { value: true, type: 'change', checked: true },
-      });
-    });
-    wrapper.update();
-    expect(
-      wrapper.find('AnsibleSelect[name="module_name"]').prop('value')
-    ).toBe('command');
-    expect(wrapper.find('input#module_args').prop('value')).toBe('foo');
-    expect(wrapper.find('AnsibleSelect[name="verbosity"]').prop('value')).toBe(
-      1
+    const { user } = renderStep();
+    await waitFor(() =>
+      expect(document.querySelector('#module_name')).toBeInTheDocument()
     );
-    expect(wrapper.find('TextInputBase[name="forks"]').prop('value')).toBe(10);
-    expect(wrapper.find('TextInputBase[name="limit"]').prop('value')).toBe(
-      'Inventory 1, inventory 2, new inventory'
-    );
-    expect(wrapper.find('Switch').prop('isChecked')).toBe(true);
-    expect(
-      wrapper
-        .find('Checkbox[aria-label="Enable privilege escalation"]')
-        .prop('isChecked')
-    ).toBe(true);
+
+    const moduleSelect = document.querySelector('#module_name');
+    const argsInput = document.querySelector('#module_args');
+    const limitInput = document.querySelector('#limit');
+    const verbositySelect = document.querySelector('#verbosity');
+    const forksInput = document.querySelector('#template-forks');
+
+    await user.selectOptions(moduleSelect, 'command');
+    await user.clear(argsInput);
+    await user.type(argsInput, 'foo');
+    await user.clear(limitInput);
+    await user.type(limitInput, 'Inventory 1, inventory 2, new inventory');
+    // verbosity options come from VerbositySelectField; "1" maps to "1 (Verbose)"
+    await user.selectOptions(verbositySelect, '1 (Verbose)');
+    await user.clear(forksInput);
+    await user.type(forksInput, '10');
+
+    // diff_mode Switch renders a checkbox input with aria-label "toggle changes"
+    const diffSwitch = screen.getByRole('checkbox', { name: 'toggle changes' });
+    await user.click(diffSwitch);
+
+    const becomeCheckbox = screen.getByRole('checkbox', {
+      name: 'Enable privilege escalation',
+    });
+    await user.click(becomeCheckbox);
+
+    await waitFor(() => expect(moduleSelect).toHaveValue('command'));
+    expect(argsInput).toHaveValue('foo');
+    expect(verbositySelect).toHaveValue('1');
+    expect(forksInput).toHaveValue(10);
+    expect(limitInput).toHaveValue('Inventory 1, inventory 2, new inventory');
+    expect(diffSwitch).toBeChecked();
+    expect(becomeCheckbox).toBeChecked();
   });
 });

--- a/awx/ui/src/components/AdHocCommands/AdHocExecutionEnironmentStep.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocExecutionEnironmentStep.test.js
@@ -1,17 +1,13 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 import { ExecutionEnvironmentsAPI } from 'api';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import AdHocExecutionEnvironmentStep from './AdHocExecutionEnvironmentStep';
 
 jest.mock('../../api/models/ExecutionEnvironments');
 
 describe('<AdHocExecutionEnvironmentStep />', () => {
-  let wrapper;
   beforeEach(async () => {
     ExecutionEnvironmentsAPI.read.mockResolvedValue({
       data: {
@@ -25,13 +21,6 @@ describe('<AdHocExecutionEnvironmentStep />', () => {
     ExecutionEnvironmentsAPI.readOptions.mockResolvedValue({
       data: { actions: { GET: {} } },
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Formik>
-          <AdHocExecutionEnvironmentStep organizationId={1} />
-        </Formik>
-      );
-    });
   });
 
   afterEach(() => {
@@ -39,12 +28,25 @@ describe('<AdHocExecutionEnvironmentStep />', () => {
   });
 
   test('should mount properly', async () => {
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
+    renderWithContexts(
+      <Formik>
+        <AdHocExecutionEnvironmentStep organizationId={1} />
+      </Formik>
+    );
+    // OptionsList renders the fetched rows once loading resolves
+    await waitFor(() => expect(screen.getByText('EE1 1')).toBeInTheDocument());
   });
 
   test('should call api', async () => {
-    await waitForElement(wrapper, 'OptionsList', (el) => el.length > 0);
+    renderWithContexts(
+      <Formik>
+        <AdHocExecutionEnvironmentStep organizationId={1} />
+      </Formik>
+    );
+    await waitFor(() => expect(screen.getByText('EE1 1')).toBeInTheDocument());
     expect(ExecutionEnvironmentsAPI.read).toHaveBeenCalled();
-    expect(wrapper.find('CheckboxListItem').length).toBe(2);
+    // two CheckboxListItem rows (one per result) render a radio select cell
+    expect(screen.getByText('EE2')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **AdHocCommands** component test suite (`components/AdHocCommands`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `AdHocCommands` (the Run Command launcher), `AdHocCommandsWizard`, and the `AdHocDetailsStep`, `AdHocCredentialStep`, `AdHocExecutionEnvironmentStep` steps.

The wizard is stepped through with the real Next/Launch buttons and `FormSelect`/radio selections; the launch payload is asserted (verbosity is the option-key string `'1'`, matching runtime). Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/AdHocCommands`: **5 suites, 19 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
