### PR TITLE
Migrate deprecated PF5 Wizard to composable API

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -24124,9 +24124,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
+++ b/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
@@ -2,9 +2,7 @@ import React, { useState } from 'react';
 import {
 	ExpandableSection
 } from '@patternfly/react-core';
-import {
-	Wizard
-} from '@patternfly/react-core/deprecated';
+import Wizard from 'components/Wizard';
 import { useLingui } from '@lingui/react/macro';
 import { Formik, useFormikContext } from 'formik';
 import { useDismissableError } from 'hooks/useRequest';

--- a/awx/ui/src/components/Schedule/shared/SchedulePromptableFields.js
+++ b/awx/ui/src/components/Schedule/shared/SchedulePromptableFields.js
@@ -2,9 +2,7 @@ import React, { useState } from 'react';
 import {
 	ExpandableSection
 } from '@patternfly/react-core';
-import {
-	Wizard
-} from '@patternfly/react-core/deprecated';
+import Wizard from 'components/Wizard';
 import { useLingui } from '@lingui/react/macro';
 import { useFormikContext } from 'formik';
 import { useDismissableError } from 'hooks/useRequest';

--- a/awx/ui/src/components/Wizard/Wizard.js
+++ b/awx/ui/src/components/Wizard/Wizard.js
@@ -1,10 +1,163 @@
+import React, { useCallback } from 'react';
 import {
-	Wizard
-} from '@patternfly/react-core/deprecated';
+  Modal,
+  ModalVariant,
+  Wizard as PFWizard,
+  WizardStep,
+  WizardHeader,
+} from '@patternfly/react-core';
 import styled from 'styled-components';
 
