### PR TITLE
Bump eslint-plugin-i18next from 6.1.4 to 6.1.5

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -67,7 +67,7 @@
         "eslint": "^9.39.4",
         "eslint-config-airbnb-extended": "^3.1.0",
         "eslint-config-prettier": "10.1.8",
-        "eslint-plugin-i18next": "^6.1.4",
+        "eslint-plugin-i18next": "^6.1.5",
         "eslint-plugin-jsx-a11y": "6.10.2",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -11690,13 +11690,12 @@
       }
     },
     "node_modules/eslint-plugin-i18next": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.1.4.tgz",
-      "integrity": "sha512-BekXQu1VaVFkREepQGsntBYoKuPsf89V16n/s2xpKMtsw0/lDseds1wBhj3RtO1dKnHsfTPaG+xul1vF0R7LEQ==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18next/-/eslint-plugin-i18next-6.1.5.tgz",
+      "integrity": "sha512-xCTfstbK9ZpQ6UFT5S1s6zbZMhKn2o2jRSQYiU2UkV7wt8y1m3WjkUYGkGlipgRdFInYI9+LAqE+JQU/L73HmA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "lodash": "^4.17.21",
         "requireindex": "~1.1.0"
       },
       "engines": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -67,7 +67,7 @@
     "eslint": "^9.39.4",
     "eslint-config-airbnb-extended": "^3.1.0",
     "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-i18next": "^6.1.4",
+    "eslint-plugin-i18next": "^6.1.5",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",


### PR DESCRIPTION
## Summary
- Patch bump for eslint-plugin-i18next (dev dependency)
- Changelog: https://github.com/edvardchen/eslint-plugin-i18next/releases/tag/v6.1.5

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm test` passes