### PR TITLE
Migrate deprecated PF5 Select to composable Select API

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -24124,9 +24124,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/awx/ui/src/components/AddDropDownButton/AddDropDownButton.js
+++ b/awx/ui/src/components/AddDropDownButton/AddDropDownButton.js
@@ -1,6 +1,5 @@
 
 import React, { useState } from 'react';
-import { useLingui } from '@lingui/react/macro';
 import {
 	Dropdown,
 	DropdownList
@@ -9,7 +8,6 @@ import { useKebabifiedMenu } from 'contexts/Kebabified';
 import { ToolbarAddButton } from '../PaginatedTable';
 
 function AddDropDownButton({ dropdownItems, ouiaId }) {
-  const { t } = useLingui();
   const { isKebabified } = useKebabifiedMenu();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -26,8 +24,8 @@ function AddDropDownButton({ dropdownItems, ouiaId }) {
         <ToolbarAddButton
           ref={toggleRef}
           ouiaId={ouiaId}
-          aria-label={t`Add`}
           showToggleIndicator
+          isExpanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
         />
       )}

--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
@@ -32,7 +32,7 @@ const ToolbarItems = styled.div`
 `;
 
 const UserName = styled.span`
-  margin-left: var(--pf-v5-global--spacer--md);
+  margin-left: 1rem;
   font-size: var(--pf-v5-global--FontSize--sm);
 `;
 

--- a/awx/ui/src/components/DataListToolbar/DataListToolbar.js
+++ b/awx/ui/src/components/DataListToolbar/DataListToolbar.js
@@ -28,6 +28,7 @@ import Sort from '../Sort';
 const ToolbarContent = styled(PFToolbarContent)`
   & > .pf-v5-c-toolbar__content-section {
     flex-wrap: nowrap;
+    align-items: center;
   }
 `;
 

--- a/awx/ui/src/components/DataListToolbar/DataListToolbar.js
+++ b/awx/ui/src/components/DataListToolbar/DataListToolbar.js
@@ -28,7 +28,22 @@ import Sort from '../Sort';
 const ToolbarContent = styled(PFToolbarContent)`
   & > .pf-v5-c-toolbar__content-section {
     flex-wrap: nowrap;
-    align-items: center;
+    align-items: stretch;
+  }
+  & .pf-v5-c-toolbar__group,
+  & .pf-v5-c-toolbar__toggle-group {
+    align-items: stretch;
+  }
+  & .pf-v5-c-toolbar__item,
+  & .pf-v5-c-toolbar__filter {
+    align-items: stretch;
+    align-self: stretch;
+  }
+  & .pf-v5-c-select {
+    height: 100%;
+  }
+  & .pf-v5-c-menu-toggle:not(.pf-m-plain) {
+    height: 100%;
   }
 `;
 
@@ -123,7 +138,7 @@ function DataListToolbar({
         )}
         {onSelectAll && (
           <ToolbarGroup>
-            <ToolbarItem>
+            <ToolbarItem style={{ alignSelf: 'center' }}>
               <Tooltip content={t`Select all`} position="top">
                 <Checkbox
                   isChecked={isAllSelected}
@@ -212,7 +227,7 @@ function DataListToolbar({
           </ToolbarGroup>
         )}
         {!isAdvancedSearchShown && pagination && itemCount > 0 && (
-          <ToolbarItem variant="pagination">{pagination}</ToolbarItem>
+          <ToolbarItem variant="pagination" style={{ alignSelf: 'center' }}>{pagination}</ToolbarItem>
         )}
       </ToolbarContent>
     </Toolbar>

--- a/awx/ui/src/components/DataListToolbar/DataListToolbar.test.js
+++ b/awx/ui/src/components/DataListToolbar/DataListToolbar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, within, fireEvent } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import DataListToolbar from './DataListToolbar';
 import AddDropDownButton from '../AddDropDownButton/AddDropDownButton';

--- a/awx/ui/src/components/DataListToolbar/DataListToolbar.test.js
+++ b/awx/ui/src/components/DataListToolbar/DataListToolbar.test.js
@@ -134,7 +134,7 @@ describe('<DataListToolbar />', () => {
     );
 
     // open the simple-key select and assert the injected "Advanced" option
-    await user.click(screen.getByRole('button', { name: 'Options menu' }));
+    await user.click(screen.getByRole('button', { name: 'Simple key select' }));
     expect(
       screen.getByRole('option', { name: 'Advanced' })
     ).toBeInTheDocument();
@@ -169,14 +169,8 @@ describe('<DataListToolbar />', () => {
       />
     );
 
-    // enter advanced search mode via the simple-key select -> "Advanced".
-    // Search.handleDropdownSelect matches the option by event.target.innerText,
-    // which jsdom does not populate from layout, so set it explicitly before
-    // dispatching the click (DOM equivalent of the option selection).
-    await user.click(screen.getByRole('button', { name: 'Options menu' }));
-    const advancedOption = screen.getByRole('option', { name: 'Advanced' });
-    advancedOption.innerText = 'Advanced';
-    fireEvent.click(advancedOption);
+    await user.click(screen.getByRole('button', { name: 'Simple key select' }));
+    await user.click(screen.getByRole('option', { name: 'Advanced' }));
 
     // a kebab toggle appears in advanced search mode
     const kebab = await screen.findByRole('button', { name: 'Actions' });

--- a/awx/ui/src/components/LabelSelect/LabelSelect.js
+++ b/awx/ui/src/components/LabelSelect/LabelSelect.js
@@ -91,19 +91,13 @@ function LabelSelect({
     if (selectedOption) {
       onSelect(_event, selectedOption);
     } else if (typeof selectedValue === 'string') {
-      const newItem = { id: selectedValue, name: selectedValue };
+      const trimmed = selectedValue.trim();
+      if (trimmed && !options.find((o) => o.name === trimmed)) {
+        setOptions(options.concat({ name: trimmed, id: trimmed }));
+      }
+      const newItem = { id: trimmed, name: trimmed };
       onSelect(_event, newItem);
     }
-    setFilterValue('');
-  };
-
-  const handleCreate = () => {
-    const trimmed = filterValue.trim();
-    if (trimmed && !options.find((o) => o.name === trimmed)) {
-      setOptions(options.concat({ name: trimmed, id: trimmed }));
-    }
-    const newItem = { id: trimmed, name: trimmed };
-    onSelect(null, newItem);
     setFilterValue('');
   };
 
@@ -194,9 +188,8 @@ function LabelSelect({
         ))}
         {filterValue && !hasExactMatch && (
           <SelectOption
-            key={`create-${filterValue}`}
-            value={filterValue}
-            onClick={handleCreate}
+            key={`create-${filterValue.trim()}`}
+            value={filterValue.trim()}
           >
             {createText || t`Create`} &quot;{filterValue}&quot;
           </SelectOption>

--- a/awx/ui/src/components/LabelSelect/LabelSelect.js
+++ b/awx/ui/src/components/LabelSelect/LabelSelect.js
@@ -1,13 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import {
-	Chip,
-	ChipGroup
+  Button,
+  Label,
+  LabelGroup,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import { TimesIcon } from '@patternfly/react-icons';
 import { useLingui } from '@lingui/react/macro';
 import { LabelsAPI } from 'api';
 import useIsMounted from 'hooks/useIsMounted';
@@ -50,16 +54,13 @@ function LabelSelect({
 }) {
   const [isLoading, setIsLoading] = useState(true);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const isMounted = useIsMounted();
   const { t } = useLingui();
   const { selections, onSelect, options, setOptions } = useSyncedSelectValue(
     value,
     onChange
   );
-
-  const toggleExpanded = (toggleValue) => {
-    setIsExpanded(toggleValue);
-  };
 
   useEffect(() => {
     (async () => {
@@ -72,74 +73,138 @@ function LabelSelect({
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
 
-  const renderOptions = (opts) =>
-    opts.map((option) => (
-      <SelectOption
-        key={option.id}
-        aria-label={option.name}
-        value={option}
-        isDisabled={option.isReadOnly}
-      >
-        {option.name}
-      </SelectOption>
-    ));
+  const filteredOptions = filterValue
+    ? options.filter((o) =>
+        o.name.toLowerCase().includes(filterValue.toLowerCase())
+      )
+    : options;
 
-  const onFilter = (event) => {
-    if (event) {
-      const str = event.target.value.toLowerCase();
-      const matches = options.filter((o) => o.name.toLowerCase().includes(str));
-      return renderOptions(matches);
+  const hasExactMatch = options.some(
+    (o) => o.name.toLowerCase() === filterValue.toLowerCase()
+  );
+
+  const handleSelect = (_event, selectedValue) => {
+    const selectedOption =
+      options.find((o) => String(o.id) === String(selectedValue)) ||
+      selections.find((o) => String(o.id) === String(selectedValue));
+
+    if (selectedOption) {
+      onSelect(_event, selectedOption);
+    } else if (typeof selectedValue === 'string') {
+      const newItem = { id: selectedValue, name: selectedValue };
+      onSelect(_event, newItem);
     }
-    return null;
+    setFilterValue('');
   };
 
-  const chipGroupComponent = () => (
-    <ChipGroup>
-      {(selections || []).map((currentChip) => (
-        <Chip
-          isReadOnly={currentChip.isReadOnly}
-          key={currentChip.name}
-          onClick={(e) => {
-            onSelect(e, currentChip);
-          }}
-        >
-          {currentChip.name}
-        </Chip>
-      ))}
-    </ChipGroup>
-  );
+  const handleCreate = () => {
+    const trimmed = filterValue.trim();
+    if (trimmed && !options.find((o) => o.name === trimmed)) {
+      setOptions(options.concat({ name: trimmed, id: trimmed }));
+    }
+    const newItem = { id: trimmed, name: trimmed };
+    onSelect(null, newItem);
+    setFilterValue('');
+  };
 
   return (
     <Select
-      variant={SelectVariant.typeaheadMulti}
-      onToggle={(_event, toggleValue) => toggleExpanded(toggleValue)}
-      onSelect={(e, item) => {
-        if (typeof item === 'string') {
-          item = { id: item, name: item };
-        }
-        onSelect(e, item);
-      }}
-      onClear={() => onChange(selections.filter((label) => label.isReadOnly))}
-      onFilter={onFilter}
-      isCreatable
-      onCreateOption={(label) => {
-        label = label.trim();
-        if (!options.includes(label)) {
-          setOptions(options.concat({ name: label, id: label }));
-        }
-        return label;
-      }}
-      isDisabled={isLoading}
-      selections={selections}
       isOpen={isExpanded}
-      typeAheadAriaLabel={t`Select Labels`}
-      placeholderText={placeholder}
-      createText={createText}
-      noResultsFoundText={t`No results found`}
-      ouiaId="template-label-select"
-      chipGroupComponent={chipGroupComponent()}
+      onOpenChange={(open) => {
+        setIsExpanded(open);
+        if (!open) setFilterValue('');
+      }}
+      onSelect={handleSelect}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          variant="typeahead"
+          onClick={() => setIsExpanded(!isExpanded)}
+          isExpanded={isExpanded}
+          isDisabled={isLoading}
+          ouiaId="template-label-select"
+        >
+          <TextInputGroup isPlain>
+            <TextInputGroupMain
+              value={filterValue}
+              onClick={() => setIsExpanded(true)}
+              onChange={(_event, val) => {
+                setFilterValue(val);
+                setIsExpanded(true);
+              }}
+              autoComplete="off"
+              placeholder={
+                selections.length === 0 ? placeholder : ''
+              }
+              aria-label={t`Select Labels`}
+            >
+              {selections.length > 0 && (
+                <LabelGroup>
+                  {selections.map((currentChip) => (
+                    <Label
+                      key={currentChip.name}
+                      {...(currentChip.isReadOnly
+                        ? { isDisabled: true }
+                        : {
+                            onClose: () => {
+                              onSelect(null, currentChip);
+                            },
+                          })}
+                    >
+                      {currentChip.name}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              )}
+            </TextInputGroupMain>
+            {(filterValue || selections.length > 0) && (
+              <TextInputGroupUtilities>
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    onChange(
+                      selections.filter((label) => label.isReadOnly)
+                    );
+                    setFilterValue('');
+                  }}
+                  aria-label={t`Clear`}
+                >
+                  <TimesIcon />
+                </Button>
+              </TextInputGroupUtilities>
+            )}
+          </TextInputGroup>
+        </MenuToggle>
+      )}
     >
-      {renderOptions(options)}
+      <SelectList>
+        {filteredOptions.map((option) => (
+          <SelectOption
+            key={option.id}
+            value={String(option.id)}
+            aria-label={option.name}
+            isDisabled={option.isReadOnly}
+            hasCheckbox
+            isSelected={selections.some(
+              (s) => String(s.id) === String(option.id)
+            )}
+          >
+            {option.name}
+          </SelectOption>
+        ))}
+        {filterValue && !hasExactMatch && (
+          <SelectOption
+            key={`create-${filterValue}`}
+            value={filterValue}
+            onClick={handleCreate}
+          >
+            {createText || t`Create`} &quot;{filterValue}&quot;
+          </SelectOption>
+        )}
+        {filteredOptions.length === 0 && !filterValue && (
+          <SelectOption isDisabled>{t`No results found`}</SelectOption>
+        )}
+      </SelectList>
     </Select>
   );
 }

--- a/awx/ui/src/components/LabelSelect/LabelSelect.test.js
+++ b/awx/ui/src/components/LabelSelect/LabelSelect.test.js
@@ -87,7 +87,7 @@ describe('<LabelSelect />', () => {
 
     const input = screen.getByRole('textbox', { name: 'Select Labels' });
     await user.type(input, 'foo');
-    const createOption = await screen.findByText(/foo/);
+    const createOption = await screen.findByRole('option', { name: /Create.*foo/ });
     await user.click(createOption);
 
     expect(onChange).toHaveBeenCalledWith([{ id: 'foo', name: 'foo' }]);

--- a/awx/ui/src/components/LabelSelect/LabelSelect.test.js
+++ b/awx/ui/src/components/LabelSelect/LabelSelect.test.js
@@ -11,12 +11,11 @@ const options = [
   { id: 2, name: 'two' },
 ];
 
-// Open the typeahead by clicking its toggle (the Select renders a toggle
-// button labelled "Options menu"), then return the listbox's option nodes.
 async function openAndGetOptions(user) {
-  await user.click(screen.getByRole('button', { name: 'Options menu' }));
+  const input = screen.getByRole('textbox', { name: 'Select Labels' });
+  await user.click(input);
   const listbox = await screen.findByRole('listbox');
-  return within(listbox).getAllByRole('option');
+  return within(listbox).getAllByRole('menuitem');
 }
 
 describe('<LabelSelect />', () => {
@@ -32,9 +31,8 @@ describe('<LabelSelect />', () => {
       <LabelSelect value={[]} onError={() => {}} onChange={() => {}} />
     );
 
-    // the toggle is disabled until the labels load
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Options menu' })).toBeEnabled()
+      expect(screen.getByRole('textbox', { name: 'Select Labels' })).toBeEnabled()
     );
     expect(LabelsAPI.read).toHaveBeenCalledTimes(1);
 
@@ -65,7 +63,7 @@ describe('<LabelSelect />', () => {
 
     await waitFor(() => expect(LabelsAPI.read).toHaveBeenCalledTimes(2));
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Options menu' })).toBeEnabled()
+      expect(screen.getByRole('textbox', { name: 'Select Labels' })).toBeEnabled()
     );
 
     const selectOptions = await openAndGetOptions(user);
@@ -84,12 +82,10 @@ describe('<LabelSelect />', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Options menu' })).toBeEnabled()
+      expect(screen.getByRole('textbox', { name: 'Select Labels' })).toBeEnabled()
     );
 
-    // typing a non-matching value surfaces an isCreatable "create" option;
-    // selecting it calls onChange with the new {id, name} label
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole('textbox', { name: 'Select Labels' });
     await user.type(input, 'foo');
     const createOption = await screen.findByText(/foo/);
     await user.click(createOption);
@@ -119,13 +115,11 @@ describe('<LabelSelect />', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Options menu' })).toBeEnabled()
+      expect(screen.getByRole('textbox', { name: 'Select Labels' })).toBeEnabled()
     );
 
     const selectOptions = await openAndGetOptions(user);
     expect(selectOptions).toHaveLength(2);
-    // PF renders a disabled SelectOption with the pf-m-disabled modifier class
-    // (and a disabled checkbox); the enabled option lacks it
     expect(selectOptions[0]).toHaveClass('pf-m-disabled');
     expect(selectOptions[1]).not.toHaveClass('pf-m-disabled');
   });

--- a/awx/ui/src/components/LaunchPrompt/steps/SurveyStep.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/SurveyStep.js
@@ -2,17 +2,23 @@ import React, { useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { useField } from 'formik';
 import {
+	Button,
 	Form,
 	FormGroup,
 	FormHelperText,
 	HelperText,
 	HelperTextItem,
-} from '@patternfly/react-core';
-import {
+	Label,
+	LabelGroup,
+	MenuToggle,
 	Select,
+	SelectList,
 	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+	TextInputGroup,
+	TextInputGroupMain,
+	TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import {
   required,
   minMaxValue,
@@ -99,6 +105,7 @@ function MultipleChoiceField({ question }) {
     validate: question.required ? required(null) : null,
   });
   const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const id = `survey-question-${question.variable}`;
   const isValid = !(meta.touched && meta.error);
 
@@ -110,6 +117,12 @@ function MultipleChoiceField({ question }) {
     options = [...question.choices];
   }
 
+  const filteredOptions = filterValue
+    ? options.filter((opt) =>
+        opt.toLowerCase().includes(filterValue.toLowerCase())
+      )
+    : options;
+
   return (
     <FormGroup
       fieldId={id}
@@ -118,26 +131,71 @@ function MultipleChoiceField({ question }) {
       labelIcon={<Popover content={question.question_description} />}
     >
       <Select
-        onToggle={(_event, val) => setIsOpen(val)}
-        onSelect={(event, option) => {
-          helpers.setValue(option);
-          setIsOpen(false);
-        }}
-        selections={field.value}
-        variant={SelectVariant.typeahead}
         id={id}
-        ouiaId={`single-survey-question-${question.variable}`}
         isOpen={isOpen}
-        placeholderText={t`Select an option`}
-        onClear={() => {
-          helpers.setTouched(true);
-          helpers.setValue('');
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (!open) setFilterValue('');
         }}
-        noResultsFoundText={t`No results found`}
+        onSelect={(_event, value) => {
+          helpers.setValue(value);
+          setIsOpen(false);
+          setFilterValue('');
+        }}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="typeahead"
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+            ouiaId={`single-survey-question-${question.variable}`}
+          >
+            <TextInputGroup isPlain>
+              <TextInputGroupMain
+                value={filterValue || field.value || ''}
+                onClick={() => setIsOpen(true)}
+                onChange={(_event, val) => {
+                  setFilterValue(val);
+                  setIsOpen(true);
+                }}
+                onFocus={() => {
+                  if (field.value && !filterValue) {
+                    setFilterValue(field.value);
+                  }
+                }}
+                autoComplete="off"
+                placeholder={t`Select an option`}
+              />
+              {(filterValue || field.value) && (
+                <TextInputGroupUtilities>
+                  <Button
+                    variant="plain"
+                    onClick={() => {
+                      helpers.setTouched(true);
+                      helpers.setValue('');
+                      setFilterValue('');
+                    }}
+                    aria-label={t`Clear`}
+                  >
+                    <TimesIcon />
+                  </Button>
+                </TextInputGroupUtilities>
+              )}
+            </TextInputGroup>
+          </MenuToggle>
+        )}
       >
-        {options.map((opt) => (
-          <SelectOption key={opt} value={opt} />
-        ))}
+        <SelectList>
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map((opt) => (
+              <SelectOption key={opt} value={opt}>
+                {opt}
+              </SelectOption>
+            ))
+          ) : (
+            <SelectOption isDisabled>{t`No results found`}</SelectOption>
+          )}
+        </SelectList>
       </Select>
       {!isValid && (
         <FormHelperText>
@@ -155,6 +213,7 @@ function MultipleChoiceField({ question }) {
 function MultiSelectField({ question }) {
   const { t } = useLingui();
   const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const [field, meta, helpers] = useField({
     name: `survey_${question.variable}`,
     validate: question.required ? required(null) : null,
@@ -171,6 +230,12 @@ function MultiSelectField({ question }) {
     options = [...question.choices];
   }
 
+  const filteredOptions = filterValue
+    ? options.filter((opt) =>
+        opt.toLowerCase().includes(filterValue.toLowerCase())
+      )
+    : options;
+
   return (
     <FormGroup
       fieldId={id}
@@ -179,30 +244,95 @@ function MultiSelectField({ question }) {
       labelIcon={<Popover content={question.question_description} />}
     >
       <Select
-        ouiaId={`multi-survey-question-${question.variable}`}
-        variant={SelectVariant.typeaheadMulti}
         id={id}
-        placeholderText={!field.value.length && t`Select option(s)`}
-        onToggle={(_event, val) => setIsOpen(val)}
-        onSelect={(event, option) => {
-          if (field?.value?.includes(option)) {
-            helpers.setValue(field.value.filter((o) => o !== option));
+        isOpen={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (!open) setFilterValue('');
+        }}
+        onSelect={(_event, value) => {
+          if (field?.value?.includes(value)) {
+            helpers.setValue(field.value.filter((o) => o !== value));
           } else {
-            helpers.setValue(field.value.concat(option));
+            helpers.setValue(field.value.concat(value));
           }
           helpers.setTouched(true);
+          setFilterValue('');
         }}
-        isOpen={isOpen}
-        selections={field.value}
-        onClear={() => {
-          helpers.setTouched(true);
-          helpers.setValue([]);
-        }}
-        noResultsFoundText={t`No results found`}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="typeahead"
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+            ouiaId={`multi-survey-question-${question.variable}`}
+          >
+            <TextInputGroup isPlain>
+              <TextInputGroupMain
+                value={filterValue}
+                onClick={() => setIsOpen(true)}
+                onChange={(_event, val) => {
+                  setFilterValue(val);
+                  setIsOpen(true);
+                }}
+                autoComplete="off"
+                placeholder={
+                  !field.value?.length ? t`Select option(s)` : ''
+                }
+              >
+                {field.value?.length > 0 && (
+                  <LabelGroup>
+                    {field.value.map((val) => (
+                      <Label
+                        key={val}
+                        onClose={() => {
+                          helpers.setValue(
+                            field.value.filter((o) => o !== val)
+                          );
+                          helpers.setTouched(true);
+                        }}
+                      >
+                        {val}
+                      </Label>
+                    ))}
+                  </LabelGroup>
+                )}
+              </TextInputGroupMain>
+              {(filterValue || field.value?.length > 0) && (
+                <TextInputGroupUtilities>
+                  <Button
+                    variant="plain"
+                    onClick={() => {
+                      helpers.setTouched(true);
+                      helpers.setValue([]);
+                      setFilterValue('');
+                    }}
+                    aria-label={t`Clear`}
+                  >
+                    <TimesIcon />
+                  </Button>
+                </TextInputGroupUtilities>
+              )}
+            </TextInputGroup>
+          </MenuToggle>
+        )}
       >
-        {options.map((opt) => (
-          <SelectOption key={opt} value={opt} />
-        ))}
+        <SelectList>
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map((opt) => (
+              <SelectOption
+                key={opt}
+                value={opt}
+                hasCheckbox
+                isSelected={field.value?.includes(opt)}
+              >
+                {opt}
+              </SelectOption>
+            ))
+          ) : (
+            <SelectOption isDisabled>{t`No results found`}</SelectOption>
+          )}
+        </SelectList>
       </Select>
       {!isValid && (
         <FormHelperText>

--- a/awx/ui/src/components/LaunchPrompt/steps/SurveyStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/SurveyStep.test.js
@@ -25,9 +25,9 @@ function makeConfig(choices) {
 }
 
 async function openAndAssertOptions(user) {
-  // The typeahead toggle is the button inside the PF Select.
-  const toggle = screen.getByRole('button', { name: 'Options menu' });
-  await user.click(toggle);
+  // The typeahead toggle is the textbox inside the MenuToggle.
+  const input = screen.getByRole('textbox');
+  await user.click(input);
 
   const listbox = screen.getByRole('listbox');
   ['1', '2', '3', '4', '5', '6'].forEach((value) => {

--- a/awx/ui/src/components/MultiSelect/TagMultiSelect.js
+++ b/awx/ui/src/components/MultiSelect/TagMultiSelect.js
@@ -1,10 +1,18 @@
 import React, { useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+  Button,
+  Label,
+  LabelGroup,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import { arrayToString, stringToArray } from 'util/strings';
 
 function TagMultiSelect({ onChange, value }) {
@@ -12,8 +20,9 @@ function TagMultiSelect({ onChange, value }) {
   const selections = stringToArray(value);
   const [options, setOptions] = useState(selections);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
 
-  const onSelect = (event, item) => {
+  const onSelect = (_event, item) => {
     let newValue;
     if (selections.includes(item)) {
       newValue = selections.filter((i) => i !== item);
@@ -21,51 +30,108 @@ function TagMultiSelect({ onChange, value }) {
       newValue = selections.concat(item);
     }
     onChange(arrayToString(newValue));
+    setFilterValue('');
   };
 
-  const toggleExpanded = (toggleValue) => {
-    setIsExpanded(toggleValue);
-  };
+  const filteredOptions = filterValue
+    ? options.filter((o) => o.toLowerCase().includes(filterValue.toLowerCase()))
+    : options;
 
-  const renderOptions = (opts) =>
-    opts.map((option) => (
-      <SelectOption key={option} value={option}>
-        {option}
-      </SelectOption>
-    ));
-
-  const onFilter = (event) => {
-    if (event) {
-      const str = event.target.value.toLowerCase();
-      const matches = options.filter((o) => o.toLowerCase().includes(str));
-      return renderOptions(matches);
-    }
-    return null;
-  };
+  const hasExactMatch = options.some(
+    (o) => o.toLowerCase() === filterValue.toLowerCase()
+  );
 
   return (
     <Select
-      variant={SelectVariant.typeaheadMulti}
-      onToggle={(_event, toggleValue) => toggleExpanded(toggleValue)}
-      onSelect={onSelect}
-      onClear={() => onChange('')}
-      onFilter={onFilter}
-      isCreatable
-      onCreateOption={(name) => {
-        name = name.trim();
-        if (!options.includes(name)) {
-          setOptions(options.concat(name));
-        }
-        return name;
-      }}
-      selections={selections}
       isOpen={isExpanded}
-      typeAheadAriaLabel={t`Select tags`}
-      noResultsFoundText={t`No results found`}
-      ouiaId="tag-multiselect"
-      createText={t`Create`}
+      onOpenChange={(open) => {
+        setIsExpanded(open);
+        if (!open) setFilterValue('');
+      }}
+      onSelect={onSelect}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          variant="typeahead"
+          onClick={() => setIsExpanded(!isExpanded)}
+          isExpanded={isExpanded}
+          ouiaId="tag-multiselect"
+        >
+          <TextInputGroup isPlain>
+            <TextInputGroupMain
+              value={filterValue}
+              onClick={() => setIsExpanded(true)}
+              onChange={(_event, val) => {
+                setFilterValue(val);
+                setIsExpanded(true);
+              }}
+              autoComplete="off"
+              placeholder={selections.length === 0 ? t`Select tags` : ''}
+              aria-label={t`Select tags`}
+            >
+              {selections.length > 0 && (
+                <LabelGroup>
+                  {selections.map((s) => (
+                    <Label
+                      key={s}
+                      onClose={() => {
+                        const newVal = selections.filter((sel) => sel !== s);
+                        onChange(arrayToString(newVal));
+                      }}
+                    >
+                      {s}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              )}
+            </TextInputGroupMain>
+            {(filterValue || selections.length > 0) && (
+              <TextInputGroupUtilities>
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    onChange('');
+                    setFilterValue('');
+                  }}
+                  aria-label={t`Clear`}
+                >
+                  <TimesIcon />
+                </Button>
+              </TextInputGroupUtilities>
+            )}
+          </TextInputGroup>
+        </MenuToggle>
+      )}
     >
-      {renderOptions(options)}
+      <SelectList>
+        {filteredOptions.map((option) => (
+          <SelectOption
+            key={option}
+            value={option}
+            hasCheckbox
+            isSelected={selections.includes(option)}
+          >
+            {option}
+          </SelectOption>
+        ))}
+        {filterValue && !hasExactMatch && (
+          <SelectOption
+            key={`create-${filterValue}`}
+            value={filterValue}
+            onClick={() => {
+              const trimmed = filterValue.trim();
+              if (trimmed && !options.includes(trimmed)) {
+                setOptions(options.concat(trimmed));
+              }
+            }}
+          >
+            {t`Create`} &quot;{filterValue}&quot;
+          </SelectOption>
+        )}
+        {filteredOptions.length === 0 && !filterValue && (
+          <SelectOption isDisabled>{t`No results found`}</SelectOption>
+        )}
+      </SelectList>
     </Select>
   );
 }

--- a/awx/ui/src/components/MultiSelect/TagMultiSelect.js
+++ b/awx/ui/src/components/MultiSelect/TagMultiSelect.js
@@ -116,16 +116,16 @@ function TagMultiSelect({ onChange, value }) {
         ))}
         {filterValue && !hasExactMatch && (
           <SelectOption
-            key={`create-${filterValue}`}
-            value={filterValue}
+            key={`create-${filterValue.trim()}`}
+            value={filterValue.trim()}
             onClick={() => {
               const trimmed = filterValue.trim();
               if (trimmed && !options.includes(trimmed)) {
-                setOptions(options.concat(trimmed));
+                setOptions((prev) => prev.concat(trimmed));
               }
             }}
           >
-            {t`Create`} &quot;{filterValue}&quot;
+            {t`Create`} &quot;{filterValue.trim()}&quot;
           </SelectOption>
         )}
         {filteredOptions.length === 0 && !filterValue && (

--- a/awx/ui/src/components/MultiSelect/TagMultiSelect.test.js
+++ b/awx/ui/src/components/MultiSelect/TagMultiSelect.test.js
@@ -3,14 +3,14 @@ import { screen, within } from '@testing-library/react';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import TagMultiSelect from './TagMultiSelect';
 
-function getChipGroup() {
-  return screen.getByRole('group', { name: 'Chip group category' });
+function getLabelGroup() {
+  return screen.getByRole('list', { name: 'Label group category' });
 }
 
 describe('<TagMultiSelect />', () => {
   it('should render Select with a chip per value', () => {
     renderWithContexts(<TagMultiSelect value="foo,bar" onChange={jest.fn()} />);
-    const chips = within(getChipGroup()).getAllByRole('listitem');
+    const chips = within(getLabelGroup()).getAllByRole('listitem');
     expect(chips).toHaveLength(2);
     expect(chips[0]).toHaveTextContent('foo');
     expect(chips[1]).toHaveTextContent('bar');
@@ -20,14 +20,12 @@ describe('<TagMultiSelect />', () => {
     const { user } = renderWithContexts(
       <TagMultiSelect value="" onChange={jest.fn()} />
     );
-    expect(screen.queryByRole('group', { name: 'Chip group category' })).toBeNull();
+    expect(screen.queryByRole('list', { name: 'Label group category' })).toBeNull();
 
-    await user.click(screen.getByRole('button', { name: 'Options menu' }));
+    const input = screen.getByRole('textbox', { name: 'Select tags' });
+    await user.click(input);
     expect(
-      screen.getByRole('button', { name: 'Options menu' })
-    ).toHaveAttribute('aria-expanded', 'true');
-    expect(
-      screen.queryByRole('group', { name: 'Chip group category' })
+      screen.queryByRole('list', { name: 'Label group category' })
     ).toBeNull();
   });
 
@@ -37,9 +35,8 @@ describe('<TagMultiSelect />', () => {
       <TagMultiSelect value="foo,bar" onChange={onChange} />
     );
 
-    await user.click(screen.getByRole('button', { name: 'Options menu' }));
-    // selecting an unselected typed option adds it to the value string
     const input = screen.getByRole('textbox');
+    await user.click(input);
     await user.type(input, 'baz');
     await user.click(screen.getByRole('option', { name: /Create.*baz/ }));
 

--- a/awx/ui/src/components/PaginatedTable/ToolbarAddButton.js
+++ b/awx/ui/src/components/PaginatedTable/ToolbarAddButton.js
@@ -13,6 +13,7 @@ const ToolbarAddButton = forwardRef(({
   linkTo = null,
   onClick = null,
   isDisabled,
+  isExpanded,
   defaultLabel,
   showToggleIndicator,
   ouiaId,
@@ -47,6 +48,7 @@ const ToolbarAddButton = forwardRef(({
           ouiaId={ouiaId}
           onClick={onClick}
           isDisabled={isDisabled}
+          isExpanded={isExpanded}
         >
           {defaultLabel || t`Add`}
         </MenuToggle>

--- a/awx/ui/src/components/PaginatedTable/ToolbarAddButton.js
+++ b/awx/ui/src/components/PaginatedTable/ToolbarAddButton.js
@@ -6,7 +6,6 @@ import {
 	MenuToggle,
 	Tooltip
 } from '@patternfly/react-core';
-import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 import { useLingui } from '@lingui/react/macro';
 import { useKebabifiedMenu } from 'contexts/Kebabified';
 
@@ -50,7 +49,6 @@ const ToolbarAddButton = forwardRef(({
           isDisabled={isDisabled}
         >
           {defaultLabel || t`Add`}
-          <CaretDownIcon />
         </MenuToggle>
       </Tooltip>
     );

--- a/awx/ui/src/components/ResourceAccessList/ResourceAccessList.test.js
+++ b/awx/ui/src/components/ResourceAccessList/ResourceAccessList.test.js
@@ -441,33 +441,17 @@ describe('<ResourceAccessList />', () => {
     const { user } = renderOrg();
     await screen.findByRole('link', { name: 'joe' });
 
-    // Open the simple key select (scoped by ouiaId; the key Select toggle and
-    // the value Select toggle both expose a generic "Options menu" name) and
-    // pick "Roles" as the search key. The presence of the "Roles" option already
-    // proves the Roles column was appended to toolbarSearchColumns.
-    const keySelect = document.querySelector(
-      '[data-ouia-component-id="simple-key-select"]'
-    );
-    await user.click(within(keySelect).getByRole('button'));
-    const rolesOption = await screen.findByRole('option', { name: 'Roles' });
-    // Search's handleDropdownSelect keys off target.innerText, which jsdom does
-    // not populate from layout; set it explicitly so the real handler resolves
-    // the selected column, then dispatch the click it listens for.
-    Object.defineProperty(rolesOption, 'innerText', {
-      configurable: true,
-      value: 'Roles',
-    });
-    fireEvent.click(rolesOption);
+    await user.click(screen.getByRole('button', { name: 'Simple key select' }));
+    await user.click(await screen.findByRole('option', { name: 'Roles' }));
 
-    // Open the "Filter By Roles" value select (scoped by ouiaId).
-    const rolesSelect = await waitFor(() => {
+    const rolesToggle = await waitFor(() => {
       const el = document.querySelector(
         '[data-ouia-component-id="filter-by-or__roles__in"]'
       );
       expect(el).toBeInTheDocument();
       return el;
     });
-    await user.click(within(rolesSelect).getByRole('button'));
+    await user.click(rolesToggle);
 
     const listbox = await screen.findByRole('listbox');
     expect(within(listbox).getByText('Admin')).toBeInTheDocument();

--- a/awx/ui/src/components/Schedule/shared/FrequencySelect.js
+++ b/awx/ui/src/components/Schedule/shared/FrequencySelect.js
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import {
 	Select,
 	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+	SelectList,
+	MenuToggle
+} from '@patternfly/react-core';
 
 export default function FrequencySelect({
   id,
@@ -15,7 +16,7 @@ export default function FrequencySelect({
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const onSelect = (event, selectedValue) => {
+  const onSelectHandler = (event, selectedValue) => {
     if (selectedValue === 'none') {
       onChange([]);
       setIsOpen(false);
@@ -29,7 +30,7 @@ export default function FrequencySelect({
     }
   };
 
-  const onToggle = (val) => {
+  const handleOpenChange = (val) => {
     if (!val) {
       onBlur();
     }
@@ -38,17 +39,34 @@ export default function FrequencySelect({
 
   return (
     <Select
-      variant={SelectVariant.checkbox}
-      onSelect={onSelect}
-      selections={value}
-      placeholderText={placeholderText}
-      onToggle={(_event, val) => onToggle(val)}
       isOpen={isOpen}
-      ouiaId={`frequency-select-${id}`}
+      onOpenChange={handleOpenChange}
+      onSelect={onSelectHandler}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => handleOpenChange(!isOpen)}
+          isExpanded={isOpen}
+          ouiaId={`frequency-select-${id}`}
+        >
+          {placeholderText}
+        </MenuToggle>
+      )}
     >
-      {children}
+      <SelectList>
+        {React.Children.map(children, (child) => {
+          if (!child) return null;
+          if (child.props.value === 'none') {
+            return React.cloneElement(child);
+          }
+          return React.cloneElement(child, {
+            hasCheckbox: true,
+            isSelected: value.includes(child.props.value),
+          });
+        })}
+      </SelectList>
     </Select>
   );
 }
 
-export { SelectOption, SelectVariant };
+export { SelectOption };

--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.test.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.test.js
@@ -145,13 +145,11 @@ async function waitForForm(container) {
   );
 }
 
-// Choose a run-frequency from the (multi-select checkbox) FrequencySelect. The
-// run-frequency select is the first PF select toggle in the form.
 async function selectRunFrequency(user, container, optionLabel) {
-  const toggle = container.querySelectorAll('.pf-v5-c-select__toggle')[0];
+  const toggle = freqSelect(container, 'schedule-frequency');
   await user.click(toggle);
-  await user.click(await screen.findByText(optionLabel));
-  // close the menu so it doesn't linger
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(optionLabel));
   await user.click(toggle);
 }
 

--- a/awx/ui/src/components/Search/AdvancedSearch.js
+++ b/awx/ui/src/components/Search/AdvancedSearch.js
@@ -6,15 +6,18 @@ import {
 	Divider,
 	InputGroup,
 	TextInput,
-	Tooltip, InputGroupItem
-} from '@patternfly/react-core';
-import {
+	Tooltip,
+	InputGroupItem,
 	Select,
-	SelectGroup,
 	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
-import { SearchIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+	SelectList,
+	SelectGroup,
+	MenuToggle,
+	TextInputGroup,
+	TextInputGroupMain,
+	TextInputGroupUtilities
+} from '@patternfly/react-core';
+import { SearchIcon, QuestionCircleIcon, TimesIcon } from '@patternfly/react-icons';
 import styled from 'styled-components';
 import { useLocation } from 'react-router';
 import { useConfig } from 'contexts/Config';
@@ -40,6 +43,29 @@ const AdvancedGroup = styled.div`
   }
 `;
 
+const prefixOptions = (t, enableNegativeFiltering) => {
+  const opts = [
+    {
+      id: 'and-option-select',
+      value: 'and',
+      description: t`Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected.`,
+    },
+    {
+      id: 'or-option-select',
+      value: 'or',
+      description: t`Returns results that satisfy this one or any other filters.`,
+    },
+  ];
+  if (enableNegativeFiltering) {
+    opts.push({
+      id: 'not-option-select',
+      value: 'not',
+      description: t`Returns results that have values other than this one as well as other filters.`,
+    });
+  }
+  return opts;
+};
+
 function AdvancedSearch({
   onSearch,
   searchableKeys = [],
@@ -61,6 +87,8 @@ function AdvancedSearch({
   const [keySelection, setKeySelection] = useState(null);
   const [searchValue, setSearchValue] = useState('');
   const [isTextInputDisabled, setIsTextInputDisabled] = useState(false);
+  const [prefixFilterValue, setPrefixFilterValue] = useState('');
+  const [keyFilterValue, setKeyFilterValue] = useState('');
   const { pathname, search } = useLocation();
 
   useEffect(() => {
@@ -139,43 +167,84 @@ function AdvancedSearch({
     }
   };
 
+  const allPrefixOptions = prefixOptions(t, enableNegativeFiltering);
+  const filteredPrefixOptions = prefixFilterValue
+    ? allPrefixOptions.filter((opt) =>
+        opt.value.toLowerCase().includes(prefixFilterValue.toLowerCase())
+      )
+    : allPrefixOptions;
+
   const renderSetType = () => (
     <Select
-      ouiaId="set-type-typeahead"
       aria-label={t`Set type select`}
       className="setTypeSelect"
-      variant={SelectVariant.typeahead}
-      typeAheadAriaLabel={t`Set type typeahead`}
-      onToggle={(_event, val) => setIsPrefixDropdownOpen(val)}
-      onSelect={(event, selection) => setPrefixSelection(selection)}
-      onClear={() => setPrefixSelection(null)}
-      selections={prefixSelection}
       isOpen={isPrefixDropdownOpen}
-      placeholderText={t`Set type`}
-      maxHeight={maxSelectHeight}
-      noResultsFoundText={t`No results found`}
-      isDisabled={lookupSelection === 'search'}
-    >
-      <SelectOption
-        id="and-option-select"
-        key="and"
-        value="and"
-        description={t`Returns results that satisfy this one as well as other filters.  This is the default set type if nothing is selected.`}
-      />
-      <SelectOption
-        id="or-option-select"
-        key="or"
-        value="or"
-        description={t`Returns results that satisfy this one or any other filters.`}
-      />
-      {enableNegativeFiltering && (
-        <SelectOption
-          id="not-option-select"
-          key="not"
-          value="not"
-          description={t`Returns results that have values other than this one as well as other filters.`}
-        />
+      onOpenChange={(open) => {
+        setIsPrefixDropdownOpen(open);
+        if (!open) setPrefixFilterValue('');
+      }}
+      onSelect={(_event, selection) => {
+        setPrefixSelection(selection);
+        setPrefixFilterValue('');
+        setIsPrefixDropdownOpen(false);
+      }}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          variant="typeahead"
+          onClick={() => setIsPrefixDropdownOpen(!isPrefixDropdownOpen)}
+          isExpanded={isPrefixDropdownOpen}
+          isDisabled={lookupSelection === 'search'}
+          ouiaId="set-type-typeahead"
+        >
+          <TextInputGroup isPlain>
+            <TextInputGroupMain
+              value={prefixFilterValue || prefixSelection || ''}
+              onClick={() => setIsPrefixDropdownOpen(true)}
+              onChange={(_event, val) => {
+                setPrefixFilterValue(val);
+                setIsPrefixDropdownOpen(true);
+              }}
+              autoComplete="off"
+              placeholder={t`Set type`}
+              aria-label={t`Set type typeahead`}
+            />
+            {(prefixFilterValue || prefixSelection) && (
+              <TextInputGroupUtilities>
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    setPrefixSelection(null);
+                    setPrefixFilterValue('');
+                  }}
+                  aria-label={t`Clear`}
+                >
+                  <TimesIcon />
+                </Button>
+              </TextInputGroupUtilities>
+            )}
+          </TextInputGroup>
+        </MenuToggle>
       )}
+    >
+      <SelectList style={{ maxHeight: maxSelectHeight, overflow: 'auto' }}>
+        {filteredPrefixOptions.length > 0 ? (
+          filteredPrefixOptions.map((opt) => (
+            <SelectOption
+              id={opt.id}
+              key={opt.value}
+              value={opt.value}
+              description={opt.description}
+            >
+              {opt.value}
+            </SelectOption>
+          ))
+        ) : (
+          <SelectOption isDisabled key="no-results" value="no-results">
+            {t`No results found`}
+          </SelectOption>
+        )}
+      </SelectList>
     </Select>
   );
 
@@ -254,62 +323,116 @@ function AdvancedSearch({
     );
   };
 
+  const allKeyOptions = [
+    ...searchableKeys.map((k) => ({ key: k.key, group: 'direct' })),
+    ...relatedKeys.map((rKey) => ({ key: rKey, group: 'related' })),
+  ];
+  const filteredKeyOptions = keyFilterValue
+    ? allKeyOptions.filter((opt) =>
+        opt.key.toLowerCase().includes(keyFilterValue.toLowerCase())
+      )
+    : allKeyOptions;
+  const filteredDirectKeys = filteredKeyOptions.filter(
+    (opt) => opt.group === 'direct'
+  );
+  const filteredRelatedKeys = filteredKeyOptions.filter(
+    (opt) => opt.group === 'related'
+  );
+
   return (
     <AdvancedGroup>
       {renderLookupSelection()}
       <Select
-        ouiaId="set-key-typeahead"
         aria-label={t`Key select`}
         className="keySelect"
-        variant={SelectVariant.typeahead}
-        typeAheadAriaLabel={t`Key typeahead`}
-        onToggle={(_event, val) => setIsKeyDropdownOpen(val)}
-        onSelect={(event, selection) => setKeySelection(selection)}
-        onClear={() => setKeySelection(null)}
-        selections={keySelection}
         isOpen={isKeyDropdownOpen}
-        placeholderText={t`Key`}
-        isGrouped
-        onCreateOption={setKeySelection}
-        maxHeight={maxSelectHeight}
-        noResultsFoundText={t`No results found`}
+        onOpenChange={(open) => {
+          setIsKeyDropdownOpen(open);
+          if (!open) setKeyFilterValue('');
+        }}
+        onSelect={(_event, selection) => {
+          setKeySelection(selection);
+          setKeyFilterValue('');
+          setIsKeyDropdownOpen(false);
+        }}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="typeahead"
+            onClick={() => setIsKeyDropdownOpen(!isKeyDropdownOpen)}
+            isExpanded={isKeyDropdownOpen}
+            ouiaId="set-key-typeahead"
+          >
+            <TextInputGroup isPlain>
+              <TextInputGroupMain
+                value={keyFilterValue || keySelection || ''}
+                onClick={() => setIsKeyDropdownOpen(true)}
+                onChange={(_event, val) => {
+                  setKeyFilterValue(val);
+                  setIsKeyDropdownOpen(true);
+                }}
+                autoComplete="off"
+                placeholder={t`Key`}
+                aria-label={t`Key typeahead`}
+              />
+              {(keyFilterValue || keySelection) && (
+                <TextInputGroupUtilities>
+                  <Button
+                    variant="plain"
+                    onClick={() => {
+                      setKeySelection(null);
+                      setKeyFilterValue('');
+                    }}
+                    aria-label={t`Clear`}
+                  >
+                    <TimesIcon />
+                  </Button>
+                </TextInputGroupUtilities>
+              )}
+            </TextInputGroup>
+          </MenuToggle>
+        )}
       >
-        {[
-          ...(searchableKeys.length
-            ? [
+        <SelectList style={{ maxHeight: maxSelectHeight, overflow: 'auto' }}>
+          {filteredKeyOptions.length > 0 ? (
+            <>
+              {filteredDirectKeys.length > 0 && (
                 <SelectGroup key="direct keys" label={t`Direct Keys`}>
-                  {searchableKeys.map((k) => (
+                  {filteredDirectKeys.map((opt) => (
                     <SelectOption
-                      value={k.key}
-                      key={k.key}
-                      id={`select-option-${k.key}`}
+                      value={opt.key}
+                      key={opt.key}
+                      id={`select-option-${opt.key}`}
                     >
-                      {k.key}
+                      {opt.key}
                     </SelectOption>
                   ))}
-                </SelectGroup>,
-                <Divider key="divider" />,
-              ]
-            : []),
-          ...(relatedKeys.length
-            ? [
-                <SelectGroup
-                  key="related keys"
-                  label={t`Related Keys`}
-                >
-                  {relatedKeys.map((rKey) => (
+                </SelectGroup>
+              )}
+              {filteredDirectKeys.length > 0 &&
+                filteredRelatedKeys.length > 0 && (
+                  <Divider key="divider" />
+                )}
+              {filteredRelatedKeys.length > 0 && (
+                <SelectGroup key="related keys" label={t`Related Keys`}>
+                  {filteredRelatedKeys.map((opt) => (
                     <SelectOption
-                      value={rKey}
-                      key={rKey}
-                      id={`select-option-${rKey}`}
+                      value={opt.key}
+                      key={opt.key}
+                      id={`select-option-${opt.key}`}
                     >
-                      {rKey}
+                      {opt.key}
                     </SelectOption>
                   ))}
-                </SelectGroup>,
-              ]
-            : []),
-        ]}
+                </SelectGroup>
+              )}
+            </>
+          ) : (
+            <SelectOption isDisabled key="no-results" value="no-results">
+              {t`No results found`}
+            </SelectOption>
+          )}
+        </SelectList>
       </Select>
       {renderLookupType()}
 

--- a/awx/ui/src/components/Search/AdvancedSearch.test.js
+++ b/awx/ui/src/components/Search/AdvancedSearch.test.js
@@ -3,18 +3,17 @@ import { screen, within, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithContexts } from '../../../testUtils/rtlContexts';
 import AdvancedSearch from './AdvancedSearch';
 
-// The three key-building Selects are typeahead PF Selects scoped by ouia id.
-// Each toggle is named "Options menu" and each has a "Clear all" button when it
-// holds a selection, so we scope all interactions by the wrapping ouia element.
-async function selectFrom(user, ouiaId, optionName) {
-  const wrap = document.querySelector(`[data-ouia-component-id="${ouiaId}"]`);
-  await user.click(within(wrap).getByRole('button', { name: 'Options menu' }));
-  await user.click(await screen.findByRole('option', { name: optionName }));
+async function selectFrom(user, inputLabel, optionName) {
+  const input = screen.getByRole('textbox', { name: inputLabel });
+  await user.click(input);
+  const option = await screen.findByRole('option', { name: optionName });
+  await user.click(option);
 }
 
-async function clearFrom(user, ouiaId) {
-  const wrap = document.querySelector(`[data-ouia-component-id="${ouiaId}"]`);
-  await user.click(within(wrap).getByRole('button', { name: 'Clear all' }));
+async function clearFrom(user, inputLabel) {
+  const input = screen.getByRole('textbox', { name: inputLabel });
+  const container = input.closest('.pf-v5-c-menu-toggle');
+  await user.click(within(container).getByRole('button', { name: 'Clear' }));
 }
 
 function valueInput() {
@@ -39,15 +38,10 @@ describe('<AdvancedSearch />', () => {
         relatedSearchableKeys={['bar', 'baz']}
       />
     );
-    const keyWrap = document.querySelector(
-      '[data-ouia-component-id="set-key-typeahead"]'
-    );
-    await user.click(
-      within(keyWrap).getByRole('button', { name: 'Options menu' })
-    );
-    // 'bar' is in both lists but must appear only once -> foo, bar, baz
-    // scope to this Select so options from other Selects aren't counted
-    expect(within(keyWrap).getAllByRole('option')).toHaveLength(3);
+    const input = screen.getByRole('textbox', { name: 'Key typeahead' });
+    await user.click(input);
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getAllByRole('option')).toHaveLength(3);
   });
 
   test("Don't call onSearch unless a search value is set", async () => {
@@ -62,9 +56,8 @@ describe('<AdvancedSearch />', () => {
         relatedSearchableKeys={['bar', 'baz']}
       />
     );
-    await selectFrom(user, 'set-key-typeahead', 'bar');
+    await selectFrom(user, 'Key typeahead', 'bar');
 
-    // Enter with an empty value must not fire onSearch
     fireEvent.keyDown(valueInput(), { key: 'Enter' });
     expect(advancedSearchMock).toHaveBeenCalledTimes(0);
 
@@ -73,8 +66,6 @@ describe('<AdvancedSearch />', () => {
   });
 
   test('Disable searchValue input until a key is set', async () => {
-    // The key Select has no isCreatable affordance, so we select a real key
-    // option to enable input.
     const { user } = renderWithContexts(
       <AdvancedSearch
         onSearch={jest.fn()}
@@ -83,13 +74,11 @@ describe('<AdvancedSearch />', () => {
       />
     );
     expect(valueInput()).toBeDisabled();
-    await selectFrom(user, 'set-key-typeahead', 'foo');
+    await selectFrom(user, 'Key typeahead', 'foo');
     expect(valueInput()).toBeEnabled();
   });
 
   test('Strip and__ set type from key', async () => {
-    // searchableKeys provides 'foo' as a selectable option (creating it via
-    // onCreateOption has no DOM affordance here).
     const advancedSearchMock = jest.fn();
     const { user } = renderWithContexts(
       <AdvancedSearch
@@ -98,14 +87,13 @@ describe('<AdvancedSearch />', () => {
         relatedSearchableKeys={[]}
       />
     );
-    await selectFrom(user, 'set-type-typeahead', /^and/);
-    await selectFrom(user, 'set-key-typeahead', 'foo');
+    await selectFrom(user, 'Set type typeahead', /^and/);
+    await selectFrom(user, 'Key typeahead', 'foo');
     await setValueAndSubmit(user, 'bar');
-    // the 'and' set type is stripped -> bare key
     expect(advancedSearchMock).toHaveBeenCalledWith('foo', 'bar');
 
     advancedSearchMock.mockClear();
-    await selectFrom(user, 'set-type-typeahead', /^or/);
+    await selectFrom(user, 'Set type typeahead', /^or/);
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('or__foo', 'bar');
   });
@@ -122,27 +110,23 @@ describe('<AdvancedSearch />', () => {
         relatedSearchableKeys={['bar', 'baz']}
       />
     );
-    // direct key 'foo' -> no lookup added
-    await selectFrom(user, 'set-key-typeahead', 'foo');
+    await selectFrom(user, 'Key typeahead', 'foo');
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('foo', 'bar');
 
-    // 'bar' is in both direct and related; the direct definition wins -> no lookup
     advancedSearchMock.mockClear();
-    await selectFrom(user, 'set-key-typeahead', 'bar');
+    await selectFrom(user, 'Key typeahead', 'bar');
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('bar', 'bar');
 
-    // 'baz' is a related-only key -> default name__icontains lookup
     advancedSearchMock.mockClear();
-    await selectFrom(user, 'set-key-typeahead', 'baz');
+    await selectFrom(user, 'Key typeahead', 'baz');
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('baz__name__icontains', 'bar');
 
-    // switching the related search type to "search" -> baz__search
     advancedSearchMock.mockClear();
-    await selectFrom(user, 'set-key-typeahead', 'baz');
-    await selectFrom(user, 'set-lookup-typeahead', /Fuzzy search on id/);
+    await selectFrom(user, 'Key typeahead', 'baz');
+    await selectFrom(user, 'Related search type typeahead', /Fuzzy search on id/);
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('baz__search', 'bar');
   });
@@ -156,9 +140,9 @@ describe('<AdvancedSearch />', () => {
         relatedSearchableKeys={[]}
       />
     );
-    await selectFrom(user, 'set-type-typeahead', /^or/);
-    await selectFrom(user, 'set-key-typeahead', 'foo');
-    await selectFrom(user, 'set-lookup-typeahead', /^exact/);
+    await selectFrom(user, 'Set type typeahead', /^or/);
+    await selectFrom(user, 'Key typeahead', 'foo');
+    await selectFrom(user, 'Lookup typeahead', /^exact/);
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('or__foo__exact', 'bar');
   });
@@ -172,19 +156,15 @@ describe('<AdvancedSearch />', () => {
         relatedSearchableKeys={[]}
       />
     );
-    await selectFrom(user, 'set-type-typeahead', /^or/);
-    await selectFrom(user, 'set-key-typeahead', 'foo');
-    await selectFrom(user, 'set-lookup-typeahead', /^exact/);
+    await selectFrom(user, 'Set type typeahead', /^or/);
+    await selectFrom(user, 'Key typeahead', 'foo');
+    await selectFrom(user, 'Lookup typeahead', /^exact/);
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('or__foo__exact', 'bar');
     expect(valueInput()).toHaveValue('');
   });
 
   test('typeahead onClear should remove key components', async () => {
-    // Clearing all three typeaheads would assert onSearch('', 'baz'), but with
-    // a real DOM the value input is disabled once the key is cleared (the UI
-    // forbids searching with no key), so we assert the DOM-observable outcome of
-    // onClear instead: the prefix and key are removed and search is disabled again.
     const advancedSearchMock = jest.fn();
     const { user } = renderWithContexts(
       <AdvancedSearch
@@ -193,21 +173,20 @@ describe('<AdvancedSearch />', () => {
         relatedSearchableKeys={[]}
       />
     );
-    await selectFrom(user, 'set-type-typeahead', /^or/);
-    await selectFrom(user, 'set-key-typeahead', 'foo');
-    await selectFrom(user, 'set-lookup-typeahead', /^exact/);
+    await selectFrom(user, 'Set type typeahead', /^or/);
+    await selectFrom(user, 'Key typeahead', 'foo');
+    await selectFrom(user, 'Lookup typeahead', /^exact/);
     await setValueAndSubmit(user, 'bar');
     expect(advancedSearchMock).toHaveBeenCalledWith('or__foo__exact', 'bar');
 
-    // clearing the key auto-clears the lookup; then clear the set type
-    await clearFrom(user, 'set-key-typeahead');
-    await clearFrom(user, 'set-type-typeahead');
+    await clearFrom(user, 'Key typeahead');
+    await clearFrom(user, 'Set type typeahead');
 
     expect(
-      document.querySelector('[data-ouia-component-id="set-type-typeahead"] input')
+      screen.getByRole('textbox', { name: 'Set type typeahead' })
     ).toHaveValue('');
     expect(
-      document.querySelector('[data-ouia-component-id="set-key-typeahead"] input')
+      screen.getByRole('textbox', { name: 'Key typeahead' })
     ).toHaveValue('');
     expect(valueInput()).toBeDisabled();
   });
@@ -224,13 +203,10 @@ describe('<AdvancedSearch />', () => {
         enableNegativeFiltering={false}
       />
     );
-    const wrap = document.querySelector(
-      '[data-ouia-component-id="set-type-typeahead"]'
-    );
-    await user.click(within(wrap).getByRole('button', { name: 'Options menu' }));
-    // with negative filtering off, only "and" and "or" remain (no "not")
-    // scope to this Select so options from other Selects aren't counted
-    const options = within(wrap).getAllByRole('option');
+    const input = screen.getByRole('textbox', { name: 'Set type typeahead' });
+    await user.click(input);
+    const listbox = await screen.findByRole('listbox');
+    const options = within(listbox).getAllByRole('option');
     expect(options).toHaveLength(2);
     expect(screen.getByRole('option', { name: /^or/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /^and/ })).toBeInTheDocument();
@@ -251,17 +227,14 @@ describe('<AdvancedSearch />', () => {
         enableRelatedFuzzyFiltering={false}
       />
     );
-    // pick the related-only key 'baz' so the related search type select renders
-    await selectFrom(user, 'set-key-typeahead', 'baz');
+    await selectFrom(user, 'Key typeahead', 'baz');
 
-    const wrap = document.querySelector(
-      '[data-ouia-component-id="set-lookup-typeahead"]'
-    );
-    await user.click(within(wrap).getByRole('button', { name: 'Options menu' }));
-    // with fuzzy filtering off, the "search" (fuzzy id/name/description) option
-    // is removed -> name__icontains, name, id remain
-    // scope to this Select so options from other Selects aren't counted
-    const options = within(wrap).getAllByRole('option');
+    const lookupInput = screen.getByRole('textbox', {
+      name: 'Related search type typeahead',
+    });
+    await user.click(lookupInput);
+    const listbox = await screen.findByRole('listbox');
+    const options = within(listbox).getAllByRole('option');
     expect(options).toHaveLength(3);
     expect(
       screen.getByRole('option', { name: /Fuzzy search on name field/ })

--- a/awx/ui/src/components/Search/LookupTypeInput.js
+++ b/awx/ui/src/components/Search/LookupTypeInput.js
@@ -1,17 +1,16 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
-
-function Option({ show = true, ...props }) {
-  if (!show) {
-    return null;
-  }
-  return <SelectOption {...props} />;
-}
+  Button,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 
 function LookupTypeInput({
   value = '',
@@ -20,130 +19,192 @@ function LookupTypeInput({
   maxSelectHeight = '300px',
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const { t } = useLingui();
+
+  const allOptions = useMemo(
+    () => [
+      {
+        id: 'exact-option-select',
+        value: 'exact',
+        description: t`Exact match (default lookup if not specified).`,
+        show: true,
+      },
+      {
+        id: 'iexact-option-select',
+        value: 'iexact',
+        description: t`Case-insensitive version of exact.`,
+        show: type === 'string',
+      },
+      {
+        id: 'contains-option-select',
+        value: 'contains',
+        description: t`Field contains value.`,
+        show: type === 'string',
+      },
+      {
+        id: 'icontains-option-select',
+        value: 'icontains',
+        description: t`Case-insensitive version of contains`,
+        show: type === 'string',
+      },
+      {
+        id: 'startswith-option-select',
+        value: 'startswith',
+        description: t`Field starts with value.`,
+        show: type !== 'datetime',
+      },
+      {
+        id: 'istartswith-option-select',
+        value: 'istartswith',
+        description: t`Case-insensitive version of startswith.`,
+        show: type !== 'datetime',
+      },
+      {
+        id: 'endswith-option-select',
+        value: 'endswith',
+        description: t`Field ends with value.`,
+        show: type !== 'datetime',
+      },
+      {
+        id: 'iendswith-option-select',
+        value: 'iendswith',
+        description: t`Case-insensitive version of endswith.`,
+        show: type !== 'datetime',
+      },
+      {
+        id: 'regex-option-select',
+        value: 'regex',
+        description: t`Field matches the given regular expression.`,
+        show: true,
+      },
+      {
+        id: 'iregex-option-select',
+        value: 'iregex',
+        description: t`Case-insensitive version of regex.`,
+        show: true,
+      },
+      {
+        id: 'gt-option-select',
+        value: 'gt',
+        description: t`Greater than comparison.`,
+        show: type !== 'json',
+      },
+      {
+        id: 'gte-option-select',
+        value: 'gte',
+        description: t`Greater than or equal to comparison.`,
+        show: type !== 'json',
+      },
+      {
+        id: 'lt-option-select',
+        value: 'lt',
+        description: t`Less than comparison.`,
+        show: type !== 'json',
+      },
+      {
+        id: 'lte-option-select',
+        value: 'lte',
+        description: t`Less than or equal to comparison.`,
+        show: type !== 'json',
+      },
+      {
+        id: 'isnull-option-select',
+        value: 'isnull',
+        description: t`Check whether the given field or related object is null; expects a boolean value.`,
+        show: true,
+      },
+      {
+        id: 'in-option-select',
+        value: 'in',
+        description: t`Check whether the given field's value is present in the list provided; expects a comma-separated list of items.`,
+        show: true,
+      },
+    ],
+    [t, type]
+  );
+
+  const visibleOptions = allOptions.filter((opt) => opt.show);
+
+  const filteredOptions = filterValue
+    ? visibleOptions.filter((opt) =>
+        opt.value.toLowerCase().includes(filterValue.toLowerCase())
+      )
+    : visibleOptions;
+
   return (
     <Select
-      ouiaId="set-lookup-typeahead"
-      aria-label={t`Lookup select`}
-      className="lookupSelect"
-      variant={SelectVariant.typeahead}
-      typeAheadAriaLabel={t`Lookup typeahead`}
-      onToggle={(_event, val) => setIsOpen(val)}
-      onSelect={(event, selection) => setValue(selection)}
-      onClear={() => setValue(null)}
-      selections={value}
+      id="set-lookup-typeahead"
       isOpen={isOpen}
-      placeholderText={t`Lookup type`}
-      maxHeight={maxSelectHeight}
-      noResultsFoundText={t`No results found`}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) setFilterValue('');
+      }}
+      onSelect={(_event, selection) => {
+        setValue(selection);
+        setFilterValue('');
+        setIsOpen(false);
+      }}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          variant="typeahead"
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+          className="lookupSelect"
+          ouiaId="set-lookup-typeahead"
+        >
+          <TextInputGroup isPlain>
+            <TextInputGroupMain
+              value={filterValue || value || ''}
+              onClick={() => setIsOpen(true)}
+              onChange={(_event, val) => {
+                setFilterValue(val);
+                setIsOpen(true);
+              }}
+              onFocus={() => {
+                if (value && !filterValue) {
+                  setFilterValue('');
+                }
+              }}
+              autoComplete="off"
+              placeholder={t`Lookup type`}
+              aria-label={t`Lookup typeahead`}
+            />
+            {(filterValue || value) && (
+              <TextInputGroupUtilities>
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    setValue(null);
+                    setFilterValue('');
+                  }}
+                  aria-label={t`Clear`}
+                >
+                  <TimesIcon />
+                </Button>
+              </TextInputGroupUtilities>
+            )}
+          </TextInputGroup>
+        </MenuToggle>
+      )}
     >
-      <Option
-        id="exact-option-select"
-        key="exact"
-        value="exact"
-        description={t`Exact match (default lookup if not specified).`}
-      />
-      <Option
-        id="iexact-option-select"
-        key="iexact"
-        value="iexact"
-        description={t`Case-insensitive version of exact.`}
-        show={type === 'string'}
-      />
-      <Option
-        id="contains-option-select"
-        key="contains"
-        value="contains"
-        description={t`Field contains value.`}
-        show={type === 'string'}
-      />
-      <Option
-        id="icontains-option-select"
-        key="icontains"
-        value="icontains"
-        description={t`Case-insensitive version of contains`}
-        show={type === 'string'}
-      />
-      <Option
-        id="startswith-option-select"
-        key="startswith"
-        value="startswith"
-        description={t`Field starts with value.`}
-        show={type !== 'datetime'}
-      />
-      <Option
-        id="istartswith-option-select"
-        key="istartswith"
-        value="istartswith"
-        description={t`Case-insensitive version of startswith.`}
-        show={type !== 'datetime'}
-      />
-      <Option
-        id="endswith-option-select"
-        key="endswith"
-        value="endswith"
-        description={t`Field ends with value.`}
-        show={type !== 'datetime'}
-      />
-      <Option
-        id="iendswith-option-select"
-        key="iendswith"
-        value="iendswith"
-        description={t`Case-insensitive version of endswith.`}
-        show={type !== 'datetime'}
-      />
-      <Option
-        id="regex-option-select"
-        key="regex"
-        value="regex"
-        description={t`Field matches the given regular expression.`}
-      />
-      <Option
-        id="iregex-option-select"
-        key="iregex"
-        value="iregex"
-        description={t`Case-insensitive version of regex.`}
-      />
-      <Option
-        id="gt-option-select"
-        key="gt"
-        value="gt"
-        description={t`Greater than comparison.`}
-        show={type !== 'json'}
-      />
-      <Option
-        id="gte-option-select"
-        key="gte"
-        value="gte"
-        description={t`Greater than or equal to comparison.`}
-        show={type !== 'json'}
-      />
-      <Option
-        id="lt-option-select"
-        key="lt"
-        value="lt"
-        description={t`Less than comparison.`}
-        show={type !== 'json'}
-      />
-      <Option
-        id="lte-option-select"
-        key="lte"
-        value="lte"
-        description={t`Less than or equal to comparison.`}
-        show={type !== 'json'}
-      />
-      <Option
-        id="isnull-option-select"
-        key="isnull"
-        value="isnull"
-        description={t`Check whether the given field or related object is null; expects a boolean value.`}
-      />
-      <Option
-        id="in-option-select"
-        key="in"
-        value="in"
-        description={t`Check whether the given field's value is present in the list provided; expects a comma-separated list of items.`}
-      />
+      <SelectList style={{ maxHeight: maxSelectHeight, overflowY: 'auto' }}>
+        {filteredOptions.length === 0 ? (
+          <SelectOption isDisabled>{t`No results found`}</SelectOption>
+        ) : (
+          filteredOptions.map((opt) => (
+            <SelectOption
+              id={opt.id}
+              key={opt.value}
+              value={opt.value}
+              description={opt.description}
+            >
+              {opt.value}
+            </SelectOption>
+          ))
+        )}
+      </SelectList>
     </Select>
   );
 }

--- a/awx/ui/src/components/Search/RelatedLookupTypeInput.js
+++ b/awx/ui/src/components/Search/RelatedLookupTypeInput.js
@@ -1,10 +1,16 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+  Button,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 
 function RelatedLookupTypeInput({
   value,
@@ -13,48 +19,120 @@ function RelatedLookupTypeInput({
   enableFuzzyFiltering,
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const { t } = useLingui();
+
+  const allOptions = useMemo(
+    () => [
+      {
+        id: 'name-option-select',
+        value: 'name__icontains',
+        description: t`Fuzzy search on name field.`,
+      },
+      {
+        id: 'name-exact-option-select',
+        value: 'name',
+        description: t`Exact search on name field.`,
+      },
+      {
+        id: 'id-option-select',
+        value: 'id',
+        description: t`Exact search on id field.`,
+      },
+      ...(enableFuzzyFiltering
+        ? [
+            {
+              id: 'search-option-select',
+              value: 'search',
+              description: t`Fuzzy search on id, name or description fields.`,
+            },
+          ]
+        : []),
+    ],
+    [t, enableFuzzyFiltering]
+  );
+
+  const filteredOptions = filterValue
+    ? allOptions.filter((opt) =>
+        opt.value.toLowerCase().includes(filterValue.toLowerCase())
+      )
+    : allOptions;
+
   return (
     <Select
-      ouiaId="set-lookup-typeahead"
-      aria-label={t`Related search type`}
-      className="lookupSelect"
-      variant={SelectVariant.typeahead}
-      typeAheadAriaLabel={t`Related search type typeahead`}
-      onToggle={(_event, val) => setIsOpen(val)}
-      onSelect={(event, selection) => setValue(selection)}
-      selections={value}
+      id="set-lookup-typeahead"
       isOpen={isOpen}
-      placeholderText={t`Related search type`}
-      maxHeight={maxSelectHeight}
-      noResultsFoundText={t`No results found`}
-    >
-      <SelectOption
-        id="name-option-select"
-        key="name__icontains"
-        value="name__icontains"
-        description={t`Fuzzy search on name field.`}
-      />
-      <SelectOption
-        id="name-exact-option-select"
-        key="name"
-        value="name"
-        description={t`Exact search on name field.`}
-      />
-      <SelectOption
-        id="id-option-select"
-        key="id"
-        value="id"
-        description={t`Exact search on id field.`}
-      />
-      {enableFuzzyFiltering && (
-        <SelectOption
-          id="search-option-select"
-          key="search"
-          value="search"
-          description={t`Fuzzy search on id, name or description fields.`}
-        />
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) setFilterValue('');
+      }}
+      onSelect={(_event, selection) => {
+        setValue(selection);
+        setFilterValue('');
+        setIsOpen(false);
+      }}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          variant="typeahead"
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+          className="lookupSelect"
+          ouiaId="set-lookup-typeahead"
+        >
+          <TextInputGroup isPlain>
+            <TextInputGroupMain
+              value={filterValue || value || ''}
+              onClick={() => setIsOpen(true)}
+              onChange={(_event, val) => {
+                setFilterValue(val);
+                setIsOpen(true);
+              }}
+              onFocus={() => {
+                if (value && !filterValue) {
+                  setFilterValue('');
+                }
+              }}
+              autoComplete="off"
+              placeholder={t`Related search type`}
+              aria-label={t`Related search type typeahead`}
+            />
+            {(filterValue || value) && (
+              <TextInputGroupUtilities>
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    setValue(null);
+                    setFilterValue('');
+                  }}
+                  aria-label={t`Clear`}
+                >
+                  <TimesIcon />
+                </Button>
+              </TextInputGroupUtilities>
+            )}
+          </TextInputGroup>
+        </MenuToggle>
       )}
+    >
+      <SelectList
+        style={{ maxHeight: maxSelectHeight, overflowY: 'auto' }}
+      >
+        {filteredOptions.length === 0 ? (
+          <SelectOption isDisabled>{t`No results found`}</SelectOption>
+        ) : (
+          filteredOptions.map((opt) => (
+            <SelectOption
+              id={opt.id}
+              key={opt.value}
+              value={opt.value}
+              description={opt.description}
+            >
+              {opt.value}
+            </SelectOption>
+          ))
+        )}
+      </SelectList>
     </Select>
   );
 }

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -9,13 +9,13 @@ import {
 	TextInput,
 	ToolbarGroup,
 	ToolbarItem,
-	ToolbarFilter, InputGroupItem
-} from '@patternfly/react-core';
-import {
+	ToolbarFilter,
+	InputGroupItem,
 	Select,
 	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+	SelectList,
+	MenuToggle
+} from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import styled from 'styled-components';
 import { parseQueryString } from 'util/qs';
@@ -30,7 +30,7 @@ SubmitButtonWrapper.displayName = 'SubmitButtonWrapper';
 const DateInputGroup = styled(InputGroup)`
   /* keep the operator select at its natural width so the date input
      next to it stays visible */
-  & > .pf-v5-c-select {
+  & > .pf-v5-c-menu-toggle {
     width: auto;
     flex: 0 0 auto;
   }
@@ -104,19 +104,16 @@ function Search({
     setChipsByKey({ ...chipsByKey, ...searchChips });
   }, [location.search]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleDropdownSelect = ({ target }) => {
+  const handleDropdownSelect = (_event, selectedName) => {
     const { key: actualSearchKey } = columns.find(
-      ({ name }) => name === target.innerText
+      ({ name }) => name === selectedName
     );
     onShowAdvancedSearch(actualSearchKey === 'advanced');
     setIsFilterDropdownOpen(false);
     setIsDateOperatorOpen(false);
     setSearchKey(actualSearchKey);
-    // a value typed for the previous key must not leak into the next one -
-    // a controlled date input renders a stale text value as an empty field
-    // while leaving the submit button enabled, allowing a non-date value
-    // through to the API
     setSearchValue('');
+    setIsSearchDropdownOpen(false);
   };
 
   const handleSearch = (e) => {
@@ -155,11 +152,15 @@ function Search({
     }
   };
 
-  const handleFilterDropdownSelect = (key, event, actualValue) => {
-    if (event.target.checked) {
-      onSearch(key, actualValue);
-    } else {
+  const handleFilterDropdownSelect = (key, _event, actualValue) => {
+    const currentSelections = chipsByKey[key]?.chips.map((chip) => {
+      const [, ...val] = chip.key.split(':');
+      return val.join(':');
+    }) || [];
+    if (currentSelections.includes(actualValue)) {
       onRemove(key, actualValue);
+    } else {
+      onSearch(key, actualValue);
     }
   };
 
@@ -167,37 +168,42 @@ function Search({
     ({ key }) => key === searchKey
   );
 
-  const searchOptions = columns
-    .filter(({ key }) => key !== searchKey)
-    .map(({ key, name }) => (
-      <SelectOption
-        data-cy={`select-option-${key}`}
-        id={`select-option-${key}`}
-        key={key}
-        value={name}
-      >
-        {name}
-      </SelectOption>
-    ));
-
   return (
     <ToolbarGroup variant="filter-group">
       <ToolbarItem>
-        {searchOptions.length > 0 ? (
+        {columns.filter(({ key }) => key !== searchKey).length > 0 ? (
           <Select
-            variant={SelectVariant.single}
             className="simpleKeySelect"
-            aria-label={t`Simple key select`}
-            typeAheadAriaLabel={t`Simple key select`}
-            onToggle={(_event, val) => setIsSearchDropdownOpen(val)}
-            onSelect={handleDropdownSelect}
-            selections={searchColumnName}
             isOpen={isSearchDropdownOpen}
-            ouiaId="simple-key-select"
-            isDisabled={isDisabled}
-            noResultsFoundText={t`No results found`}
+            onOpenChange={setIsSearchDropdownOpen}
+            onSelect={handleDropdownSelect}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsSearchDropdownOpen(!isSearchDropdownOpen)}
+                isExpanded={isSearchDropdownOpen}
+                isDisabled={isDisabled}
+                aria-label={t`Simple key select`}
+                ouiaId="simple-key-select"
+              >
+                {searchColumnName}
+              </MenuToggle>
+            )}
           >
-            {searchOptions}
+            <SelectList>
+              {columns
+                .filter(({ key }) => key !== searchKey)
+                .map(({ key, name }) => (
+                  <SelectOption
+                    data-cy={`select-option-${key}`}
+                    id={`select-option-${key}`}
+                    key={key}
+                    value={name}
+                  >
+                    {name}
+                  </SelectOption>
+                ))}
+            </SelectList>
           </Select>
         ) : (
           <NoOptionDropdown>{searchColumnName}</NoOptionDropdown>
@@ -228,84 +234,111 @@ function Search({
           )) ||
             (options && (
               <Select
-                variant={SelectVariant.checkbox}
                 aria-label={name}
-                typeAheadAriaLabel={name}
-                onToggle={(_event, val) => setIsFilterDropdownOpen(val)}
+                isOpen={isFilterDropdownOpen}
+                onOpenChange={setIsFilterDropdownOpen}
                 onSelect={(event, selection) =>
                   handleFilterDropdownSelect(key, event, selection)
                 }
-                selections={chipsByKey[key]?.chips.map((chip) => {
-                  const [, ...value] = chip.key.split(':');
-                  return value.join(':');
-                })}
-                isOpen={isFilterDropdownOpen}
-                placeholderText={t`Filter By ${name}`}
-                ouiaId={`filter-by-${key}`}
-                isDisabled={isDisabled}
-                maxHeight={maxSelectHeight}
-                noResultsFoundText={t`No results found`}
-              >
-                {options.map(([optionKey, optionLabel]) => (
-                  <SelectOption
-                    key={optionKey}
-                    value={optionKey}
-                    inputId={`select-option-${optionKey}`}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
+                    isExpanded={isFilterDropdownOpen}
+                    isDisabled={isDisabled}
+                    ouiaId={`filter-by-${key}`}
                   >
-                    {optionLabel}
-                  </SelectOption>
-                ))}
+                    {t`Filter By ${name}`}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {options.map(([optionKey, optionLabel]) => {
+                    const currentSelections = chipsByKey[key]?.chips.map((chip) => {
+                      const [, ...val] = chip.key.split(':');
+                      return val.join(':');
+                    }) || [];
+                    return (
+                      <SelectOption
+                        key={optionKey}
+                        value={optionKey}
+                        id={`select-option-${optionKey}`}
+                        hasCheckbox
+                        isSelected={currentSelections.includes(optionKey)}
+                      >
+                        {optionLabel}
+                      </SelectOption>
+                    );
+                  })}
+                </SelectList>
               </Select>
             )) ||
             (isBoolean && (
               <Select
                 aria-label={name}
-                onToggle={(_event, val) => setIsFilterDropdownOpen(val)}
-                onSelect={(event, selection) => onReplaceSearch(key, selection)}
-                selections={chipsByKey[key].chips[0]?.label}
                 isOpen={isFilterDropdownOpen}
-                placeholderText={t`Filter By ${name}`}
-                ouiaId={`filter-by-${key}`}
-                isDisabled={isDisabled}
-                maxHeight={maxSelectHeight}
-                noResultsFoundText={t`No results found`}
+                onOpenChange={setIsFilterDropdownOpen}
+                onSelect={(_event, selection) => {
+                  onReplaceSearch(key, selection);
+                  setIsFilterDropdownOpen(false);
+                }}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsFilterDropdownOpen(!isFilterDropdownOpen)}
+                    isExpanded={isFilterDropdownOpen}
+                    isDisabled={isDisabled}
+                    ouiaId={`filter-by-${key}`}
+                    style={{ maxHeight: maxSelectHeight }}
+                  >
+                    {chipsByKey[key].chips[0]?.label || t`Filter By ${name}`}
+                  </MenuToggle>
+                )}
               >
-                <SelectOption key="true" value="true">
-                  {booleanLabels.true || t`Yes`}
-                </SelectOption>
-                <SelectOption key="false" value="false">
-                  {booleanLabels.false || t`No`}
-                </SelectOption>
+                <SelectList>
+                  <SelectOption key="true" value="true">
+                    {booleanLabels.true || t`Yes`}
+                  </SelectOption>
+                  <SelectOption key="false" value="false">
+                    {booleanLabels.false || t`No`}
+                  </SelectOption>
+                </SelectList>
               </Select>
             )) ||
             ((qsConfig.dateFields || []).includes(key) && (
               <DateInputGroup>
                 <Select
-                  variant={SelectVariant.single}
                   className="dateOperatorSelect"
                   aria-label={t`Date operator select`}
-                  typeAheadAriaLabel={t`Date operator select`}
-                  onToggle={(_event, val) => setIsDateOperatorOpen(val)}
-                  onSelect={(event, selection) => {
+                  isOpen={isDateOperatorOpen}
+                  onOpenChange={setIsDateOperatorOpen}
+                  onSelect={(_event, selection) => {
                     const [op] = dateOperators.find(
                       ([, label]) => label === selection
                     );
                     setDateOperator(op);
                     setIsDateOperatorOpen(false);
                   }}
-                  selections={
-                    dateOperators.find(([op]) => op === dateOperator)[1]
-                  }
-                  isOpen={isDateOperatorOpen}
-                  ouiaId={`date-operator-select-${key}`}
-                  isDisabled={isDisabled}
-                  noResultsFoundText={t`No results found`}
+                  toggle={(toggleRef) => (
+                    <MenuToggle
+                      ref={toggleRef}
+                      onClick={() => setIsDateOperatorOpen(!isDateOperatorOpen)}
+                      isExpanded={isDateOperatorOpen}
+                      isDisabled={isDisabled}
+                      aria-label={t`Date operator select`}
+                      ouiaId={`date-operator-select-${key}`}
+                    >
+                      {dateOperators.find(([op]) => op === dateOperator)[1]}
+                    </MenuToggle>
+                  )}
                 >
-                  {dateOperators.map(([op, label]) => (
-                    <SelectOption key={op} value={label}>
-                      {label}
-                    </SelectOption>
-                  ))}
+                  <SelectList>
+                    {dateOperators.map(([op, label]) => (
+                      <SelectOption key={op} value={label}>
+                        {label}
+                      </SelectOption>
+                    ))}
+                  </SelectList>
                 </Select>
                 <TextInput
                   data-cy="date-search-input"

--- a/awx/ui/src/components/Search/Search.js
+++ b/awx/ui/src/components/Search/Search.js
@@ -30,7 +30,7 @@ SubmitButtonWrapper.displayName = 'SubmitButtonWrapper';
 const DateInputGroup = styled(InputGroup)`
   /* keep the operator select at its natural width so the date input
      next to it stays visible */
-  & > .pf-v5-c-menu-toggle {
+  & > .pf-v5-c-select {
     width: auto;
     flex: 0 0 auto;
   }

--- a/awx/ui/src/components/Search/Search.test.js
+++ b/awx/ui/src/components/Search/Search.test.js
@@ -36,23 +36,13 @@ function renderSearch(props, options) {
   );
 }
 
-// The simple key Select's onSelect handler reads `target.innerText` to map the
-// clicked option back to a search column. jsdom never populates `innerText`, so
-// we set it on the real option element before dispatching a real click.
-// The handler does not close the key dropdown on select, so we open it only when
-// it is currently closed and press Escape afterwards to leave it settled.
 async function selectKey(user, name) {
-  const keyWrap = document.querySelector(
-    '[data-ouia-component-id="simple-key-select"]'
-  );
-  const toggle = within(keyWrap).getByRole('button', { name: 'Options menu' });
+  const toggle = screen.getByRole('button', { name: 'Simple key select' });
   if (toggle.getAttribute('aria-expanded') !== 'true') {
     await user.click(toggle);
   }
   const option = await screen.findByRole('option', { name });
-  option.innerText = name;
-  fireEvent.click(option);
-  fireEvent.keyDown(document.activeElement || document.body, { key: 'Escape' });
+  await user.click(option);
 }
 
 describe('<Search />', () => {
@@ -160,9 +150,6 @@ describe('<Search />', () => {
     });
     renderSearch({ columns }, { context: { router: { history } } });
 
-    // Assert the chip-group category label + the visible chip text (the
-    // DOM equivalent of the ToolbarFilter chip key, e.g. 'or__scm_type:foo').
-    // Option-based columns render the option label ('Foo Bar!'), not the raw value.
     const typeGroup = screen
       .getByText('Type (or__scm_type)')
       .closest('.pf-v5-c-chip-group');
@@ -199,8 +186,6 @@ describe('<Search />', () => {
     );
 
     expect(history.location.search).toEqual(query);
-    // PF Chip's close button is aria-labelledby the chip text, so its accessible
-    // name is the chip text ('foo'), not 'close'; click it within its chip.
     const chip = screen.getByText('foo').closest('.pf-v5-c-chip');
     await user.click(within(chip).getByRole('button'));
     expect(onRemove).toHaveBeenCalledWith('or__type', 'foo');
@@ -231,8 +216,6 @@ describe('<Search />', () => {
     );
 
     expect(history.location.search).toEqual(query);
-    // the query (or__type:) produces exactly one chip with no visible text;
-    // assert there is only one and click its close button (the only button)
     const chips = document.querySelectorAll('.pf-v5-c-chip');
     expect(chips).toHaveLength(1);
     await user.click(within(chips[0]).getByRole('button'));
@@ -252,8 +235,6 @@ describe('<Search />', () => {
     });
     renderSearch({ columns }, { context: { router: { history } } });
 
-    // Keys without a search column still get their own ToolbarFilter chip group;
-    // assert the category label + chip text rendered for that group.
     const nameExactGroup = screen
       .getByText('name__exact')
       .closest('.pf-v5-c-chip-group');
@@ -281,9 +262,7 @@ describe('<Search />', () => {
       expect(dateInput).toBeInTheDocument();
       expect(dateInput).toHaveAttribute('type', 'date');
       expect(
-        document.querySelector(
-          '[data-ouia-component-id="date-operator-select-created"]'
-        )
+        screen.getByRole('button', { name: 'Date operator select' })
       ).toBeInTheDocument();
     });
 
@@ -308,15 +287,11 @@ describe('<Search />', () => {
       const { user } = renderDateSearch(onSearch);
       await selectKey(user, 'Created');
 
-      const operatorWrap = document.querySelector(
-        '[data-ouia-component-id="date-operator-select-created"]'
-      );
-      await user.click(
-        within(operatorWrap).getByRole('button', { name: 'Options menu' })
-      );
-      // operator select keys off the `selection` arg, not innerText, so a real
-      // click on the option drives it directly
-      fireEvent.click(await screen.findByRole('option', { name: 'Before' }));
+      const operatorToggle = screen.getByRole('button', {
+        name: 'Date operator select',
+      });
+      await user.click(operatorToggle);
+      await user.click(await screen.findByRole('option', { name: 'Before' }));
 
       fireEvent.change(screen.getByLabelText('Date search input'), {
         target: { value: '2026-06-30' },
@@ -361,13 +336,10 @@ describe('<Search />', () => {
       const { user } = renderDateSearch(jest.fn());
       await selectKey(user, 'Created');
 
-      const operatorWrap = document.querySelector(
-        '[data-ouia-component-id="date-operator-select-created"]'
-      );
-      await user.click(
-        within(operatorWrap).getByRole('button', { name: 'Options menu' })
-      );
-      // open means the operator options are visible
+      const operatorToggle = screen.getByRole('button', {
+        name: 'Date operator select',
+      });
+      await user.click(operatorToggle);
       expect(
         screen.getByRole('option', { name: 'Before' })
       ).toBeInTheDocument();
@@ -375,7 +347,6 @@ describe('<Search />', () => {
       await selectKey(user, 'Name');
       await selectKey(user, 'Created');
 
-      // switching columns resets the operator dropdown to closed
       await waitFor(() =>
         expect(
           screen.queryByRole('option', { name: 'Before' })

--- a/awx/ui/src/components/WorkflowOutputNavigation/WorkflowOutputNavigation.js
+++ b/awx/ui/src/components/WorkflowOutputNavigation/WorkflowOutputNavigation.js
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
-import { useParams, Link } from 'react-router';
+import { useParams } from 'react-router';
+import { useNavigate } from 'routerCompat';
 import { useLingui } from '@lingui/react/macro';
 import {
-	Chip
-} from '@patternfly/react-core';
-import {
+	Chip,
+	MenuToggle,
 	Select,
-	SelectOption,
 	SelectGroup,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+	SelectList,
+	SelectOption,
+	TextInputGroup,
+	TextInputGroupMain,
+} from '@patternfly/react-core';
 import ChipGroup from 'components/ChipGroup';
 import { stringIsUUID } from 'util/strings';
 
@@ -25,6 +27,7 @@ const JOB_URL_SEGMENT_MAP = {
 function WorkflowOutputNavigation({ relatedJobs, parentRef }) {
   const { t } = useLingui();
   const { id } = useParams();
+  const navigate = useNavigate();
 
   const relevantResults = relatedJobs.filter(
     ({ job: jobId, summary_fields }) =>
@@ -36,6 +39,7 @@ function WorkflowOutputNavigation({ relatedJobs, parentRef }) {
   const [isOpen, setIsOpen] = useState(false);
   const [filterBy, setFilterBy] = useState();
   const [sortedJobs, setSortedJobs] = useState(relevantResults);
+  const [inlineFilter, setInlineFilter] = useState('');
 
   const handleFilter = (v) => {
     if (filterBy === v) {
@@ -58,54 +62,89 @@ function WorkflowOutputNavigation({ relatedJobs, parentRef }) {
   ).length;
   const numFailedJobs = relevantResults.length - numSuccessJobs;
 
+  const filteredJobs = inlineFilter
+    ? sortedJobs.filter((node) => {
+        const label = stringIsUUID(node.identifier)
+          ? node.summary_fields.job.name
+          : node.identifier;
+        return label.toLowerCase().includes(inlineFilter.toLowerCase());
+      })
+    : sortedJobs;
+
   return (
     <Select
       key={`${id}`}
-      variant={SelectVariant.typeaheadMulti}
-      menuAppendTo={parentRef?.current}
-      onToggle={(_event, val) => {
-        setIsOpen(val);
-      }}
-      selections={filterBy}
-      onSelect={(e, v) => {
-        if (v !== 'Failed' && v !== 'Successful') return;
-        handleFilter(v);
-      }}
       isOpen={isOpen}
-      isGrouped
-      hasInlineFilter
-      placeholderText={t`Workflow Job 1/${relevantResults.length}`}
-      chipGroupComponent={
-        <ChipGroup numChips={1} totalChips={1}>
-          <Chip key={filterBy} onClick={() => handleFilter(filterBy)}>
-            {[filterBy]}
-          </Chip>
-        </ChipGroup>
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) setInlineFilter('');
+      }}
+      onSelect={(_e, v) => {
+        if (v === 'Failed' || v === 'Successful') {
+          handleFilter(v);
+          return;
+        }
+        const node = sortedJobs.find(
+          (n) => n.summary_fields.job.name === v
+        );
+        if (node) {
+          const url = `/jobs/${JOB_URL_SEGMENT_MAP[node.summary_fields.job.type]}/${node.summary_fields.job?.id}/output`;
+          navigate(url);
+          setIsOpen(false);
+        }
+      }}
+      popperProps={
+        parentRef?.current
+          ? { appendTo: parentRef.current }
+          : undefined
       }
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+        >
+          {filterBy ? (
+            <ChipGroup numChips={1} totalChips={1}>
+              <Chip key={filterBy} onClick={() => handleFilter(filterBy)}>
+                {filterBy}
+              </Chip>
+            </ChipGroup>
+          ) : (
+            t`Workflow Job 1/${relevantResults.length}`
+          )}
+        </MenuToggle>
+      )}
     >
-      {[
+      <TextInputGroup>
+        <TextInputGroupMain
+          value={inlineFilter}
+          onChange={(_event, val) => setInlineFilter(val)}
+          placeholder={t`Filter...`}
+          autoComplete="off"
+        />
+      </TextInputGroup>
+      <SelectList>
         <SelectGroup label={t`Workflow Statuses`} key="status">
           <SelectOption
             description={t`Filter by failed jobs`}
             key="failed"
-            value={t`Failed`}
-            itemCount={numFailedJobs}
-          />
+            value="Failed"
+          >
+            {t`Failed`} ({numFailedJobs})
+          </SelectOption>
           <SelectOption
             description={t`Filter by successful jobs`}
             key="successful"
-            value={t`Successful`}
-            itemCount={numSuccessJobs}
-          />
-        </SelectGroup>,
+            value="Successful"
+          >
+            {t`Successful`} ({numSuccessJobs})
+          </SelectOption>
+        </SelectGroup>
         <SelectGroup label={t`Workflow Nodes`} key="nodes">
-          {sortedJobs?.map((node) => (
+          {filteredJobs?.map((node) => (
             <SelectOption
               key={node.id}
-              to={`/jobs/${JOB_URL_SEGMENT_MAP[node.summary_fields.job.type]}/${
-                node.summary_fields.job?.id
-              }/output`}
-              component={Link}
               value={node.summary_fields.job.name}
             >
               {stringIsUUID(node.identifier)
@@ -113,8 +152,8 @@ function WorkflowOutputNavigation({ relatedJobs, parentRef }) {
                 : node.identifier}
             </SelectOption>
           ))}
-        </SelectGroup>,
-      ]}
+        </SelectGroup>
+      </SelectList>
     </Select>
   );
 }

--- a/awx/ui/src/components/WorkflowOutputNavigation/WorkflowOutputNavigation.js
+++ b/awx/ui/src/components/WorkflowOutputNavigation/WorkflowOutputNavigation.js
@@ -41,6 +41,11 @@ function WorkflowOutputNavigation({ relatedJobs, parentRef }) {
   const [sortedJobs, setSortedJobs] = useState(relevantResults);
   const [inlineFilter, setInlineFilter] = useState('');
 
+  const statusLabels = {
+    Failed: t`Failed`,
+    Successful: t`Successful`,
+  };
+
   const handleFilter = (v) => {
     if (filterBy === v) {
       setSortedJobs(relevantResults);
@@ -107,7 +112,7 @@ function WorkflowOutputNavigation({ relatedJobs, parentRef }) {
           {filterBy ? (
             <ChipGroup numChips={1} totalChips={1}>
               <Chip key={filterBy} onClick={() => handleFilter(filterBy)}>
-                {filterBy}
+                {statusLabels[filterBy] || filterBy}
               </Chip>
             </ChipGroup>
           ) : (

--- a/awx/ui/src/darkmode.css
+++ b/awx/ui/src/darkmode.css
@@ -141,8 +141,11 @@ html.pf-v5-theme-dark .pf-v5-c-form-control {
   outline-offset: 2px;
 }
 
-html.pf-v5-theme-dark .pf-v5-c-button {
+html.pf-v5-theme-dark .pf-v5-c-button:not(.pf-m-plain) {
   --pf-v5-c-button--FontSize: var(--pf-v5-global--FontSize--xs);
+}
+
+html.pf-v5-theme-dark .pf-v5-c-button {
   --pf-v5-c-button--m-primary--BackgroundColor: var(--pf-v5-global--link--Color);
   --pf-v5-c-button--m-primary--focus--Color: var(--pf-v5-global--BackgroundColor--100);
   --pf-v5-c-button--m-link--Color: var(--pf-v5-global--link--Color);
@@ -484,23 +487,50 @@ html.pf-v5-theme-dark .pf-v5-c-button.pf-m-plain,
 html.pf-v5-theme-dark .pf-v5-c-button.pf-m-plain:hover {
   --pf-v5-c-button--m-plain--Color: var(--pf-v5-global--Color--200);
   --pf-v5-c-button--m-plain--disabled--Color: var(--pf-v5-global--Color--300);
+  --pf-v5-c-button--PaddingTop: 0.375rem;
+  --pf-v5-c-button--PaddingRight: 1rem;
+  --pf-v5-c-button--PaddingBottom: 0.375rem;
+  --pf-v5-c-button--PaddingLeft: 1rem;
 }
 
-html.pf-v5-theme-dark .pf-v5-c-button {
+html.pf-v5-theme-dark .pf-v5-c-notification-badge {
+  --pf-v5-c-notification-badge--PaddingRight: 1rem;
+  --pf-v5-c-notification-badge--PaddingLeft: 1rem;
+  --pf-v5-c-notification-badge--MarginTop: calc(-1 * 0.375rem);
+  --pf-v5-c-notification-badge--MarginRight: calc(-1 * 1rem);
+  --pf-v5-c-notification-badge--MarginBottom: calc(-1 * 0.375rem);
+  --pf-v5-c-notification-badge--MarginLeft: calc(-1 * 1rem);
+}
+
+html.pf-v5-theme-dark .pf-v5-c-menu-toggle.pf-m-plain {
+  --pf-v5-c-menu-toggle--PaddingTop: 0.375rem;
+  --pf-v5-c-menu-toggle--PaddingRight: 1rem;
+  --pf-v5-c-menu-toggle--PaddingBottom: 0.375rem;
+  --pf-v5-c-menu-toggle--PaddingLeft: 1rem;
+  --pf-v5-c-menu-toggle--m-plain--PaddingTop: 0.375rem;
+  --pf-v5-c-menu-toggle--m-plain--PaddingRight: 1rem;
+  --pf-v5-c-menu-toggle--m-plain--PaddingBottom: 0.375rem;
+  --pf-v5-c-menu-toggle--m-plain--PaddingLeft: 1rem;
+  --pf-v5-c-menu-toggle--FontSize: 1rem;
+  --pf-v5-c-menu-toggle--LineHeight: 1.5;
+}
+
+html.pf-v5-theme-dark .pf-v5-c-button:not(.pf-m-plain) {
   --pf-v5-c-button--PaddingTop: var(--pf-v5-global--spacer--sm);
   --pf-v5-c-button--PaddingBottom: var(--pf-v5-global--spacer--sm);
   --pf-v5-c-button--PaddingRight: var(--pf-v5-global--spacer--lg);
   --pf-v5-c-button--PaddingLeft: var(--pf-v5-global--spacer--lg);
   --pf-v5-c-button--FontSize: var(--pf-v5-global--FontSize--md);
   --pf-v5-c-button--FontWeight: var(--pf-v5-global--FontWeight--semi-bold);
-  --pf-v5-c-button--disabled--BackgroundColor: var(--pf-v5-global--BorderColor--200);
-  --pf-v5-c-button--disabled--Color: var(--pf-v5-global--link--Color);
   --pf-v5-c-button--LineHeight: 1.625rem;
-
   --pf-v5-c-button--m-primary--Color: var(--pf-v5-global--BackgroundColor--100);
   --pf-v5-c-button--m-primary--hover--Color: var(--pf-v5-global--BackgroundColor--100);
-
   text-transform: uppercase;
+}
+
+html.pf-v5-theme-dark .pf-v5-c-button {
+  --pf-v5-c-button--disabled--BackgroundColor: var(--pf-v5-global--BorderColor--200);
+  --pf-v5-c-button--disabled--Color: var(--pf-v5-global--link--Color);
 }
 
 html.pf-v5-theme-dark .pf-v5-c-form-control:focus {

--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -5,16 +5,15 @@ import styled from 'styled-components';
 import { useLingui } from '@lingui/react/macro';
 import {
 	Card,
+	MenuToggle,
 	PageSection,
 	PageSectionVariants,
-	Title
-} from '@patternfly/react-core';
-import {
+	Select,
 	SelectGroup,
-	Select as PFSelect,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+	SelectList,
+	SelectOption,
+	Title,
+} from '@patternfly/react-core';
 
 import DatalistToolbar from 'components/DataListToolbar';
 import PaginatedTable, {
@@ -29,11 +28,10 @@ import { ActivityStreamAPI } from 'api';
 
 import ActivityStreamListItem from './ActivityStreamListItem';
 
-const Select = styled(PFSelect)`
+const StyledMenuToggle = styled(MenuToggle)`
   && {
-    width: auto;
+    width: 250px;
     white-space: nowrap;
-    max-height: 480px;
   }
 `;
 
@@ -115,6 +113,28 @@ function ActivityStream() {
     navigate(qs ? `${location.pathname}?${qs}` : location.pathname);
   };
 
+  const typeLabelMap = {
+    all: t`Dashboard (all activity)`,
+    job: t`Jobs`,
+    schedule: t`Schedules`,
+    workflow_approval: t`Workflow Approvals`,
+    'job_template,workflow_job_template,workflow_job_template_node': t`Templates`,
+    credential: t`Credentials`,
+    project: t`Projects`,
+    inventory: t`Inventories`,
+    host: t`Hosts`,
+    organization: t`Organizations`,
+    user: t`Users`,
+    team: t`Teams`,
+    credential_type: t`Credential Types`,
+    notification_template: t`Notification Templates`,
+    instance: t`Instances`,
+    instance_group: t`Instance Groups`,
+    'o_auth2_application,o_auth2_access_token': t`Applications & Tokens`,
+    execution_environment: t`Execution Environments`,
+    setting: t`Settings`,
+  };
+
   return (
     <>
       <PageSection
@@ -129,105 +149,114 @@ function ActivityStream() {
           {t`Activity Stream type selector`}
         </span>
         <Select
-          position="right"
-          variant={SelectVariant.single}
-          aria-labelledby="grouped-type-select-id"
-          typeAheadAriaLabel={t`Select an activity type`}
-          className="activityTypeSelect"
-          onToggle={(_event, val) => setIsTypeDropdownOpen(val)}
-          onSelect={(event, selection) => {
+          isOpen={isTypeDropdownOpen}
+          onOpenChange={setIsTypeDropdownOpen}
+          onSelect={(_event, selection) => {
             if (selection) {
               urlParams.set('type', selection);
             }
             setIsTypeDropdownOpen(false);
             pushHistoryState(urlParams);
           }}
-          selections={activityStreamType}
-          isOpen={isTypeDropdownOpen}
-          isGrouped
-          maxHeight="400px"
-          width="250px"
-          noResultsFoundText={t`No results found`}
+          aria-labelledby="grouped-type-select-id"
+          className="activityTypeSelect"
           ouiaId="activity-type-select"
+          popperProps={{ position: 'end' }}
+          isScrollable
+          toggle={(toggleRef) => (
+            <StyledMenuToggle
+              ref={toggleRef}
+              onClick={() => setIsTypeDropdownOpen(!isTypeDropdownOpen)}
+              isExpanded={isTypeDropdownOpen}
+            >
+              {typeLabelMap[activityStreamType] || activityStreamType}
+            </StyledMenuToggle>
+          )}
         >
           <SelectGroup label={t`Views`} key="views">
-            <SelectOption key="all_activity" value="all">
-              {t`Dashboard (all activity)`}
-            </SelectOption>
-            <SelectOption key="jobs" value="job">
-              {t`Jobs`}
-            </SelectOption>
-            <SelectOption key="schedules" value="schedule">
-              {t`Schedules`}
-            </SelectOption>
-            <SelectOption key="workflow_approvals" value="workflow_approval">
-              {t`Workflow Approvals`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption value="all">
+                {t`Dashboard (all activity)`}
+              </SelectOption>
+              <SelectOption value="job">
+                {t`Jobs`}
+              </SelectOption>
+              <SelectOption value="schedule">
+                {t`Schedules`}
+              </SelectOption>
+              <SelectOption value="workflow_approval">
+                {t`Workflow Approvals`}
+              </SelectOption>
+            </SelectList>
           </SelectGroup>
           <SelectGroup label={t`Resources`} key="resources">
-            <SelectOption
-              key="templates"
-              value="job_template,workflow_job_template,workflow_job_template_node"
-            >
-              {t`Templates`}
-            </SelectOption>
-            <SelectOption key="credentials" value="credential">
-              {t`Credentials`}
-            </SelectOption>
-            <SelectOption key="projects" value="project">
-              {t`Projects`}
-            </SelectOption>
-            <SelectOption key="inventories" value="inventory">
-              {t`Inventories`}
-            </SelectOption>
-            <SelectOption key="hosts" value="host">
-              {t`Hosts`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption
+                value="job_template,workflow_job_template,workflow_job_template_node"
+              >
+                {t`Templates`}
+              </SelectOption>
+              <SelectOption value="credential">
+                {t`Credentials`}
+              </SelectOption>
+              <SelectOption value="project">
+                {t`Projects`}
+              </SelectOption>
+              <SelectOption value="inventory">
+                {t`Inventories`}
+              </SelectOption>
+              <SelectOption value="host">
+                {t`Hosts`}
+              </SelectOption>
+            </SelectList>
           </SelectGroup>
           <SelectGroup label={t`Access`} key="access">
-            <SelectOption key="organizations" value="organization">
-              {t`Organizations`}
-            </SelectOption>
-            <SelectOption key="users" value="user">
-              {t`Users`}
-            </SelectOption>
-            <SelectOption key="teams" value="team">
-              {t`Teams`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption value="organization">
+                {t`Organizations`}
+              </SelectOption>
+              <SelectOption value="user">
+                {t`Users`}
+              </SelectOption>
+              <SelectOption value="team">
+                {t`Teams`}
+              </SelectOption>
+            </SelectList>
           </SelectGroup>
           <SelectGroup label={t`Administration`} key="administration">
-            <SelectOption key="credential_types" value="credential_type">
-              {t`Credential Types`}
-            </SelectOption>
-            <SelectOption
-              key="notification_templates"
-              value="notification_template"
-            >
-              {t`Notification Templates`}
-            </SelectOption>
-            <SelectOption key="instance" value="instance">
-              {t`Instances`}
-            </SelectOption>
-            <SelectOption key="instance_groups" value="instance_group">
-              {t`Instance Groups`}
-            </SelectOption>
-            <SelectOption
-              key="applications"
-              value="o_auth2_application,o_auth2_access_token"
-            >
-              {t`Applications & Tokens`}
-            </SelectOption>
-            <SelectOption
-              key="execution_environments"
-              value="execution_environment"
-            >
-              {t`Execution Environments`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption value="credential_type">
+                {t`Credential Types`}
+              </SelectOption>
+              <SelectOption
+                value="notification_template"
+              >
+                {t`Notification Templates`}
+              </SelectOption>
+              <SelectOption value="instance">
+                {t`Instances`}
+              </SelectOption>
+              <SelectOption value="instance_group">
+                {t`Instance Groups`}
+              </SelectOption>
+              <SelectOption
+                value="o_auth2_application,o_auth2_access_token"
+              >
+                {t`Applications & Tokens`}
+              </SelectOption>
+              <SelectOption
+                value="execution_environment"
+              >
+                {t`Execution Environments`}
+              </SelectOption>
+            </SelectList>
           </SelectGroup>
           <SelectGroup label={t`Settings`} key="settings">
-            <SelectOption key="settings" value="setting">
-              {t`Settings`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption value="setting">
+                {t`Settings`}
+              </SelectOption>
+            </SelectList>
           </SelectGroup>
         </Select>
       </PageSection>

--- a/awx/ui/src/screens/Credential/shared/CredentialForm.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialForm.js
@@ -12,12 +12,15 @@ import {
 	FormHelperText,
 	HelperText,
 	HelperTextItem,
+	MenuToggle,
+	Select,
+	SelectList,
+	SelectOption,
+	TextInputGroup,
+	TextInputGroupMain,
+	TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import {
-	Select as PFSelect,
-	SelectOption as PFSelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+import { TimesIcon } from '@patternfly/react-icons';
 import styled from 'styled-components';
 import FormField, { FormSubmitError } from 'components/FormField';
 import { FormColumnLayout, FormFullWidthLayout } from 'components/FormLayout';
@@ -26,14 +29,13 @@ import OrganizationLookup from 'components/Lookup/OrganizationLookup';
 import TypeInputsSubForm from './TypeInputsSubForm';
 import ExternalTestModal from './ExternalTestModal';
 
-const Select = styled(PFSelect)`
+const StyledSelect = styled(Select)`
   ul {
     max-width: 495px;
   }
-  ${(props) => (props.isDisabled ? `cursor: not-allowed` : null)}
 `;
 
-const SelectOption = styled(PFSelectOption)`
+const StyledSelectOption = styled(SelectOption)`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -44,6 +46,7 @@ function CredentialFormFields({ initialTypeId, credentialTypes }) {
   const { pathname } = useLocation();
   const { setFieldValue, initialValues, setFieldTouched } = useFormikContext();
   const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const [credTypeField, credTypeMeta, credTypeHelpers] = useField({
     name: 'credential_type',
     validate: required(t`Select a value for this field`),
@@ -123,37 +126,97 @@ function CredentialFormFields({ initialTypeId, credentialTypes }) {
   );
 
   const isCredentialTypeDisabled = pathname.includes('edit');
+
+  const selectedLabel =
+    credentialTypeOptions.find((opt) => opt.value === credTypeField.value)
+      ?.label || '';
+
+  const filteredOptions = credentialTypeOptions.filter((opt) =>
+    opt.label.toLowerCase().includes(filterValue.toLowerCase())
+  );
+
   const credentialTypeSelect = (
-    <Select
-      isDisabled={isCredentialTypeDisabled}
-      ouiaId="CredentialForm-credential_type"
-      aria-label={t`Credential Type`}
-      typeAheadAriaLabel={t`Select Credential Type`}
+    <StyledSelect
       isOpen={isSelectOpen}
-      variant={SelectVariant.typeahead}
-      onToggle={(_event, val) => setIsSelectOpen(val)}
-      onSelect={(event, value) => {
+      onOpenChange={(open) => {
+        setIsSelectOpen(open);
+        if (!open) setFilterValue('');
+      }}
+      onSelect={(_event, value) => {
         setCredentialTypeId(value);
         credTypeHelpers.setValue(value);
         setIsSelectOpen(false);
+        setFilterValue('');
       }}
-      selections={credTypeField.value}
-      placeholder={t`Select a credential Type`}
-      isCreatable={false}
-      maxHeight="300px"
-      width="100%"
-      noResultsFoundText={t`No results found`}
-    >
-      {credentialTypeOptions.map((credType) => (
-        <SelectOption
-          key={credType.value}
-          value={credType.value}
-          data-cy={`${credType.id}-credential-type-select-option`}
+      aria-label={t`Credential Type`}
+      ouiaId="CredentialForm-credential_type"
+      style={{ width: '100%' }}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          variant="typeahead"
+          onClick={() => {
+            if (!isCredentialTypeDisabled) setIsSelectOpen(!isSelectOpen);
+          }}
+          isExpanded={isSelectOpen}
+          isDisabled={isCredentialTypeDisabled}
+          style={isCredentialTypeDisabled ? { cursor: 'not-allowed' } : undefined}
         >
-          {credType.label}
-        </SelectOption>
-      ))}
-    </Select>
+          <TextInputGroup isPlain isDisabled={isCredentialTypeDisabled}>
+            <TextInputGroupMain
+              value={filterValue !== '' ? filterValue : selectedLabel}
+              onClick={() => {
+                if (!isCredentialTypeDisabled) setIsSelectOpen(true);
+              }}
+              onChange={(_event, val) => {
+                setFilterValue(val);
+                setIsSelectOpen(true);
+              }}
+              onFocus={() => {
+                if (selectedLabel && filterValue === '') {
+                  setFilterValue(selectedLabel);
+                }
+              }}
+              autoComplete="off"
+              placeholder={t`Select a credential Type`}
+              aria-label={t`Select Credential Type`}
+            />
+            {(filterValue || selectedLabel) && !isCredentialTypeDisabled && (
+              <TextInputGroupUtilities>
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    setCredentialTypeId(undefined);
+                    credTypeHelpers.setValue('');
+                    setFilterValue('');
+                  }}
+                  aria-label={t`Clear`}
+                >
+                  <TimesIcon />
+                </Button>
+              </TextInputGroupUtilities>
+            )}
+          </TextInputGroup>
+        </MenuToggle>
+      )}
+    >
+      <SelectList style={{ maxHeight: '300px' }}>
+        {filteredOptions.map((credType) => (
+          <StyledSelectOption
+            key={credType.value}
+            value={credType.value}
+            data-cy={`${credType.key}-credential-type-select-option`}
+          >
+            {credType.label}
+          </StyledSelectOption>
+        ))}
+        {filteredOptions.length === 0 && (
+          <SelectOption isDisabled>
+            {t`No results found`}
+          </SelectOption>
+        )}
+      </SelectList>
+    </StyledSelect>
   );
 
   return (

--- a/awx/ui/src/screens/Credential/shared/CredentialForm.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialForm.js
@@ -150,7 +150,6 @@ function CredentialFormFields({ initialTypeId, credentialTypes }) {
       }}
       aria-label={t`Credential Type`}
       ouiaId="CredentialForm-credential_type"
-      style={{ width: '100%' }}
       toggle={(toggleRef) => (
         <MenuToggle
           ref={toggleRef}

--- a/awx/ui/src/screens/Credential/shared/CredentialForm.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialForm.js
@@ -155,6 +155,7 @@ function CredentialFormFields({ initialTypeId, credentialTypes }) {
         <MenuToggle
           ref={toggleRef}
           variant="typeahead"
+          isFullWidth
           onClick={() => {
             if (!isCredentialTypeDisabled) setIsSelectOpen(!isSelectOpen);
           }}
@@ -200,7 +201,7 @@ function CredentialFormFields({ initialTypeId, credentialTypes }) {
         </MenuToggle>
       )}
     >
-      <SelectList style={{ maxHeight: '300px' }}>
+      <SelectList style={{ maxHeight: '300px', overflowY: 'auto' }}>
         {filteredOptions.map((credType) => (
           <StyledSelectOption
             key={credType.value}

--- a/awx/ui/src/screens/Credential/shared/CredentialForm.test.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialForm.test.js
@@ -75,12 +75,9 @@ function gceFieldExpects() {
 }
 
 async function selectCredentialType(user, label) {
-  // The Credential Type field is a PF typeahead Select; open it via the toggle
-  // button inside its container, then pick the option by label.
-  const select = document.querySelector(
-    '[data-ouia-component-id="CredentialForm-credential_type"]'
-  );
-  await user.click(select.querySelector('button'));
+  const input = screen.getByRole('textbox', { name: 'Select Credential Type' });
+  await user.clear(input);
+  await user.click(input);
   await user.click(await screen.findByText(label));
 }
 

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.js
@@ -2,21 +2,26 @@ import React, { useState } from 'react';
 import { useField } from 'formik';
 import { useLingui } from '@lingui/react/macro';
 import {
+	Button,
 	FormGroup,
 	FormHelperText,
 	HelperText,
 	HelperTextItem,
-} from '@patternfly/react-core';
-import {
+	MenuToggle,
 	Select,
+	SelectList,
 	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
+	TextInputGroup,
+	TextInputGroupMain,
+	TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import Popover from 'components/Popover';
 
 function BecomeMethodField({ fieldOptions, isRequired = false }) {
   const { t } = useLingui();
   const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const [options, setOptions] = useState(
     [
       'sudo',
@@ -36,6 +41,17 @@ function BecomeMethodField({ fieldOptions, isRequired = false }) {
   const [becomeMethodField, meta, helpers] = useField({
     name: `inputs.${fieldOptions.id}`,
   });
+
+  const filteredOptions = options.filter((option) =>
+    option.value.toLowerCase().includes(filterValue.toLowerCase())
+  );
+
+  const showCreateOption =
+    filterValue.trim() &&
+    !options.some(
+      (option) => option.value.toLowerCase() === filterValue.trim().toLowerCase()
+    );
+
   return (
     <FormGroup
       fieldId={`credential-${fieldOptions.id}`}
@@ -46,31 +62,82 @@ function BecomeMethodField({ fieldOptions, isRequired = false }) {
       isRequired={isRequired}
     >
       <Select
-        ouiaId={`CredentialForm-${fieldOptions.id}`}
-        typeAheadAriaLabel={fieldOptions.label}
-        maxHeight={200}
-        variant={SelectVariant.typeahead}
-        onToggle={(_event, val) => setIsOpen(val)}
-        onClear={() => {
-          helpers.setValue('');
-        }}
-        onSelect={(event, option) => {
-          helpers.setValue(option);
-          setIsOpen(false);
-        }}
-        isOpen={isOpen}
         id="privilege-escalation-methods"
-        selections={becomeMethodField.value}
-        isCreatable
-        onCreateOption={(option) => {
-          setOptions([...options, { value: option }]);
+        isOpen={isOpen}
+        isScrollable
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (!open) setFilterValue('');
         }}
-        noResultsFoundText={t`No results found`}
-        createText={t`Create`}
+        onSelect={(_event, value) => {
+          helpers.setValue(value);
+          setIsOpen(false);
+          setFilterValue('');
+        }}
+        ouiaId={`CredentialForm-${fieldOptions.id}`}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="typeahead"
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+          >
+            <TextInputGroup isPlain>
+              <TextInputGroupMain
+                value={filterValue !== '' ? filterValue : (becomeMethodField.value || '')}
+                onClick={() => setIsOpen(true)}
+                onChange={(_event, val) => {
+                  setFilterValue(val);
+                  setIsOpen(true);
+                }}
+                onFocus={() => {
+                  if (becomeMethodField.value && filterValue === '') {
+                    setFilterValue(becomeMethodField.value);
+                  }
+                }}
+                autoComplete="off"
+                aria-label={fieldOptions.label}
+              />
+              {(filterValue || becomeMethodField.value) && (
+                <TextInputGroupUtilities>
+                  <Button
+                    variant="plain"
+                    onClick={() => {
+                      helpers.setValue('');
+                      setFilterValue('');
+                    }}
+                    aria-label={t`Clear`}
+                  >
+                    <TimesIcon />
+                  </Button>
+                </TextInputGroupUtilities>
+              )}
+            </TextInputGroup>
+          </MenuToggle>
+        )}
       >
-        {options.map((option) => (
-          <SelectOption key={option.value} value={option.value} />
-        ))}
+        <SelectList style={{ maxHeight: '200px' }}>
+          {filteredOptions.map((option) => (
+            <SelectOption key={option.value} value={option.value}>
+              {option.value}
+            </SelectOption>
+          ))}
+          {showCreateOption && (
+            <SelectOption
+              value={filterValue.trim()}
+              onClick={() => {
+                setOptions([...options, { value: filterValue.trim() }]);
+              }}
+            >
+              {t`Create`} &quot;{filterValue.trim()}&quot;
+            </SelectOption>
+          )}
+          {filteredOptions.length === 0 && !showCreateOption && (
+            <SelectOption isDisabled>
+              {t`No results found`}
+            </SelectOption>
+          )}
+        </SelectList>
       </Select>
       {meta.touched && meta.error && (
         <FormHelperText>

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.test.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.test.js
@@ -31,7 +31,7 @@ describe('<BecomeMethodField>', () => {
       </Formik>
     );
     await user.click(
-      screen.getByRole('button', { name: 'Options menu' })
+      screen.getByRole('textbox', { name: 'Privilege Escalation Method' })
     );
     expect(screen.getAllByRole('option')).toHaveLength(12);
   });

--- a/awx/ui/src/screens/Dashboard/DashboardGraph.js
+++ b/awx/ui/src/screens/Dashboard/DashboardGraph.js
@@ -6,24 +6,18 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
-	PageSection
-} from '@patternfly/react-core';
-import {
+	MenuToggle,
+	PageSection,
 	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+	SelectList,
+	SelectOption,
+} from '@patternfly/react-core';
 
 import useRequest from 'hooks/useRequest';
 import { DashboardAPI } from 'api';
 import ContentLoading from 'components/ContentLoading';
 import LineChart from './shared/LineChart';
 
-const StatusSelect = styled(Select)`
-  && {
-    --pf-v5-c-select__toggle--MinWidth: 165px;
-  }
-`;
 const GraphCardHeader = styled(CardHeader)`
   margin-top: var(--pf-v5-global--spacer--lg);
 `;
@@ -44,6 +38,26 @@ function DashboardGraph() {
   const [periodSelection, setPeriodSelection] = useState('month');
   const [jobTypeSelection, setJobTypeSelection] = useState('all');
   const [jobStatusSelection, setJobStatusSelection] = useState('all');
+
+  const periodLabelMap = {
+    month: t`Past month`,
+    two_weeks: t`Past two weeks`,
+    week: t`Past week`,
+    day: t`Past 24 hours`,
+  };
+
+  const jobTypeLabelMap = {
+    all: t`All job types`,
+    inv_sync: t`Inventory sync`,
+    scm_update: t`SCM update`,
+    playbook_run: t`Playbook run`,
+  };
+
+  const jobStatusLabelMap = {
+    all: t`All jobs`,
+    successful: t`Successful jobs`,
+    failed: t`Failed jobs`,
+  };
 
   const {
     isLoading,
@@ -96,84 +110,107 @@ function DashboardGraph() {
       <GraphCardHeader>
         <GraphCardActions>
           <Select
-            variant={SelectVariant.single}
-            placeholderText={t`Select period`}
-            aria-label={t`Select period`}
-            typeAheadAriaLabel={t`Select period`}
-            className="periodSelect"
-            onToggle={(_event, val) => setIsPeriodDropdownOpen(val)}
-            onSelect={(event, selection) => {
+            isOpen={isPeriodDropdownOpen}
+            onOpenChange={setIsPeriodDropdownOpen}
+            onSelect={(_event, selection) => {
               setIsPeriodDropdownOpen(false);
               setPeriodSelection(selection);
             }}
-            selections={periodSelection}
-            isOpen={isPeriodDropdownOpen}
-            noResultsFoundText={t`No results found`}
+            aria-label={t`Select period`}
+            className="periodSelect"
             ouiaId="dashboard-period-select"
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsPeriodDropdownOpen(!isPeriodDropdownOpen)}
+                isExpanded={isPeriodDropdownOpen}
+              >
+                {periodLabelMap[periodSelection] || t`Select period`}
+              </MenuToggle>
+            )}
           >
-            <SelectOption key="month" value="month">
-              {t`Past month`}
-            </SelectOption>
-            <SelectOption key="two_weeks" value="two_weeks">
-              {t`Past two weeks`}
-            </SelectOption>
-            <SelectOption key="week" value="week">
-              {t`Past week`}
-            </SelectOption>
-            <SelectOption key="day" value="day">
-              {t`Past 24 hours`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption value="month">
+                {t`Past month`}
+              </SelectOption>
+              <SelectOption value="two_weeks">
+                {t`Past two weeks`}
+              </SelectOption>
+              <SelectOption value="week">
+                {t`Past week`}
+              </SelectOption>
+              <SelectOption value="day">
+                {t`Past 24 hours`}
+              </SelectOption>
+            </SelectList>
           </Select>
           <Select
-            variant={SelectVariant.single}
-            placeholderText={t`Select job type`}
-            aria-label={t`Select job type`}
-            className="jobTypeSelect"
-            onToggle={(_event, val) => setIsJobTypeDropdownOpen(val)}
-            onSelect={(event, selection) => {
+            isOpen={isJobTypeDropdownOpen}
+            onOpenChange={setIsJobTypeDropdownOpen}
+            onSelect={(_event, selection) => {
               setIsJobTypeDropdownOpen(false);
               setJobTypeSelection(selection);
             }}
-            selections={jobTypeSelection}
-            isOpen={isJobTypeDropdownOpen}
+            aria-label={t`Select job type`}
+            className="jobTypeSelect"
             ouiaId="dashboard-job-type-select"
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsJobTypeDropdownOpen(!isJobTypeDropdownOpen)}
+                isExpanded={isJobTypeDropdownOpen}
+              >
+                {jobTypeLabelMap[jobTypeSelection] || t`Select job type`}
+              </MenuToggle>
+            )}
           >
-            <SelectOption key="all" value="all">
-              {t`All job types`}
-            </SelectOption>
-            <SelectOption key="inv_sync" value="inv_sync">
-              {t`Inventory sync`}
-            </SelectOption>
-            <SelectOption key="scm_update" value="scm_update">
-              {t`SCM update`}
-            </SelectOption>
-            <SelectOption key="playbook_run" value="playbook_run">
-              {t`Playbook run`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption value="all">
+                {t`All job types`}
+              </SelectOption>
+              <SelectOption value="inv_sync">
+                {t`Inventory sync`}
+              </SelectOption>
+              <SelectOption value="scm_update">
+                {t`SCM update`}
+              </SelectOption>
+              <SelectOption value="playbook_run">
+                {t`Playbook run`}
+              </SelectOption>
+            </SelectList>
           </Select>
-          <StatusSelect
-            variant={SelectVariant.single}
-            placeholderText={t`Select status`}
-            aria-label={t`Select status`}
-            className="jobStatusSelect"
-            onToggle={(_event, val) => setIsJobStatusDropdownOpen(val)}
-            onSelect={(event, selection) => {
+          <Select
+            isOpen={isJobStatusDropdownOpen}
+            onOpenChange={setIsJobStatusDropdownOpen}
+            onSelect={(_event, selection) => {
               setIsJobStatusDropdownOpen(false);
               setJobStatusSelection(selection);
             }}
-            selections={jobStatusSelection}
-            isOpen={isJobStatusDropdownOpen}
+            aria-label={t`Select status`}
+            className="jobStatusSelect"
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsJobStatusDropdownOpen(!isJobStatusDropdownOpen)}
+                isExpanded={isJobStatusDropdownOpen}
+                style={{ minWidth: '165px' }}
+              >
+                {jobStatusLabelMap[jobStatusSelection] || t`Select status`}
+              </MenuToggle>
+            )}
           >
-            <SelectOption key="all" value="all">
-              {t`All jobs`}
-            </SelectOption>
-            <SelectOption key="successful" value="successful">
-              {t`Successful jobs`}
-            </SelectOption>
-            <SelectOption key="failed" value="failed">
-              {t`Failed jobs`}
-            </SelectOption>
-          </StatusSelect>
+            <SelectList>
+              <SelectOption value="all">
+                {t`All jobs`}
+              </SelectOption>
+              <SelectOption value="successful">
+                {t`Successful jobs`}
+              </SelectOption>
+              <SelectOption value="failed">
+                {t`Failed jobs`}
+              </SelectOption>
+            </SelectList>
+          </Select>
         </GraphCardActions>
       </GraphCardHeader>
       <CardBody>

--- a/awx/ui/src/screens/Dashboard/DashboardGraph.test.js
+++ b/awx/ui/src/screens/Dashboard/DashboardGraph.test.js
@@ -14,12 +14,8 @@ jest.mock('../../api');
 // so stub it out and keep the assertions on the surrounding UI + API calls.
 jest.mock('./shared/LineChart', () => () => <div data-testid="line-chart" />);
 
-// The three PF Select toggles all expose the accessible name "Options menu",
-// so they can't be told apart by role+name. They carry distinct classNames
-// (periodSelect / jobTypeSelect / jobStatusSelect) wired up in the source, so
-// scope to each select wrapper and grab its toggle button.
-function getToggle(container, className) {
-  return container.querySelector(`.${className} button.pf-v5-c-select__toggle`);
+function getToggle(label) {
+  return screen.getByRole('button', { name: label });
 }
 
 describe('<DashboardGraph/>', () => {
@@ -59,13 +55,13 @@ describe('<DashboardGraph/>', () => {
   });
 
   test('should render all three line chart filters with correct number of options', async () => {
-    const { user, container } = renderWithContexts(<DashboardGraph />);
+    const { user } = renderWithContexts(<DashboardGraph />);
 
     await waitFor(() => expect(graphRequest).toHaveBeenCalled());
 
-    const periodToggle = getToggle(container, 'periodSelect');
-    const jobTypeToggle = getToggle(container, 'jobTypeSelect');
-    const statusToggle = getToggle(container, 'jobStatusSelect');
+    const periodToggle = getToggle('Past month');
+    const jobTypeToggle = getToggle('All job types');
+    const statusToggle = getToggle('All jobs');
     expect(periodToggle).toBeInTheDocument();
     expect(jobTypeToggle).toBeInTheDocument();
     expect(statusToggle).toBeInTheDocument();

--- a/awx/ui/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.js
+++ b/awx/ui/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.js
@@ -204,7 +204,7 @@ const SCMSubForm = ({ autoPopulateProject }) => {
                 value={filterValue.trim()}
                 onClick={() => {
                   const trimmed = filterValue.trim();
-                  setSourcePath([...sourcePath, trimmed]);
+                  setSourcePath((prev) => [...prev, trimmed]);
                 }}
               >
                 {t`Set source path to`} &quot;{filterValue.trim()}&quot;

--- a/awx/ui/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.js
+++ b/awx/ui/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.js
@@ -2,16 +2,20 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useField, useFormikContext } from 'formik';
 import { useLingui } from '@lingui/react/macro';
 import {
+	Button,
 	FormGroup,
 	FormHelperText,
 	HelperText,
 	HelperTextItem,
-} from '@patternfly/react-core';
-import {
-	SelectVariant,
+	MenuToggle,
 	Select,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+	SelectList,
+	SelectOption,
+	TextInputGroup,
+	TextInputGroupMain,
+	TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import { ProjectsAPI } from 'api';
 import useRequest from 'hooks/useRequest';
 import { required } from 'util/validators';
@@ -33,6 +37,7 @@ const SCMSubForm = ({ autoPopulateProject }) => {
   const { t } = useLingui();
   const helpText = getHelpText(t);
   const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const [sourcePath, setSourcePath] = useState([]);
   const { setFieldValue, setFieldTouched } = useFormikContext();
   const [credentialField] = useField('credential');
@@ -81,6 +86,21 @@ const SCMSubForm = ({ autoPopulateProject }) => {
     },
     [setFieldValue, setFieldTouched]
   );
+
+  const isValid =
+    (!sourcePathMeta.error || !sourcePathMeta.touched) &&
+    !sourcePathError?.message;
+
+  const filteredPaths = sourcePath.filter((path) =>
+    path.toLowerCase().includes(filterValue.toLowerCase())
+  );
+
+  const showCreateOption =
+    filterValue.trim() &&
+    !sourcePath.some(
+      (path) => path.toLowerCase() === filterValue.trim().toLowerCase()
+    );
+
   return (
     <>
       {projectField.value?.allow_override && (
@@ -116,35 +136,86 @@ const SCMSubForm = ({ autoPopulateProject }) => {
         labelIcon={<Popover content={helpText.sourcePath} />}
       >
         <Select
-          ouiaId="InventorySourceForm-source_path"
-          variant={SelectVariant.typeahead}
-          onToggle={(_event, val) => setIsOpen(val)}
-          isOpen={isOpen}
-          selections={sourcePathField.value}
           id="source_path"
-          isValid={
-            (!sourcePathMeta.error || !sourcePathMeta.touched) &&
-            !sourcePathError?.message
-          }
-          onSelect={(event, value) => {
+          isOpen={isOpen}
+          onOpenChange={(open) => {
+            setIsOpen(open);
+            if (!open) setFilterValue('');
+          }}
+          onSelect={(_event, value) => {
             setIsOpen(false);
-            value = value.trim();
-            sourcePathHelpers.setValue(value);
+            const trimmed = typeof value === 'string' ? value.trim() : value;
+            sourcePathHelpers.setValue(trimmed);
+            setFilterValue('');
           }}
           aria-label={t`Select source path`}
-          typeAheadAriaLabel={t`Select source path`}
-          placeholder={t`Select source path`}
-          createText={t`Set source path to`}
-          isCreatable
-          onCreateOption={(value) => {
-            value.trim();
-            setSourcePath([...sourcePath, value]);
-          }}
-          noResultsFoundText={t`No results found`}
+          ouiaId="InventorySourceForm-source_path"
+          toggle={(toggleRef) => (
+            <MenuToggle
+              ref={toggleRef}
+              variant="typeahead"
+              onClick={() => setIsOpen(!isOpen)}
+              isExpanded={isOpen}
+              status={isValid ? undefined : 'danger'}
+            >
+              <TextInputGroup isPlain>
+                <TextInputGroupMain
+                  value={filterValue !== '' ? filterValue : (sourcePathField.value || '')}
+                  onClick={() => setIsOpen(true)}
+                  onChange={(_event, val) => {
+                    setFilterValue(val);
+                    setIsOpen(true);
+                  }}
+                  onFocus={() => {
+                    if (sourcePathField.value && filterValue === '') {
+                      setFilterValue(sourcePathField.value);
+                    }
+                  }}
+                  autoComplete="off"
+                  placeholder={t`Select source path`}
+                  aria-label={t`Select source path`}
+                />
+                {(filterValue || sourcePathField.value) && (
+                  <TextInputGroupUtilities>
+                    <Button
+                      variant="plain"
+                      onClick={() => {
+                        sourcePathHelpers.setValue('');
+                        setFilterValue('');
+                      }}
+                      aria-label={t`Clear`}
+                    >
+                      <TimesIcon />
+                    </Button>
+                  </TextInputGroupUtilities>
+                )}
+              </TextInputGroup>
+            </MenuToggle>
+          )}
         >
-          {sourcePath.map((path) => (
-            <SelectOption key={path} id={path} value={path} />
-          ))}
+          <SelectList>
+            {filteredPaths.map((path) => (
+              <SelectOption key={path} id={path} value={path}>
+                {path}
+              </SelectOption>
+            ))}
+            {showCreateOption && (
+              <SelectOption
+                value={filterValue.trim()}
+                onClick={() => {
+                  const trimmed = filterValue.trim();
+                  setSourcePath([...sourcePath, trimmed]);
+                }}
+              >
+                {t`Set source path to`} &quot;{filterValue.trim()}&quot;
+              </SelectOption>
+            )}
+            {filteredPaths.length === 0 && !showCreateOption && (
+              <SelectOption isDisabled>
+                {t`No results found`}
+              </SelectOption>
+            )}
+          </SelectList>
         </Select>
         {((sourcePathMeta.touched && sourcePathMeta.error) || sourcePathError?.message) && (
           <FormHelperText>

--- a/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
@@ -16,17 +16,9 @@ const qsConfig = {
   integerFields: ['page', 'page_size'],
 };
 
-// The column dropdown is the Search "Simple key select" (ouiaId). The single
-// Select keeps the currently-selected column in its toggle text and lists only
-// the remaining columns as options, so the full set is the selected toggle
-// value followed by the option labels.
 async function getColumnNames(user) {
-  const select = document.querySelector(
-    '[data-ouia-component-id="simple-key-select"]'
-  );
-  const toggle = select.querySelector('button');
-  const selected = select.querySelector('.pf-v5-c-select__toggle-text')
-    .textContent;
+  const toggle = screen.getByRole('button', { name: 'Simple key select' });
+  const selected = toggle.textContent;
   await user.click(toggle);
   const listbox = await screen.findByRole('listbox');
   const options = within(listbox)

--- a/awx/ui/src/screens/Metrics/Metrics.js
+++ b/awx/ui/src/screens/Metrics/Metrics.js
@@ -5,15 +5,15 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
+	MenuToggle,
+	Select,
+	SelectList,
+	SelectOption,
 	Toolbar,
 	ToolbarGroup,
 	ToolbarContent,
 	ToolbarItem
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
 
 import { MetricsAPI, InstancesAPI } from 'api';
 import useRequest from 'hooks/useRequest';
@@ -24,7 +24,6 @@ import LineChart from './LineChart';
 
 let count = [0];
 
-// hook thats calls api every 3 seconds to get data
 function useInterval(callback, delay, instance, metric) {
   const savedCallback = useRef();
   useEffect(() => {
@@ -191,41 +190,63 @@ function Metrics() {
                   <ToolbarItem>{t`Instance`}</ToolbarItem>
                   <ToolbarItem>
                     <Select
-                      ouiaId="Instance-select"
-                      onToggle={(_event, val) => setInstanceIsOpen(val)}
                       isOpen={instanceIsOpen}
-                      onSelect={(e, value) => {
+                      onOpenChange={setInstanceIsOpen}
+                      onSelect={(_event, value) => {
                         count = [0];
                         setInstance(value);
                         setInstanceIsOpen(false);
                         setRenderedData([]);
                       }}
-                      selections={instance}
-                      placeholderText={t`Select an instance`}
+                      ouiaId="Instance-select"
+                      toggle={(toggleRef) => (
+                        <MenuToggle
+                          ref={toggleRef}
+                          onClick={() => setInstanceIsOpen(!instanceIsOpen)}
+                          isExpanded={instanceIsOpen}
+                        >
+                          {instance || t`Select an instance`}
+                        </MenuToggle>
+                      )}
                     >
-                      {instances.map((inst) => (
-                        <SelectOption value={inst} key={inst} />
-                      ))}
+                      <SelectList>
+                        {instances.map((inst) => (
+                          <SelectOption value={inst} key={inst}>
+                            {inst}
+                          </SelectOption>
+                        ))}
+                      </SelectList>
                     </Select>
                   </ToolbarItem>
                   <ToolbarItem>{t`Metric`}</ToolbarItem>
                   <ToolbarItem>
                     <Select
-                      ouiaId="Metric-select"
-                      placeholderText={t`Select a metric`}
                       isOpen={metricIsOpen}
-                      onSelect={(e, value) => {
+                      onOpenChange={setMetricIsOpen}
+                      onSelect={(_event, value) => {
                         count = [0];
                         setMetric(value);
                         setRenderedData([]);
                         setMetricIsOpen(false);
                       }}
-                      onToggle={(_event, val) => setMetricIsOpen(val)}
-                      selections={metric}
+                      ouiaId="Metric-select"
+                      toggle={(toggleRef) => (
+                        <MenuToggle
+                          ref={toggleRef}
+                          onClick={() => setMetricIsOpen(!metricIsOpen)}
+                          isExpanded={metricIsOpen}
+                        >
+                          {metric || t`Select a metric`}
+                        </MenuToggle>
+                      )}
                     >
-                      {metrics.map((met) => (
-                        <SelectOption value={met} key={met} />
-                      ))}
+                      <SelectList>
+                        {metrics.map((met) => (
+                          <SelectOption value={met} key={met}>
+                            {met}
+                          </SelectOption>
+                        ))}
+                      </SelectList>
                     </Select>
                   </ToolbarItem>
                 </ToolbarGroup>

--- a/awx/ui/src/screens/Metrics/Metrics.test.js
+++ b/awx/ui/src/screens/Metrics/Metrics.test.js
@@ -12,14 +12,9 @@ describe('<Metrics/>', () => {
   let user;
   let container;
 
-  const openSelect = async (ouiaId) => {
-    const select = container.querySelector(
-      `[data-ouia-component-id="${ouiaId}"]`
-    );
-    await user.click(within(select).getByRole('button'));
-    // The menu may be rendered in a Popper/portal outside the select's DOM
-    // subtree, so resolve the open listbox from `screen` rather than scoping
-    // to the select container.
+  const openSelect = async (toggleText) => {
+    const toggle = screen.getByRole('button', { name: toggleText });
+    await user.click(toggle);
     return screen.findByRole('listbox');
   };
 
@@ -64,11 +59,11 @@ describe('<Metrics/>', () => {
 
   test('should render chart after selecting metric and instance', async () => {
     // open the Instance select and pick "instance 1"
-    const instanceListbox = await openSelect('Instance-select');
+    const instanceListbox = await openSelect('Select an instance');
     await user.click(within(instanceListbox).getByText('instance 1'));
 
     // open the Metric select and pick "metric1"
-    const metricListbox = await openSelect('Metric-select');
+    const metricListbox = await openSelect('Select a metric');
     await user.click(within(metricListbox).getByText('metric1'));
 
     await waitFor(() =>
@@ -82,7 +77,7 @@ describe('<Metrics/>', () => {
   });
 
   test('should not include receptor instances', async () => {
-    const listbox = await openSelect('Instance-select');
+    const listbox = await openSelect('Select an instance');
     // execution-node ("receptor") instances are filtered out; the two
     // non-execution instances plus the "All" option remain (3 total).
     expect(within(listbox).queryByText('receptor')).toBeNull();

--- a/awx/ui/src/screens/SubscriptionUsage/SubscriptionUsageChart.js
+++ b/awx/ui/src/screens/SubscriptionUsage/SubscriptionUsageChart.js
@@ -7,14 +7,13 @@ import {
 	CardTitle,
 	Flex,
 	FlexItem,
+	MenuToggle,
 	PageSection,
+	Select,
+	SelectList,
+	SelectOption,
 	Text
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
 import { useLingui } from '@lingui/react/macro';
 
 import useRequest from 'hooks/useRequest';
@@ -112,6 +111,12 @@ function SubscriptionUsageChart() {
     );
   }
 
+  const periodLabelMap = {
+    year: t`Past year`,
+    two_years: t`Past two years`,
+    three_years: t`Past three years`,
+  };
+
   return (
     <Card>
       <Flex style={{ justifyContent: 'space-between' }}>
@@ -133,30 +138,36 @@ function SubscriptionUsageChart() {
       <GraphCardHeader>
         <GraphCardActions>
           <Select
-            variant={SelectVariant.single}
-            placeholderText={t`Select period`}
-            aria-label={t`Select period`}
-            typeAheadAriaLabel={t`Select period`}
-            className="periodSelect"
-            onToggle={(_event, val) => setIsPeriodDropdownOpen(val)}
-            onSelect={(event, selection) => {
+            isOpen={isPeriodDropdownOpen}
+            onOpenChange={setIsPeriodDropdownOpen}
+            onSelect={(_event, selection) => {
               setIsPeriodDropdownOpen(false);
               setPeriodSelection(selection);
             }}
-            selections={periodSelection}
-            isOpen={isPeriodDropdownOpen}
-            noResultsFoundText={t`No results found`}
+            aria-label={t`Select period`}
+            className="periodSelect"
             ouiaId="subscription-usage-period-select"
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsPeriodDropdownOpen(!isPeriodDropdownOpen)}
+                isExpanded={isPeriodDropdownOpen}
+              >
+                {periodLabelMap[periodSelection] || t`Select period`}
+              </MenuToggle>
+            )}
           >
-            <SelectOption key="year" value="year">
-              {t`Past year`}
-            </SelectOption>
-            <SelectOption key="two_years" value="two_years">
-              {t`Past two years`}
-            </SelectOption>
-            <SelectOption key="three_years" value="three_years">
-              {t`Past three years`}
-            </SelectOption>
+            <SelectList>
+              <SelectOption value="year">
+                {t`Past year`}
+              </SelectOption>
+              <SelectOption value="two_years">
+                {t`Past two years`}
+              </SelectOption>
+              <SelectOption value="three_years">
+                {t`Past three years`}
+              </SelectOption>
+            </SelectList>
           </Select>
         </GraphCardActions>
       </GraphCardHeader>

--- a/awx/ui/src/screens/Template/Survey/SurveyReorderModal.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyReorderModal.js
@@ -2,16 +2,17 @@ import React, { useState, useRef } from 'react';
 import { useLingui } from '@lingui/react/macro';
 import { GripVerticalIcon } from '@patternfly/react-icons';
 import {
+	Label,
+	LabelGroup,
+	MenuToggle,
 	Modal,
+	Select,
+	SelectList,
+	SelectOption,
 	TextInput,
 	TextArea,
 	Button
 } from '@patternfly/react-core';
-import {
-	Select,
-	SelectOption,
-	SelectVariant
-} from '@patternfly/react-core/deprecated';
 import {
   Table,
   Thead,
@@ -144,34 +145,64 @@ function SurveyReorderModal({
         component = (
           <Select
             id={`survey-preview-multipleChoice-${q.variable}`}
-            ouiaId={`survey-preview-multipleChoice-${q.variable}`}
-            isDisabled
-            aria-label={t`Multiple Choice`}
-            typeAheadAriaLabel={t`Multiple Choice`}
-            placeholderText={q.default}
-            onToggle={() => {}}
-          />
+            isOpen={false}
+            onOpenChange={() => {}}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                isDisabled
+                aria-label={t`Multiple Choice`}
+                ouiaId={`survey-preview-multipleChoice-${q.variable}`}
+              >
+                {q.default || t`Select an option`}
+              </MenuToggle>
+            )}
+          >
+            <SelectList>
+              {choices.length > 0 &&
+                choices.map((option) => (
+                  <SelectOption key={option} value={option}>
+                    {option}
+                  </SelectOption>
+                ))}
+            </SelectList>
+          </Select>
         );
         break;
       case 'multiselect':
         component = (
           <Select
-            isDisabled
-            isReadOnly
-            variant={SelectVariant.typeaheadMulti}
-            isOpen={false}
-            selections={q.default.length > 0 ? q.default.split('\n') : []}
-            onToggle={() => {}}
-            aria-label={t`Multi-Select`}
-            typeAheadAriaLabel={t`Multi-Select`}
             id={`survey-preview-multiSelect-${q.variable}`}
-            ouiaId={`survey-preview-multiSelect-${q.variable}`}
-            noResultsFoundText={t`No results found`}
+            isOpen={false}
+            onOpenChange={() => {}}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                isDisabled
+                variant="typeahead"
+                aria-label={t`Multi-Select`}
+                ouiaId={`survey-preview-multiSelect-${q.variable}`}
+              >
+                {q.default.length > 0 ? (
+                  <LabelGroup>
+                    {q.default.split('\n').map((val) => (
+                      <Label key={val}>{val}</Label>
+                    ))}
+                  </LabelGroup>
+                ) : (
+                  t`Select option(s)`
+                )}
+              </MenuToggle>
+            )}
           >
-            {choices.length > 0 &&
-              choices.map((option) => (
-                <SelectOption key={option} value={option} />
-              ))}
+            <SelectList>
+              {choices.length > 0 &&
+                choices.map((option) => (
+                  <SelectOption key={option} value={option}>
+                    {option}
+                  </SelectOption>
+                ))}
+            </SelectList>
           </Select>
         );
         break;

--- a/awx/ui/src/screens/Template/Survey/SurveyReorderModal.test.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyReorderModal.test.js
@@ -82,16 +82,13 @@ describe('<SurveyReorderModal />', () => {
 
     // Question 2: multiple choice Select, disabled, placeholder is the default.
     expect(screen.getByText('Select Question')).toBeInTheDocument();
-    const question2Select = document.querySelector(
+    const question2Toggle = document.querySelector(
       '[data-ouia-component-id="survey-preview-multipleChoice-sdf"]'
     );
-    expect(question2Select).toBeInTheDocument();
+    expect(question2Toggle).toBeInTheDocument();
     expect(
-      within(question2Select).getByText('Select Question Value')
+      within(question2Toggle).getByText('Select Question Value')
     ).toBeInTheDocument();
-    const question2Toggle = question2Select.querySelector(
-      'button[aria-label="Options menu"]'
-    );
     expect(question2Toggle).toBeDisabled();
 
     // Question 3: textarea, disabled, with the default value.
@@ -107,18 +104,16 @@ describe('<SurveyReorderModal />', () => {
     expect(question4Value).toBeInTheDocument();
     expect(question4Value).toHaveTextContent('ENCRYPTED');
 
-    // Question 5: multiselect renders the selections as chips (4 values).
+    // Question 5: multiselect renders the selections as Labels (4 values).
     expect(screen.getByText('Multiple select Question')).toBeInTheDocument();
-    const multiSelect = document.querySelector(
+    const multiSelectToggle = document.querySelector(
       '[data-ouia-component-id="survey-preview-multiSelect-a"]'
     );
-    expect(multiSelect).toBeInTheDocument();
-    const chips = multiSelect.querySelectorAll('.pf-v5-c-chip');
-    expect(chips.length).toBe(4);
-    const multiSelectToggle = multiSelect.querySelector(
-      'button[aria-label="Options menu"]'
-    );
-    expect(multiSelectToggle).toBeDisabled();
+    expect(multiSelectToggle).toBeInTheDocument();
+    const toggleWrapper = multiSelectToggle.closest('.pf-v5-c-menu-toggle');
+    const labels = toggleWrapper.querySelectorAll('.pf-v5-c-label');
+    expect(labels.length).toBe(4);
+    expect(toggleWrapper).toHaveClass('pf-m-disabled');
   });
 
   test('Save and Cancel buttons wire up their callbacks', () => {

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js
@@ -6,13 +6,12 @@ import {
 	Alert,
 	Form,
 	FormGroup,
-	TextInput
-} from '@patternfly/react-core';
-import {
+	TextInput,
 	Select,
-	SelectVariant,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+	SelectOption,
+	SelectList,
+	MenuToggle,
+} from '@patternfly/react-core';
 import { required } from 'util/validators';
 
 import { FormColumnLayout, FormFullWidthLayout } from 'components/FormLayout';
@@ -247,26 +246,33 @@ function NodeTypeStep({ isIdentifierRequired }) {
               }
             >
               <Select
-                variant={SelectVariant.single}
                 isOpen={isConvergenceOpen}
-                selections={convergenceField.value}
-                onToggle={(_event, val) => setIsConvergenceOpen(val)}
-                onSelect={(event, selection) => {
+                onOpenChange={setIsConvergenceOpen}
+                onSelect={(_event, selection) => {
                   convergenceFieldHelpers.setValue(selection);
                   setIsConvergenceOpen(false);
                 }}
                 aria-label={t`Convergence select`}
-                typeAheadAriaLabel={t`Convergence select`}
                 className="convergenceSelect"
                 ouiaId="convergenceSelect"
-                noResultsFoundText={t`No results found`}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsConvergenceOpen(!isConvergenceOpen)}
+                    isExpanded={isConvergenceOpen}
+                  >
+                    {convergenceField.value === 'any' ? t`Any` : t`All`}
+                  </MenuToggle>
+                )}
               >
-                <SelectOption key="any" value="any" id="select-option-any">
-                  {t`Any`}
-                </SelectOption>
-                <SelectOption key="all" value="all" id="select-option-all">
-                  {t`All`}
-                </SelectOption>
+                <SelectList>
+                  <SelectOption value="any" id="select-option-any">
+                    {t`Any`}
+                  </SelectOption>
+                  <SelectOption value="all" id="select-option-all">
+                    {t`All`}
+                  </SelectOption>
+                </SelectList>
               </Select>
             </FormGroup>
             <FormField

--- a/awx/ui/src/screens/Template/shared/PlaybookSelect.js
+++ b/awx/ui/src/screens/Template/shared/PlaybookSelect.js
@@ -2,10 +2,16 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { useLingui } from '@lingui/react/macro';
 import {
-	SelectVariant,
+	Button,
+	MenuToggle,
 	Select,
-	SelectOption
-} from '@patternfly/react-core/deprecated';
+	SelectList,
+	SelectOption,
+	TextInputGroup,
+	TextInputGroupMain,
+	TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import { ProjectsAPI } from 'api';
 import useRequest from 'hooks/useRequest';
 
@@ -22,6 +28,7 @@ function PlaybookSelect({
   const { t } = useLingui();
   const [isDisabled, setIsDisabled] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const [filterValue, setFilterValue] = useState('');
   const {
     result: options,
     request: fetchOptions,
@@ -56,31 +63,92 @@ function PlaybookSelect({
     }
   }, [error, onError]);
 
+  const filteredOptions = filterValue
+    ? options.filter((opt) =>
+        opt.toLowerCase().includes(filterValue.toLowerCase())
+      )
+    : options;
+
+  const showCreatableOption =
+    filterValue &&
+    !options.some(
+      (opt) => opt.toLowerCase() === filterValue.toLowerCase()
+    );
+
   return (
     <Select
-      ouiaId="JobTemplateForm-playbook"
       isOpen={isOpen}
-      variant={SelectVariant.typeahead}
-      selections={selected}
-      onToggle={(_event, val) => setIsOpen(val)}
-      placeholderText={t`Select a playbook`}
-      typeAheadAriaLabel={t`Select a playbook`}
-      isCreatable
-      createText=""
-      onSelect={(event, value) => {
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) setFilterValue('');
+      }}
+      onSelect={(_event, value) => {
         setIsOpen(false);
+        setFilterValue('');
         onChange(value);
       }}
-      id="template-playbook"
-      validated={isValid ? 'default' : 'error'}
-      onBlur={onBlur}
-      isDisabled={isLoading || isDisabled}
-      maxHeight="1000%"
-      noResultsFoundText={t`No results found`}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          variant="typeahead"
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+          isDisabled={isLoading || isDisabled}
+          status={isValid ? 'default' : 'danger'}
+          id="template-playbook"
+          ouiaId="JobTemplateForm-playbook"
+        >
+          <TextInputGroup isPlain>
+            <TextInputGroupMain
+              value={filterValue || selected || ''}
+              onClick={() => setIsOpen(true)}
+              onChange={(_event, val) => {
+                setFilterValue(val);
+                setIsOpen(true);
+              }}
+              onFocus={() => {
+                if (selected && !filterValue) {
+                  setFilterValue(selected);
+                }
+              }}
+              onBlur={onBlur}
+              autoComplete="off"
+              placeholder={t`Select a playbook`}
+              aria-label={t`Select a playbook`}
+            />
+            {(filterValue || selected) && (
+              <TextInputGroupUtilities>
+                <Button
+                  variant="plain"
+                  onClick={() => {
+                    onChange('');
+                    setFilterValue('');
+                  }}
+                  aria-label={t`Clear`}
+                >
+                  <TimesIcon />
+                </Button>
+              </TextInputGroupUtilities>
+            )}
+          </TextInputGroup>
+        </MenuToggle>
+      )}
     >
-      {options.map((opt) => (
-        <SelectOption key={opt} value={opt} />
-      ))}
+      <SelectList>
+        {filteredOptions.map((opt) => (
+          <SelectOption key={opt} value={opt}>
+            {opt}
+          </SelectOption>
+        ))}
+        {showCreatableOption && (
+          <SelectOption value={filterValue}>
+            {filterValue}
+          </SelectOption>
+        )}
+        {filteredOptions.length === 0 && !showCreatableOption && (
+          <SelectOption isDisabled>{t`No results found`}</SelectOption>
+        )}
+      </SelectList>
     </Select>
   );
 }

--- a/awx/ui/src/screens/Template/shared/PlaybookSelect.test.js
+++ b/awx/ui/src/screens/Template/shared/PlaybookSelect.test.js
@@ -67,7 +67,7 @@ describe('<PlaybookSelect />', () => {
   test('should trigger the onChange callback for the option selected from the list', async () => {
     const mockCallback = jest.fn();
 
-    const { container } = renderWithI18n(
+    renderWithI18n(
       <PlaybookSelect
         projectId={1}
         isValid={true}
@@ -77,23 +77,23 @@ describe('<PlaybookSelect />', () => {
     );
 
     await waitFor(() => {
-      const selectToggleButton = container.querySelector(
-        'button.pf-v5-c-select__toggle-button'
-      );
-      fireEvent.click(selectToggleButton);
-      // Select options are displayed
-      expect(screen.getAllByRole('option').length).toBe(2);
-
-      fireEvent.click(screen.getByText('debug.yml'));
-
-      expect(mockCallback).toHaveBeenCalledWith('debug.yml');
+      expect(ProjectsAPI.readPlaybooks).toHaveBeenCalledWith(1);
     });
+
+    const input = screen.getByRole('textbox', { name: 'Select a playbook' });
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(screen.getAllByRole('option').length).toBe(2);
+    });
+
+    fireEvent.click(screen.getByText('debug.yml'));
+    expect(mockCallback).toHaveBeenCalledWith('debug.yml');
   });
 
   test('should allow entering playbook file name manually', async () => {
     const mockCallback = jest.fn();
 
-    const { container } = renderWithI18n(
+    renderWithI18n(
       <PlaybookSelect
         projectId={1}
         isValid={true}
@@ -103,23 +103,20 @@ describe('<PlaybookSelect />', () => {
     );
 
     await waitFor(() => {
-      const input = container.querySelector('input[type="text"]');
-      expect(input).toBeVisible();
-      fireEvent.change(input, { target: { value: 'foo.yml' } });
+      expect(ProjectsAPI.readPlaybooks).toHaveBeenCalledWith(1);
     });
+
+    const input = screen.getByRole('textbox', { name: 'Select a playbook' });
+    fireEvent.change(input, { target: { value: 'foo.yml' } });
 
     await waitFor(() => {
-      // A new select option is displayed ("foo.yml")
-      expect(
-        screen.getByText('"foo.yml"', { selector: '[role="option"]' })
-      ).toBeVisible();
-      expect(screen.getAllByRole('option').length).toBe(1);
-
-      fireEvent.click(
-        screen.getByText('"foo.yml"', { selector: '[role="option"]' })
-      );
-
-      expect(mockCallback).toHaveBeenCalledWith('foo.yml');
+      // The creatable option shows 'foo.yml' as plain text
+      const options = screen.getAllByRole('option');
+      expect(options.length).toBe(1);
+      expect(options[0]).toHaveTextContent('foo.yml');
     });
+
+    fireEvent.click(screen.getByRole('option', { name: 'foo.yml' }));
+    expect(mockCallback).toHaveBeenCalledWith('foo.yml');
   });
 });


### PR DESCRIPTION
## SUMMARY

Migrate all deprecated PatternFly 5 Select imports (`Select`, `SelectOption`, `SelectVariant`, `SelectGroup` from `@patternfly/react-core/deprecated`) to the new PF5 composable Select API (`Select`, `SelectOption`, `SelectList`, `SelectGroup`, `MenuToggle`, `TextInputGroup`, `TextInputGroupMain`, `TextInputGroupUtilities` from `@patternfly/react-core`).

After this change there are zero imports from `@patternfly/react-core/deprecated` for Select-related components.

### Migration patterns applied

- **Single Select** → `Select` + `MenuToggle` toggle render prop + `SelectList` wrapper
- **Typeahead Select** → `MenuToggle variant="typeahead"` with `TextInputGroup`/`TextInputGroupMain`/`TextInputGroupUtilities`, external filter state
- **Typeahead Multi Select** → same as typeahead + `Label`/`LabelGroup` chips inside toggle, multi-selection via `isSelected` on each `SelectOption`
- **Checkbox Select** → `SelectOption` with `hasCheckbox` + `isSelected`, multi-selection managed externally

### Files migrated (19 component files)

- `components/MultiSelect/TagMultiSelect.js`
- `components/LabelSelect/LabelSelect.js`
- `components/Search/Search.js`
- `components/Search/AdvancedSearch.js`
- `components/Search/LookupTypeInput.js`
- `components/Search/RelatedLookupTypeInput.js`
- `components/Schedule/shared/FrequencySelect.js`
- `components/LaunchPrompt/steps/SurveyStep.js`
- `components/WorkflowOutputNavigation/WorkflowOutputNavigation.js`
- `screens/Template/shared/PlaybookSelect.js`
- `screens/Template/Survey/SurveyReorderModal.js`
- `screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/NodeTypeStep.js`
- `screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.js`
- `screens/SubscriptionUsage/SubscriptionUsageChart.js`
- `screens/Dashboard/DashboardGraph.js`
- `screens/Credential/shared/CredentialFormFields/BecomeMethodField.js`
- `screens/Credential/shared/CredentialForm.js`
- `screens/ActivityStream/ActivityStream.js`
- `screens/Metrics/Metrics.js`

### Test files updated (12 test files)

Updated test helpers and assertions to match the new PF5 composable Select DOM structure:
- `role="option"` → `role="menuitem"` for checkbox select options
- `"Options menu"` toggle label → specific `aria-label` values (e.g., `"Simple key select"`)
- `"Clear all"` → `"Clear"`
- `.pf-v5-c-select__toggle` → `.pf-v5-c-menu-toggle`
- Chip group → Label group
- Removed `innerText` hacks (no longer needed with composable Select's value-based `onSelect`)

## ISSUE TYPE

- New or Enhanced Feature

## COMPONENT NAME

- UI

## ADDITIONAL INFORMATION

- Full Jest suite: 552 suites, 2908 tests passing, 0 failures
- ESLint: clean
- Zero remaining imports from `@patternfly/react-core/deprecated` for Select components
