### PR TITLE
Bump @tanstack/react-virtual from 3.14.3 to 3.14.4

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@patternfly/react-core": "^6.5.1",
         "@patternfly/react-icons": "^6.5.1",
         "@patternfly/react-table": "^6.5.1",
-        "@tanstack/react-virtual": "^3.14.3",
+        "@tanstack/react-virtual": "^3.14.4",
         "ace-builds": "^1.44.0",
         "ansi-to-html": "0.7.2",
         "d3": "7.9.0",
@@ -6339,12 +6339,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
-      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.4.tgz",
+      "integrity": "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.1"
+        "@tanstack/virtual-core": "3.17.2"
       },
       "funding": {
         "type": "github",
@@ -6356,9 +6356,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
-      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.2.tgz",
+      "integrity": "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -12,7 +12,7 @@
     "@patternfly/react-core": "^6.5.1",
     "@patternfly/react-icons": "^6.5.1",
     "@patternfly/react-table": "^6.5.1",
-    "@tanstack/react-virtual": "^3.14.3",
+    "@tanstack/react-virtual": "^3.14.4",
     "ace-builds": "^1.44.0",
     "ansi-to-html": "0.7.2",
     "d3": "7.9.0",


### PR DESCRIPTION
## Summary
- Patch bump for @tanstack/react-virtual (production dependency)
- Changelog: https://github.com/TanStack/virtual/releases/tag/v3.14.4

## Test plan
- [ ] `npm test` passes
- [ ] UI virtualised lists render correctly