### PR TITLE
Bump js-yaml from 4.2.0 to 5.2.0

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -20,7 +20,7 @@
         "formik": "2.4.9",
         "has-ansi": "5.0.1",
         "html-entities": "2.6.0",
-        "js-yaml": "4.2.0",
+        "js-yaml": "5.2.0",
         "luxon": "^3.7.2",
         "react": "18.3.1",
         "react-ace": "^14.0.1",
@@ -3401,6 +3401,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/js": {
@@ -9610,6 +9633,29 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -17565,9 +17611,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
+      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
       "funding": [
         {
           "type": "github",
@@ -17583,7 +17629,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {
@@ -19748,6 +19794,29 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-loader/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/postcss-logical": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -20,7 +20,7 @@
     "formik": "2.4.9",
     "has-ansi": "5.0.1",
     "html-entities": "2.6.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "5.2.0",
     "luxon": "^3.7.2",
     "react": "18.3.1",
     "react-ace": "^14.0.1",

--- a/awx/ui/src/util/prompt/mergeExtraVars.js
+++ b/awx/ui/src/util/prompt/mergeExtraVars.js
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 
 export default function mergeExtraVars(extraVars = '', survey = {}) {
-  const vars = yaml.load(extraVars) || {};
+  const vars = (extraVars ? yaml.load(extraVars) : undefined) || {};
   return {
     ...vars,
     ...survey,

--- a/awx/ui/src/util/yaml.js
+++ b/awx/ui/src/util/yaml.js
@@ -1,6 +1,9 @@
 import yaml from 'js-yaml';
 
 export function yamlToJson(yamlString) {
+  if (!yamlString || !yamlString.trim()) {
+    return '{}';
+  }
   const value = yaml.load(yamlString);
   if (!value) {
     return '{}';


### PR DESCRIPTION
## Summary
- Major version bump for js-yaml (production dependency)
- v5 throws on empty input to `yaml.load()` instead of returning `undefined`
- Guarded two call sites against empty input:
  - `src/util/prompt/mergeExtraVars.js`: skip load when extraVars is falsy
  - `src/util/yaml.js`: early return `'{}'` when yamlString is empty/blank

## Test plan
- [ ] `npm test` passes
- [ ] Extra variables fields handle empty input without errors
- [ ] YAML/JSON conversion in variable editor works correctly