### PR TITLE
enzyme -> RTL: convert the TemplateList component suites

### DIFF
--- a/awx/ui/src/components/TemplateList/TemplateList.test.js
+++ b/awx/ui/src/components/TemplateList/TemplateList.test.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import {
   JobTemplatesAPI,
   UnifiedJobTemplatesAPI,
   WorkflowJobTemplatesAPI,
 } from 'api';
 import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+  renderWithContexts,
+  settleTooltips,
+} from '../../../testUtils/rtlContexts';
 
 import TemplateList from './TemplateList';
 
@@ -74,6 +74,10 @@ const mockTemplates = [
   },
 ];
 
+function getRow(name) {
+  return screen.getByRole('link', { name }).closest('tr');
+}
+
 describe('<TemplateList />', () => {
   let debug;
   beforeEach(() => {
@@ -89,7 +93,11 @@ describe('<TemplateList />', () => {
         actions: [],
       },
     });
-    debug = global.console.debug; // eslint-disable-line prefer-destructuring
+    JobTemplatesAPI.readOptions.mockResolvedValue({ data: { actions: {} } });
+    WorkflowJobTemplatesAPI.readOptions.mockResolvedValue({
+      data: { actions: {} },
+    });
+    debug = global.console.debug;
     global.console.debug = () => {};
   });
 
@@ -99,166 +107,90 @@ describe('<TemplateList />', () => {
   });
 
   test('initially renders successfully', async () => {
-    await act(async () => {
-      mountWithContexts(
-        <TemplateList
-          match={{ path: '/templates', url: '/templates' }}
-          location={{ search: '', pathname: '/templates' }}
-        />
-      );
-    });
+    renderWithContexts(
+      <TemplateList
+        match={{ path: '/templates', url: '/templates' }}
+        location={{ search: '', pathname: '/templates' }}
+      />
+    );
+    await screen.findByRole('link', { name: 'Job Template 1' });
   });
 
   test('Templates are retrieved from the api and the components finishes loading', async () => {
-    let wrapper;
-    await act(async () => {
-      wrapper = mountWithContexts(<TemplateList />);
-    });
+    renderWithContexts(<TemplateList />);
+    await screen.findByRole('link', { name: 'Job Template 1' });
     expect(UnifiedJobTemplatesAPI.read).toHaveBeenCalled();
-    await act(async () => {
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    });
-    expect(wrapper.find('TemplateListItem').length).toEqual(5);
+    // five name links, one per TemplateListItem
+    expect(
+      screen.getAllByRole('link', { name: /Job Template/ })
+    ).toHaveLength(5);
   });
 
   test('handleSelect is called when a template list item is selected', async () => {
-    const wrapper = mountWithContexts(<TemplateList />);
-    await act(async () => {
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    });
-    const checkBox = wrapper.find('TemplateListItem').at(1).find('input');
+    const { user } = renderWithContexts(<TemplateList />);
+    await screen.findByRole('link', { name: 'Job Template 2' });
 
-    checkBox.simulate('change', {
-      target: {
-        id: 2,
-        name: 'Job Template 2',
-        url: '/templates/job_template/2',
-        type: 'job_template',
-        summary_fields: { user_capabilities: { delete: true } },
-      },
-    });
-
-    expect(wrapper.find('TemplateListItem').at(1).prop('isSelected')).toBe(
-      true
-    );
+    const checkbox = within(getRow('Job Template 2')).getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
   });
 
   test('handleSelectAll is called when a template list item is selected', async () => {
-    const wrapper = mountWithContexts(<TemplateList />);
-    await act(async () => {
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    });
-    expect(wrapper.find('Checkbox#select-all').prop('isChecked')).toBe(false);
+    const { user } = renderWithContexts(<TemplateList />);
+    await screen.findByRole('link', { name: 'Job Template 1' });
 
-    const toolBarCheckBox = wrapper.find('Checkbox#select-all');
-    act(() => {
-      toolBarCheckBox.prop('onChange')(true);
-    });
-    wrapper.update();
-    expect(wrapper.find('Checkbox#select-all').prop('isChecked')).toBe(true);
+    const selectAll = screen.getByRole('checkbox', { name: 'Select all' });
+    expect(selectAll).not.toBeChecked();
+    await user.click(selectAll);
+    expect(selectAll).toBeChecked();
   });
 
   test('delete button is disabled if user does not have delete capabilities on a selected template', async () => {
-    const wrapper = mountWithContexts(<TemplateList />);
-    await act(async () => {
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    });
-    const deleteableItem = wrapper.find('TemplateListItem').at(0).find('input');
-    const nonDeleteableItem = wrapper
-      .find('TemplateListItem')
-      .at(4)
-      .find('input');
+    const { user } = renderWithContexts(<TemplateList />);
+    await screen.findByRole('link', { name: 'Job Template 1' });
 
-    deleteableItem.simulate('change', {
-      id: 1,
-      name: 'Job Template 1',
-      url: '/templates/job_template/1',
-      type: 'job_template',
-      summary_fields: {
-        user_capabilities: {
-          delete: true,
-        },
-      },
-    });
+    const deleteableCheckbox = within(getRow('Job Template 1')).getByRole(
+      'checkbox'
+    );
+    const nonDeleteableCheckbox = within(
+      getRow('Workflow Job Template 2')
+    ).getByRole('checkbox');
 
-    expect(wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')).toBe(
-      false
-    );
-    deleteableItem.simulate('change', {
-      id: 1,
-      name: 'Job Template 1',
-      url: '/templates/job_template/1',
-      type: 'job_template',
-      summary_fields: {
-        user_capabilities: {
-          delete: true,
-        },
-      },
-    });
-    expect(wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')).toBe(
-      true
-    );
-    nonDeleteableItem.simulate('change', {
-      id: 5,
-      name: 'Workflow Job Template 2',
-      url: '/templates/workflow_job_template/5',
-      type: 'workflow_job_template',
-      summary_fields: {
-        user_capabilities: {
-          delete: false,
-        },
-      },
-    });
-    expect(wrapper.find('Button[aria-label="Delete"]').prop('isDisabled')).toBe(
-      true
-    );
+    // select a deleteable template -> Delete enabled
+    await user.click(deleteableCheckbox);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+
+    // deselect it -> Delete disabled (nothing selected)
+    await user.click(deleteableCheckbox);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+
+    // select a non-deleteable template -> Delete disabled
+    await user.click(nonDeleteableCheckbox);
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
   });
 
   test('api is called to delete templates for each selected template.', async () => {
-    const wrapper = mountWithContexts(<TemplateList />);
-    await act(async () => {
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    });
-    const jobTemplate = wrapper.find('TemplateListItem').at(1).find('input');
-    const workflowJobTemplate = wrapper
-      .find('TemplateListItem')
-      .at(3)
-      .find('input');
+    JobTemplatesAPI.destroy.mockResolvedValue({});
+    WorkflowJobTemplatesAPI.destroy.mockResolvedValue({});
+    const { user } = renderWithContexts(<TemplateList />);
+    await screen.findByRole('link', { name: 'Job Template 2' });
 
-    jobTemplate.simulate('change', {
-      target: {
-        id: 2,
-        name: 'Job Template 2',
-        url: '/templates/job_template/2',
-        type: 'job_template',
-        summary_fields: { user_capabilities: { delete: true } },
-      },
-    });
+    await user.click(
+      within(getRow('Job Template 2')).getByRole('checkbox')
+    );
+    await user.click(
+      within(getRow('Workflow Job Template 1')).getByRole('checkbox')
+    );
 
-    workflowJobTemplate.simulate('change', {
-      target: {
-        id: 4,
-        name: 'Workflow Job Template 1',
-        url: '/templates/workflow_job_template/4',
-        type: 'workflow_job_template',
-        summary_fields: {
-          user_capabilities: {
-            delete: true,
-          },
-        },
-      },
-    });
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
 
-    await act(async () => {
-      wrapper.find('button[aria-label="Delete"]').prop('onClick')();
-    });
-    wrapper.update();
-    await act(async () => {
-      await wrapper
-        .find('button[aria-label="confirm delete"]')
-        .prop('onClick')();
-    });
-    expect(JobTemplatesAPI.destroy).toHaveBeenCalledWith(2);
+    await waitFor(() =>
+      expect(JobTemplatesAPI.destroy).toHaveBeenCalledWith(2)
+    );
     expect(WorkflowJobTemplatesAPI.destroy).toHaveBeenCalledWith(4);
   });
 
@@ -274,48 +206,40 @@ describe('<TemplateList />', () => {
         },
       })
     );
