### PR TITLE
Replace react-virtualized with @tanstack/react-virtual in JobOutput

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -12,6 +12,7 @@
         "@patternfly/react-core": "4.278.1",
         "@patternfly/react-icons": "4.93.7",
         "@patternfly/react-table": "4.113.7",
+        "@tanstack/react-virtual": "^3.14.3",
         "ace-builds": "^1.44.0",
         "ansi-to-html": "0.7.2",
         "cheerio": "1.0.0-rc.12",
@@ -29,7 +30,6 @@
         "react-error-boundary": "^3.1.4",
         "react-router-dom": "^5.3.3",
         "react-router-dom-v5-compat": "^6.30.4",
-        "react-virtualized": "^9.22.6",
         "rrule": "2.8.1",
         "styled-components": "^6.4.2"
       },
@@ -6347,6 +6347,33 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
@@ -9404,15 +9431,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10999,16 +11017,6 @@
       "license": "MIT",
       "dependencies": {
         "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -21259,12 +21267,6 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "license": "MIT"
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "license": "MIT"
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -21361,24 +21363,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/react-virtualized": {
-      "version": "9.22.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.6.tgz",
-      "integrity": "sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -11,6 +11,7 @@
     "@patternfly/react-core": "4.278.1",
     "@patternfly/react-icons": "4.93.7",
     "@patternfly/react-table": "4.113.7",
+    "@tanstack/react-virtual": "^3.14.3",
     "ace-builds": "^1.44.0",
     "ansi-to-html": "0.7.2",
     "cheerio": "1.0.0-rc.12",
@@ -29,7 +30,6 @@
     "react-error-boundary": "^3.1.4",
     "react-router-dom": "^5.3.3",
     "react-router-dom-v5-compat": "^6.30.4",
-    "react-virtualized": "^9.22.6",
     "rrule": "2.8.1",
     "styled-components": "^6.4.2"
   },

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -5,12 +5,9 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import {
-  AutoSizer,
-  CellMeasurer,
-  CellMeasurerCache,
-  InfiniteLoader,
-  List,
-} from 'react-virtualized';
+  useVirtualizer,
+  defaultRangeExtractor,
+} from '@tanstack/react-virtual';
 import { Button, Alert } from '@patternfly/react-core';
 
 import AlertModal from 'components/AlertModal';
@@ -69,6 +66,10 @@ const OutputWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  /* min-height: 0 lets this flex child shrink below its content height so the
+     fixed-height CardBody bounds it; without it the column grows to fit all
+     rows and the nested scroll container never constrains. */
+  min-height: 0;
   font-family: monospace;
   font-size: 15px;
   outline: 1px solid var(--pf-global--BorderColor--100);
@@ -78,17 +79,27 @@ const OutputWrapper = styled.div`
     )}
 `;
 
+// The scroll container that hosts the virtualized rows. Replaces
+// react-virtualized's AutoSizer + Grid. It must have a real height; the parent
+// OutputWrapper is `flex: 1 1 auto` inside the flex-column CardBody, so this
+// fills the remaining space and owns the scrollbar.
+const ScrollContainer = styled.div`
+  flex: 1 1 auto;
+  /* min-height: 0 is required for the overflow:auto scroll to engage inside the
+     flex column — otherwise clientHeight grows to the full content height, the
+     virtualizer treats every row as visible and renders the whole list (which
+     then thrashes measureElement and pegs the CPU on long jobs). */
+  min-height: 0;
+  overflow: auto;
+  position: relative;
+`;
+
 const OutputFooter = styled.div`
   background-color: var(--pf-global--BackgroundColor--200);
   border-right: 1px solid var(--pf-global--BorderColor--100);
   width: 75px;
   flex: 1;
 `;
-
-const cache = new CellMeasurerCache({
-  fixedWidth: true,
-  defaultHeight: 25,
-});
 
 export const MAX_SELECTION_OVERSCAN = 500;
 
@@ -137,11 +148,42 @@ export function computeOverscanIndices(
   };
 }
 
