### PR TITLE
Upgrade react-router-dom v6 to react-router v7

### DIFF
--- a/awx/ui/config/jest/textEncoderPolyfill.js
+++ b/awx/ui/config/jest/textEncoderPolyfill.js
@@ -1,0 +1,8 @@
+const { TextEncoder, TextDecoder } = require('util');
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder;
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = TextDecoder;
+}

--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -27,7 +27,7 @@
         "react-ace": "^14.0.1",
         "react-dom": "18.3.1",
         "react-error-boundary": "^6.1.2",
-        "react-router-dom": "^6.30.4",
+        "react-router": "^7.18.0",
         "rrule": "2.8.1",
         "styled-components": "^6.4.2"
       },
@@ -5736,15 +5736,6 @@
         "webpack-plugin-serve": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rspack/binding": {
@@ -21146,35 +21137,38 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/readable-stream": {
@@ -22149,6 +22143,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -6,6 +6,7 @@
     "node": ">=22.19.0"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@lingui/react": "^6.3.0",
     "@patternfly/patternfly": "4.224.5",
     "@patternfly/react-core": "4.278.1",
@@ -16,7 +17,6 @@
     "ansi-to-html": "0.7.2",
     "cheerio": "1.0.0-rc.12",
     "d3": "7.9.0",
-    "@dagrejs/dagre": "^3.0.0",
     "dompurify": "^3.4.11",
     "formik": "2.4.9",
     "has-ansi": "5.0.1",
@@ -27,7 +27,7 @@
     "react-ace": "^14.0.1",
     "react-dom": "18.3.1",
     "react-error-boundary": "^6.1.2",
-    "react-router-dom": "^6.30.4",
+    "react-router": "^7.18.0",
     "rrule": "2.8.1",
     "styled-components": "^6.4.2"
   },
@@ -154,6 +154,7 @@
       "testUtils/**/*.{js,jsx}"
     ],
     "setupFiles": [
+      "<rootDir>/config/jest/textEncoderPolyfill.js",
       "react-app-polyfill/jsdom"
     ],
     "setupFilesAfterEnv": [

--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -6,7 +6,7 @@ import {
   Navigate,
   useLocation,
   useNavigate,
-} from 'react-router-dom';
+} from 'react-router';
 import { ErrorBoundary } from 'react-error-boundary';
 import locationReplace from 'util/navigation';
 import { I18nProvider } from '@lingui/react';

--- a/awx/ui/src/components/AdHocCommands/AdHocCommands.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommands.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
@@ -19,8 +19,8 @@ jest.mock('../../api/models/Credentials');
 jest.mock('../../api/models/ExecutionEnvironments');
 jest.mock('../../api/models/Root');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/components/AddRole/SelectResourceStep.js
+++ b/awx/ui/src/components/AddRole/SelectResourceStep.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import useRequest from 'hooks/useRequest';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/components/AppContainer/NavExpandableGroup.js
+++ b/awx/ui/src/components/AppContainer/NavExpandableGroup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { matchPath, Link, useLocation  } from 'react-router-dom';
+import { matchPath, Link, useLocation  } from 'react-router';
 import { NavExpandable, NavItem } from '@patternfly/react-core';
 
 function NavExpandableGroup(props) {

--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
@@ -4,7 +4,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styled from 'styled-components';
 import {
   Dropdown,

--- a/awx/ui/src/components/ContentError/ContentError.js
+++ b/awx/ui/src/components/ContentError/ContentError.js
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/components/DetailList/LaunchedByDetail.js
+++ b/awx/ui/src/components/DetailList/LaunchedByDetail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import getScheduleUrl from 'util/getScheduleUrl';
 import Detail from './Detail';

--- a/awx/ui/src/components/DetailList/UserDateDetail.js
+++ b/awx/ui/src/components/DetailList/UserDateDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Trans } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styled from 'styled-components';
 import { formatDateString } from 'util/dates';
 import _Detail from './Detail';

--- a/awx/ui/src/components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js
+++ b/awx/ui/src/components/ExecutionEnvironmentDetail/ExecutionEnvironmentDetail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 import { Popover, Tooltip } from '@patternfly/react-core';

--- a/awx/ui/src/components/InstanceGroupLabels/InstanceGroupLabels.js
+++ b/awx/ui/src/components/InstanceGroupLabels/InstanceGroupLabels.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Label, LabelGroup } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 function InstanceGroupLabels({ labels, isLinkable = false }) {
   const buildLinkURL = (isContainerGroup) =>

--- a/awx/ui/src/components/JobList/JobList.js
+++ b/awx/ui/src/components/JobList/JobList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui, Plural } from '@lingui/react/macro';
 
 import { Card } from '@patternfly/react-core';

--- a/awx/ui/src/components/JobList/JobListItem.js
+++ b/awx/ui/src/components/JobList/JobListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { Button, Chip } from '@patternfly/react-core';

--- a/awx/ui/src/components/JobList/useWsJobs.js
+++ b/awx/ui/src/components/JobList/useWsJobs.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import useWebsocket from 'hooks/useWebsocket';
 import useThrottle from 'hooks/useThrottle';
 import { parseQueryString } from 'util/qs';

--- a/awx/ui/src/components/LabelLists/LabelListItem.js
+++ b/awx/ui/src/components/LabelLists/LabelListItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 function LabelListItem({ label, searchOrg }) {

--- a/awx/ui/src/components/LabelLists/LabelLists.js
+++ b/awx/ui/src/components/LabelLists/LabelLists.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback } from 'react';
 import { Card } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import useRequest from 'hooks/useRequest';
 import { LabelsAPI } from 'api';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { useField } from 'formik';

--- a/awx/ui/src/components/ListHeader/ListHeader.js
+++ b/awx/ui/src/components/ListHeader/ListHeader.js
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import styled from 'styled-components';
 import { Toolbar, ToolbarContent } from '@patternfly/react-core';

--- a/awx/ui/src/components/Lookup/ApplicationLookup.js
+++ b/awx/ui/src/components/Lookup/ApplicationLookup.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { FormGroup } from '@patternfly/react-core';
 import { ApplicationsAPI } from 'api';

--- a/awx/ui/src/components/Lookup/ExecutionEnvironmentLookup.js
+++ b/awx/ui/src/components/Lookup/ExecutionEnvironmentLookup.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
 import { ExecutionEnvironmentsAPI, ProjectsAPI } from 'api';

--- a/awx/ui/src/components/Lookup/HostFilterLookup.js
+++ b/awx/ui/src/components/Lookup/HostFilterLookup.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import styled from 'styled-components';

