### PR TITLE
Allow GitHub App SSH username for SCM URLs

### DIFF
--- a/awx/main/tests/unit/utils/test_common.py
+++ b/awx/main/tests/unit/utils/test_common.py
@@ -240,7 +240,15 @@ def test_extract_ansible_vars():
         ('git', 'https://example.com/bar.git', 'user', 'pw', True, False, 'https://user:pw@example.com/bar.git'),
         ('git', 'https://example@example.com/bar.git', False, 'something', True, False, 'https://example.com/bar.git'),
         # Special github/bitbucket cases
-        ('git', 'notgit@github.com:ansible/awx.git', True, True, True, False, ValueError('Username must be "git" for SSH access to github.com.')),
+        (
+            'git',
+            'notgit@github.com:ansible/awx.git',
+            True,
+            True,
+            True,
+            False,
+            ValueError('Username must be "git" or "x-access-token" (for github app) for SSH access to github.com.'),
+        ),
         (
             'git',
             'notgit@bitbucket.org:does-not-exist/example.git',

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -321,12 +321,22 @@ def update_scm_url(scm_type, url, username=True, password=True, check_special_ca
 
     # Special handling for github/bitbucket SSH URLs.
     if check_special_cases:
-        special_git_hosts = ('github.com', 'bitbucket.org', 'altssh.bitbucket.org')
-        if scm_type == 'git' and parts.scheme.endswith('ssh') and parts.hostname in special_git_hosts and netloc_username != 'git':
-            raise ValueError(_('Username must be "git" for SSH access to %s.') % parts.hostname)
-        if scm_type == 'git' and parts.scheme.endswith('ssh') and parts.hostname in special_git_hosts and netloc_password:
-            # raise ValueError('Password not allowed for SSH access to %s.' % parts.hostname)
-            netloc_password = ''
+        github_hosts = ('github.com',)
+        bitbucket_hosts = ('bitbucket.org', 'altssh.bitbucket.org')
+        allowed_github_usernames = {'git', 'x-access-token'}
+
+        if scm_type == 'git' and parts.scheme.endswith('ssh') and parts.hostname:
+            is_github_host = parts.hostname in github_hosts or parts.hostname.endswith('.github.com')
+            is_bitbucket_host = parts.hostname in bitbucket_hosts or parts.hostname.endswith('.bitbucket.com') or 'bitbucket' in parts.hostname
+
+            if is_github_host and netloc_username not in allowed_github_usernames:
+                raise ValueError(_('Username must be "git" or "x-access-token" (for github app) for SSH access to %s.') % parts.hostname)
+            if is_bitbucket_host and netloc_username != 'git':
+                raise ValueError(_('Username must be "git" for SSH access to %s.') % parts.hostname)
+
+            if (is_github_host or is_bitbucket_host) and netloc_password:
+                # raise ValueError('Password not allowed for SSH access to %s.' % parts.hostname)
+                netloc_password = ''
 
     if netloc_username and parts.scheme != 'file' and scm_type not in ("insights", "archive"):
         netloc = u':'.join([urllib.parse.quote(x, safe='') for x in (netloc_username, netloc_password) if x])


### PR DESCRIPTION
##### SUMMARY

Backports the relevant ansible/awx#15807 SCM URL validation behavior so GitHub App SSH URLs using `x-access-token` pass special Git host validation.

Fixes #292.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ADDITIONAL INFORMATION

Tests:
- `py.test awx/main/tests/unit/utils/test_common.py -k update_scm_url`
- 38 passed, 50 deselected

Hoping I did the pull request correct. Let me know if you need any more information.