### PR TITLE
Hoist ScheduleOccurrences default time zone to a module constant

### DIFF
--- a/awx/ui/src/components/Schedule/ScheduleOccurrences/ScheduleOccurrences.js
+++ b/awx/ui/src/components/Schedule/ScheduleOccurrences/ScheduleOccurrences.js
@@ -22,9 +22,15 @@ const OccurrencesLabel = styled.div`
   }
 `;
 
+// Resolve the browser's time zone once at module load rather than on every
+// render. As a `defaultProps` value this was evaluated a single time; an ES
+// default parameter re-runs `Intl.DateTimeFormat()` on each render when `tz`
+// is omitted, so hoist it to a module constant to preserve the old timing.
+const DEFAULT_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 function ScheduleOccurrences({
   preview = { local: [], utc: [] },
-  tz = Intl.DateTimeFormat().resolvedOptions().timeZone,
+  tz = DEFAULT_TIME_ZONE,
 }) {
   const { t } = useLingui();
   const [mode, setMode] = useState('local');


### PR DESCRIPTION
##### SUMMARY

Follow-up to the `defaultProps` → ES default-parameters conversion (#491), addressing the review suggestion that was deferred to a separate PR.

In `ScheduleOccurrences`, the `tz` prop default became:

```js
tz = Intl.DateTimeFormat().resolvedOptions().timeZone
```

As a `defaultProps` value the browser time zone was resolved **once** at module initialization. As an ES default parameter, `Intl.DateTimeFormat().resolvedOptions().timeZone` re-runs on **every render** where `tz` is omitted. This hoists the lookup to a module-level `DEFAULT_TIME_ZONE` constant so it is evaluated a single time, restoring the original timing. The resolved value is unchanged.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ASCENDER VERSION

```
awx: 25.4.1.dev111+ga2e996cf10
```

##### ADDITIONAL INFORMATION

- `npm --prefix awx/ui run lint` clean; `ScheduleOccurrences` suite (4 tests) green.
