### PR TITLE
Remove unused tailwindcss devDependency

### DIFF
--- a/awx/ui/config/webpack.config.js
+++ b/awx/ui/config/webpack.config.js
@@ -58,11 +58,6 @@ const imageInlineSizeLimit = parseInt(
 // Check if TypeScript is setup
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 
-// Check if Tailwind config exists
-const useTailwind = fs.existsSync(
-  path.join(paths.appPath, 'tailwind.config.js')
-);
-
 // Get the path to the uncompiled service worker (if it exists).
 const swSrc = paths.swSrc;
 
@@ -131,8 +126,7 @@ module.exports = function (webpackEnv) {
             // https://github.com/facebook/create-react-app/issues/2677
             ident: 'postcss',
             config: false,
-            plugins: !useTailwind
-              ? [
+            plugins: [
                   'postcss-flexbugs-fixes',
                   [
                     'postcss-preset-env',
@@ -147,19 +141,6 @@ module.exports = function (webpackEnv) {
                   // so that it honors browserslist config in package.json
                   // which in turn let's users customize the target behavior as per their needs.
                   'postcss-normalize',
-                ]
-              : [
-                  'tailwindcss',
-                  'postcss-flexbugs-fixes',
-                  [
-                    'postcss-preset-env',
-                    {
-                      autoprefixer: {
-                        flexbox: 'no-2009',
-                      },
-                      stage: 3,
-                    },
-                  ],
                 ],
           },
           sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,

--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -101,7 +101,6 @@
         "semver": "^7.8.0",
         "style-loader": "^4.0.0",
         "styled-components": "^6.4.2",
-        "tailwindcss": "^4.3.0",
         "terser-webpack-plugin": "^5.6.0",
         "webpack": "^5.106.2",
         "webpack-dev-server": "^5.2.5",
@@ -22870,13 +22869,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
       "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
-      "license": "MIT"
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/terser": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -101,7 +101,6 @@
     "semver": "^7.8.0",
     "style-loader": "^4.0.0",
     "styled-components": "^6.4.2",
-    "tailwindcss": "^4.3.0",
     "terser-webpack-plugin": "^5.6.0",
     "webpack": "^5.106.2",
     "webpack-dev-server": "^5.2.5",


### PR DESCRIPTION
## SUMMARY
Remove tailwindcss, which is installed but never loaded.

- webpack.config.js references tailwindcss behind a `useTailwind` guard
  that checks for `tailwind.config.js`, which does not exist
- No component uses tailwind utility classes, @apply, or any tailwind directive
- The package is installed but the code path that loads it is never reached
- Lint, Jest (552 suites, 2,908 tests), and production build all pass without it

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- UI

## ASCENDER VERSION
```
awx: 25.4.1.dev
```

## ADDITIONAL INFORMATION
Identified by auditing npm devDependencies for unused packages.