### PR TITLE
Remove unused babel-plugin-named-asset-import

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -52,7 +52,6 @@
         "babel-jest": "^30.3.0",
         "babel-loader": "^10.1.1",
         "babel-plugin-macros": "3.1.0",
-        "babel-plugin-named-asset-import": "^0.3.8",
         "babel-plugin-styled-components": "^2.3.0",
         "babel-preset-react-app": "^10.1.0",
         "bfj": "^9.1.3",
@@ -8598,16 +8597,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/babel-plugin-named-asset-import": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@babel/core": "^7.1.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -52,7 +52,6 @@
     "babel-jest": "^30.3.0",
     "babel-loader": "^10.1.1",
     "babel-plugin-macros": "3.1.0",
-    "babel-plugin-named-asset-import": "^0.3.8",
     "babel-plugin-styled-components": "^2.3.0",
     "babel-preset-react-app": "^10.1.0",
     "bfj": "^9.1.3",


### PR DESCRIPTION
## Summary
- CRA leftover with zero references in the codebase
- Not used by babel-preset-react-app or any other config

## Test plan
- [ ] `npm test` passes
- [ ] `npm run build` succeeds