--- a/awx/ui/src/components/NotificationList/NotificationList.js
+++ b/awx/ui/src/components/NotificationList/NotificationList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/components/NotificationList/NotificationListItem.js
+++ b/awx/ui/src/components/NotificationList/NotificationListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Switch } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { ActionsTd, ActionItem } from '../PaginatedTable';

--- a/awx/ui/src/components/PaginatedTable/HeaderRow.js
+++ b/awx/ui/src/components/PaginatedTable/HeaderRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Thead, Tr, Th as PFTh } from '@patternfly/react-table';
 import styled from 'styled-components';

--- a/awx/ui/src/components/PaginatedTable/PaginatedTable.js
+++ b/awx/ui/src/components/PaginatedTable/PaginatedTable.js
@@ -3,7 +3,7 @@
 //
 import React, { useEffect } from 'react';
 import { TableComposable, Tbody } from '@patternfly/react-table';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/PaginatedTable/ToolbarAddButton.js
+++ b/awx/ui/src/components/PaginatedTable/ToolbarAddButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/PromptDetail/PromptDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import styled from 'styled-components';
 import { Chip, Divider, Title } from '@patternfly/react-core';
 import { toTitleCase } from 'util/strings';

--- a/awx/ui/src/components/PromptDetail/PromptInventorySourceDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptInventorySourceDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   Chip,
   TextList,

--- a/awx/ui/src/components/PromptDetail/PromptJobTemplateDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptJobTemplateDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   Chip,
   TextList,

--- a/awx/ui/src/components/PromptDetail/PromptProjectDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptProjectDetail.js
@@ -6,7 +6,7 @@ import {
   TextListVariants,
   TextListItemVariants,
 } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Config } from 'contexts/Config';
 import { toTitleCase } from 'util/strings';
 import { Detail, DeletedDetail } from '../DetailList';

--- a/awx/ui/src/components/PromptDetail/PromptWFJobTemplateDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptWFJobTemplateDetail.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   Chip,
   TextList,

--- a/awx/ui/src/components/RelatedTemplateList/RelatedTemplateList.js
+++ b/awx/ui/src/components/RelatedTemplateList/RelatedTemplateList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card } from '@patternfly/react-core';
 import { JobTemplatesAPI } from 'api';

--- a/awx/ui/src/components/ResourceAccessList/ResourceAccessList.js
+++ b/awx/ui/src/components/ResourceAccessList/ResourceAccessList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { RolesAPI, TeamsAPI, UsersAPI } from 'api';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/components/ResourceAccessList/ResourceAccessListItem.js
+++ b/awx/ui/src/components/ResourceAccessList/ResourceAccessListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Chip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import ChipGroup from '../ChipGroup';
 import { DetailList, Detail } from '../DetailList';

--- a/awx/ui/src/components/RoutedTabs/RoutedTabs.js
+++ b/awx/ui/src/components/RoutedTabs/RoutedTabs.js
@@ -4,7 +4,7 @@ import {
   Tabs as PFTabs,
   TabTitleText,
 } from '@patternfly/react-core';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import styled from 'styled-components';
 import { getPersistentFilters } from 'components/PersistentFilters';

--- a/awx/ui/src/components/Schedule/Schedule.js
+++ b/awx/ui/src/components/Schedule/Schedule.js
@@ -6,7 +6,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { SchedulesAPI } from 'api';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/components/Schedule/ScheduleAdd/ScheduleAdd.js
+++ b/awx/ui/src/components/Schedule/ScheduleAdd/ScheduleAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Card } from '@patternfly/react-core';
 import yaml from 'js-yaml';

--- a/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
+++ b/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import styled from 'styled-components';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
+++ b/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Card } from '@patternfly/react-core';
 import yaml from 'js-yaml';

--- a/awx/ui/src/components/Schedule/ScheduleList/ScheduleList.js
+++ b/awx/ui/src/components/Schedule/ScheduleList/ScheduleList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { SchedulesAPI } from 'api';
 import useRequest, { useDeleteItems } from 'hooks/useRequest';

