### PR TITLE
Remove redundant mock-socket devDependency

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -86,7 +86,6 @@
         "jest-watch-typeahead": "^3.0.1",
         "jest-websocket-mock": "^2.5.0",
         "mini-css-extract-plugin": "^2.10.2",
-        "mock-socket": "^9.3.1",
         "postcss": "^8.5.14",
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-loader": "^8.2.1",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -86,7 +86,6 @@
     "jest-watch-typeahead": "^3.0.1",
     "jest-websocket-mock": "^2.5.0",
     "mini-css-extract-plugin": "^2.10.2",
-    "mock-socket": "^9.3.1",
     "postcss": "^8.5.14",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^8.2.1",


### PR DESCRIPTION
## SUMMARY
Remove mock-socket from devDependencies - it is redundant.

- mock-socket is a direct dependency of jest-websocket-mock and is
  installed automatically as a transitive dep
- The project never imports mock-socket directly
- The explicit devDependency entry is unnecessary
- Lint, Jest (552 suites, 2,908 tests), and production build all pass without it

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev
```

## ADDITIONAL INFORMATION
Identified by auditing npm devDependencies for redundant entries.