### PR TITLE
Bump prettier from 3.8.3 to 3.9.1

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -90,7 +90,7 @@
         "postcss-loader": "^8.2.1",
         "postcss-normalize": "^13.0.1",
         "postcss-preset-env": "^7.8.3",
-        "prettier": "3.8.3",
+        "prettier": "3.9.1",
         "prompts": "^2.4.2",
         "react-app-polyfill": "^3.0.0",
         "react-dev-utils": "^12.0.1",
@@ -20548,9 +20548,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
+      "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -90,7 +90,7 @@
     "postcss-loader": "^8.2.1",
     "postcss-normalize": "^13.0.1",
     "postcss-preset-env": "^7.8.3",
-    "prettier": "3.8.3",
+    "prettier": "3.9.1",
     "prompts": "^2.4.2",
     "react-app-polyfill": "^3.0.0",
     "react-dev-utils": "^12.0.1",


### PR DESCRIPTION
## SUMMARY

Bump prettier from 3.8.3 to 3.9.1 (minor release).

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

- UI

## ADDITIONAL INFORMATION

**Test results:** All 552 test suites pass (2911 tests, 0 failures).