### PR TITLE
Fix NotificationTemplate Add error

### DIFF
--- a/awx/ui/src/screens/NotificationTemplate/shared/CustomMessagesSubForm.js
+++ b/awx/ui/src/screens/NotificationTemplate/shared/CustomMessagesSubForm.js
@@ -15,13 +15,18 @@ function CustomMessagesSubForm({ defaultMessages, type }) {
 
   const { setFieldValue } = useFormikContext();
   const config = useConfig();
-  const mountedRef = useRef(null);
+  const prevTypeRef = useRef(type);
   useEffect(
     () => {
-      if (!mountedRef.current) {
-        mountedRef.current = true;
+      // Only reset messages when the notification type actually changes.
+      // Initializing the ref with the current type skips the initial mount,
+      // and the equality check keeps this resilient to React StrictMode's
+      // double-invocation of effects (which would otherwise overwrite
+      // pre-populated values when editing an existing template).
+      if (prevTypeRef.current === type) {
         return;
       }
+      prevTypeRef.current = type;
       const defs = defaultMessages[type];
       if (!defs) {
         return;

--- a/awx/ui/src/screens/NotificationTemplate/shared/CustomMessagesSubForm.js
+++ b/awx/ui/src/screens/NotificationTemplate/shared/CustomMessagesSubForm.js
@@ -23,6 +23,9 @@ function CustomMessagesSubForm({ defaultMessages, type }) {
         return;
       }
       const defs = defaultMessages[type];
+      if (!defs) {
+        return;
+      }
 
       const resetFields = (name, defaults) => {
         setFieldValue(`${name}.message`, defaults.message || '');


### PR DESCRIPTION
The crash happened because the effect read defs.started while defs (i.e. defaultMessages[type]) was undefined — type is '' on the Add form, and under React 18 StrictMode the effect re-runs on mount, bypassing the mountedRef guard. Added an early if (!defs) return; so the reset logic only runs once a valid notification type is selected.