### PR TITLE
enzyme -> RTL: convert the NotificationList component suites

### DIFF
--- a/awx/ui/src/components/NotificationList/NotificationList.test.js
+++ b/awx/ui/src/components/NotificationList/NotificationList.test.js
@@ -1,13 +1,14 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { NotificationTemplatesAPI, JobTemplatesAPI } from 'api';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import NotificationList from './NotificationList';
 
 jest.mock('../../api');
 
 describe('<NotificationList />', () => {
-  let wrapper;
+  let container;
+  let user;
   const data = {
     count: 2,
     results: [
@@ -31,6 +32,11 @@ describe('<NotificationList />', () => {
       },
     ],
   };
+
+  // The PF Switch renders the toggle as an <input type="checkbox" id={...}>;
+  // toggles share aria-labels across rows, so query the underlying input by
+  // its stable id to disambiguate per row.
+  const toggle = (id) => container.querySelector(`#${id}`);
 
   beforeEach(async () => {
     NotificationTemplatesAPI.readOptions.mockReturnValue({
@@ -59,16 +65,13 @@ describe('<NotificationList />', () => {
       data: { results: [{ id: 3 }] },
     });
 
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <NotificationList
-          id={1}
-          canToggleNotifications
-          apiModel={JobTemplatesAPI}
-        />
-      );
-    });
-    wrapper.update();
+    ({ container, user } = renderWithContexts(
+      <NotificationList id={1} canToggleNotifications apiModel={JobTemplatesAPI} />
+    ));
+
+    await waitFor(() =>
+      expect(toggle('notification-1-success-toggle')).toBeInTheDocument()
+    );
   });
 
   test('should render list fetched of items', () => {
@@ -77,136 +80,92 @@ describe('<NotificationList />', () => {
     expect(JobTemplatesAPI.readNotificationTemplatesSuccess).toHaveBeenCalled();
     expect(JobTemplatesAPI.readNotificationTemplatesError).toHaveBeenCalled();
     expect(JobTemplatesAPI.readNotificationTemplatesStarted).toHaveBeenCalled();
-    expect(wrapper.find('NotificationListItem').length).toBe(3);
-    expect(
-      wrapper.find('input#notification-1-success-toggle').props().checked
-    ).toBe(true);
-    expect(
-      wrapper.find('input#notification-1-error-toggle').props().checked
-    ).toBe(false);
-    expect(
-      wrapper.find('input#notification-1-started-toggle').props().checked
-    ).toBe(false);
-    expect(
-      wrapper.find('input#notification-2-success-toggle').props().checked
-    ).toBe(false);
-    expect(
-      wrapper.find('input#notification-2-error-toggle').props().checked
-    ).toBe(true);
-    expect(
-      wrapper.find('input#notification-2-started-toggle').props().checked
-    ).toBe(false);
-    expect(
-      wrapper.find('input#notification-3-success-toggle').props().checked
-    ).toBe(false);
-    expect(
-      wrapper.find('input#notification-3-error-toggle').props().checked
-    ).toBe(false);
-    expect(
-      wrapper.find('input#notification-3-started-toggle').props().checked
-    ).toBe(true);
+    // three notification rows rendered
+    expect(container.querySelectorAll('#notification-row-1')).toHaveLength(1);
+    expect(container.querySelectorAll('#notification-row-2')).toHaveLength(1);
+    expect(container.querySelectorAll('#notification-row-3')).toHaveLength(1);
+
+    expect(toggle('notification-1-success-toggle')).toBeChecked();
+    expect(toggle('notification-1-error-toggle')).not.toBeChecked();
+    expect(toggle('notification-1-started-toggle')).not.toBeChecked();
+    expect(toggle('notification-2-success-toggle')).not.toBeChecked();
+    expect(toggle('notification-2-error-toggle')).toBeChecked();
+    expect(toggle('notification-2-started-toggle')).not.toBeChecked();
+    expect(toggle('notification-3-success-toggle')).not.toBeChecked();
+    expect(toggle('notification-3-error-toggle')).not.toBeChecked();
+    expect(toggle('notification-3-started-toggle')).toBeChecked();
   });
 
   test('should enable success notification', async () => {
-    expect(
-      wrapper.find('input#notification-2-success-toggle').props().checked
-    ).toBe(false);
-    await act(async () => {
-      wrapper.find('Switch#notification-2-success-toggle').prop('onChange')();
-    });
-    wrapper.update();
+    expect(toggle('notification-2-success-toggle')).not.toBeChecked();
+    await user.click(toggle('notification-2-success-toggle'));
     expect(JobTemplatesAPI.associateNotificationTemplate).toHaveBeenCalledWith(
       1,
       2,
       'success'
     );
-    expect(
-      wrapper.find('input#notification-2-success-toggle').props().checked
-    ).toBe(true);
+    await waitFor(() =>
+      expect(toggle('notification-2-success-toggle')).toBeChecked()
+    );
   });
 
   test('should enable error notification', async () => {
-    expect(
-      wrapper.find('input#notification-1-error-toggle').props().checked
-    ).toBe(false);
-    await act(async () => {
-      wrapper.find('Switch#notification-1-error-toggle').prop('onChange')();
-    });
-    wrapper.update();
+    expect(toggle('notification-1-error-toggle')).not.toBeChecked();
+    await user.click(toggle('notification-1-error-toggle'));
     expect(JobTemplatesAPI.associateNotificationTemplate).toHaveBeenCalledWith(
       1,
       1,
       'error'
     );
-    expect(
-      wrapper.find('input#notification-1-error-toggle').props().checked
-    ).toBe(true);
+    await waitFor(() =>
+      expect(toggle('notification-1-error-toggle')).toBeChecked()
+    );
   });
 
   test('should enable start notification', async () => {
-    expect(
-      wrapper.find('input#notification-1-started-toggle').props().checked
-    ).toBe(false);
-    await act(async () => {
-      wrapper.find('Switch#notification-1-started-toggle').prop('onChange')();
-    });
-    wrapper.update();
+    expect(toggle('notification-1-started-toggle')).not.toBeChecked();
+    await user.click(toggle('notification-1-started-toggle'));
     expect(JobTemplatesAPI.associateNotificationTemplate).toHaveBeenCalledWith(
       1,
       1,
       'started'
     );
-    expect(
-      wrapper.find('input#notification-1-started-toggle').props().checked
-    ).toBe(true);
+    await waitFor(() =>
+      expect(toggle('notification-1-started-toggle')).toBeChecked()
+    );
   });
 
   test('should disable success notification', async () => {
-    expect(
-      wrapper.find('input#notification-1-success-toggle').props().checked
-    ).toBe(true);
-    await act(async () => {
-      wrapper.find('Switch#notification-1-success-toggle').prop('onChange')();
-    });
-    wrapper.update();
+    expect(toggle('notification-1-success-toggle')).toBeChecked();
+    await user.click(toggle('notification-1-success-toggle'));
     expect(
       JobTemplatesAPI.disassociateNotificationTemplate
     ).toHaveBeenCalledWith(1, 1, 'success');
-    expect(
-      wrapper.find('input#notification-1-success-toggle').props().checked
-    ).toBe(false);
+    await waitFor(() =>
+      expect(toggle('notification-1-success-toggle')).not.toBeChecked()
+    );
   });
 
   test('should disable error notification', async () => {
-    expect(
-      wrapper.find('input#notification-2-error-toggle').props().checked
-    ).toBe(true);
-    await act(async () => {
-      wrapper.find('Switch#notification-2-error-toggle').prop('onChange')();
-    });
-    wrapper.update();
+    expect(toggle('notification-2-error-toggle')).toBeChecked();
+    await user.click(toggle('notification-2-error-toggle'));
     expect(
       JobTemplatesAPI.disassociateNotificationTemplate
     ).toHaveBeenCalledWith(1, 2, 'error');
-    expect(
-      wrapper.find('input#notification-2-error-toggle').props().checked
-    ).toBe(false);
+    await waitFor(() =>
+      expect(toggle('notification-2-error-toggle')).not.toBeChecked()
+    );
   });
 
   test('should disable start notification', async () => {
-    expect(
-      wrapper.find('input#notification-3-started-toggle').props().checked
-    ).toBe(true);
-    await act(async () => {
-      wrapper.find('Switch#notification-3-started-toggle').prop('onChange')();
-    });
-    wrapper.update();
+    expect(toggle('notification-3-started-toggle')).toBeChecked();
+    await user.click(toggle('notification-3-started-toggle'));
     expect(
       JobTemplatesAPI.disassociateNotificationTemplate
     ).toHaveBeenCalledWith(1, 3, 'started');
-    expect(
-      wrapper.find('input#notification-3-started-toggle').props().checked
-    ).toBe(false);
+    await waitFor(() =>
+      expect(toggle('notification-3-started-toggle')).not.toBeChecked()
+    );
   });
 
   test('should throw toggle error', async () => {
@@ -221,16 +180,15 @@ describe('<NotificationList />', () => {
         },
       })
     );
-    expect(wrapper.find('ErrorDetail').length).toBe(0);
-    await act(async () => {
-      wrapper.find('Switch#notification-1-started-toggle').prop('onChange')();
-    });
-    wrapper.update();
+    expect(screen.queryByText('Error!')).not.toBeInTheDocument();
+    await user.click(toggle('notification-1-started-toggle'));
     expect(JobTemplatesAPI.associateNotificationTemplate).toHaveBeenCalledWith(
       1,
       1,
       'started'
     );
-    expect(wrapper.find('ErrorDetail').length).toBe(1);
+    // the original suite asserted an ErrorDetail rendered; the toggle failure
+    // surfaces it inside the "Error!" AlertModal dialog.
+    expect(await screen.findByText('Error!')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/NotificationList/NotificationList.test.js
+++ b/awx/ui/src/components/NotificationList/NotificationList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { NotificationTemplatesAPI, JobTemplatesAPI } from 'api';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import NotificationList from './NotificationList';
@@ -187,8 +187,9 @@ describe('<NotificationList />', () => {
       1,
       'started'
     );
-    // the original suite asserted an ErrorDetail rendered; the toggle failure
-    // surfaces it inside the "Error!" AlertModal dialog.
-    expect(await screen.findByText('Error!')).toBeInTheDocument();
+    // the toggle failure surfaces in the "Error!" AlertModal dialog, which
+    // includes the expandable ErrorDetail ("Details" toggle)
+    const errorDialog = await screen.findByRole('dialog', { name: /Error!/ });
+    expect(within(errorDialog).getByText('Details')).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/NotificationList/NotificationListItem.test.js
+++ b/awx/ui/src/components/NotificationList/NotificationListItem.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import NotificationListItem from './NotificationListItem';
 
 describe('<NotificationListItem canToggleNotifications />', () => {
-  let wrapper;
   let toggleNotification;
 
   const mockNotif = {
@@ -16,6 +16,23 @@ describe('<NotificationListItem canToggleNotifications />', () => {
     slack: 'Slack',
   };
 
+  function setup(props = {}) {
+    return renderWithContexts(
+      <table>
+        <tbody>
+          <NotificationListItem
+            notification={mockNotif}
+            toggleNotification={toggleNotification}
+            detailUrl="/foo"
+            canToggleNotifications
+            typeLabels={typeLabels}
+            {...props}
+          />
+        </tbody>
+      </table>
+    );
+  }
+
   beforeEach(() => {
     toggleNotification = jest.fn();
   });
@@ -25,234 +42,86 @@ describe('<NotificationListItem canToggleNotifications />', () => {
   });
 
   test('initially renders successfully and displays correct label', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Switch').length).toBe(3);
+    setup();
+    // PF Switch renders as role="checkbox"; the three default toggles
+    // (start/success/failure) are present, approvals hidden by default.
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
   });
 
   test('shows approvals toggle when configured', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-            showApprovalsToggle
-          />
-        </tbody>
-      </table>
-    );
-    expect(wrapper.find('Switch').length).toBe(4);
+    setup({ showApprovalsToggle: true });
+    expect(screen.getAllByRole('checkbox')).toHaveLength(4);
   });
 
   test('displays correct type', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
-    );
-    const typeCell = wrapper.find('Td').at(1);
-    expect(typeCell.text()).toContain('Slack');
+    setup();
+    expect(screen.getByText('Slack')).toBeInTheDocument();
   });
 
-  test('handles approvals click when toggle is on', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            approvalsTurnedOn
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-            showApprovalsToggle
-          />
-        </tbody>
-      </table>
+  test('handles approvals click when toggle is on', async () => {
+    const { user } = setup({ showApprovalsToggle: true, approvalsTurnedOn: true });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification approvals' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification approvals"]')
-      .first()
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, true, 'approvals');
   });
 
-  test('handles approvals click when toggle is off', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            approvalsTurnedOn={false}
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-            showApprovalsToggle
-          />
-        </tbody>
-      </table>
+  test('handles approvals click when toggle is off', async () => {
+    const { user } = setup({
+      showApprovalsToggle: true,
+      approvalsTurnedOn: false,
+    });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification approvals' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification approvals"]')
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, false, 'approvals');
   });
 
-  test('handles started click when toggle is on', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            startedTurnedOn
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
+  test('handles started click when toggle is on', async () => {
+    const { user } = setup({ startedTurnedOn: true });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification start' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification start"]')
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, true, 'started');
   });
 
-  test('handles started click when toggle is off', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            startedTurnedOn={false}
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
+  test('handles started click when toggle is off', async () => {
+    const { user } = setup({ startedTurnedOn: false });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification start' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification start"]')
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, false, 'started');
   });
 
-  test('handles success click when toggle is on', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            successTurnedOn
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
+  test('handles success click when toggle is on', async () => {
+    const { user } = setup({ successTurnedOn: true });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification success' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification success"]')
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, true, 'success');
   });
 
