### PR TITLE
enzyme -> RTL: convert the DetailList component suites

### DIFF
--- a/awx/ui/src/components/DetailList/Detail.test.js
+++ b/awx/ui/src/components/DetailList/Detail.test.js
@@ -1,18 +1,21 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../testUtils/rtlContexts';
 
 import Detail from './Detail';
 
 describe('Detail', () => {
   test('renders the expected content', () => {
-    render(<Detail label="foo" value="bar" />);
+    renderWithContexts(<Detail label="foo" value="bar" />);
     // Detail renders a <dt>label</dt><dd>value</dd> pair.
-    const term = screen.getByText('foo');
-    expect(term.nextElementSibling).toHaveTextContent('bar');
+    assertDetail('foo', 'bar');
   });
 
   test('renders nothing when value is empty and not alwaysVisible', () => {
-    const { container } = render(<Detail label="foo" />);
-    expect(container).toBeEmptyDOMElement();
+    renderWithContexts(<Detail label="foo" value="" />);
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
   });
 });

--- a/awx/ui/src/components/DetailList/Detail.test.js
+++ b/awx/ui/src/components/DetailList/Detail.test.js
@@ -1,11 +1,18 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import Detail from './Detail';
 
 describe('Detail', () => {
   test('renders the expected content', () => {
-    const wrapper = mount(<Detail label="foo" />);
-    expect(wrapper).toHaveLength(1);
+    render(<Detail label="foo" value="bar" />);
+    // Detail renders a <dt>label</dt><dd>value</dd> pair.
+    const term = screen.getByText('foo');
+    expect(term.nextElementSibling).toHaveTextContent('bar');
+  });
+
+  test('renders nothing when value is empty and not alwaysVisible', () => {
+    const { container } = render(<Detail label="foo" />);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/awx/ui/src/components/DetailList/DetailList.test.js
+++ b/awx/ui/src/components/DetailList/DetailList.test.js
@@ -1,17 +1,19 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {
+  renderWithContexts,
+  assertDetail,
+} from '../../../testUtils/rtlContexts';
 
 import DetailList from './DetailList';
 import Detail from './Detail';
 
 describe('DetailList', () => {
   test('renders the expected content', () => {
-    render(
+    renderWithContexts(
       <DetailList>
         <Detail label="foo" value="bar" />
       </DetailList>
     );
-    const term = screen.getByText('foo');
-    expect(term.nextElementSibling).toHaveTextContent('bar');
+    assertDetail('foo', 'bar');
   });
 });

--- a/awx/ui/src/components/DetailList/DetailList.test.js
+++ b/awx/ui/src/components/DetailList/DetailList.test.js
@@ -1,11 +1,17 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 
 import DetailList from './DetailList';
+import Detail from './Detail';
 
 describe('DetailList', () => {
   test('renders the expected content', () => {
-    const wrapper = mount(<DetailList />);
-    expect(wrapper).toHaveLength(1);
+    render(
+      <DetailList>
+        <Detail label="foo" value="bar" />
+      </DetailList>
+    );
+    const term = screen.getByText('foo');
+    expect(term.nextElementSibling).toHaveTextContent('bar');
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **DetailList** component test suite (`components/DetailList`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

Files migrated off enzyme onto `renderWithContexts`: `Detail`, `DetailList`. Label/value pairs are asserted via the rendered `dt`/`dd` DOM (and a null-render case). Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/DetailList`: all passing. ESLint clean (`--no-ignore`). No production code changed — test-only.
