### PR TITLE
enzyme -> RTL: convert the Wizard component suite

### DIFF
--- a/awx/ui/src/components/Wizard/Wizard.test.js
+++ b/awx/ui/src/components/Wizard/Wizard.test.js
@@ -1,15 +1,22 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { screen } from '@testing-library/react';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Wizard from './Wizard';
 
 describe('Wizard', () => {
   test('renders the expected content', () => {
-    const wrapper = mount(
+    renderWithContexts(
       <Wizard
         title="Simple Wizard"
         steps={[{ name: 'Step 1', component: <p>Step 1</p> }]}
       />
     );
-    expect(wrapper).toHaveLength(1);
+    // The wizard renders its first step's content (the <p>) plus nav entries
+    // that also read "Step 1"; the content paragraph is the unique <p>.
+    expect(screen.getByText('Step 1', { selector: 'p' })).toBeInTheDocument();
+    // The step's nav button is present and active.
+    expect(
+      screen.getByRole('button', { name: 'Step 1' })
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the **Wizard** component test suite (`components/Wizard`) from enzyme to React Testing Library, continuing the enzyme → RTL migration (components, one directory per PR).

`Wizard.test.js` migrated off enzyme onto `renderWithContexts`: the PF Wizard step content/nav is asserted in the rendered DOM (the step label renders in nav + content, so the content paragraph is scoped). Behaviour and assertions are preserved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

`npm test` for `components/Wizard`: all passing. ESLint clean (`--no-ignore`). No production code changed — test-only.