-  test('handles success click when toggle is off', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            successTurnedOn={false}
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
+  test('handles success click when toggle is off', async () => {
+    const { user } = setup({ successTurnedOn: false });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification success' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification success"]')
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, false, 'success');
   });
 
-  test('handles error click when toggle is on', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            errorTurnedOn
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
+  test('handles error click when toggle is on', async () => {
+    const { user } = setup({ errorTurnedOn: true });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification failure' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification failure"]')
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, true, 'error');
   });
 
-  test('handles error click when toggle is off', () => {
-    wrapper = mountWithContexts(
-      <table>
-        <tbody>
-          <NotificationListItem
-            notification={mockNotif}
-            errorTurnedOn={false}
-            toggleNotification={toggleNotification}
-            detailUrl="/foo"
-            canToggleNotifications
-            typeLabels={typeLabels}
-          />
-        </tbody>
-      </table>
+  test('handles error click when toggle is off', async () => {
+    const { user } = setup({ errorTurnedOn: false });
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Toggle notification failure' })
     );
-    wrapper
-      .find('Switch[aria-label="Toggle notification failure"]')
-      .find('input')
-      .simulate('change');
     expect(toggleNotification).toHaveBeenCalledWith(9000, false, 'error');
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **NotificationList** component test suite (`components/NotificationList`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off `mountWithContexts`/enzyme onto `renderWithContexts`: `NotificationList`, `NotificationListItem`.

The per-row start/success/error/approval toggles are driven through the real PF `Switch` controls (disambiguated by their stable input ids / accessible names) and asserted via `toBeChecked()` + the associate/disassociate API calls; the failure path asserts the `Error!` AlertModal. Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/NotificationList`: **2 suites, 19 tests, all passing.** ESLint clean (`--no-ignore`). No production code changed — test-only.