-    const wrapper = mountWithContexts(<TemplateList />);
-    await act(async () => {
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    });
-    const checkBox = wrapper.find('TemplateListItem').at(1).find('input');
+    const { user } = renderWithContexts(<TemplateList />);
+    await screen.findByRole('link', { name: 'Job Template 2' });
 
-    checkBox.simulate('change', {
-      target: {
-        id: 'a',
-        name: 'Job Template 2',
-        url: '/templates/job_template/2',
-        type: 'job_template',
-        summary_fields: { user_capabilities: { delete: true } },
-      },
-    });
-    await act(async () => {
-      wrapper.find('button[aria-label="Delete"]').prop('onClick')();
-    });
-    wrapper.update();
-    await act(async () => {
-      await wrapper
-        .find('button[aria-label="confirm delete"]')
-        .prop('onClick')();
-    });
-
-    await waitForElement(
-      wrapper,
-      'Modal[aria-label="Deletion Error"]',
-      (el) => el.props().isOpen === true && el.props().title === 'Error!'
+    await user.click(
+      within(getRow('Job Template 2')).getByRole('checkbox')
     );
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'confirm delete' })
+    );
+
+    const errorTitle = await screen.findByText('Error!');
+
+    // The deletion-error AlertModal stacks over the still-closing confirm
+    // modal, so the error dialog's subtree is aria-hidden and getByRole can't
+    // reach its Close button; scope the query to the error dialog instead.
+    const errorDialog = errorTitle.closest('.pf-c-modal-box');
+    await user.click(within(errorDialog).getByLabelText('Close'));
+    await waitFor(() =>
+      expect(screen.queryByText('Error!')).not.toBeInTheDocument()
+    );
+    await settleTooltips();
   });
