### PR TITLE
Upgrade daphne to resolve CVE-2026-44545 CVE-2026-44546

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -14,7 +14,7 @@ channels
 channels-valkey
 cryptography>=46.0.7  # CVE-2026-39892
 Cython>=3 # this is needed as a build dependency, one day we may have separated build deps; <3 cap removed once pyyaml>=6.0.1 supported Cython 3
-daphne
+daphne>=4.2.2  # CVE-2026-44545 CVE-2026-44546
 distro
 django>=5.2.14,<6.0 # CVE-2026-5766 CVE-2026-35192 CVE-2026-6907; <6.0 also enforced by django-ansible-base (Django<6.0, djangorestframework<3.16)
 django-auth-ldap

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -93,7 +93,7 @@ cryptography==46.0.7
     #   social-auth-core
 cython==3.2.5
     # via -r /awx_devel/requirements/requirements.in
-daphne==4.1.2
+daphne==4.2.2
     # via -r /awx_devel/requirements/requirements.in
 defusedxml==0.7.1
     # via


### PR DESCRIPTION
##### SUMMARY

Upgrades `daphne` from 4.1.2 to 4.2.2 to resolve two security advisories in the ASGI server:

- CVE-2026-44545 (PYSEC-2026-213)
- CVE-2026-44546 (PYSEC-2026-214)

4.2.2 is the current latest release, so this is a clean bump-to-latest. Single package, no other dependency changes (daphne's runtime deps, asgiref and twisted, are already satisfied by the existing pins).

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ASCENDER VERSION

```
awx: 25.4.1.dev61+gf6533b2f61
```

##### ADDITIONAL INFORMATION

Found by `pip-audit` against `requirements/requirements.txt` on current main. Validated in the dev container with daphne 4.2.2 installed: the package imports, `awx.main.routing.application` (the ASGI `AWXProtocolTypeRouter`) loads, and `daphne.server` imports cleanly.