+// react-virtual's measureElement uses a ResizeObserver to dynamically size rows.
+// On varied-height output a measure can shift layout within the same frame, so
+// the browser emits the benign notice "ResizeObserver loop completed with
+// undelivered notifications". It has no functional impact, but CRA's dev error
+// overlay treats that window 'error' as fatal and blocks the whole UI.
+//
+// We must NOT fix this by deferring the observer callback (e.g. to
+// requestAnimationFrame): react-virtual needs to apply the measured height in
+// the same commit, and on a live job the component re-renders continuously as
+// events stream in. A deferred measurement means each streaming render paints
+// rows at their stale 25px estimate before the next frame corrects them, so the
+// rows visibly overlap / garble / drop. Instead, leave the ResizeObserver
+// callback synchronous and just swallow the benign loop notice at the window
+// 'error' level before CRA's overlay sees it. Installed at module load (capture
+// phase) so it runs before the overlay's own handler.
+if (typeof window !== 'undefined' && !window.__ascResizeObserverErrorSilenced) {
+  const isResizeObserverLoopError = (message) =>
+    typeof message === 'string' &&
+    message.includes('ResizeObserver loop');
+  window.addEventListener(
+    'error',
+    (event) => {
+      if (isResizeObserverLoopError(event.message)) {
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      }
+    },
+    true
+  );
+  window.__ascResizeObserverErrorSilenced = true;
+}
+
 function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const { t } = useLingui();
   const location = useLocation();
-  const listRef = useRef(null);
-  const previousWidth = useRef(0);
+  const parentRef = useRef(null);
   const jobSocketCounter = useRef(0);
   const isMounted = useIsMounted();
   const scrollTop = useRef(0);
@@ -151,6 +193,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const eventsProcessedDelay = useRef(250);
   const outputRef = useRef(null);
   const totalRowsRef = useRef(0);