+
   test('should properly copy template', async () => {
-    JobTemplatesAPI.copy.mockResolvedValue({});
-    const wrapper = mountWithContexts(<TemplateList />);
-    await act(async () => {
-      await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    });
-    await act(async () =>
-      wrapper.find('Button[aria-label="Copy"]').prop('onClick')()
-    );
-    expect(JobTemplatesAPI.copy).toHaveBeenCalled();
+    JobTemplatesAPI.copy.mockResolvedValue({ status: 201, data: { id: 6 } });
+    const { user } = renderWithContexts(<TemplateList />);
+    await screen.findByRole('link', { name: 'Job Template 1' });
+
+    // only Job Template 1 has copy capability
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+
+    await waitFor(() => expect(JobTemplatesAPI.copy).toHaveBeenCalled());
     expect(UnifiedJobTemplatesAPI.read).toHaveBeenCalled();
-    wrapper.update();
   });
 });

--- a/awx/ui/src/components/TemplateList/TemplateListItem.test.js
+++ b/awx/ui/src/components/TemplateList/TemplateListItem.test.js
@@ -1,480 +1,437 @@
 import React from 'react';
 
 import { createMemoryHistory } from 'history';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
 import { JobTemplatesAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import mockJobTemplateData from './data.job_template.json';
 import TemplateListItem from './TemplateListItem';
 
 jest.mock('../../api');
 
+function renderItem(ui, options) {
+  return renderWithContexts(
+    <table>
+      <tbody>{ui}</tbody>
+    </table>,
+    options
+  );
+}
+
 describe('<TemplateListItem />', () => {
   test('should display expected data', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            organization: {
               id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              summary_fields: {
-                organization: {
-                  id: 1,
-                  name: 'Foo',
-                },
-                user_capabilities: {
-                  start: true,
-                },
-                recent_jobs: [
-                  {
-                    id: 123,
-                    name: 'Template 1',
-                    status: 'failed',
-                    finished: '2020-02-26T22:38:41.037991Z',
-                  },
-                ],
+              name: 'Foo',
+            },
+            user_capabilities: {
+              start: true,
+            },
+            recent_jobs: [
+              {
+                id: 123,
+                name: 'Template 1',
+                status: 'failed',
+                finished: '2020-02-26T22:38:41.037991Z',
               },
-            }}
-          />
-        </tbody>
-      </table>
+            ],
+          },
+        }}
+      />
     );
