### PR TITLE
Upgrade cryptography to resolve GHSA-537c-gmf6-5ccf

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,7 +12,7 @@ botocore
 cachetools
 channels
 channels-valkey
-cryptography>=46.0.7  # CVE-2026-39892
+cryptography>=49.0.0  # CVE-2026-39892 GHSA-537c-gmf6-5ccf
 Cython>=3 # this is needed as a build dependency, one day we may have separated build deps; <3 cap removed once pyyaml>=6.0.1 supported Cython 3
 daphne
 distro
@@ -40,6 +40,7 @@ jinja2>=3.1.6  # CVE-2025-27516
 JSON-log-formatter
 jsonschema
 Markdown>=3.8.1  # CVE-2025-69534 # used for formatting API help
+msal>=1.37.0  # cryptography>=49 compatibility (msal<1.37 caps cryptography<49)
 openshift
 packaging==24.2
 pexpect==4.7.0  # see library notes
@@ -48,7 +49,7 @@ psycopg
 psutil
 pygerduty
 pygithub
-pyopenssl>=26.0.0  # resolve dep conflict from cryptography pin above
+pyopenssl>=26.3.0  # tracks cryptography pin above (pyopenssl 26.3.0 requires cryptography>=49)
 pyparsing==2.4.6  # Upgrading to v3 of pyparsing introduce errors on smart host filtering: Expected 'or' term, found 'or'  (at char 15), (line:1, col:16)
 python-daemon>3.0.0
 python-dsv-sdk>=1.0.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -79,7 +79,7 @@ click==8.1.7
     # via receptorctl
 constantly==23.10.4
     # via twisted
-cryptography==46.0.7
+cryptography==49.0.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   autobahn
@@ -250,7 +250,7 @@ more-itertools==10.2.0
     #   irc
     #   jaraco-functools
     #   jaraco-text
-msal==1.34.0
+msal==1.37.0
     # via
     #   azure-identity
     #   msal-extensions
@@ -324,7 +324,7 @@ pyjwt[crypto]==2.13.0
     #   twilio
 pynacl==1.6.2
     # via pygithub
-pyopenssl==26.0.0
+pyopenssl==26.3.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   twisted


### PR DESCRIPTION
##### SUMMARY

Upgrades `cryptography` from 46.0.7 to 49.0.0 to resolve **GHSA-537c-gmf6-5ccf**.

`cryptography` is tightly coupled to `pyOpenSSL` in this repo (`requirements.in` already pins pyOpenSSL to track the cryptography pin), so moving cryptography to 49 has to move the two packages that cap it below 49. They go together as one coordinated set, all bumped to their current latest:

- `cryptography` 46.0.7 -> 49.0.0  (fixes GHSA-537c-gmf6-5ccf)
- `pyOpenSSL` 26.0.0 -> 26.3.0  (26.0.0 requires `cryptography<47`; 26.3.0 requires `cryptography>=49`)
- `msal` 1.34.0 -> 1.37.0  (1.34.0 caps `cryptography<49`; 1.37.0 allows `<51`)

cryptography cannot be bumped on its own; pyOpenSSL and msal are forced compatibility bumps.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ASCENDER VERSION

```
awx: 25.4.1.dev61+g50c72c324c
```

##### ADDITIONAL INFORMATION

Found by `pip-audit` against `requirements/requirements.txt` on current main. Validated in the dev container with the three new versions installed:

- `pip check` reports no conflicts among cryptography / pyOpenSSL / msal (the only unrelated notice is a pre-existing `tox`/`cachetools` dev pin).
- Django boots cleanly (`django.setup()`), and `cryptography`, `OpenSSL` and `msal` import.
- The credential-encryption unit suite `awx/main/tests/unit/utils/test_encryption.py` passes 11/11 (Fernet encrypt/decrypt is the main cryptography consumer).
