### PR TITLE
Bump globals from 17.4.0 to 17.7.0

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -72,7 +72,7 @@
         "eslint-webpack-plugin": "^6.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.3.5",
-        "globals": "^17.4.0",
+        "globals": "^17.7.0",
         "html-webpack-plugin": "^5.6.7",
         "http-proxy-middleware": "4.1.1",
         "inject-manifest-plugin": "^0.6.5",
@@ -12929,9 +12929,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -72,7 +72,7 @@
     "eslint-webpack-plugin": "^6.0.0",
     "file-loader": "^6.2.0",
     "fs-extra": "^11.3.5",
-    "globals": "^17.4.0",
+    "globals": "^17.7.0",
     "html-webpack-plugin": "^5.6.7",
     "http-proxy-middleware": "4.1.1",
     "inject-manifest-plugin": "^0.6.5",


### PR DESCRIPTION
## SUMMARY

Bump globals from 17.4.0 to 17.7.0 (minor release).

## ISSUE TYPE

- Bug, Docs Fix or other nominal change

## COMPONENT NAME

- UI

## ADDITIONAL INFORMATION

**Test results:** All 552 test suites pass (2911 tests, 0 failures).