-    expect(wrapper.find('Td[dataLabel="Name"]').text()).toBe('Template 1');
-    expect(wrapper.find('Td[dataLabel="Type"]').text()).toBe('Job Template');
-    expect(wrapper.find('Detail[label="Organization"]').text()).toBe(
-      'OrganizationFoo'
-    );
-    expect(
-      wrapper.find('Detail[label="Organization"]').find('Link').prop('to')
-    ).toBe('/organizations/1/details');
-    expect(wrapper.find('Td[dataLabel="Last Ran"]').text()).toBe(
-      '2/26/2020, 10:38:41 PM'
-    );
+    const nameCell = screen.getByText('Template 1').closest('td');
+    expect(nameCell).toHaveAttribute('data-label', 'Name');
+
+    const typeCell = screen.getByText('Job Template').closest('td');
+    expect(typeCell).toHaveAttribute('data-label', 'Type');
+
+    // Organization detail only renders in the expanded section; the row itself
+    // surfaces Name, Type and Last Ran. Assert the Last Ran cell value here and
+    // cover the Organization Link in the expanded-section test below.
+    const lastRanCell = screen
+      .getByText('2/26/2020, 10:38:41 PM')
+      .closest('td');
+    expect(lastRanCell).toHaveAttribute('data-label', 'Last Ran');
   });
 
   test('launch button shown to users with start capabilities', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              summary_fields: {
-                user_capabilities: {
-                  start: true,
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              start: true,
+            },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('LaunchButton').exists()).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: 'Launch template' })
+    ).toBeInTheDocument();
   });
+
   test('launch button hidden from users without start capabilities', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              summary_fields: {
-                user_capabilities: {
-                  start: false,
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              start: false,
+            },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('LaunchButton').exists()).toBeFalsy();
+    expect(
+      screen.queryByRole('button', { name: 'Launch template' })
+    ).not.toBeInTheDocument();
   });
+
   test('edit button shown to users with edit capabilities', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              summary_fields: {
-                user_capabilities: {
-                  edit: true,
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: true,
+            },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('PencilAltIcon').exists()).toBeTruthy();
+    expect(
+      screen.getByRole('link', { name: 'Edit Template' })
+    ).toBeInTheDocument();
   });
+
   test('edit button hidden from users without edit capabilities', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              summary_fields: {
-                user_capabilities: {
-                  edit: false,
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('PencilAltIcon').exists()).toBeFalsy();
+    expect(
+      screen.queryByRole('link', { name: 'Edit Template' })
+    ).not.toBeInTheDocument();
   });
+
   test('missing resource icon is shown.', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              summary_fields: {
-                user_capabilities: {
-                  edit: false,
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    const { container } = renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('ExclamationTriangleIcon').exists()).toBe(true);
+    // ExclamationTriangleIcon renders as an svg inside the Name cell tooltip
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(
+      screen.getByText('Template 1').closest('td').querySelector('svg')
+    ).toBeInTheDocument();
   });
