### PR TITLE
Bump has-ansi from 5.0.1 to 6.0.2

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -18,7 +18,7 @@
         "d3": "7.9.0",
         "dompurify": "^3.4.11",
         "formik": "2.4.9",
-        "has-ansi": "5.0.1",
+        "has-ansi": "6.0.2",
         "html-entities": "2.6.0",
         "js-yaml": "4.2.0",
         "luxon": "^3.7.2",
@@ -13391,15 +13391,15 @@
       "license": "MIT"
     },
     "node_modules/has-ansi": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-5.0.1.tgz",
-      "integrity": "sha512-Fp2IsZDnnyoJkKg22ZyQFvD7QRCcMTsLAtloKXyXWJ1joGLtItRU9Bv/k1o0tELL2NF3ZZBcycSKryZUM+Yl3g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-6.0.2.tgz",
+      "integrity": "sha512-vAyM+6+jAYwSwz0/M0jYKfU9AvAMCz0kH791RsUhvMKGUHXled/3FjcQB3YiQ4Astj5srHdb6B2FHGIfZkOQNg==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/has-ansi?sponsor=1"

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -18,7 +18,7 @@
     "d3": "7.9.0",
     "dompurify": "^3.4.11",
     "formik": "2.4.9",
-    "has-ansi": "5.0.1",
+    "has-ansi": "6.0.2",
     "html-entities": "2.6.0",
     "js-yaml": "4.2.0",
     "luxon": "^3.7.2",


### PR DESCRIPTION
## Summary
- Major version bump for has-ansi (production dependency)
- Drop-in upgrade: same API, same ESM format, just updated ansi-regex internally
- Node engine bumped from >=14 to >=18 (project requires >=22.19)
- Single usage in `src/screens/Job/JobOutput/getLineTextHtml.js`

## Test plan
- [ ] `npm test` passes
- [ ] Job output page renders ANSI-colored lines correctly