-Wizard.displayName = 'PFWizard';
-export default styled(Wizard)`
+/**
+ * Compatibility wrapper that accepts the legacy PF4/deprecated Wizard API
+ * (steps array, onNext, onBack, onGoToStep, onSave, onClose, isOpen, etc.)
+ * and renders using the new PF5 composable Wizard API internally.
+ *
+ * Legacy step shape: { id, name, component, enableNext, canJumpTo, nextButtonText }
+ *
+ * - `canJumpTo` controls whether the nav sidebar item is clickable.
+ *   Mapped to `navItem={{ isDisabled: true }}` (not `isDisabled` on WizardStep,
+ *   which would also prevent Next/Back from reaching the step).
+ * - `enableNext` controls whether the Next button is disabled on that step.
+ *   Mapped to `footer={{ isNextDisabled: true }}`.
+ * - `nextButtonText` overrides the Next button label for that step.
+ *   Mapped to `footer={{ nextButtonText }}`.
+ */
+function WizardWrapper({
+  steps = [],
+  onSave,
+  onClose,
+  onNext,
+  onBack,
+  onGoToStep,
+  title,
+  description,
+  isOpen,
+  footer,
+  backButtonText,
+  cancelButtonText,
+  nextButtonText,
+  height,
+  style,
+  css: cssProp,
+  className,
+  ...rest
+}) {
+  const handleStepChange = useCallback(
+    (_event, currentStep, prevStep, scope) => {
+      const legacyCurrent = {
+        id: currentStep.id,
+        name: currentStep.name,
+      };
+      const legacyPrev = {
+        id: prevStep.id,
+        name: prevStep.name,
+        prevId: prevStep.id,
+      };
+
+      if (scope === 'next' && onNext) {
+        onNext(legacyCurrent, legacyPrev);
+      } else if (scope === 'back' && onBack) {
+        onBack(legacyCurrent, legacyPrev);
+      } else if (scope === 'nav' && onGoToStep) {
+        onGoToStep(legacyCurrent, legacyPrev);
+      }
+    },
+    [onNext, onBack, onGoToStep]
+  );
+
+  // Build the wizard-level footer prop.
+  // If a custom footer React element is provided, use it directly.
+  // Otherwise, build a partial WizardFooterProps object for button text.
+  let wizardFooter;
+  if (footer) {
+    wizardFooter = footer;
+  } else {
+    const footerProps = {};
+    if (backButtonText) footerProps.backButtonText = backButtonText;
+    if (cancelButtonText) footerProps.cancelButtonText = cancelButtonText;
+    if (nextButtonText) footerProps.nextButtonText = nextButtonText;
+    if (Object.keys(footerProps).length > 0) {
+      wizardFooter = footerProps;
+    }
+  }
+
+  const wizardContent = (
+    <PFWizard
+      header={
+        title ? (
+          <WizardHeader
+            title={title}
+            description={description}
+            onClose={onClose}
+          />
+        ) : undefined
+      }
+      footer={wizardFooter}
+      onStepChange={handleStepChange}
+      onSave={onSave}
+      onClose={onClose}
+      height={height}
+      className={className}
+      style={style}
+      {...rest}
+    >
+      {steps.map((step) => {
+        // Build per-step footer overrides from legacy enableNext / nextButtonText.
+        // Only apply when NO custom footer element is provided, because PF5's
+        // WizardContext resolves per-step footer overrides before the wizard-level
+        // footer. A per-step partial (e.g. {nextButtonText}) would replace the
+        // custom footer element with PF5's default footer on that step.
+        let stepFooter;
+        const hasCustomFooter = React.isValidElement(footer);
+        const hasNextOverride = step.nextButtonText !== undefined;
+        const hasEnableOverride = step.enableNext === false;
+        if (!hasCustomFooter && (hasNextOverride || hasEnableOverride)) {
+          stepFooter = {};
+          if (hasNextOverride) stepFooter.nextButtonText = step.nextButtonText;
+          if (hasEnableOverride) stepFooter.isNextDisabled = true;
+        }
+
+        // canJumpTo controls the nav sidebar item only (not Next/Back).
+        // Use navItem.isDisabled so the step is still reachable via Next/Back.
+        const navItemOverride =
+          step.canJumpTo === false ? { isDisabled: true } : undefined;
+
+        return (
+          <WizardStep
+            key={step.id != null ? step.id : step.name}
+            id={step.id != null ? step.id : step.name}
+            name={step.name}
+            footer={stepFooter}
+            navItem={navItemOverride}
+          >
+            {step.component}
+          </WizardStep>
+        );
+      })}
+    </PFWizard>
+  );
+
+  if (isOpen !== undefined) {
+    return (
+      <Modal
+        isOpen={isOpen}
+        variant={ModalVariant.large}
+        showClose={false}
+        hasNoBodyWrapper
+        aria-label={title || 'Wizard'}
+      >
+        {wizardContent}
+      </Modal>
+    );
+  }
+
+  return wizardContent;
+}
+
+WizardWrapper.displayName = 'PFWizard';
+
+export default styled(WizardWrapper)`
   .pf-v5-c-toolbar__content {
     padding: 0 !important;
   }