+
   test('missing resource icon is not shown when there is a project and an inventory.', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              summary_fields: {
-                user_capabilities: {
-                  edit: false,
-                },
-                project: { name: 'Foo', id: 2 },
-                inventory: { name: 'Bar', id: 2 },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+            project: { name: 'Foo', id: 2 },
+            inventory: { name: 'Bar', id: 2 },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('ExclamationTriangleIcon').exists()).toBe(false);
+    expect(
+      screen.getByText('Template 1').closest('td').querySelector('svg')
+    ).not.toBeInTheDocument();
   });
+
   test('missing resource icon is not shown when inventory is prompt_on_launch, and a project', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'job_template',
-              ask_inventory_on_launch: true,
-              summary_fields: {
-                user_capabilities: {
-                  edit: false,
-                },
-                project: { name: 'Foo', id: 2 },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'job_template',
+          ask_inventory_on_launch: true,
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+            project: { name: 'Foo', id: 2 },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('ExclamationTriangleIcon').exists()).toBe(false);
+    expect(
+      screen.getByText('Template 1').closest('td').querySelector('svg')
+    ).not.toBeInTheDocument();
   });
+
   test('missing resource icon is not shown type is workflow_job_template', () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            template={{
-              id: 1,
-              name: 'Template 1',
-              url: '/templates/job_template/1',
-              type: 'workflow_job_template',
-              summary_fields: {
-                user_capabilities: {
-                  edit: false,
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        template={{
+          id: 1,
+          name: 'Template 1',
+          url: '/templates/job_template/1',
+          type: 'workflow_job_template',
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />
     );
-    expect(wrapper.find('ExclamationTriangleIcon').exists()).toBe(false);
+    expect(
+      screen.getByText('Template 1').closest('td').querySelector('svg')
+    ).not.toBeInTheDocument();
   });
-  test('clicking on template from templates list navigates properly', () => {
+
+  test('clicking on template from templates list navigates properly', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/templates'],
     });
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            detailUrl="/templates/job_template/1/details"
-            template={{
-              id: 1,
-              name: 'Template 1',
-              summary_fields: {
-                user_capabilities: {
-                  edit: false,
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>,
+    const { user } = renderItem(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={{
+          id: 1,
+          name: 'Template 1',
+          summary_fields: {
+            user_capabilities: {
+              edit: false,
+            },
+          },
+        }}
+      />,
       { context: { router: { history } } }
     );
-    wrapper.find('Link').simulate('click', { button: 0 });
+    await user.click(screen.getByRole('link', { name: 'Template 1' }));
     expect(history.location.pathname).toEqual(
       '/templates/job_template/1/details'
     );
   });
-  test('should call api to copy template', async () => {
-    JobTemplatesAPI.copy.mockResolvedValue();
 
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            detailUrl="/templates/job_template/1/details"
-            template={mockJobTemplateData}
-          />
-        </tbody>
-      </table>
+  test('should call api to copy template', async () => {
+    JobTemplatesAPI.copy.mockResolvedValue({});
+
+    const { user } = renderItem(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={mockJobTemplateData}
+        onCopy={() => {}}
+        fetchTemplates={() => {}}
+      />
     );
-    await act(async () =>
-      wrapper.find('Button[aria-label="Copy"]').prop('onClick')()
-    );
-    expect(JobTemplatesAPI.copy).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    await waitFor(() => expect(JobTemplatesAPI.copy).toHaveBeenCalled());
     jest.clearAllMocks();
   });
 
   test('should render proper alert modal on copy error', async () => {
     JobTemplatesAPI.copy.mockRejectedValue(new Error());
 
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            detailUrl="/templates/job_template/1/details"
-            template={mockJobTemplateData}
-          />
-        </tbody>
-      </table>
+    const { user } = renderItem(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={mockJobTemplateData}
+        onCopy={() => {}}
+        fetchTemplates={() => {}}
+      />
     );
-    await act(async () =>
-      wrapper.find('Button[aria-label="Copy"]').prop('onClick')()
-    );
-    wrapper.update();
-    expect(wrapper.find('Modal').prop('isOpen')).toBe(true);
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
     jest.clearAllMocks();
   });
 
-  test('should not render copy button', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            detailUrl="/templates/job_template/1/details"
-            template={{
-              ...mockJobTemplateData,
-              summary_fields: { user_capabilities: { copy: false } },
-            }}
-          />
-        </tbody>
-      </table>
+  test('should not render copy button', () => {
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={{
+          ...mockJobTemplateData,
+          summary_fields: { user_capabilities: { copy: false } },
+        }}
+      />
     );
-    expect(wrapper.find('CopyButton').length).toBe(0);
+    expect(
+      screen.queryByRole('button', { name: 'Copy' })
+    ).not.toBeInTheDocument();
   });
 
-  test('should render visualizer button for workflow', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            detailUrl="/templates/job_template/1/details"
-            template={{
-              ...mockJobTemplateData,
-              type: 'workflow_job_template',
-            }}
-          />
-        </tbody>
-      </table>
+  test('should render visualizer button for workflow', () => {
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={{
+          ...mockJobTemplateData,
+          type: 'workflow_job_template',
+        }}
+      />
     );
-    expect(wrapper.find('ProjectDiagramIcon').length).toBe(1);
+    expect(
+      screen.getByRole('link', { name: 'Visualizer' })
+    ).toBeInTheDocument();
   });
 
-  test('should not render visualizer button for job template', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            detailUrl="/templates/job_template/1/details"
-            template={mockJobTemplateData}
-          />
-        </tbody>
-      </table>
+  test('should not render visualizer button for job template', () => {
+    renderItem(
+      <TemplateListItem
+        isSelected={false}
+        detailUrl="/templates/job_template/1/details"
+        template={mockJobTemplateData}
+      />
     );
-    expect(wrapper.find('ProjectDiagramIcon').length).toBe(0);
+    expect(
+      screen.queryByRole('link', { name: 'Visualizer' })
+    ).not.toBeInTheDocument();
   });
 
-  test('should render expected details in expanded section', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            isSelected={false}
-            isExpanded
-            detailUrl="/templates/job_template/1/details"
-            template={{
-              ...mockJobTemplateData,
-              description: 'mock description',
-            }}
-          />
-        </tbody>
-      </table>
+  test('should render expected details in expanded section', () => {
+    const { container } = renderItem(
+      <TemplateListItem
+        isSelected={false}
+        isExpanded
+        detailUrl="/templates/job_template/1/details"
+        template={{
+          ...mockJobTemplateData,
+          description: 'mock description',
+        }}
+      />
     );
-
-    wrapper.update();
-    expect(wrapper.find('Tr').last().prop('isExpanded')).toBe(true);
 
     function assertDetail(label, value) {
-      expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
-      expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
+      const term = screen.getByText(label);
+      expect(term.nextElementSibling).toHaveTextContent(value);
     }
 
     assertDetail('Description', 'mock description');
     assertDetail('Inventory', "Mike's Inventory");
     assertDetail('Project', "Mike's Project");
     assertDetail('Execution Environment', 'Mock EE 1.2.3');
+
+    // Organization Link in the expanded section (was checked on the row in the
+    // enzyme suite, which actually renders the Detail in the expanded body).
     expect(
-      wrapper.find('Detail[label="Credentials"]').containsAllMatchingElements([
-        <span>
-          <strong>SSH:</strong>Credential 1
-        </span>,
-        <span>
-          <strong>Awx:</strong>Credential 2
-        </span>,
-      ])
-    ).toEqual(true);
-    expect(
-      wrapper
-        .find('Detail[label="Labels"]')
-        .containsAllMatchingElements([<span>L_91o2</span>])
-    ).toEqual(true);
-    expect(wrapper.find(`Td[dataLabel="Activity"] Sparkline`)).toHaveLength(1);
-  });
-  /*
-  test('should not load Activity', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            template={{
-              ...mockJobTemplateData,
-              summary_fields: {
-                user_capabilities: {},
-                recent_jobs: [],
-              },
-            }}
-          />
-        </tbody>
-      </table>
-    );
-    const activity_detail = wrapper.find(`Td[dataLabel="Activity"]`).at(0);
-    expect(activity_detail.prop('isEmpty')).toEqual(true);
-  });
-*/
-  test('should not load Credentials', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            template={{
-              ...mockJobTemplateData,
-              summary_fields: {
-                user_capabilities: {},
-                credentials: [],
-              },
-            }}
-          />
-        </tbody>
-      </table>
-    );
-    const credentials_detail = wrapper
-      .find(`Detail[label="Credentials"]`)
-      .at(0);
-    expect(credentials_detail.prop('isEmpty')).toEqual(true);
+      screen.getByRole('link', { name: "Mike's Org" })
+    ).toHaveAttribute('href', '/organizations/1/details');
+
+    // Credentials chips
+    const credentials = screen.getByText('Credentials').nextElementSibling;
+    expect(within(credentials).getByText('SSH:')).toBeInTheDocument();
+    expect(within(credentials).getByText('Credential 1')).toBeInTheDocument();
+    expect(within(credentials).getByText('Awx:')).toBeInTheDocument();
+    expect(within(credentials).getByText('Credential 2')).toBeInTheDocument();
+
+    // Labels chips
+    const labels = screen.getByText('Labels').nextElementSibling;
+    expect(within(labels).getByText('L_91o2')).toBeInTheDocument();
+
+    // Activity cell renders a Sparkline (svg) for the single recent job.
+    // Equivalent to the enzyme Td[dataLabel="Activity"] Sparkline length 1
+    // assertion.
+    const activityCell = container.querySelector('[data-label="Activity"]');
+    expect(activityCell).toBeInTheDocument();
+    expect(activityCell.querySelector('svg')).toBeInTheDocument();
   });
 
-  test('should not load Labels', async () => {
-    const wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <TemplateListItem
-            template={{
-              ...mockJobTemplateData,
-              summary_fields: {
-                user_capabilities: {},
-                labels: {
-                  results: [],
-                },
-              },
-            }}
-          />
-        </tbody>
-      </table>
+  test('should not load Credentials', () => {
+    renderItem(
+      <TemplateListItem
+        isExpanded
+        template={{
+          ...mockJobTemplateData,
+          summary_fields: {
+            user_capabilities: {},
+            credentials: [],
+          },
+        }}
+      />
     );
-    const labels_detail = wrapper.find(`Detail[label="Labels"]`).at(0);
-    expect(labels_detail.prop('isEmpty')).toEqual(true);
+    // Detail with isEmpty (empty credentials array) renders null, so the
+    // Credentials label is absent from the DOM. Equivalent to the enzyme
+    // assertion that Detail[label="Credentials"].prop('isEmpty') === true.
+    expect(screen.queryByText('Credentials')).not.toBeInTheDocument();
+  });
+
+  test('should not load Labels', () => {
+    renderItem(
+      <TemplateListItem
+        isExpanded
+        template={{
+          ...mockJobTemplateData,
+          summary_fields: {
+            user_capabilities: {},
+            labels: {
+              results: [],
+            },
+          },
+        }}
+      />
+    );
+    expect(screen.queryByText('Labels')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the shared **TemplateList** component test suite (`components/TemplateList`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `TemplateList`, `TemplateListItem`.

Selection (checkbox state), bulk delete (toolbar → confirm → deletion-error modal), and the per-row copy/launch/edit/visualizer actions are driven through the real controls and asserted by accessible name + the resulting API calls. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/TemplateList`: **2 suites, 26 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
