### PR TITLE
Convert the Templates route tree to react-router v6 (the last Switch)

### DIFF
--- a/awx/ui/src/screens/Template/Template.js
+++ b/awx/ui/src/screens/Template/Template.js
@@ -3,8 +3,8 @@ import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
+import { Link, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate, useParams } from 'react-router-dom-v5-compat';
 import RoutedTabs from 'components/RoutedTabs';
 import { useConfig } from 'contexts/Config';
 import useRequest from 'hooks/useRequest';
@@ -191,7 +191,7 @@ function Template({ setBreadcrumb }) {
         {template && (
           <Routes>
             <Route
-              path=":templateType/:id/details"
+              path="details"
               element={
                 <JobTemplateDetail
                   hasTemplateLoading={isLoading}
@@ -200,7 +200,7 @@ function Template({ setBreadcrumb }) {
               }
             />
             <Route
-              path=":templateType/:id/edit"
+              path="edit"
               element={
                 <JobTemplateEdit
                   template={template}
@@ -209,7 +209,7 @@ function Template({ setBreadcrumb }) {
               }
             />
             <Route
-              path=":templateType/:id/access"
+              path="access"
               element={
                 <ResourceAccessList
                   resource={template}
@@ -218,7 +218,7 @@ function Template({ setBreadcrumb }) {
               }
             />
             <Route
-              path=":templateType/:id/schedules/*"
+              path="schedules/*"
               element={
                 <Schedules
                   apiModel={JobTemplatesAPI}
@@ -234,7 +234,7 @@ function Template({ setBreadcrumb }) {
             />
             {canSeeNotificationsTab && (
               <Route
-                path=":templateType/:id/notifications"
+                path="notifications"
                 element={
                   <NotificationList
                     id={Number(templateId)}
@@ -245,13 +245,13 @@ function Template({ setBreadcrumb }) {
               />
             )}
             <Route
-              path=":templateType/:id/jobs"
+              path="jobs"
               element={
                 <JobList defaultParams={{ job__job_template: template.id }} />
               }
             />
             <Route
-              path=":templateType/:id/survey/*"
+              path="survey/*"
               element={
                 <TemplateSurvey
                   template={template}
@@ -259,10 +259,7 @@ function Template({ setBreadcrumb }) {
                 />
               }
             />
-            <Route
-              path=":templateType/:id"
-              element={<Navigate to={`${baseUrl}/details`} replace />}
-            />
+            <Route index element={<Navigate to="details" replace />} />
             <Route
               path="*"
               element={

--- a/awx/ui/src/screens/Template/Template.test.js
+++ b/awx/ui/src/screens/Template/Template.test.js
@@ -1,13 +1,10 @@
 import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { act } from 'react-dom/test-utils';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { JobTemplatesAPI, OrganizationsAPI } from 'api';
 
-import { Routes, Route } from 'react-router-dom-v5-compat';
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import Template from './Template';
 import mockJobTemplateData from './shared/data.job_template.json';
 
@@ -25,7 +22,7 @@ const mockMe = {
 // no detail subcomponent fetches).
 function renderTemplate(entry = '/templates/job_template/1/foobar') {
   const history = createMemoryHistory({ initialEntries: [entry] });
-  return mountWithContexts(
+  return renderWithContexts(
     <Routes>
       <Route
         path="/templates/job_template/:id/*"
@@ -37,7 +34,6 @@ function renderTemplate(entry = '/templates/job_template/1/foobar') {
 }
 
 describe('<Template />', () => {
-  let wrapper;
   beforeEach(() => {
     JobTemplatesAPI.readDetail.mockResolvedValue({
       data: { ...mockJobTemplateData, survey_enabled: false },
@@ -68,91 +64,66 @@ describe('<Template />', () => {
         count: 1,
         next: null,
         previous: null,
-        results: [
-          {
-            id: 1,
-          },
-        ],
+        results: [{ id: 1 }],
       },
     });
     JobTemplatesAPI.readLaunch.mockResolvedValue({ data: {} });
     JobTemplatesAPI.readWebhookKey.mockResolvedValue({
-      data: {
-        webhook_key: 'key',
-      },
+      data: { webhook_key: 'key' },
     });
   });
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   test('initially renders successfully', async () => {
-    await act(async () => {
-      wrapper = renderTemplate();
-    });
+    renderTemplate();
+    await waitFor(() => expect(JobTemplatesAPI.readDetail).toHaveBeenCalled());
   });
+
   test('When component mounts API is called and the response is put in state', async () => {
-    await act(async () => {
-      wrapper = renderTemplate();
-    });
-    expect(JobTemplatesAPI.readDetail).toHaveBeenCalled();
+    renderTemplate();
+    await waitFor(() => expect(JobTemplatesAPI.readDetail).toHaveBeenCalled());
     expect(OrganizationsAPI.read).toHaveBeenCalled();
   });
-  test('notifications tab shown for admins', async () => {
-    await act(async () => {
-      wrapper = renderTemplate();
-    });
 
-    const tabs = await waitForElement(
-      wrapper,
-      '.pf-c-tabs__item',
-      (el) => el.length === 7
-    );
-    expect(tabs.at(3).text()).toEqual('Notifications');
+  test('notifications tab shown for admins', async () => {
+    renderTemplate();
+    await waitFor(() => expect(screen.getAllByRole('tab')).toHaveLength(7));
+    expect(
+      screen.getByRole('tab', { name: 'Notifications' })
+    ).toBeInTheDocument();
   });
+
   test('notifications tab hidden with reduced permissions', async () => {
     OrganizationsAPI.read.mockResolvedValue({
-      data: {
-        count: 0,
-        next: null,
-        previous: null,
-        results: [],
-      },
+      data: { count: 0, next: null, previous: null, results: [] },
     });
-
-    await act(async () => {
-      wrapper = renderTemplate();
-    });
-    const tabs = await waitForElement(
-      wrapper,
-      '.pf-c-tabs__item',
-      (el) => el.length === 6
-    );
-    tabs.forEach((tab) => expect(tab.text()).not.toEqual('Notifications'));
+    renderTemplate();
+    await waitFor(() => expect(screen.getAllByRole('tab')).toHaveLength(6));
+    expect(
+      screen.queryByRole('tab', { name: 'Notifications' })
+    ).not.toBeInTheDocument();
   });
 
   test('should show content error when user attempts to navigate to erroneous route', async () => {
-    await act(async () => {
-      wrapper = renderTemplate('/templates/job_template/1/foobar');
-    });
+    renderTemplate('/templates/job_template/1/foobar');
+    expect(await screen.findByText('Not Found')).toBeInTheDocument();
+  });
 
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
-  });
   test('should call to get webhook key', async () => {
-    await act(async () => {
-      wrapper = renderTemplate('/templates/job_template/1/foobar');
-    });
-    expect(JobTemplatesAPI.readWebhookKey).toHaveBeenCalled();
+    renderTemplate('/templates/job_template/1/foobar');
+    await waitFor(() =>
+      expect(JobTemplatesAPI.readWebhookKey).toHaveBeenCalled()
+    );
   });
+
   test('should not call to get webhook key', async () => {
     JobTemplatesAPI.readTemplateOptions.mockResolvedValueOnce({
-      data: {
-        actions: {},
-      },
+      data: { actions: {} },
     });
-
-    await act(async () => {
-      wrapper = renderTemplate('/templates/job_template/1/foobar');
-    });
+    renderTemplate('/templates/job_template/1/foobar');
+    await waitFor(() => expect(JobTemplatesAPI.readDetail).toHaveBeenCalled());
     expect(JobTemplatesAPI.readWebhookKey).not.toHaveBeenCalled();
   });
 });

--- a/awx/ui/src/screens/Template/Template.test.js
+++ b/awx/ui/src/screens/Template/Template.test.js
@@ -3,6 +3,7 @@ import { createMemoryHistory } from 'history';
 import { act } from 'react-dom/test-utils';
 import { JobTemplatesAPI, OrganizationsAPI } from 'api';
 
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import {
   mountWithContexts,
   waitForElement,
@@ -17,6 +18,24 @@ const mockMe = {
   is_super_user: true,
   is_system_auditor: false,
 };
+
+// Template is a v6 descendant mounted by Templates at job_template/:id/*, so it
+// reads :id from the route. Mount it under the same real v6 route here; the
+// default /foobar subpath hits Template's not-found branch (only tabs render,
+// no detail subcomponent fetches).
+function renderTemplate(entry = '/templates/job_template/1/foobar') {
+  const history = createMemoryHistory({ initialEntries: [entry] });
+  return mountWithContexts(
+    <Routes>
+      <Route
+        path="/templates/job_template/:id/*"
+        element={<Template setBreadcrumb={() => {}} me={mockMe} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
 describe('<Template />', () => {
   let wrapper;
   beforeEach(() => {
@@ -68,25 +87,19 @@ describe('<Template />', () => {
   });
   test('initially renders successfully', async () => {
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderTemplate();
     });
   });
   test('When component mounts API is called and the response is put in state', async () => {
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderTemplate();
     });
     expect(JobTemplatesAPI.readDetail).toHaveBeenCalled();
     expect(OrganizationsAPI.read).toHaveBeenCalled();
   });
   test('notifications tab shown for admins', async () => {
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderTemplate();
     });
 
     const tabs = await waitForElement(
@@ -107,9 +120,7 @@ describe('<Template />', () => {
     });
 
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
-      );
+      wrapper = renderTemplate();
     });
     const tabs = await waitForElement(
       wrapper,
@@ -120,56 +131,15 @@ describe('<Template />', () => {
   });
 
   test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/1/foobar'],
-    });
-
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/templates/job_template/1/foobar',
-                  path: '/templates/job_template/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
+      wrapper = renderTemplate('/templates/job_template/1/foobar');
     });
 
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });
   test('should call to get webhook key', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/1/foobar'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/templates/job_template/1/foobar',
-                  path: '/templates/job_template/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
+      wrapper = renderTemplate('/templates/job_template/1/foobar');
     });
     expect(JobTemplatesAPI.readWebhookKey).toHaveBeenCalled();
   });
@@ -180,28 +150,8 @@ describe('<Template />', () => {
       },
     });
 
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/job_template/1/foobar'],
-    });
     await act(async () => {
-      wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/templates/job_template/1/foobar',
-                  path: '/templates/job_template/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
+      wrapper = renderTemplate('/templates/job_template/1/foobar');
     });
     expect(JobTemplatesAPI.readWebhookKey).not.toHaveBeenCalled();
   });

--- a/awx/ui/src/screens/Template/Templates.js
+++ b/awx/ui/src/screens/Template/Templates.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 
-import { Route, Switch } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
 
@@ -65,27 +65,31 @@ function Templates() {
         streamType="job_template,workflow_job_template,workflow_job_template_node"
         breadcrumbConfig={breadcrumbConfig}
       />
-      <Switch>
-        <Route path="/templates/job_template/add">
-          <JobTemplateAdd />
-        </Route>
-        <Route path="/templates/workflow_job_template/add">
-          <WorkflowJobTemplateAdd />
-        </Route>
-        <Route path="/templates/job_template/:id">
-          <Template setBreadcrumb={setBreadcrumbConfig} />
-        </Route>
-        <Route path="/templates/workflow_job_template/:id">
-          <WorkflowJobTemplate setBreadcrumb={setBreadcrumbConfig} />
-        </Route>
-        <Route path="/templates">
-          <PageSection>
-            <PersistentFilters pageKey="templates">
-              <TemplateList />
-            </PersistentFilters>
-          </PageSection>
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path="job_template/add" element={<JobTemplateAdd />} />
+        <Route
+          path="workflow_job_template/add"
+          element={<WorkflowJobTemplateAdd />}
+        />
+        <Route
+          path="job_template/:id/*"
+          element={<Template setBreadcrumb={setBreadcrumbConfig} />}
+        />
+        <Route
+          path="workflow_job_template/:id/*"
+          element={<WorkflowJobTemplate setBreadcrumb={setBreadcrumbConfig} />}
+        />
+        <Route
+          index
+          element={
+            <PageSection>
+              <PersistentFilters pageKey="templates">
+                <TemplateList />
+              </PersistentFilters>
+            </PageSection>
+          }
+        />
+      </Routes>
     </>
   );
 }

--- a/awx/ui/src/screens/Template/Templates.test.js
+++ b/awx/ui/src/screens/Template/Templates.test.js
@@ -1,29 +1,28 @@
 import React from 'react';
+import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Routes, Route } from 'react-router-dom-v5-compat';
-import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import Templates from './Templates';
 
 describe('<Templates />', () => {
-  let pageWrapper;
-
-  beforeEach(() => {
+  test('initially renders without crashing', () => {
     // Templates is a v6 descendant mounted at /templates/*; render it under the
     // same route. A non-matching subpath keeps its <Routes> from rendering a
     // child screen (which would fetch), so this stays a render-only smoke test.
     const history = createMemoryHistory({
       initialEntries: ['/templates/unknown'],
     });
-    pageWrapper = mountWithContexts(
+    renderWithContexts(
       <Routes>
         <Route path="/templates/*" element={<Templates />} />
       </Routes>,
       { context: { router: { history } } }
     );
-  });
-
-  test('initially renders without crashing', () => {
-    expect(pageWrapper.find('Templates').length).toBe(1);
+    // The ScreenHeader breadcrumb renders regardless of the matched route.
+    expect(
+      screen.getByRole('navigation', { name: 'Breadcrumb' })
+    ).toBeInTheDocument();
   });
 });

--- a/awx/ui/src/screens/Template/Templates.test.js
+++ b/awx/ui/src/screens/Template/Templates.test.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { createMemoryHistory } from 'history';
+import { Routes, Route } from 'react-router-dom-v5-compat';
 import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 
 import Templates from './Templates';
@@ -7,10 +9,21 @@ describe('<Templates />', () => {
   let pageWrapper;
 
   beforeEach(() => {
-    pageWrapper = mountWithContexts(<Templates />);
+    // Templates is a v6 descendant mounted at /templates/*; render it under the
+    // same route. A non-matching subpath keeps its <Routes> from rendering a
+    // child screen (which would fetch), so this stays a render-only smoke test.
+    const history = createMemoryHistory({
+      initialEntries: ['/templates/unknown'],
+    });
+    pageWrapper = mountWithContexts(
+      <Routes>
+        <Route path="/templates/*" element={<Templates />} />
+      </Routes>,
+      { context: { router: { history } } }
+    );
   });
 
   test('initially renders without crashing', () => {
-    expect(pageWrapper.length).toBe(1);
+    expect(pageWrapper.find('Templates').length).toBe(1);
   });
 });

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.js
@@ -3,8 +3,8 @@ import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
-import { Link, useLocation, useParams } from 'react-router-dom';
-import { Routes, Route, Navigate } from 'react-router-dom-v5-compat';
+import { Link, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate, useParams } from 'react-router-dom-v5-compat';
 import RoutedTabs from 'components/RoutedTabs';
 import { useConfig } from 'contexts/Config';
 import useRequest from 'hooks/useRequest';
@@ -184,19 +184,19 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
         <Routes>
           {template && (
             <Route
-              path=":templateType/:id/details"
+              path="details"
               element={<WorkflowJobTemplateDetail template={template} />}
             />
           )}
           {template && (
             <Route
-              path=":templateType/:id/edit"
+              path="edit"
               element={<WorkflowJobTemplateEdit template={template} />}
             />
           )}
           {template && (
             <Route
-              path=":templateType/:id/access"
+              path="access"
               element={
                 <ResourceAccessList
                   resource={template}
@@ -207,7 +207,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template && (
             <Route
-              path=":templateType/:id/schedules/*"
+              path="schedules/*"
               element={
                 <Schedules
                   apiModel={WorkflowJobTemplatesAPI}
@@ -223,7 +223,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {canSeeNotificationsTab && (
             <Route
-              path=":templateType/:id/notifications"
+              path="notifications"
               element={
                 <NotificationList
                   id={Number(templateId)}
@@ -236,7 +236,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template && (
             <Route
-              path="workflow_job_template/:id/visualizer"
+              path="visualizer"
               element={
                 <AppendBody>
                   <FullPage>
@@ -248,7 +248,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template?.id && (
             <Route
-              path=":templateType/:id/jobs"
+              path="jobs"
               element={
                 <JobList
                   defaultParams={{
@@ -260,7 +260,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
           )}
           {template && (
             <Route
-              path=":templateType/:id/survey/*"
+              path="survey/*"
               element={
                 <TemplateSurvey
                   template={template}
@@ -270,10 +270,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
             />
           )}
           {template && (
-            <Route
-              path=":templateType/:id"
-              element={<Navigate to={`${baseUrl}/details`} replace />}
-            />
+            <Route index element={<Navigate to="details" replace />} />
           )}
           {!hasRolesandTemplateLoading && (
             <Route

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
@@ -247,7 +247,7 @@ describe('<WorkflowJobTemplate />', () => {
       wrapper = mountWithContexts(
         <Routes>
           <Route
-            path="/templates/*"
+            path="/templates/workflow_job_template/:id/*"
             element={
               <WorkflowJobTemplate
                 setBreadcrumb={() => {}}

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
@@ -1,17 +1,14 @@
 import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Routes, Route } from 'react-router-dom-v5-compat';
-import { act } from 'react-dom/test-utils';
 import {
   WorkflowJobTemplatesAPI,
   OrganizationsAPI,
   NotificationTemplatesAPI,
 } from 'api';
 
-import {
-  mountWithContexts,
-  waitForElement,
-} from '../../../testUtils/enzymeHelpers';
+import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import WorkflowJobTemplate from './WorkflowJobTemplate';
 import mockWorkflowJobTemplateData from './shared/data.workflow_job_template.json';
 
@@ -21,34 +18,42 @@ const mockMe = {
   is_super_user: true,
   is_system_auditor: false,
 };
+
+// WorkflowJobTemplate is a v6 descendant mounted by Templates at
+// workflow_job_template/:id/*; mount it under the same real v6 route so it
+// reads :id and its relative child routes resolve.
+function renderWFJT(entry = '/templates/workflow_job_template/1/foobar', me = mockMe) {
+  const history = createMemoryHistory({ initialEntries: [entry] });
+  return renderWithContexts(
+    <Routes>
+      <Route
+        path="/templates/workflow_job_template/:id/*"
+        element={<WorkflowJobTemplate setBreadcrumb={() => {}} me={me} />}
+      />
+    </Routes>,
+    { context: { router: { history } } }
+  );
+}
+
 describe('<WorkflowJobTemplate />', () => {
-  let wrapper;
   beforeEach(() => {
     WorkflowJobTemplatesAPI.readDetail.mockResolvedValue({
       data: { ...mockWorkflowJobTemplateData, survey_enabled: false },
     });
     WorkflowJobTemplatesAPI.readWorkflowJobTemplateOptions.mockResolvedValue({
-      data: {
-        actions: { PUT: true },
-      },
+      data: { actions: { PUT: true } },
     });
     OrganizationsAPI.read.mockResolvedValue({
       data: {
         count: 1,
         next: null,
         previous: null,
-        results: [
-          {
-            id: 1,
-          },
-        ],
+        results: [{ id: 1 }],
       },
     });
     WorkflowJobTemplatesAPI.readLaunch.mockResolvedValue({ data: {} });
     WorkflowJobTemplatesAPI.readWebhookKey.mockResolvedValue({
-      data: {
-        webhook_key: 'key',
-      },
+      data: { webhook_key: 'key' },
     });
   });
 
@@ -57,149 +62,59 @@ describe('<WorkflowJobTemplate />', () => {
   });
 
   test('initially renders successfully', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
-      );
-    });
+    renderWFJT();
+    await waitFor(() =>
+      expect(WorkflowJobTemplatesAPI.readDetail).toHaveBeenCalled()
+    );
   });
 
   test('When component mounts API is called and the response is put in state', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
-      );
-    });
-    expect(WorkflowJobTemplatesAPI.readDetail).toHaveBeenCalled();
+    renderWFJT();
+    await waitFor(() =>
+      expect(WorkflowJobTemplatesAPI.readDetail).toHaveBeenCalled()
+    );
     expect(OrganizationsAPI.read).toHaveBeenCalled();
   });
 
   test('notifications tab shown for admins', async () => {
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
-      );
-    });
-
-    const tabs = await waitForElement(
-      wrapper,
-      '.pf-c-tabs__item',
-      (el) => el.length === 8
-    );
-    expect(tabs.at(3).text()).toEqual('Notifications');
+    renderWFJT();
+    await waitFor(() => expect(screen.getAllByRole('tab')).toHaveLength(8));
+    expect(
+      screen.getByRole('tab', { name: 'Notifications' })
+    ).toBeInTheDocument();
   });
 
   test('notifications tab hidden with reduced permissions', async () => {
     OrganizationsAPI.read.mockResolvedValue({
-      data: {
-        count: 0,
-        next: null,
-        previous: null,
-        results: [],
-      },
+      data: { count: 0, next: null, previous: null, results: [] },
     });
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
-      );
-    });
-    const tabs = await waitForElement(
-      wrapper,
-      '.pf-c-tabs__item',
-      (el) => el.length === 7
-    );
-    tabs.forEach((tab) => expect(tab.text()).not.toEqual('Notifications'));
+    renderWFJT();
+    await waitFor(() => expect(screen.getAllByRole('tab')).toHaveLength(7));
+    expect(
+      screen.queryByRole('tab', { name: 'Notifications' })
+    ).not.toBeInTheDocument();
   });
 
   test('should show content error when user attempts to navigate to erroneous route', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/workflow_job_template/1/foobar'],
-    });
-
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/templates/workflow_job_template/1/foobar',
-                  path: '/templates/workflow_job_template/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-
-    await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
+    renderWFJT('/templates/workflow_job_template/1/foobar');
+    expect(await screen.findByText('Not Found')).toBeInTheDocument();
   });
 
   test('should call to get webhook key', async () => {
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/workflow_job_template/1/foobar'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/templates/workflow_job_template/1/foobar',
-                  path: '/templates/workflow_job_template/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
-    });
-    expect(WorkflowJobTemplatesAPI.readWebhookKey).toHaveBeenCalled();
+    renderWFJT('/templates/workflow_job_template/1/foobar');
+    await waitFor(() =>
+      expect(WorkflowJobTemplatesAPI.readWebhookKey).toHaveBeenCalled()
+    );
   });
 
   test('should not call to get webhook key', async () => {
     WorkflowJobTemplatesAPI.readWorkflowJobTemplateOptions.mockResolvedValueOnce(
-      {
-        data: {
-          actions: {},
-        },
-      }
+      { data: { actions: {} } }
     );
-
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/workflow_job_template/1/foobar'],
-    });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />,
-        {
-          context: {
-            router: {
-              history,
-              route: {
-                location: history.location,
-                match: {
-                  params: { id: 1 },
-                  url: '/templates/workflow_job_template/1/foobar',
-                  path: '/templates/workflow_job_template/1/foobar',
-                },
-              },
-            },
-          },
-        }
-      );
-    });
+    renderWFJT('/templates/workflow_job_template/1/foobar');
+    await waitFor(() =>
+      expect(WorkflowJobTemplatesAPI.readDetail).toHaveBeenCalled()
+    );
     expect(WorkflowJobTemplatesAPI.readWebhookKey).not.toHaveBeenCalled();
   });
 
@@ -219,11 +134,7 @@ describe('<WorkflowJobTemplate />', () => {
     NotificationTemplatesAPI.readOptions.mockReturnValue({
       data: {
         actions: {
-          GET: {
-            notification_type: {
-              choices: [['email', 'Email']],
-            },
-          },
+          GET: { notification_type: { choices: [['email', 'Email']] } },
         },
       },
     });
@@ -240,34 +151,23 @@ describe('<WorkflowJobTemplate />', () => {
         ],
       },
     });
-    const history = createMemoryHistory({
-      initialEntries: ['/templates/workflow_job_template/1/notifications'],
+    renderWFJT('/templates/workflow_job_template/1/notifications', {
+      is_system_auditor: true,
     });
-    await act(async () => {
-      wrapper = mountWithContexts(
-        <Routes>
-          <Route
-            path="/templates/workflow_job_template/:id/*"
-            element={
-              <WorkflowJobTemplate
-                setBreadcrumb={() => {}}
-                me={{
-                  is_system_auditor: true,
-                }}
-              />
-            }
-          />
-        </Routes>,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
-    expect(wrapper.find('NotificationListItem').length).toBe(1);
-    expect(wrapper.find('Switch[label="Approval"]')).toHaveLength(1);
-    expect(wrapper.find('Switch[label="Start"]')).toHaveLength(1);
-    expect(wrapper.find('Switch[label="Success"]')).toHaveLength(1);
-    expect(wrapper.find('Switch[label="Failure"]')).toHaveLength(1);
+    expect(
+      await screen.findByRole('link', { name: 'Notification one' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Toggle notification approvals' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Toggle notification start' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Toggle notification success' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'Toggle notification failure' })
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
##### SUMMARY

Converts the `Templates` route tree to react-router v6, which removes the last `<Switch>` left on main.

Now that App.js is v6 (#425), it mounts `Templates` as a descendant at `/templates/*`. `Templates.js` was still a v5-compat `<Switch>` with absolute paths, kept that way deliberately while the rest of the migration landed. It kept working because `<Switch>` prefix-matches the full path, but it has to become v6 `<Routes>` before the `react-router-dom-v5-compat` bridge can be removed.

What changed:

- `Templates.js`: `<Switch>` becomes `<Routes>` with relative children (`job_template/add`, `workflow_job_template/add`, `job_template/:id/*`, `workflow_job_template/:id/*`, and an index route for the list).
- `Template.js` and `WorkflowJobTemplate.js`: their internal `<Routes>` move to relative paths (dropping the `:templateType/:id/` prefix that assumed a `/templates` base), and `useParams` now comes from `react-router-dom-v5-compat`. A v5 `useParams` returns `{}` for a v6 descendant, which would have made the template id come through as `undefined`.
- The three test files remount these components under the real v6 parent route so `useParams` resolves the id, matching how `Templates.js` mounts them.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ASCENDER VERSION

```
awx: 25.4.1.dev61+gb47febf4d1
```

##### ADDITIONAL INFORMATION

Verified locally:

- `npm --prefix awx/ui run test` for the four Template suites: 23 of 23 tests pass. ESLint clean on the three production files.
- Browser smoke test on a dev instance (port 3002) against a running backend, since unit tests mock the router and miss real route resolution. Logged in and walked all 18 Template routes: the list, both add forms, and every detail tab for a job template and a workflow job template (details, access, notifications, schedules, jobs, survey, edit, visualizer). No route landed on a not-found page and there were no `/api/v2/.../undefined/...` requests. The one 4xx seen was `/api/v2/projects/null/` on a job template whose `project` field is genuinely null, which is a property of that template's edit form and not related to routing. Re-running edit on a job template that has a project was clean.
