### PR TITLE
Upgrade react-ace from 10.1.0 to 14.0.1

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -24,7 +24,7 @@
         "js-yaml": "4.2.0",
         "luxon": "^3.7.2",
         "react": "18.3.1",
-        "react-ace": "^10.1.0",
+        "react-ace": "^14.0.1",
         "react-dom": "18.3.1",
         "react-error-boundary": "^3.1.4",
         "react-router-dom": "^6.30.4",
@@ -20995,20 +20995,20 @@
       }
     },
     "node_modules/react-ace": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-10.1.0.tgz",
-      "integrity": "sha512-VkvUjZNhdYTuKOKQpMIZi7uzZZVgzCjM7cLYu6F64V0mejY8a2XTyPUIMszC6A4trbeMIHbK5fYFcT/wkP/8VA==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-14.0.1.tgz",
+      "integrity": "sha512-z6YAZ20PNf/FqmYEic//G/UK6uw0rn21g58ASgHJHl9rfE4nITQLqthr9rHMVQK4ezwohJbp2dGrZpkq979PYQ==",
       "license": "MIT",
       "dependencies": {
-        "ace-builds": "^1.4.14",
+        "ace-builds": "^1.36.3",
         "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-app-polyfill": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -24,7 +24,7 @@
     "js-yaml": "4.2.0",
     "luxon": "^3.7.2",
     "react": "18.3.1",
-    "react-ace": "^10.1.0",
+    "react-ace": "^14.0.1",
     "react-dom": "18.3.1",
     "react-error-boundary": "^3.1.4",
     "react-router-dom": "^6.30.4",


### PR DESCRIPTION
## SUMMARY

Upgrade `react-ace` from 10.1.0 to 14.0.1. No code changes needed — the component API (mode, theme, setOptions, commands, ref with `refEditor`) is stable across major versions.

Used in one component (`CodeEditor.js`) and exercised by 28 test files; all pass.

Depends on: #501

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

UI

## ASCENDER VERSION

```
awx: 25.4.1.dev126+gebb3790da5
```

## ADDITIONAL INFORMATION

All 552 test suites pass (2908 tests). No code changes — only `package.json` and `package-lock.json`.