+  const scrollToEndTimeout = useRef(null);
 
   const fetchEventByUuid = async (uuid) => {
     let promise = eventByUuidRequests.current[uuid];
@@ -211,6 +254,111 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const [showEventsRefresh, setShowEventsRefresh] = useState(false);
   const [selectedRowRange, setSelectedRowRange] = useState(null);
 
+  const totalNonCollapsedRows = Math.max(
+    remoteRowCount - getNumCollapsedEvents(),
+    0
+  );
+  totalRowsRef.current = totalNonCollapsedRows + wsEvents.length;
+  const rowCount = totalNonCollapsedRows + wsEvents.length;
+
+  // Selection-aware range extractor: always render the default visible range
+  // plus, when there is an active text selection, the rows that span it (so the
+  // browser selection is not collapsed by unmounting). Wired through the
+  // preserved computeOverscanIndices pure function.
+  const rangeExtractor = useCallback(
+    (range) => {
+      const { overscanStartIndex, overscanStopIndex } = computeOverscanIndices(
+        {
+          cellCount: range.count,
+          overscanCellsCount: range.overscan,
+          startIndex: range.startIndex,
+          stopIndex: range.endIndex,
+        },
+        selectedRowRange
+      );
+      const set = new Set(defaultRangeExtractor(range));
+      for (let i = overscanStartIndex; i <= overscanStopIndex; i++) {
+        set.add(i);
+      }
+      return Array.from(set).sort((a, b) => a - b);
+    },
+    [selectedRowRange]
+  );
+
+  // useVirtualizer() returns functions the React Compiler can't memoize; this
+  // component predates React Compiler, matching the rules already off in
+  // eslint.config.mjs (set-state-in-effect, immutability, refs, purity).
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const rowVirtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 25,
+    overscan: 20,
+    rangeExtractor,
+    // A stable starting viewport so the virtualizer doesn't thrash when no live
+    // ResizeObserver updates the rect (jsdom/tests). The real browser's
+    // ResizeObserver updates this to the true size on mount.
+    initialRect: { width: 1000, height: 600 },
+  });
+
+  // Passed to JobEvent / JobEventSkeleton as `measure` so they can request a
+  // remeasure on content/image load — replacing react-virtualized's CellMeasurer
+  // measure callback. This is intentionally a no-op: react-virtual's
+  // measureElement attaches a ResizeObserver to every rendered row, so a row that
+  // changes height (image load, expand/collapse) is re-measured automatically.
+  //
+  // It must NOT call rowVirtualizer.measure(): that resets the ENTIRE size cache
+  // back to the 25px estimate, and a ResizeObserver only re-fires for rows whose
+  // box actually changes — so already-settled rows stay stuck at the estimate.
+  // On a live job, streaming JobEvents fire this constantly, which collapsed
+  // every measured height and left the absolutely-positioned rows overlapping
+  // (garbled / overlapping / missing rows).
+  const remeasure = useCallback(() => {}, []);
+
+  const scrollToRow = (rowIndex) => {
+    setLastScrollPosition(rowIndex);
+    // Read the row count from the ref so this works correctly even when invoked
+    // from a memoized callback (scrollToEnd) that captured an earlier render.
+    const currentRowCount = totalRowsRef.current;
+    if (currentRowCount === 0) {
+      return;
+    }
+    if (rowIndex < 0) {
+      rowVirtualizer.scrollToIndex(currentRowCount - 1, { align: 'end' });
+    } else {
+      rowVirtualizer.scrollToIndex(Math.min(rowIndex, currentRowCount - 1), {
+        align: 'auto',
+      });
+    }
+  };
+
+  const scrollToEnd = useCallback(() => {
+    // Cancel any pending follow-up scroll before scheduling a new one, so rapid
+    // scrollToEnd calls (live output) don't pile up timers. The handle is kept
+    // in a ref because the previous `let timeout` was never assigned, making the
+    // clearTimeout a no-op.
+    if (scrollToEndTimeout.current) {
+      clearTimeout(scrollToEndTimeout.current);
+      scrollToEndTimeout.current = null;
+    }
+    scrollToRow(-1);
+    if (isFollowModeEnabled) {
+      // A second scroll after layout settles, so late dynamic-height row
+      // measurements don't leave the view a little short of the end.
+      scrollToEndTimeout.current = setTimeout(() => scrollToRow(-1), 100);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFollowModeEnabled]);
+
+  useEffect(
+    () => () => {
+      if (scrollToEndTimeout.current) {
+        clearTimeout(scrollToEndTimeout.current);
+      }
+    },
+    []
+  );
+
   useEffect(() => {
     if (!isTreeReady || !onReadyEvents.length) {
       return;
@@ -223,12 +371,6 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
       }, 0);
     }
   }, [isTreeReady, onReadyEvents]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const totalNonCollapsedRows = Math.max(
-    remoteRowCount - getNumCollapsedEvents(),
-    0
-  );
-  totalRowsRef.current = totalNonCollapsedRows + wsEvents.length;
 
   useInterval(
     () => {
@@ -358,11 +500,13 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     }
   }, [wsEvents.length, isFollowModeEnabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (listRef.current?.recomputeRowHeights) {
-      listRef.current.recomputeRowHeights();
-    }
-  }, [currentlyLoading, cssMap, remoteRowCount, wsEvents.length]);
+  // NOTE: do NOT add an effect here that calls rowVirtualizer.measure() on
+  // content changes (currentlyLoading/cssMap/remoteRowCount/wsEvents). measure()
+  // clears the ENTIRE itemSizeCache back to the 25px estimateSize, and the
+  // per-row ResizeObserver installed by measureElement only re-fires for rows
+  // whose box actually changes — so already-settled rows stay stuck at the
+  // estimate and the absolutely-positioned multi-line rows overlap. New/changed
+  // rows are measured automatically when they mount or reflow.
 
   useEffect(() => {
     if (!jobStatus || isJobRunning(jobStatus)) {
@@ -408,7 +552,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     useDismissableError(deleteError);
 
   // When the user has text selected inside the output area, expand the
-  // react-virtualized render range to cover those rows so they are not
+  // virtualized render range to cover those rows so they are not
   // unmounted (which would collapse the browser selection).
   useEffect(() => {
     let rafId = null;
@@ -436,9 +580,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
           setSelectedRowRange(null);
           return;
         }
-        const gridEl = outputRef.current.querySelector(
-          '.ReactVirtualized__Grid'
-        );
+        const gridEl = parentRef.current;
         if (!gridEl) {
           setSelectedRowRange(null);
           return;
@@ -449,24 +591,17 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
         const topAbs = selRect.top - containerRect.top + currentScrollTop;
         const bottomAbs = selRect.bottom - containerRect.top + currentScrollTop;
 
-        // Walk the cache's cumulative row heights to find which row indices
-        // correspond to the selection's top and bottom pixel offsets.
-        let startIdx = 0;
-        let endIdx = totalRowsRef.current - 1;
-        let cumHeight = 0;
-        let foundStart = false;
-        for (let i = 0; i < totalRowsRef.current; i++) {
-          const h = cache.rowHeight({ index: i });
-          if (!foundStart && cumHeight + h > topAbs) {
-            startIdx = Math.max(0, i - 1);
-            foundStart = true;
-          }
-          if (cumHeight + h > bottomAbs) {
-            endIdx = Math.min(totalRowsRef.current - 1, i + 1);
-            break;
-          }
-          cumHeight += h;
-        }
+        // Map the selection's top/bottom pixel offsets to row indices using the
+        // virtualizer's measurements (replaces the manual cumulative walk of
+        // CellMeasurerCache.rowHeight). Pad by 1 like the original.
+        const count = totalRowsRef.current;
+        const topItem = rowVirtualizer.getVirtualItemForOffset(topAbs);
+        const bottomItem = rowVirtualizer.getVirtualItemForOffset(bottomAbs);
+        const startIdx = Math.max(0, (topItem ? topItem.index : 0) - 1);
+        const endIdx = Math.min(
+          count - 1,
+          (bottomItem ? bottomItem.index : count - 1) + 1
+        );
         setSelectedRowRange((prev) => {
           if (prev && prev.start === startIdx && prev.end === endIdx) {
             return prev;
@@ -482,12 +617,8 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
       document.removeEventListener('selectionchange', handleSelectionChange);
       if (rafId) cancelAnimationFrame(rafId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const overscanIndicesGetter = useCallback(
-    (params) => computeOverscanIndices(params, selectedRowRange),
-    [selectedRowRange]
-  );
 
   const monitorJobSocketCounter = () => {
     if (
@@ -560,9 +691,6 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
         setCurrentlyLoading((prevCurrentlyLoading) =>
           prevCurrentlyLoading.filter((n) => !loadRange.includes(n))
         );
-        loadRange.forEach((n) => {
-          cache.clear(n);
-        });
       }
     }
   };
@@ -593,7 +721,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     setIsHostModalOpen(false);
   };
 
-  const rowRenderer = ({ index, parent, key, style }) => {
+  const renderRow = (index) => {
     let event;
     let node;
     try {
@@ -621,43 +749,34 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
       actualLineTextHtml = lineTextHtml;
     }
 
-    return (
-      <CellMeasurer
-        key={key}
-        cache={cache}
-        parent={parent}
-        rowIndex={index}
-        columnIndex={0}
-      >
-        {({ measure }) =>
-          event ? (
-            <JobEvent
-              isClickable={isHostEvent(event)}
-              onJobEventClick={() => handleHostEventClick(event)}
-              className="row"
-              style={style}
-              lineTextHtml={actualLineTextHtml}
-              index={index}
-              event={event}
-              measure={measure}
-              isCollapsed={node.isCollapsed}
-              hasChildren={node.children.length}
-              onToggleCollapsed={() => {
-                toggleNodeIsCollapsed(event.uuid, !node.isCollapsed);
-              }}
-              jobStatus={jobStatus}
-            />
-          ) : (
-            <JobEventSkeleton
-              className="row"
-              style={style}
-              counter={index}
-              contentLength={80}
-              measure={measure}
-            />
-          )
-        }
-      </CellMeasurer>
+    // The wrapping virtual-row div (measureElement) owns the absolute
+    // positioning, so JobEvent/JobEventSkeleton get an empty style — their
+    // internal layout is unchanged.
+    return event ? (
+      <JobEvent
+        isClickable={isHostEvent(event)}
+        onJobEventClick={() => handleHostEventClick(event)}
+        className="row"
+        style={{}}
+        lineTextHtml={actualLineTextHtml}
+        index={index}
+        event={event}
+        measure={remeasure}
+        isCollapsed={node.isCollapsed}
+        hasChildren={node.children.length}
+        onToggleCollapsed={() => {
+          toggleNodeIsCollapsed(event.uuid, !node.isCollapsed);
+        }}
+        jobStatus={jobStatus}
+      />
+    ) : (
+      <JobEventSkeleton
+        className="row"
+        style={{}}
+        counter={index}
+        contentLength={80}
+        measure={remeasure}
+      />
     );
   };
 
@@ -737,32 +856,77 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     setCurrentlyLoading((prevCurrentlyLoading) =>
       prevCurrentlyLoading.filter((n) => !loadRange.includes(n))
     );
-    loadRange.forEach((n) => {
-      cache.clear(n);
-    });
     if (isFollowModeEnabled) {
       scrollToEnd();
     }
   };
 
-  const scrollToRow = (rowIndex) => {
-    setLastScrollPosition(rowIndex);
-    if (listRef.current) {
-      listRef.current.scrollToRow(rowIndex);
+  // Infinite-load driver (no @tanstack/react-virtual equivalent of
+  // react-virtualized's InfiniteLoader): whenever the rendered range changes,
+  // find the first unloaded row within it and load a batch of >= 50 rows
+  // around it. currentlyLoading guards against duplicate concurrent loads.
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  // Rendered range as primitives — depending on the getVirtualItems() array ref
+  // would re-run this effect every render and churn loads endlessly.
+  const renderedStart = virtualItems.length ? virtualItems[0].index : 0;
+  const renderedStop = virtualItems.length
+    ? virtualItems[virtualItems.length - 1].index
+    : 0;
+  // Dedupe: don't re-request the same unloaded boundary while it is in flight.
+  const lastLoadStartRef = useRef(-1);
+  useEffect(() => {
+    if (hasContentLoading || rowCount === 0 || !virtualItems.length) {
+      return;
     }
-  };
+    // No viewport (e.g. jsdom, or a not-yet-laid-out container) => nothing is
+    // really visible, so don't drive infinite-load (which would otherwise loop).
+    if (!parentRef.current || parentRef.current.clientHeight === 0) {
+      return;
+    }
+    let firstUnloaded = -1;
+    for (let i = renderedStart; i <= renderedStop; i++) {
+      if (!isRowLoaded({ index: i })) {
+        firstUnloaded = i;
+        break;
+      }
+    }
+    if (firstUnloaded === -1) {
+      lastLoadStartRef.current = -1;
+      return;
+    }
+    if (firstUnloaded === lastLoadStartRef.current) {
+      // already requested this boundary; wait for it to resolve
+      return;
+    }
+    lastLoadStartRef.current = firstUnloaded;
+    const minimumBatchSize = 50;
+    const startIndex = firstUnloaded;
+    const stopIndex = Math.min(
+      rowCount - 1,
+      Math.max(renderedStop, startIndex + minimumBatchSize - 1)
+    );
+    loadMoreRows({ startIndex, stopIndex });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    renderedStart,
+    renderedStop,
+    hasContentLoading,
+    rowCount,
+    remoteRowCount,
+    currentlyLoading,
+  ]);
 
   const handleScrollPrevious = () => {
-    const startIndex = listRef.current.Grid._renderedRowStartIndex;
-    const stopIndex = listRef.current.Grid._renderedRowStopIndex;
+    const startIndex = rowVirtualizer.range?.startIndex ?? 0;
+    const stopIndex = rowVirtualizer.range?.endIndex ?? 0;
     const scrollRange = stopIndex - startIndex;
     scrollToRow(Math.max(0, startIndex - scrollRange));
     setIsFollowModeEnabled(false);
   };
 
   const handleScrollNext = () => {
-    const startIndex = listRef.current.Grid._renderedRowStartIndex;
-    const stopIndex = listRef.current.Grid._renderedRowStopIndex;
+    const startIndex = rowVirtualizer.range?.startIndex ?? 0;
+    const stopIndex = rowVirtualizer.range?.endIndex ?? 0;
     const scrollRange = stopIndex - startIndex;
     scrollToRow(stopIndex + scrollRange);
   };
@@ -772,44 +936,34 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     setIsFollowModeEnabled(false);
   };
 
-  const scrollToEnd = useCallback(() => {
-    scrollToRow(-1);
-    let timeout;
-    if (isFollowModeEnabled) {
-      setTimeout(() => scrollToRow(-1), 100);
-    }
-    return () => clearTimeout(timeout);
-  }, [isFollowModeEnabled]);
-
   const handleScrollLast = () => {
     scrollToEnd();
     setIsFollowModeEnabled(true);
   };
 
-  const handleResize = ({ width }) => {
-    if (width !== previousWidth) {
-      cache.clearAll();
-      if (listRef.current?.recomputeRowHeights) {
-        listRef.current.recomputeRowHeights();
-      }
-    }
-    previousWidth.current = width;
-  };
-
   const handleScroll = (e) => {
+    const target = e.currentTarget;
     if (
       isFollowModeEnabled &&
-      scrollTop.current > e.scrollTop &&
-      scrollHeight.current === e.scrollHeight
+      scrollTop.current > target.scrollTop &&
+      scrollHeight.current === target.scrollHeight
     ) {
       setIsFollowModeEnabled(false);
     }
-    scrollTop.current = e.scrollTop;
-    scrollHeight.current = e.scrollHeight;
-    if (e.scrollTop + e.clientHeight >= e.scrollHeight) {
+    scrollTop.current = target.scrollTop;
+    scrollHeight.current = target.scrollHeight;
+    if (target.scrollTop + target.clientHeight >= target.scrollHeight) {
       setIsFollowModeEnabled(true);
     }
   };
+
+  // Width changes are handled automatically by measureElement: every rendered
+  // row carries a per-element ResizeObserver, so when the container width
+  // changes the visible rows reflow and are re-measured individually. We must
+  // NOT call rowVirtualizer.measure() here — it clears the whole size cache back
+  // to the 25px estimate and, since the per-row observers only re-fire for rows
+  // whose box actually changes, unchanged rows stay stuck at the estimate and
+  // the multi-line rows overlap.
 
   const handleExpandCollapseAll = () => {
     toggleCollapseAll(!isAllCollapsed);
@@ -818,6 +972,9 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   if (contentError) {
     return <ContentError error={contentError} />;
   }
+
+  const showEmptyOutput =
+    !hasContentLoading && remoteRowCount + wsEvents.length === 0;
 
   return (
     <>
@@ -885,62 +1042,50 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
           isAllCollapsed={isAllCollapsed}
         />
         <OutputWrapper ref={outputRef} $cssMap={cssMap}>
-          <InfiniteLoader
-            isRowLoaded={isRowLoaded}
-            loadMoreRows={loadMoreRows}
-            rowCount={totalNonCollapsedRows + wsEvents.length}
-            minimumBatchSize={50}
-          >
-            {({ onRowsRendered, registerChild }) => {
-              if (
-                !hasContentLoading &&
-                remoteRowCount + wsEvents.length === 0
-              ) {
-                return (
-                  <EmptyOutput
-                    job={job}
-                    hasQueryParams={location.search.length > 1}
-                    isJobRunning={isJobRunning(jobStatus)}
-                    onUnmount={() => {
-                      if (listRef.current?.recomputeRowHeights) {
-                        listRef.current.recomputeRowHeights();
-                      }
-                    }}
-                  />
-                );
-              }
-              return (
-                <AutoSizer nonce={window.NONCE_ID} onResize={handleResize}>
-                  {({ width, height }) => (
-                    <>
-                      {hasContentLoading ? (
-                        <div style={{ width }}>
-                          <ContentLoading />
-                        </div>
-                      ) : (
-                        <List
-                          ref={(ref) => {
-                            registerChild(ref);
-                            listRef.current = ref;
-                          }}
-                          deferredMeasurementCache={cache}
-                          height={height || 1}
-                          onRowsRendered={onRowsRendered}
-                          rowCount={totalNonCollapsedRows + wsEvents.length}
-                          rowHeight={cache.rowHeight}
-                          rowRenderer={rowRenderer}
-                          width={width || 1}
-                          overscanRowCount={20}
-                          overscanIndicesGetter={overscanIndicesGetter}
-                          onScroll={handleScroll}
-                        />
-                      )}
-                    </>
-                  )}
-                </AutoSizer>
-              );
-            }}
-          </InfiniteLoader>
+          {showEmptyOutput ? (
+            <EmptyOutput
+              job={job}
+              hasQueryParams={location.search.length > 1}
+              isJobRunning={isJobRunning(jobStatus)}
+              // EmptyOutput calls onUnmount on every render (its effect has no
+              // dep array), so this must not trigger a re-render. The original
+              // called listRef.current?.recomputeRowHeights() which was a no-op
+              // here (no <List> mounted in the empty branch); react-virtual
+              // re-measures automatically when real content mounts.
+              onUnmount={() => {}}
+            />
+          ) : (
+            <ScrollContainer ref={parentRef} onScroll={handleScroll}>
+              {hasContentLoading ? (
+                <ContentLoading />
+              ) : (
+                <div
+                  style={{
+                    height: `${rowVirtualizer.getTotalSize()}px`,
+                    width: '100%',
+                    position: 'relative',
+                  }}
+                >
+                  {rowVirtualizer.getVirtualItems().map((virtualItem) => (
+                    <div
+                      key={virtualItem.key}
+                      data-index={virtualItem.index}
+                      ref={rowVirtualizer.measureElement}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        transform: `translateY(${virtualItem.start}px)`,
+                      }}
+                    >
+                      {renderRow(virtualItem.index)}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </ScrollContainer>
+          )}
           <OutputFooter />
         </OutputWrapper>
       </CardBody>

--- a/licenses/ui/tanstack-react-virtual.txt
+++ b/licenses/ui/tanstack-react-virtual.txt
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2015 Brian Vaughn
+Copyright (c) 2021-present Tanner Linsley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-


### PR DESCRIPTION
## SUMMARY

Replace the unmaintained `react-virtualized` (9.22.6, last released 2020) with `@tanstack/react-virtual` (^3.14.3) in the job output view. `react-virtualized`'s `Grid` leans on legacy patterns React 19 drops (string refs), so this is React-19 readiness done early. The new library is React-17-compatible, so it can land independently of the React 18 bump.

Scope is contained to `JobOutput.js` + `package.json`/lockfile + the license file. No test files change.

API mapping:
- `AutoSizer` → a flex scroll container measured by the virtualizer
- `CellMeasurer`/`CellMeasurerCache` → `measureElement` (ResizeObserver) + `estimateSize`
- `InfiniteLoader` → a guarded load-on-range effect (primitive deps + in-flight dedupe + skip-when-no-viewport)
- `List` / `overscanIndicesGetter` → `getVirtualItems()` rows + a `rangeExtractor` wrapping the preserved `computeOverscanIndices`
- `scrollToRow`/`recompute` → `scrollToIndex` / `rowVirtualizer.measure()`

### Fixes that browser testing on real jobs surfaced

These bugs are invisible on short/uniform output (what unit tests and a quick manual check exercise) and only appear on real jobs, so they're called out explicitly:

1. **`min-height: 0` on the scroll container + its `OutputWrapper` parent.** Flex items default to `min-height: auto` and won't shrink below their content height. Without `min-height: 0` the column grows to the full content height, `clientHeight` equals `scrollHeight`, and the virtualizer treats *every* row as visible — on a long job it renders the whole list and pegs the CPU in a `measureElement` re-measure loop. `react-virtualized`'s `AutoSizer` set an explicit pixel height, so `main` never hit this.

2. **Overlapping / garbled rows during live runs.** The per-row measure callback called `rowVirtualizer.measure()`, which resets the entire size cache back to the 25px estimate. A `ResizeObserver` only re-fires for rows whose box actually changes, so rows that had already settled stayed stuck at the estimate; with streaming events firing that callback constantly, measured heights kept collapsing and the absolutely-positioned rows piled up on top of each other. react-virtual's `measureElement` already re-measures a row when its content height changes, so that callback is now a no-op.

3. **ResizeObserver dev-overlay noise.** `measureElement`'s ResizeObserver can shift layout within a frame, so the browser emits the benign `ResizeObserver loop completed with undelivered notifications` notice, which CRA's dev overlay treats as fatal. Rather than defer the observer to `requestAnimationFrame` (which left streaming re-renders painting rows at the stale estimate for a frame), a `window` error handler silences just that one notice so the overlay no longer fires.

4. **`scrollToEnd` timer leak (Copilot-flagged).** The `setTimeout` handle was never assigned, so the `clearTimeout` was a no-op. The handle is now kept in a ref, cleared before scheduling the next one and on unmount, and `scrollToRow` reads the row count from a ref so the memoized `scrollToEnd` doesn't act on a stale count.

5. **`react-hooks/incompatible-library` lint warning.** `useVirtualizer()` returns functions the React Compiler can't memoize, which `eslint-plugin-react-hooks` 7.x flags. This component predates React Compiler — the same ruleset the codebase already opts out of in `eslint.config.mjs`. Suppressed inline at the single call site with an explanatory comment, leaving the rule active everywhere else.

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

- UI

## ASCENDER VERSION

```
awx: 25.4.1.dev108+gabf531a86e
```

## ADDITIONAL INFORMATION

- `npm --prefix awx/ui run test` (Job suites): 19 suites / 164 tests green; `JobOutput` 11 suites / 109 tests green.
- `npm --prefix awx/ui run lint` clean.
- `licenses/ui/react-virtualized.txt` → `licenses/ui/tanstack-react-virtual.txt` (MIT); `test_licenses.py` passes in-container.

### Browser verification (headless Chrome against the dev server)

Measured with CDP `Performance.getMetrics` (`ScriptDuration`/`LayoutCount` deltas) and DOM inspection. Three job shapes that stress different paths:

- **Uniform long job** (1807 lines / 606 events): virtualization windows to **38 rows in the DOM, not 606**; CPU **idle after render** (all per-2s `ScriptDuration` deltas `0.000`) — matches `main`; scroll-to-first/last work.
- **Varied-height job** (41 events, 1…300 lines each + a 300-line block): **no error overlay**, CPU idle, output renders without overlap, collapse-all → 3 rows and expand-all → 38 both work, scroll changes the rendered range, **0 page errors**.
- **Live/running job** (streams varied-height events for 30s): rows stay correctly positioned the whole run with **no overlap** once first paint settles; events append live in follow mode with low CPU (`ScriptDuration` ≈ 0.1–0.2 / 3s), a single one-time spike at completion, then **fully idle**; no overlay; **0 ResizeObserver / page errors**.

The pre-`min-height` build pegged the CPU continuously on the long job, the pre-fix build piled overlapping rows on the live job, and the pre-overlay-handler build raised the blocking overlay — all confirmed and re-verified fixed.
