### PR TITLE
Upgrade react-error-boundary from 3.1.4 to 6.1.2

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -26,7 +26,7 @@
         "react": "18.3.1",
         "react-ace": "^10.1.0",
         "react-dom": "18.3.1",
-        "react-error-boundary": "^3.1.4",
+        "react-error-boundary": "^6.1.2",
         "react-router-dom": "^6.30.4",
         "rrule": "2.8.1",
         "styled-components": "^6.4.2"
@@ -2240,6 +2240,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
       "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -21107,19 +21108,12 @@
       }
     },
     "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
       "peerDependencies": {
-        "react": ">=16.13.1"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-error-overlay": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -26,7 +26,7 @@
     "react": "18.3.1",
     "react-ace": "^10.1.0",
     "react-dom": "18.3.1",
-    "react-error-boundary": "^3.1.4",
+    "react-error-boundary": "^6.1.2",
     "react-router-dom": "^6.30.4",
     "rrule": "2.8.1",
     "styled-components": "^6.4.2"


### PR DESCRIPTION
## SUMMARY

Upgrade `react-error-boundary` from 3.1.4 to 6.1.2.

v6 drops the deprecated `useErrorHandler` hook (renamed to `useErrorBoundary` in v4, removed in v5). Our only usage is the `ErrorBoundary` component with `FallbackComponent` in `App.js`, which is stable across all versions. No code changes needed.

v6 also narrows the React peer dependency to `^18 || ^19`, aligning with the React 18 upgrade in PR #501.

Depends on: #501

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

UI

## ASCENDER VERSION

```
awx: 25.4.1.dev126+gebb3790da5
```

## ADDITIONAL INFORMATION

All 552 test suites pass (2908 tests). No code changes — only `package.json` and `package-lock.json`.