--- a/awx/ui/src/components/Wizard/Wizard.js
+++ b/awx/ui/src/components/Wizard/Wizard.js
@@ -39,7 +39,6 @@ function WizardWrapper({
   nextButtonText,
   height,
   style,
-  css: cssProp,
   className,
   ...rest
 }) {
@@ -145,6 +144,7 @@ function WizardWrapper({
         variant={ModalVariant.large}
         showClose={false}
         hasNoBodyWrapper
+        onClose={onClose}
         aria-label={title || 'Wizard'}
       >
         {wizardContent}

--- a/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.js
@@ -2,19 +2,77 @@ import React, { useCallback } from 'react';
 import { Formik, useField } from 'formik';
 import { useLingui } from '@lingui/react/macro';
 import {
-	Button,
-	Tooltip
+  Button,
+  Tooltip,
+  WizardFooterWrapper,
+  useWizardContext,
 } from '@patternfly/react-core';
-import {
-	Wizard,
-	WizardContextConsumer,
-	WizardFooter
-} from '@patternfly/react-core/deprecated';
+import Wizard from 'components/Wizard';
 import { CredentialsAPI } from 'api';
 import useRequest from 'hooks/useRequest';
 import CredentialsStep from './CredentialsStep';
 import MetadataStep from './MetadataStep';
 import { CredentialPluginTestAlert } from '..';
+
+function CredentialPluginFooter({
+  selectedCredential,
+  testPluginMetadata,
+  onClose,
+  steps,
+}) {
+  const { t } = useLingui();
+  const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
+  const originalStep = steps.find((s) => s.id === activeStep?.id);
+  const isMetadataStep = originalStep?.key === 'metadata';
+
+  return (
+    <WizardFooterWrapper>
+      <Button
+        ouiaId="credential-plugin-prompt-next"
+        id="credential-plugin-prompt-next"
+        variant="primary"
+        onClick={goToNextStep}
+        isDisabled={!selectedCredential.value}
+      >
+        {isMetadataStep ? t`OK` : t`Next`}
+      </Button>
+      {activeStep && isMetadataStep && (
+        <>
+          <Tooltip
+            content={t`Click this button to verify connection to the secret management system using the selected credential and specified inputs.`}
+            position="right"
+          >
+            <Button
+              ouiaId="credential-plugin-prompt-test"
+              id="credential-plugin-prompt-test"
+              variant="secondary"
+              onClick={() => testPluginMetadata()}
+            >
+              {t`Test`}
+            </Button>
+          </Tooltip>
+
+          <Button
+            ouiaId="credential-plugin-prompt-back"
+            id="credential-plugin-prompt-back"
+            variant="secondary"
+            onClick={goToPrevStep}
+          >
+            {t`Back`}
+          </Button>
+        </>
+      )}
+      <Button
+        ouiaId="credential-plugin-prompt-cancel"
+        id="credential-plugin-prompt-cancel"
+        variant="link"
+        onClick={onClose}
+      >
+        {t`Cancel`}
+      </Button>
+    </WizardFooterWrapper>
+  );
+}
 
 function CredentialPluginWizard({ handleSubmit, onClose }) {
   const { t } = useLingui();
@@ -53,62 +111,6 @@ function CredentialPluginWizard({ handleSubmit, onClose }) {
     },
   ];
 
-  const CustomFooter = (
-    <WizardFooter>
-      <WizardContextConsumer>
-        {({ activeStep, onNext, onBack }) => (
-          <>
-            <Button
-              ouiaId="credential-plugin-prompt-next"
-              id="credential-plugin-prompt-next"
-              variant="primary"
-              onClick={onNext}
-              isDisabled={!selectedCredential.value}
-            >
-              {activeStep.key === 'metadata'
-                ? t`OK`
-                : t`Next`}
-            </Button>
-            {activeStep && activeStep.key === 'metadata' && (
-              <>
-                <Tooltip
-                  content={t`Click this button to verify connection to the secret management system using the selected credential and specified inputs.`}
-                  position="right"
-                >
-                  <Button
-                    ouiaId="credential-plugin-prompt-test"
-                    id="credential-plugin-prompt-test"
-                    variant="secondary"
-                    onClick={() => testPluginMetadata()}
-                  >
-                    {t`Test`}
-                  </Button>
-                </Tooltip>
-
-                <Button
-                  ouiaId="credential-plugin-prompt-back"
-                  id="credential-plugin-prompt-back"
-                  variant="secondary"
-                  onClick={onBack}
-                >
-                  {t`Back`}
-                </Button>
-              </>
-            )}
-            <Button
-              ouiaId="credential-plugin-prompt-cancel"
-              id="credential-plugin-prompt-cancel"
-              variant="link"
-              onClick={onClose}
-            >
-              {t`Cancel`}
-            </Button>
-          </>
-        )}
-      </WizardContextConsumer>
-    </WizardFooter>
-  );
-
   return (
     <>
       <Wizard
@@ -117,7 +119,14 @@ function CredentialPluginWizard({ handleSubmit, onClose }) {
         title={t`External Secret Management System`}
         steps={steps}
         onSave={handleSubmit}
-        footer={CustomFooter}
+        footer={
+          <CredentialPluginFooter
+            selectedCredential={selectedCredential}
+            testPluginMetadata={testPluginMetadata}
+            onClose={onClose}
+            steps={steps}
+          />
+        }
       />
       {selectedCredential.value && (
         <CredentialPluginTestAlert

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js
@@ -6,13 +6,11 @@ import {
 	Alert,
 	AlertGroup,
 	Button,
-	Form
+	Form,
+	WizardFooterWrapper,
+	useWizardContext,
 } from '@patternfly/react-core';
-import {
-	Wizard,
-	WizardContextConsumer,
-	WizardFooter
-} from '@patternfly/react-core/deprecated';
+import Wizard from 'components/Wizard';
 import { ConfigAPI, SettingsAPI, RootAPI } from 'api';
 import useRequest, { useDismissableError } from 'hooks/useRequest';
 import ContentLoading from 'components/ContentLoading';
@@ -28,65 +26,60 @@ const CustomFooter = ({ isSubmitLoading }) => {
   const { values, errors } = useFormikContext();
   const { me, license_info } = useConfig();
   const navigate = useNavigate();
+  const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
 
   return (
-    <WizardFooter>
-      <WizardContextConsumer>
-        {({ activeStep, onNext, onBack }) => (
-          <>
-            {activeStep.id === 'eula-step' ? (
-              <Button
-                id="subscription-wizard-submit"
-                aria-label={t`Submit`}
-                variant="primary"
-                onClick={onNext}
-                isDisabled={
-                  (!values.manifest_file && !values.subscription) ||
-                  !me?.is_superuser ||
-                  Object.keys(errors).length !== 0
-                }
-                type="button"
-                ouiaId="subscription-wizard-submit"
-                isLoading={isSubmitLoading}
-              >
-                <Trans>Submit</Trans>
-              </Button>
-            ) : (
-              <Button
-                id="subscription-wizard-next"
-                ouiaId="subscription-wizard-next"
-                variant="primary"
-                onClick={onNext}
-                type="button"
-              >
-                <Trans>Next</Trans>
-              </Button>
-            )}
-            <Button
-              id="subscription-wizard-back"
-              variant="secondary"
-              ouiaId="subscription-wizard-back"
-              onClick={onBack}
-              isDisabled={activeStep.id === 'subscription-step'}
-              type="button"
-            >
-              <Trans>Back</Trans>
-            </Button>
-            {license_info?.valid_key && (
-              <Button
-                id="subscription-wizard-cancel"
-                ouiaId="subscription-wizard-cancel"
-                variant="link"
-                aria-label={t`Cancel subscription edit`}
-                onClick={() => navigate('/settings/subscription/details')}
-              >
-                <Trans>Cancel</Trans>
-              </Button>
-            )}
-          </>
-        )}
-      </WizardContextConsumer>
-    </WizardFooter>
+    <WizardFooterWrapper>
+      {activeStep.id === 'eula-step' ? (
+        <Button
+          id="subscription-wizard-submit"
+          aria-label={t`Submit`}
+          variant="primary"
+          onClick={goToNextStep}
+          isDisabled={
+            (!values.manifest_file && !values.subscription) ||
+            !me?.is_superuser ||
+            Object.keys(errors).length !== 0
+          }
+          type="button"
+          ouiaId="subscription-wizard-submit"
+          isLoading={isSubmitLoading}
+        >
+          <Trans>Submit</Trans>
+        </Button>
+      ) : (
+        <Button
+          id="subscription-wizard-next"
+          ouiaId="subscription-wizard-next"
+          variant="primary"
+          onClick={goToNextStep}
+          type="button"
+        >
+          <Trans>Next</Trans>
+        </Button>
+      )}
+      <Button
+        id="subscription-wizard-back"
+        variant="secondary"
+        ouiaId="subscription-wizard-back"
+        onClick={goToPrevStep}
+        isDisabled={activeStep.id === 'subscription-step'}
+        type="button"
+      >
+        <Trans>Back</Trans>
+      </Button>
+      {license_info?.valid_key && (
+        <Button
+          id="subscription-wizard-cancel"
+          ouiaId="subscription-wizard-cancel"
+          variant="link"
+          aria-label={t`Cancel subscription edit`}
+          onClick={() => navigate('/settings/subscription/details')}
+        >
+          <Trans>Cancel</Trans>
+        </Button>
+      )}
+    </WizardFooterWrapper>
   );
 };
 

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
@@ -6,12 +6,10 @@ import { Formik, useFormikContext } from 'formik';
 import yaml from 'js-yaml';
 import {
 	Button,
-	Form
+	Form,
+	WizardFooterWrapper,
+	useWizardContext,
 } from '@patternfly/react-core';
-import {
-	WizardContextConsumer,
-	WizardFooter
-} from '@patternfly/react-core/deprecated';
 import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';
 
@@ -28,6 +26,59 @@ import Wizard from 'components/Wizard';
 import AlertModal from 'components/AlertModal';
 import useWorkflowNodeSteps from './useWorkflowNodeSteps';
 import NodeNextButton from './NodeNextButton';
+
+function NodeModalCustomFooter({
+  promptSteps,
+  isLaunchLoading,
+  triggerNext,
+  setTriggerNext,
+  handleCancel,
+  nextButtonText,
+}) {
+  const { t } = useLingui();
+  const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
+
+  // Look up the original step data to get enableNext (not part of PF5 step type)
+  const originalStep = promptSteps.find((s) => s.id === activeStep?.id);
+  const stepWithEnableNext = {
+    ...activeStep,
+    enableNext: originalStep?.enableNext !== false,
+  };
+
+  return (
+    <WizardFooterWrapper>
+      <NodeNextButton
+        isDisabled={isLaunchLoading}
+        triggerNext={triggerNext}
+        activeStep={stepWithEnableNext}
+        aria-label={nextButtonText(activeStep)}
+        onNext={goToNextStep}
+        onClick={() => setTriggerNext(triggerNext + 1)}
+        buttonText={nextButtonText(activeStep)}
+      />
+      {activeStep && activeStep.id !== promptSteps[0]?.id && (
+        <Button
+          ouiaId="node-modal-back-button"
+          id="back-node-modal"
+          variant="secondary"
+          aria-label={t`Back`}
+          onClick={goToPrevStep}
+        >
+          {t`Back`}
+        </Button>
+      )}
+      <Button
+        ouiaId="node-modal-cancel-button"
+        id="cancel-node-modal"
+        variant="link"
+        aria-label={t`Cancel`}
+        onClick={handleCancel}
+      >
+        {t`Cancel`}
+      </Button>
+    </WizardFooterWrapper>
+  );
+}
 
 function NodeModalForm({
   askLinkType,
@@ -123,55 +174,18 @@ function NodeModalForm({
     contentError || credentialError
   );
 
-  function nextButtonText(activeStep) {
-    let verifyPromptSteps = false;
-    if (promptSteps.length) {
-      verifyPromptSteps =
-        activeStep.id === promptSteps[promptSteps.length - 1]?.id;
-    }
-    return verifyPromptSteps || activeStep.name === 'Preview'
-      ? t`Save`
-      : t`Next`;
-  }
-
-  const CustomFooter = (
-    <WizardFooter>
-      <WizardContextConsumer>
-        {({ activeStep, onNext, onBack }) => (
-          <>
-            <NodeNextButton
-              isDisabled={isLaunchLoading}
-              triggerNext={triggerNext}
-              activeStep={activeStep}
-              aria-label={nextButtonText(activeStep)}
-              onNext={onNext}
-              onClick={() => setTriggerNext(triggerNext + 1)}
-              buttonText={nextButtonText(activeStep)}
-            />
-            {activeStep && activeStep.id !== promptSteps[0]?.id && (
-              <Button
-                ouiaId="node-modal-back-button"
-                id="back-node-modal"
-                variant="secondary"
-                aria-label={t`Back`}
-                onClick={onBack}
-              >
-                {t`Back`}
-              </Button>
-            )}
-            <Button
-              ouiaId="node-modal-cancel-button"
-              id="cancel-node-modal"
-              variant="link"
-              aria-label={t`Cancel`}
-              onClick={handleCancel}
-            >
-              {t`Cancel`}
-            </Button>
-          </>
-        )}
-      </WizardContextConsumer>
-    </WizardFooter>
+  const getNextButtonText = useCallback(
+    (activeStep) => {
+      let verifyPromptSteps = false;
+      if (promptSteps.length) {
+        verifyPromptSteps =
+          activeStep.id === promptSteps[promptSteps.length - 1]?.id;
+      }
+      return verifyPromptSteps || activeStep.name === 'Preview'
+        ? t`Save`
+        : t`Next`;
+    },
+    [promptSteps, t]
   );
 
   if (error) {
@@ -205,7 +219,16 @@ function NodeModalForm({
   }
   return (
     <Wizard
-      footer={CustomFooter}
+      footer={
+        <NodeModalCustomFooter
+          promptSteps={promptSteps}
+          isLaunchLoading={isLaunchLoading}
+          triggerNext={triggerNext}
+          setTriggerNext={setTriggerNext}
+          handleCancel={handleCancel}
+          nextButtonText={getNextButtonText}
+        />
+      }
       isOpen={!error}
       onClose={handleCancel}
       onSave={() => {


### PR DESCRIPTION
## SUMMARY

Migrate all deprecated PatternFly 5 Wizard imports (`Wizard`, `WizardContextConsumer`, `WizardFooter` from `@patternfly/react-core/deprecated`) to the new PF5 composable Wizard API (`Wizard`, `WizardStep`, `useWizardContext`, `WizardFooterWrapper` from `@patternfly/react-core`).

After this PR, zero imports of Wizard-related components from `@patternfly/react-core/deprecated` remain.

### Approach

The existing `components/Wizard/Wizard.js` wrapper is rewritten as a compatibility shim that accepts the legacy steps-array API and maps it to PF5 `WizardStep` children internally. This keeps callers' code changes minimal while eliminating all deprecated imports.

Key mappings in the wrapper:
- `steps[].canJumpTo` -> `navItem={{ isDisabled: true }}` (disables sidebar nav item only; does NOT block Next/Back navigation, which `isDisabled` on WizardStep would)
- `steps[].enableNext` -> `footer={{ isNextDisabled: true }}`
- `steps[].nextButtonText` -> `footer={{ nextButtonText }}`
- `isOpen` -> wraps the wizard in a `<Modal>`
- `onNext`/`onBack`/`onGoToStep` -> `onStepChange` with scope detection
- Per-step footer overrides are skipped when a custom footer element is provided, because PF5's WizardContext resolves per-step footers before the wizard-level footer

### Files changed

| File | Change |
|------|--------|
| `components/Wizard/Wizard.js` | Rewritten: deprecated Wizard -> composable PF5 Wizard wrapper |
| `components/LaunchPrompt/LaunchPrompt.js` | Import path change only |
| `components/Schedule/shared/SchedulePromptableFields.js` | Import path change only |
| `screens/Setting/Subscription/SubscriptionEdit/SubscriptionEdit.js` | `WizardContextConsumer`/`WizardFooter` -> `useWizardContext()`/`WizardFooterWrapper` |
| `screens/Template/.../NodeModal.js` | `WizardContextConsumer`/`WizardFooter` -> `useWizardContext()`/`WizardFooterWrapper`; extracted `NodeModalCustomFooter` component |
| `screens/Credential/.../CredentialPluginPrompt.js` | `WizardContextConsumer`/`WizardFooter` -> `useWizardContext()`/`WizardFooterWrapper`; extracted `CredentialPluginFooter` component |

## ISSUE TYPE
- New or Enhanced Feature

## COMPONENT NAME
UI

## ADDITIONAL INFORMATION

### Tests verified
- `Wizard.test.js` - 4/4 passed
- `SubscriptionEdit.test.js` - 9/9 passed (including the 3-step wizard navigation test)
- `CredentialPluginPrompt.test.js` - 4/4 passed
- `LaunchPrompt.test.js` - 7/7 passed
- `AdHocCommandsWizard.test.js` - 6/6 passed
- `UserAndTeamAccessAdd.test.js` + `AddResourceRole.test.js` - 8/8 passed
- ESLint - passed clean