### PR TITLE
Fix PatternFly v6 component CSS not loading

### DIFF
--- a/awx/ui/config/webpack.config.js
+++ b/awx/ui/config/webpack.config.js
@@ -333,6 +333,16 @@ module.exports = function (webpackEnv) {
           resolve: { fullySpecified: false },
         },
         {
+          // PatternFly v6 ships per-component CSS via .mjs modules that
+          // `import './component.css'`. The package marks only *.css as
+          // sideEffects, so webpack tree-shakes the .mjs → .css imports
+          // away. Force all @patternfly/react-styles .mjs files to be
+          // treated as side-effectful so the CSS actually loads.
+          test: /\.mjs$/,
+          include: /node_modules\/@patternfly\/react-styles/,
+          sideEffects: true,
+        },
+        {
           // "oneOf" will traverse all following loaders until one will
           // match the requirements. When no loader matches it will fall
           // back to the "file" loader at the end of the loader list.


### PR DESCRIPTION
## SUMMARY
PatternFly v6 component CSS was silently tree-shaken by webpack,
leaving only the base reset styles (205 rules instead of ~2800).
The login page, forms, buttons — all PF6 components rendered
without any layout or styling.

Root cause: PF6 ships per-component CSS via `.mjs` modules in
`@patternfly/react-styles` that `import './component.css'`. The
package marks only `*.css` as `sideEffects`, but not the `.mjs`
files that import them. Webpack treats those `.mjs` files as
side-effect-free and drops the CSS imports during tree-shaking.

Fix: add a webpack rule forcing `@patternfly/react-styles/*.mjs`
to be treated as side-effectful so the CSS imports are preserved.

## ISSUE TYPE
- Bug, Docs Fix or other nominal change

## COMPONENT NAME
- UI

## ASCENDER VERSION
25.3.7.dev

## ADDITIONAL INFORMATION
Regression introduced by the PF5 → PF6 upgrade (PRs #519/#520).
Before: 316 CSS rules loaded. After fix: 2792 CSS rules loaded.