### PR TITLE
Bump @testing-library/react from 16.3.0 to 16.3.2

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -47,7 +47,7 @@
         "@svgr/webpack": "^8.1.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/react": "^16.3.0",
+        "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "14.6.1",
         "babel-jest": "^30.3.0",
         "babel-loader": "^10.1.1",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -47,7 +47,7 @@
     "@svgr/webpack": "^8.1.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "14.6.1",
     "babel-jest": "^30.3.0",
     "babel-loader": "^10.1.1",


### PR DESCRIPTION
## SUMMARY

Bump @testing-library/react from 16.3.0 to 16.3.2 (patch release).

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

- UI

## ADDITIONAL INFORMATION

**Test results:** All 552 test suites pass (2911 tests, 0 failures).