### PR TITLE
Bump semver from 7.8.0 to 7.8.5

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -98,7 +98,7 @@
         "resolve": "^1.22.12",
         "resolve-url-loader": "^5.0.0",
         "sass-loader": "^16.0.8",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "style-loader": "^4.0.0",
         "styled-components": "^6.4.2",
         "terser-webpack-plugin": "^5.6.0",
@@ -21868,9 +21868,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -98,7 +98,7 @@
     "resolve": "^1.22.12",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.8",
-    "semver": "^7.8.0",
+    "semver": "^7.8.5",
     "style-loader": "^4.0.0",
     "styled-components": "^6.4.2",
     "terser-webpack-plugin": "^5.6.0",


### PR DESCRIPTION
## SUMMARY

Bump semver from 7.8.0 to 7.8.5 (patch release).

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

- UI

## ADDITIONAL INFORMATION

**Test results:** All 552 test suites pass (2911 tests, 0 failures).