--- a/awx/ui/src/components/Schedule/ScheduleList/ScheduleListItem.js
+++ b/awx/ui/src/components/Schedule/ScheduleList/ScheduleListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import {

--- a/awx/ui/src/components/ScreenHeader/ScreenHeader.js
+++ b/awx/ui/src/components/ScreenHeader/ScreenHeader.js
@@ -12,7 +12,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { HistoryIcon } from '@patternfly/react-icons';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 
 const ScreenHeader = ({ breadcrumbConfig, streamType }) => {
   const { light } = PageSectionVariants;

--- a/awx/ui/src/components/Search/AdvancedSearch.js
+++ b/awx/ui/src/components/Search/AdvancedSearch.js
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import styled from 'styled-components';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useConfig } from 'contexts/Config';
 import getDocsBaseUrl from 'util/getDocsBaseUrl';
 import RelatedLookupTypeInput from './RelatedLookupTypeInput';

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import {
   Button,
   ButtonVariant,

--- a/awx/ui/src/components/Sort/Sort.js
+++ b/awx/ui/src/components/Sort/Sort.js
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import {
   Button,

--- a/awx/ui/src/components/Sort/Sort.test.js
+++ b/awx/ui/src/components/Sort/Sort.test.js
@@ -4,8 +4,8 @@ import { renderWithContexts } from '../../../testUtils/rtlContexts';
 
 import Sort from './Sort';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => ({
     pathname: '/organizations',
   }),

--- a/awx/ui/src/components/Sparkline/Sparkline.js
+++ b/awx/ui/src/components/Sparkline/Sparkline.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Link as _Link } from 'react-router-dom';
+import { Link as _Link } from 'react-router';
 import { Tooltip } from '@patternfly/react-core';
 import styled from 'styled-components';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/TemplateList/TemplateList.js
+++ b/awx/ui/src/components/TemplateList/TemplateList.js
@@ -3,7 +3,7 @@
 */
 
 import React, { useEffect, useCallback } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, DropdownItem } from '@patternfly/react-core';
 import {

--- a/awx/ui/src/components/TemplateList/TemplateListItem.js
+++ b/awx/ui/src/components/TemplateList/TemplateListItem.js
@@ -3,7 +3,7 @@
 */
 
 import React, { useState, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button, Tooltip, Chip } from '@patternfly/react-core';
 import { Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js
+++ b/awx/ui/src/components/UserAndTeamAccessAdd/UserAndTeamAccessAdd.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { useParams, useMatch } from 'react-router-dom';
+import { useParams, useMatch } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import {

--- a/awx/ui/src/components/WorkflowOutputNavigation/WorkflowOutputNavigation.js
+++ b/awx/ui/src/components/WorkflowOutputNavigation/WorkflowOutputNavigation.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import {
   Select,

--- a/awx/ui/src/contexts/Config.js
+++ b/awx/ui/src/contexts/Config.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
-import { useMatch } from 'react-router-dom';
+import { useMatch } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import {

--- a/awx/ui/src/hooks/useRequest.js
+++ b/awx/ui/src/hooks/useRequest.js
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { parseQueryString, updateQueryString } from 'util/qs';
 import useIsMounted from './useIsMounted';

--- a/awx/ui/src/routerCompat.js
+++ b/awx/ui/src/routerCompat.js
@@ -1,7 +1,6 @@
 // Single indirection point for the react-router API the app uses. The
-// react-router-dom-v5-compat -> v6 migration was landed in three steps by first
-// routing every consumer through this module and then repointing it here, so the
-// whole app flipped to react-router-dom v6 from one place. It is kept as the
+// v5-compat -> v6 -> v7 migration was landed in steps by first routing every
+// consumer through this module and then repointing it here. It is kept as the
 // canonical import site for these symbols.
 export {
   Link,
@@ -13,4 +12,4 @@ export {
   useNavigate,
   useNavigationType,
   useParams,
-} from 'react-router-dom';
+} from 'react-router';

--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import styled from 'styled-components';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/ActivityStream/ActivityStreamDescription.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStreamDescription.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 const buildAnchor = (obj, resource, activity) => {

--- a/awx/ui/src/screens/ActivityStream/ActivityStreamDetailButton.test.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStreamDetailButton.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { screen, within } from '@testing-library/react';
 import {
   renderWithContexts,

--- a/awx/ui/src/screens/ActivityStream/ActivityStreamListItem.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStreamListItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { formatDateString } from 'util/dates';
 import { ActionsTd, ActionItem } from 'components/PaginatedTable';

--- a/awx/ui/src/screens/Application/Application/Application.js
+++ b/awx/ui/src/screens/Application/Application/Application.js
@@ -4,7 +4,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Application/ApplicationDetails/ApplicationDetails.js
+++ b/awx/ui/src/screens/Application/ApplicationDetails/ApplicationDetails.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Button } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.test.js
+++ b/awx/ui/src/screens/Application/ApplicationEdit/ApplicationEdit.test.js
@@ -12,8 +12,8 @@ jest.mock('../../../api/models/Organizations');
 // The component reads useParams from react-router-dom (the route
 // tree is v6); mock it there, keeping useNavigate real so the cancel/submit
 // navigation assertions still exercise history.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({ id: 1 }),
 }));
 

--- a/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenListItem.js
+++ b/awx/ui/src/screens/Application/ApplicationTokens/ApplicationTokenListItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Tr, Td } from '@patternfly/react-table';
 
 import { formatDateString } from 'util/dates';

--- a/awx/ui/src/screens/Application/ApplicationsList/ApplicationListItem.js
+++ b/awx/ui/src/screens/Application/ApplicationsList/ApplicationListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem, TdBreakWord } from 'components/PaginatedTable';
 import { formatDateString } from 'util/dates';

--- a/awx/ui/src/screens/Application/ApplicationsList/ApplicationsList.js
+++ b/awx/ui/src/screens/Application/ApplicationsList/ApplicationsList.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Card, PageSection } from '@patternfly/react-core';
 import { getQSConfig, parseQueryString } from 'util/qs';
 import useRequest, { useDeleteItems } from 'hooks/useRequest';

--- a/awx/ui/src/screens/Application/shared/ApplicationForm.js
+++ b/awx/ui/src/screens/Application/shared/ApplicationForm.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { Formik, useField, useFormikContext } from 'formik';

--- a/awx/ui/src/screens/Credential/Credential.js
+++ b/awx/ui/src/screens/Credential/Credential.js
@@ -8,7 +8,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import useRequest from 'hooks/useRequest';
 import { ResourceAccessList } from 'components/ResourceAccessList';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Credential/CredentialAdd/CredentialAdd.js
+++ b/awx/ui/src/screens/Credential/CredentialAdd/CredentialAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { PageSection, Card } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Credential/CredentialDetail/CredentialDetail.js
+++ b/awx/ui/src/screens/Credential/CredentialDetail/CredentialDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';

--- a/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.js
+++ b/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { CardBody } from 'components/Card';
 import {
   CredentialsAPI,

--- a/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.test.js
+++ b/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.test.js
@@ -14,8 +14,8 @@ import CredentialEdit from './CredentialEdit';
 jest.mock('../../../api');
 // The component reads useParams from react-router-dom (the route
 // tree is v6); mock it there, keeping the rest of the module real.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 3,
   }),

--- a/awx/ui/src/screens/Credential/CredentialList/CredentialList.js
+++ b/awx/ui/src/screens/Credential/CredentialList/CredentialList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CredentialsAPI } from 'api';

--- a/awx/ui/src/screens/Credential/CredentialList/CredentialListItem.js
+++ b/awx/ui/src/screens/Credential/CredentialList/CredentialListItem.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { PencilAltIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Credential/shared/CredentialForm.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialForm.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Formik, useField, useFormikContext } from 'formik';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.js
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useField, useFormikContext } from 'formik';
 import styled from 'styled-components';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.js
@@ -13,8 +13,8 @@ const fieldOptions = {
   secret: true,
 };
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => ({
     pathname: '/credentials/3/edit',
   }),

--- a/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginField.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { useField } from 'formik';

--- a/awx/ui/src/screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeDetails/CredentialTypeDetails.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Button } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypeList/CredentialTypeListItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { PencilAltIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Dashboard/shared/Count.js
+++ b/awx/ui/src/screens/Dashboard/shared/Count.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Card } from '@patternfly/react-core';
 
 const CountCard = styled(Card)`

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironment.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironment.js
@@ -4,7 +4,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentDetails/ExecutionEnvironmentDetails.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Button, Label } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentList/ExecutionEnvironmentListItem.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { PencilAltIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Card } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironmentTemplate/ExecutionEnvironmentTemplateListItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Tr, Td } from '@patternfly/react-table';
 
 function ExecutionEnvironmentTemplateListItem({ template, detailUrl }) {

--- a/awx/ui/src/screens/Host/Host.js
+++ b/awx/ui/src/screens/Host/Host.js
@@ -7,7 +7,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import RoutedTabs from 'components/RoutedTabs';

--- a/awx/ui/src/screens/Host/HostDetail/HostDetail.js
+++ b/awx/ui/src/screens/Host/HostDetail/HostDetail.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Host/HostFacts/HostFacts.test.js
+++ b/awx/ui/src/screens/Host/HostFacts/HostFacts.test.js
@@ -7,8 +7,8 @@ import mockHost from '../data.host.json';
 import mockHostFacts from '../data.hostFacts.json';
 
 jest.mock('../../../api/models/Hosts');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
     hostId: 1,

--- a/awx/ui/src/screens/Host/HostGroups/HostGroupItem.js
+++ b/awx/ui/src/screens/Host/HostGroups/HostGroupItem.js
@@ -4,7 +4,7 @@ import { useLingui } from '@lingui/react/macro';
 
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem } from 'components/PaginatedTable';
 

--- a/awx/ui/src/screens/Host/HostGroups/HostGroupsList.js
+++ b/awx/ui/src/screens/Host/HostGroups/HostGroupsList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Host/HostList/HostList.js
+++ b/awx/ui/src/screens/Host/HostList/HostList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Host/HostList/HostListItem.js
+++ b/awx/ui/src/screens/Host/HostList/HostListItem.js
@@ -4,7 +4,7 @@ import { useLingui } from '@lingui/react/macro';
 
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem, TdBreakWord } from 'components/PaginatedTable';
 import HostToggle from 'components/HostToggle';

--- a/awx/ui/src/screens/HostMetrics/HostMetrics.js
+++ b/awx/ui/src/screens/HostMetrics/HostMetrics.js
@@ -10,7 +10,7 @@ import PaginatedTable, {
 import DataListToolbar from 'components/DataListToolbar';
 import { getQSConfig, parseQueryString } from 'util/qs';
 import { Card, PageSection } from '@patternfly/react-core';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import useSelected from 'hooks/useSelected';
 import HostMetricsListItem from './HostMetricsListItem';
 import HostMetricsDeleteButton from './HostMetricsDeleteButton';

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
@@ -4,7 +4,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Button, Label } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.test.js
@@ -13,8 +13,8 @@ jest.mock('../../../api');
 jest.mock('../../../hooks/useDebounce');
 // The component reads useParams from react-router-dom (the route
 // tree is v6); mock it there, keeping the rest of the module real.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 2,
     instanceId: 1,

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
@@ -4,7 +4,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import styled from 'styled-components';
 import { Button } from '@patternfly/react-core';

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router';
 
 import { Plural, useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupList/InstanceGroupListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   Button,
   Progress,

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 import { Routes, Route } from 'routerCompat';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import ScreenHeader from 'components/ScreenHeader';
 import PersistentFilters from 'components/PersistentFilters';
 import InstanceGroupAdd from './InstanceGroupAdd';

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 
 import useExpanded from 'hooks/useExpanded';

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { screen, waitFor, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
@@ -14,8 +14,8 @@ import InstanceList from './InstanceList';
 jest.mock('../../../api');
 // InstanceList reads useParams from react-router-dom (the route tree
 // is v6); mock it there, keeping the rest of the module real.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
     instanceGroupId: 2,

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceListItem.test.js
@@ -12,8 +12,8 @@ jest.mock('../../../hooks/useDebounce');
 
 // The component reads useParams from react-router-dom (the route
 // tree is v6); mock it there, keeping the rest of the module real.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/Instances/Instance.js
+++ b/awx/ui/src/screens/Instances/Instance.js
@@ -5,7 +5,7 @@ import { Link,
   Routes,
   Route,
   Navigate,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import { useConfig } from 'contexts/Config';

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate, useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import {

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.test.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.test.js
@@ -10,8 +10,8 @@ jest.mock('../../../api');
 jest.mock('../../../hooks/useDebounce');
 // The component reads useParams from react-router-dom (the route
 // tree is v6); mock it there, keeping the rest of the module real.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/Instances/InstanceEdit/InstanceEdit.js
+++ b/awx/ui/src/screens/Instances/InstanceEdit/InstanceEdit.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate, useParams } from 'routerCompat';
 import { Card, PageSection } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/Instances/InstanceEdit/InstanceEdit.test.js
+++ b/awx/ui/src/screens/Instances/InstanceEdit/InstanceEdit.test.js
@@ -11,8 +11,8 @@ jest.mock('../../../api');
 jest.mock('../../../hooks/useDebounce');
 // The component reads useParams from react-router-dom (the route
 // tree is v6); mock it there, keeping the rest of the module real.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 42,
   }),

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceList.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceList.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { PageSection, Card } from '@patternfly/react-core';
 
 import useExpanded from 'hooks/useExpanded';

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceList.test.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { createMemoryHistory } from 'history';
 import * as ConfigContext from 'contexts/Config';
 import { within, waitFor, screen } from '@testing-library/react';
@@ -12,8 +12,8 @@ import InstanceList from './InstanceList';
 jest.mock('../../../api/models/InstanceGroups');
 jest.mock('../../../api/models/Instances');
 jest.mock('../../../api/models/Settings');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import {

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.test.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.test.js
@@ -10,8 +10,8 @@ import InstanceListItem from './InstanceListItem';
 jest.mock('../../../api');
 jest.mock('../../../hooks/useDebounce');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/Instances/InstancePeers/InstancePeerList.js
+++ b/awx/ui/src/screens/Instances/InstancePeers/InstancePeerList.js
@@ -13,7 +13,7 @@ import ErrorDetail from 'components/ErrorDetail';
 import AlertModal from 'components/AlertModal';
 import useToast, { AlertVariant } from 'hooks/useToast';
 import { getQSConfig, parseQueryString } from 'util/qs';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import useRequest, { useDismissableError } from 'hooks/useRequest';
 import DataListToolbar from 'components/DataListToolbar';

--- a/awx/ui/src/screens/Instances/InstancePeers/InstancePeerListItem.js
+++ b/awx/ui/src/screens/Instances/InstancePeers/InstancePeerListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { formatDateString } from 'util/dates';

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHost/AdvancedInventoryHost.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHost/AdvancedInventoryHost.js
@@ -5,7 +5,7 @@ import { Link,
   Routes,
   Route,
   Navigate,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHostDetail/AdvancedInventoryHostDetail.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHostDetail/AdvancedInventoryHostDetail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { CardBody } from 'components/Card';

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHostList.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHostList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import DataListToolbar from 'components/DataListToolbar';

--- a/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHostListItem.js
+++ b/awx/ui/src/screens/Inventory/AdvancedInventoryHosts/AdvancedInventoryHostListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Tr, Td } from '@patternfly/react-table';
 import Sparkline from 'components/Sparkline';

--- a/awx/ui/src/screens/Inventory/ConstructedInventory.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventory.js
@@ -5,7 +5,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryDetail/ConstructedInventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryDetail/ConstructedInventoryDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useNavigate  } from 'react-router-dom';
+import { Link, useNavigate  } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import {

--- a/awx/ui/src/screens/Inventory/FederatedInventory.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventory.js
@@ -5,7 +5,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/Inventory/FederatedInventoryDetail/FederatedInventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/FederatedInventoryDetail/FederatedInventoryDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useNavigate  } from 'react-router-dom';
+import { Link, useNavigate  } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import {

--- a/awx/ui/src/screens/Inventory/Inventory.js
+++ b/awx/ui/src/screens/Inventory/Inventory.js
@@ -6,7 +6,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Inventory/InventoryDetail/InventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/InventoryDetail/InventoryDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroup/InventoryGroup.js
@@ -5,7 +5,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useState } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router';
 import { useParams } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroupHosts/InventoryGroupHostListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { Button, Tooltip } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupItem.js
@@ -4,7 +4,7 @@ import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useParams } from 'routerCompat';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem } from 'components/PaginatedTable';

--- a/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupsList.js
+++ b/awx/ui/src/screens/Inventory/InventoryGroups/InventoryGroupsList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { Tooltip } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
+++ b/awx/ui/src/screens/Inventory/InventoryHost/InventoryHost.js
@@ -5,7 +5,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { Card } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/Inventory/InventoryHostDetail/InventoryHostDetail.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostDetail/InventoryHostDetail.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupItem.js
@@ -3,7 +3,7 @@ import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem } from 'components/PaginatedTable';
 

--- a/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js
+++ b/awx/ui/src/screens/Inventory/InventoryHostGroups/InventoryHostGroupsList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHostItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHostItem.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { Button, Chip } from '@patternfly/react-core';
 import { HostsAPI } from 'api';

--- a/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHostList.js
+++ b/awx/ui/src/screens/Inventory/InventoryHosts/InventoryHostList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/screens/Inventory/InventoryList/InventoryList.js
+++ b/awx/ui/src/screens/Inventory/InventoryList/InventoryList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection, DropdownItem } from '@patternfly/react-core';
 import { InventoriesAPI } from 'api';

--- a/awx/ui/src/screens/Inventory/InventoryList/InventoryListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryList/InventoryListItem.js
@@ -4,7 +4,7 @@ import { Button, Label } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { Plural, useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { timeOfDay } from 'util/dates';
 import { InventoriesAPI } from 'api';
 import { ActionsTd, ActionItem, TdBreakWord } from 'components/PaginatedTable';

--- a/awx/ui/src/screens/Inventory/InventoryList/useWsInventories.js
+++ b/awx/ui/src/screens/Inventory/InventoryList/useWsInventories.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { parseQueryString, updateQueryString } from 'util/qs';
 import useWebsocket from 'hooks/useWebsocket';

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupList.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router';
 import { useParams } from 'routerCompat';
 
 import { DropdownItem } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js
+++ b/awx/ui/src/screens/Inventory/InventoryRelatedGroups/InventoryRelatedGroupListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useParams } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
+++ b/awx/ui/src/screens/Inventory/InventorySource/InventorySource.js
@@ -6,7 +6,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import useRequest from 'hooks/useRequest';
 

--- a/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Card } from '@patternfly/react-core';
 import { InventorySourcesAPI } from 'api';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import {

--- a/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Card } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/Inventory/InventorySources/InventorySourceList.js
+++ b/awx/ui/src/screens/Inventory/InventorySources/InventorySourceList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import { Plural, useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/Inventory/InventorySources/InventorySourceListItem.js
+++ b/awx/ui/src/screens/Inventory/InventorySources/InventorySourceListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';

--- a/awx/ui/src/screens/Inventory/SmartInventory.js
+++ b/awx/ui/src/screens/Inventory/SmartInventory.js
@@ -4,7 +4,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/SmartInventoryAdd/SmartInventoryAdd.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryAdd/SmartInventoryAdd.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Card, PageSection } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryDetail/SmartInventoryDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Inventory/SmartInventoryEdit/SmartInventoryEdit.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryEdit/SmartInventoryEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import useRequest from 'hooks/useRequest';
 import { InventoriesAPI } from 'api';
 import { CardBody } from 'components/Card';

--- a/awx/ui/src/screens/Inventory/shared/Inventory.helptext.js
+++ b/awx/ui/src/screens/Inventory/shared/Inventory.helptext.js
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 const ansibleDocUrls = {
   ec2: 'https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html',

--- a/awx/ui/src/screens/Inventory/shared/SmartInventoryForm.js
+++ b/awx/ui/src/screens/Inventory/shared/SmartInventoryForm.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import { Formik, useField, useFormikContext } from 'formik';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Form } from '@patternfly/react-core';
 import { VariablesField } from 'components/CodeEditor';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Job/Job.js
+++ b/awx/ui/src/screens/Job/Job.js
@@ -3,7 +3,7 @@ import { Link,
   Routes,
   Route,
   Navigate,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Job/Job.test.js
+++ b/awx/ui/src/screens/Job/Job.test.js
@@ -7,8 +7,8 @@ import Job from './Job';
 jest.mock('../../api');
 // Job reads useParams from react-router-dom (the route tree is v6);
 // mock it there, keeping the rest of the module real.
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
     typeSegment: 'project',

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { Button, Chip } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Job/JobOutput/EmptyOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/EmptyOutput.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import {
   SearchIcon,
   ExclamationCircleIcon as PFExclamationCircleIcon,

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -1,6 +1,6 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';

--- a/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import styled from 'styled-components';
 import {

--- a/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
@@ -4,8 +4,8 @@ import { createMemoryHistory } from 'history';
 import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import JobOutputSearch from './JobOutputSearch';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   history: () => ({
     location: '/jobs/playbook/1/output',
   }),

--- a/awx/ui/src/screens/Job/JobTypeRedirect.js
+++ b/awx/ui/src/screens/Job/JobTypeRedirect.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Navigate } from 'routerCompat';
 import { PageSection, Card } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/ManagementJob/ManagementJob.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJob.js
@@ -4,7 +4,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/ManagementJob/ManagementJobList/ManagementJobList.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobList/ManagementJobList.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Card, PageSection } from '@patternfly/react-core';
 
 import { SystemJobTemplatesAPI } from 'api';

--- a/awx/ui/src/screens/ManagementJob/ManagementJobList/ManagementJobListItem.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobList/ManagementJobListItem.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { Button, Tooltip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
@@ -7,7 +7,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import useRequest from 'hooks/useRequest';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateAdd.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateAdd.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import {
   Button,

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateListItem.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { PencilAltIcon, BellIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Organization/Organization.js
+++ b/awx/ui/src/screens/Organization/Organization.js
@@ -5,7 +5,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
+++ b/awx/ui/src/screens/Organization/OrganizationDetail/OrganizationDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate, useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js
+++ b/awx/ui/src/screens/Organization/OrganizationExecEnvList/OrganizationExecEnvList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Card } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js
+++ b/awx/ui/src/screens/Organization/OrganizationExecEnvList/OrganizationExecEnvListItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Tr, Td } from '@patternfly/react-table';
 
 function OrganizationExecEnvListItem({ executionEnvironment, detailUrl }) {

--- a/awx/ui/src/screens/Organization/OrganizationList/OrganizationList.js
+++ b/awx/ui/src/screens/Organization/OrganizationList/OrganizationList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 

--- a/awx/ui/src/screens/Organization/OrganizationList/OrganizationListItem.js
+++ b/awx/ui/src/screens/Organization/OrganizationList/OrganizationListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   PencilAltIcon,
 } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Organization/OrganizationTeams/OrganizationTeamList.js
+++ b/awx/ui/src/screens/Organization/OrganizationTeams/OrganizationTeamList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { OrganizationsAPI } from 'api';
 import PaginatedTable, {

--- a/awx/ui/src/screens/Organization/OrganizationTeams/OrganizationTeamListItem.js
+++ b/awx/ui/src/screens/Organization/OrganizationTeams/OrganizationTeamListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Project/Project.js
+++ b/awx/ui/src/screens/Project/Project.js
@@ -5,7 +5,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import { useConfig } from 'contexts/Config';

--- a/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.js
+++ b/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';

--- a/awx/ui/src/screens/Project/ProjectList/ProjectList.js
+++ b/awx/ui/src/screens/Project/ProjectList/ProjectList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 import { ProjectsAPI } from 'api';

--- a/awx/ui/src/screens/Project/ProjectList/ProjectListItem.js
+++ b/awx/ui/src/screens/Project/ProjectList/ProjectListItem.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { Button, ClipboardCopy, Tooltip } from '@patternfly/react-core';
 import { Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { useLingui } from '@lingui/react/macro';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import {
   PencilAltIcon,
   UndoIcon,

--- a/awx/ui/src/screens/Setting/AzureAD/AzureAD.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureAD.js
@@ -3,7 +3,7 @@ import { Link,
   Routes,
   Route,
   Navigate,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link, Navigate, useMatch } from 'react-router-dom';
+import { Link, Navigate, useMatch } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.test.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.test.js
@@ -10,8 +10,8 @@ import mockAllOptions from '../../shared/data.allSettingOptions.json';
 import AzureADDetail from './AzureADDetail';
 
 jest.mock('../../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useRouteMatch: () => ({
     path: '/settings/azure/default/details',
     params: { category: 'default' },

--- a/awx/ui/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.test.js
+++ b/awx/ui/src/screens/Setting/AzureAD/AzureADDetail/AzureADDetail.test.js
@@ -12,8 +12,7 @@ import AzureADDetail from './AzureADDetail';
 jest.mock('../../../../api');
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
-  useRouteMatch: () => ({
-    path: '/settings/azure/default/details',
+  useMatch: () => ({
     params: { category: 'default' },
   }),
 }));

--- a/awx/ui/src/screens/Setting/GitHub/GitHub.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHub.js
@@ -3,7 +3,7 @@ import { Link,
   Routes,
   Route,
   Navigate,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Setting/GitHub/GitHubDetail/GitHubDetail.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubDetail/GitHubDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link, Navigate, useMatch } from 'react-router-dom';
+import { Link, Navigate, useMatch } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/GitHub/GitHubDetail/GitHubDetail.test.js
+++ b/awx/ui/src/screens/Setting/GitHub/GitHubDetail/GitHubDetail.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { SettingsProvider } from 'contexts/Settings';

--- a/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.js
+++ b/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.js
+++ b/awx/ui/src/screens/Setting/GoogleOAuth2/GoogleOAuth2Detail/GoogleOAuth2Detail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/Jobs/Jobs.js
+++ b/awx/ui/src/screens/Setting/Jobs/Jobs.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/Jobs/JobsDetail/JobsDetail.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsDetail/JobsDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/LDAP/LDAP.js
+++ b/awx/ui/src/screens/Setting/LDAP/LDAP.js
@@ -3,7 +3,7 @@ import { Link,
   Routes,
   Route,
   Navigate,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/Setting/LDAP/LDAPDetail/LDAPDetail.js
+++ b/awx/ui/src/screens/Setting/LDAP/LDAPDetail/LDAPDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link, Navigate, useMatch } from 'react-router-dom';
+import { Link, Navigate, useMatch } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/LDAP/LDAPEdit/LDAPEdit.js
+++ b/awx/ui/src/screens/Setting/LDAP/LDAPEdit/LDAPEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useMatch, useNavigate  } from 'react-router-dom';
+import { useMatch, useNavigate  } from 'react-router';
 import { Formik } from 'formik';
 import { Form } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';

--- a/awx/ui/src/screens/Setting/Logging/Logging.js
+++ b/awx/ui/src/screens/Setting/Logging/Logging.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/Logging/LoggingDetail/LoggingDetail.js
+++ b/awx/ui/src/screens/Setting/Logging/LoggingDetail/LoggingDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthentication.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationDetail/MiscAuthenticationDetail.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationDetail/MiscAuthenticationDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.js
+++ b/awx/ui/src/screens/Setting/MiscSystem/MiscSystem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js
+++ b/awx/ui/src/screens/Setting/MiscSystem/MiscSystemDetail/MiscSystemDetail.js
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2023 Ctrl IQ, Inc.
 //
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/OIDC/OIDC.js
+++ b/awx/ui/src/screens/Setting/OIDC/OIDC.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/OIDC/OIDCDetail/OIDCDetail.js
+++ b/awx/ui/src/screens/Setting/OIDC/OIDCDetail/OIDCDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/RADIUS/RADIUS.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUS.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js
+++ b/awx/ui/src/screens/Setting/RADIUS/RADIUSDetail/RADIUSDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button, Alert as PFAlert } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/SAML/SAML.js
+++ b/awx/ui/src/screens/Setting/SAML/SAML.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/SAML/SAMLDetail/SAMLDetail.js
+++ b/awx/ui/src/screens/Setting/SAML/SAMLDetail/SAMLDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/SettingList.js
+++ b/awx/ui/src/screens/Setting/SettingList.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import {
   Card as _Card,

--- a/awx/ui/src/screens/Setting/Settings.js
+++ b/awx/ui/src/screens/Setting/Settings.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/Subscription/Subscription.js
+++ b/awx/ui/src/screens/Setting/Subscription/Subscription.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Trans, useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import {

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link, useMatch, useNavigate  } from 'react-router-dom';
+import { Link, useMatch, useNavigate  } from 'react-router';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { Formik, useFormikContext } from 'formik';
 import {

--- a/awx/ui/src/screens/Setting/TACACS/TACACS.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACS.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.js
+++ b/awx/ui/src/screens/Setting/TACACS/TACACSDetail/TACACSDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button, Alert as PFAlert } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.js
+++ b/awx/ui/src/screens/Setting/Troubleshooting/Troubleshooting.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingDetail/TroubleshootingDetail.js
+++ b/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingDetail/TroubleshootingDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';

--- a/awx/ui/src/screens/Setting/UI/UI.js
+++ b/awx/ui/src/screens/Setting/UI/UI.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Routes, Route, Navigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { PageSection, Card } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Setting/UI/UIDetail/UIDetail.js
+++ b/awx/ui/src/screens/Setting/UI/UIDetail/UIDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Team/Team.js
+++ b/awx/ui/src/screens/Team/Team.js
@@ -6,7 +6,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import { Config } from 'contexts/Config';

--- a/awx/ui/src/screens/Team/TeamDetail/TeamDetail.js
+++ b/awx/ui/src/screens/Team/TeamDetail/TeamDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate, useParams } from 'routerCompat';
 
 import { Button } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Team/TeamList/TeamList.js
+++ b/awx/ui/src/screens/Team/TeamList/TeamList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { Card, PageSection } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/Team/TeamList/TeamListItem.js
+++ b/awx/ui/src/screens/Team/TeamList/TeamListItem.js
@@ -3,7 +3,7 @@ import { useLingui } from '@lingui/react/macro';
 
 import { Button } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem, TdBreakWord } from 'components/PaginatedTable';
 

--- a/awx/ui/src/screens/Team/TeamRoles/TeamRoleListItem.js
+++ b/awx/ui/src/screens/Team/TeamRoles/TeamRoleListItem.js
@@ -4,7 +4,7 @@ import { Chip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
 import { useLingui } from '@lingui/react/macro';
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 function TeamRoleListItem({ role, detailUrl, onDisassociate }) {
   const { t } = useLingui();

--- a/awx/ui/src/screens/Team/TeamRoles/TeamRolesList.js
+++ b/awx/ui/src/screens/Team/TeamRoles/TeamRolesList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import {
   Button,

--- a/awx/ui/src/screens/Template/JobTemplateDetail/JobTemplateDetail.js
+++ b/awx/ui/src/screens/Template/JobTemplateDetail/JobTemplateDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate, useParams } from 'routerCompat';
 import {
   Button,

--- a/awx/ui/src/screens/Template/Survey/SurveyListItem.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Chip, Tooltip, Button } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/Template/Survey/SurveyQuestionAdd.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyQuestionAdd.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { CardBody } from 'components/Card';
 import SurveyQuestionForm from './SurveyQuestionForm';

--- a/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useNavigate, Navigate } from 'routerCompat';
 import ContentLoading from 'components/ContentLoading';
 import { CardBody } from 'components/Card';

--- a/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.test.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyQuestionEdit.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderWithContexts } from '../../../../testUtils/rtlContexts';

--- a/awx/ui/src/screens/Template/Survey/SurveyToolbar.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyToolbar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import styled from 'styled-components';

--- a/awx/ui/src/screens/Template/Template.js
+++ b/awx/ui/src/screens/Template/Template.js
@@ -3,7 +3,7 @@ import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { Routes, Route, Navigate, useParams } from 'routerCompat';
 import RoutedTabs from 'components/RoutedTabs';
 import { useConfig } from 'contexts/Config';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.js
@@ -3,7 +3,7 @@ import { useLingui } from '@lingui/react/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { Routes, Route, Navigate, useParams } from 'routerCompat';
 import RoutedTabs from 'components/RoutedTabs';
 import { useConfig } from 'contexts/Config';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateDetail/WorkflowJobTemplateDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import {

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/InventorySourcesList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { InventorySourcesAPI } from 'api';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { Popover } from '@patternfly/react-core';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/ProjectsList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { useLingui } from '@lingui/react/macro';
 import { ProjectsAPI } from 'api';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/SystemJobTemplatesList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { SystemJobTemplatesAPI } from 'api';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/WorkflowJobTemplatesList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { WorkflowJobTemplatesAPI } from 'api';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/screens/Template/shared/JobTemplateForm.test.js
+++ b/awx/ui/src/screens/Template/shared/JobTemplateForm.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { createMemoryHistory } from 'history';
 import {
   LabelsAPI,

--- a/awx/ui/src/screens/Template/shared/WebhookSubForm.js
+++ b/awx/ui/src/screens/Template/shared/WebhookSubForm.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
 import { SyncAltIcon } from '@patternfly/react-icons';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import {

--- a/awx/ui/src/screens/Template/shared/WebhookSubForm.test.js
+++ b/awx/ui/src/screens/Template/shared/WebhookSubForm.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { createMemoryHistory } from 'history';
 
 import { Formik } from 'formik';

--- a/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.test.js
+++ b/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen, waitFor, fireEvent, within } from '@testing-library/react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route } from 'react-router';
 import { createMemoryHistory } from 'history';
 import {
   WorkflowJobTemplatesAPI,

--- a/awx/ui/src/screens/TopologyView/Tooltip.js
+++ b/awx/ui/src/screens/TopologyView/Tooltip.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import styled from 'styled-components';
 import { useConfig } from 'contexts/Config';

--- a/awx/ui/src/screens/User/User.js
+++ b/awx/ui/src/screens/User/User.js
@@ -6,7 +6,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import useRequest from 'hooks/useRequest';

--- a/awx/ui/src/screens/User/UserDetail/UserDetail.js
+++ b/awx/ui/src/screens/User/UserDetail/UserDetail.js
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useNavigate } from 'routerCompat';
 
 import { useLingui } from '@lingui/react/macro';

--- a/awx/ui/src/screens/User/UserList/UserList.js
+++ b/awx/ui/src/screens/User/UserList/UserList.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { Card, PageSection } from '@patternfly/react-core';
 import { UsersAPI } from 'api';

--- a/awx/ui/src/screens/User/UserList/UserListItem.js
+++ b/awx/ui/src/screens/User/UserList/UserListItem.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Button, Label } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { ActionsTd, ActionItem, TdBreakWord } from 'components/PaginatedTable';
 

--- a/awx/ui/src/screens/User/UserOrganizations/UserOrganizationList.js
+++ b/awx/ui/src/screens/User/UserOrganizations/UserOrganizationList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 

--- a/awx/ui/src/screens/User/UserOrganizations/UserOrganizationListItem.js
+++ b/awx/ui/src/screens/User/UserOrganizations/UserOrganizationListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import { Tr, Td } from '@patternfly/react-table';

--- a/awx/ui/src/screens/User/UserRoles/UserRolesList.js
+++ b/awx/ui/src/screens/User/UserRoles/UserRolesList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 
 import {

--- a/awx/ui/src/screens/User/UserRoles/UserRolesListItem.js
+++ b/awx/ui/src/screens/User/UserRoles/UserRolesListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { Chip } from '@patternfly/react-core';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 function UserRolesListItem({ role, detailUrl, onSelect }) {
   const { t } = useLingui();

--- a/awx/ui/src/screens/User/UserTeams/UserTeamList.js
+++ b/awx/ui/src/screens/User/UserTeams/UserTeamList.js
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import PaginatedTable, {

--- a/awx/ui/src/screens/User/UserTeams/UserTeamList.test.js
+++ b/awx/ui/src/screens/User/UserTeams/UserTeamList.test.js
@@ -11,8 +11,8 @@ import {
 import UserTeamList from './UserTeamList';
 
 jest.mock('../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
     userId: 2,

--- a/awx/ui/src/screens/User/UserTeams/UserTeamListItem.js
+++ b/awx/ui/src/screens/User/UserTeams/UserTeamListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Tr, Td } from '@patternfly/react-table';
 

--- a/awx/ui/src/screens/User/UserToken/UserToken.js
+++ b/awx/ui/src/screens/User/UserToken/UserToken.js
@@ -5,7 +5,7 @@ import { Link,
   Route,
   Navigate,
   useLocation,
-  useParams } from 'react-router-dom';
+  useParams } from 'react-router';
 import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 import RoutedTabs from 'components/RoutedTabs';

--- a/awx/ui/src/screens/User/UserToken/UserToken.test.js
+++ b/awx/ui/src/screens/User/UserToken/UserToken.test.js
@@ -6,8 +6,8 @@ import UserToken from './UserToken';
 
 jest.mock('../../../api/models/Tokens');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
     tokenId: 2,

--- a/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.test.js
+++ b/awx/ui/src/screens/User/UserTokenAdd/UserTokenAdd.test.js
@@ -6,8 +6,8 @@ import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import UserTokenAdd from './UserTokenAdd';
 
 jest.mock('../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({ id: 1 }),
 }));
 

--- a/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.test.js
+++ b/awx/ui/src/screens/User/UserTokenDetail/UserTokenDetail.test.js
@@ -9,8 +9,8 @@ import UserTokenDetail from './UserTokenDetail';
 
 jest.mock('../../../api/models/Tokens');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
     tokenId: 2,

--- a/awx/ui/src/screens/User/UserTokenList/UserTokenList.js
+++ b/awx/ui/src/screens/User/UserTokenList/UserTokenList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { getQSConfig, parseQueryString } from 'util/qs';

--- a/awx/ui/src/screens/User/UserTokenList/UserTokenList.test.js
+++ b/awx/ui/src/screens/User/UserTokenList/UserTokenList.test.js
@@ -15,10 +15,6 @@ jest.mock('react-router', () => ({
   useLocation: () => ({
     search: '',
   }),
-}));
-// the component reads useParams from react-router-dom (v6 route tree)
-jest.mock('react-router', () => ({
-  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/User/UserTokenList/UserTokenList.test.js
+++ b/awx/ui/src/screens/User/UserTokenList/UserTokenList.test.js
@@ -10,15 +10,15 @@ import UserTokenList from './UserTokenList';
 jest.mock('../../../api/models/Users');
 jest.mock('../../../api/models/Tokens');
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => ({
     search: '',
   }),
 }));
 // the component reads useParams from react-router-dom (v6 route tree)
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 1,
   }),

--- a/awx/ui/src/screens/User/UserTokenList/UserTokenListItem.js
+++ b/awx/ui/src/screens/User/UserTokenList/UserTokenListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useParams } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import { Tr, Td } from '@patternfly/react-table';

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApproval.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApproval.js
@@ -8,7 +8,7 @@ import { Link,
   Route,
   Navigate,
   useParams,
-  useLocation } from 'react-router-dom';
+  useLocation } from 'react-router';
 import useRequest from 'hooks/useRequest';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useLingui } from '@lingui/react/macro';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useNavigate } from 'routerCompat';
 import styled from 'styled-components';
 import {

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalDetail/WorkflowApprovalDetail.test.js
@@ -12,8 +12,8 @@ import mockWorkflowApprovals from '../data.workflowApprovals.json';
 const workflowApproval = mockWorkflowApprovals.results[0];
 
 jest.mock('../../../api');
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useParams: () => ({
     id: 218,
   }),

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Plural, useLingui } from '@lingui/react/macro';
 import { Card, PageSection } from '@patternfly/react-core';
 import { WorkflowApprovalsAPI } from 'api';

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLingui } from '@lingui/react/macro';
 import useToast, { AlertVariant } from 'hooks/useToast';
 import { Tr, Td } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { formatDateString } from 'util/dates';
 import StatusLabel from 'components/StatusLabel';
 import JobCancelButton from 'components/JobCancelButton';

--- a/awx/ui/testUtils/rtlContexts.js
+++ b/awx/ui/testUtils/rtlContexts.js
@@ -13,7 +13,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Router } from 'react-router-dom';
+import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { I18nProvider } from '@lingui/react';
 import { i18n } from '@lingui/core';

--- a/awx/ui/testUtils/rtlContexts.test.js
+++ b/awx/ui/testUtils/rtlContexts.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { Plural } from '@lingui/react/macro';
 import { useConfig } from '../src/contexts/Config';
 import { useSession } from '../src/contexts/Session';


### PR DESCRIPTION
## SUMMARY

Upgrade from `react-router-dom` 6.30.4 to `react-router` 7.18.0. In v7 the separate `react-router-dom` package was merged into `react-router`, so this is primarily a mechanical import rewrite.

**What changed:**

- Replaced `react-router-dom` with `react-router` in `package.json`
- Repointed all 271 source/test files from `'react-router-dom'` to `'react-router'`
- Updated `jest.mock('react-router-dom', ...)` calls in 22 test files
- Added a `TextEncoder` polyfill to the jest setup (react-router v7 references it at module load; jsdom doesn't provide it)
- Updated the `routerCompat` module comment; retained the module itself as the canonical re-export site

No API changes — all hooks (`useNavigate`, `useLocation`, `useParams`, `useMatch`), components (`Routes`, `Route`, `Link`, `Navigate`, `HashRouter`, `Router`), and utilities (`matchPath`) are re-exported from `react-router` under the same names.

The `history` package (devDependency, used by the test harness's custom `Router`) is retained unchanged.

Depends on: #501

## ISSUE TYPE

- New or Enhanced Feature

## COMPONENT NAME

UI

## ASCENDER VERSION

```
awx: 25.4.1.dev126+gebb3790da5
```

## ADDITIONAL INFORMATION

All 552 test suites pass (2908 tests). Lint clean.