### PR TITLE
Remove unused resolve-url-loader

### DIFF
--- a/awx/ui/config/webpack.config.js
+++ b/awx/ui/config/webpack.config.js
@@ -148,24 +148,12 @@ module.exports = function (webpackEnv) {
       },
     ].filter(Boolean);
     if (preProcessor) {
-      loaders.push(
-        {
-          loader: require.resolve('resolve-url-loader'),
-          options: {
-            sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
-            root: [
-              paths.appSrc,
-              path.resolve(paths.appNodeModules, '@patternfly', 'patternfly', 'assets'),
-            ],
-          },
+      loaders.push({
+        loader: require.resolve(preProcessor),
+        options: {
+          sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
         },
-        {
-          loader: require.resolve(preProcessor),
-          options: {
-            sourceMap: true,
-          },
-        }
-      );
+      });
     }
     return loaders;
   };

--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -91,7 +91,6 @@
         "react-dev-utils": "^12.0.1",
         "react-refresh": "^0.18.0",
         "resolve": "^1.22.12",
-        "resolve-url-loader": "^5.0.0",
         "sass-loader": "^17.0.0",
         "semver": "^7.8.5",
         "style-loader": "^4.0.0",
@@ -10410,20 +10409,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/adjust-sourcemap-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
-      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "regex-parser": "^2.2.11"
-      },
-      "engines": {
-        "node": ">=8.9"
       }
     },
     "node_modules/agent-base": {
@@ -23665,13 +23650,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regex-parser": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.1.tgz",
-      "integrity": "sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -23941,40 +23919,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/resolve-url-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
-      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "adjust-sourcemap-loader": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "loader-utils": "^2.0.0",
-        "postcss": "^8.2.14",
-        "source-map": "0.6.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/resolve-url-loader/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/resolve-url-loader/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/restore-cursor": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -91,7 +91,6 @@
     "react-dev-utils": "^12.0.1",
     "react-refresh": "^0.18.0",
     "resolve": "^1.22.12",
-    "resolve-url-loader": "^5.0.0",
     "sass-loader": "^17.0.0",
     "semver": "^7.8.5",
     "style-loader": "^4.0.0",


### PR DESCRIPTION
## Summary
- Only referenced in the sass/scss webpack rule chain
- Zero SCSS files exist in the project, so the rule never fires
- Simplified getStyleLoaders to pass preProcessor directly without resolve-url-loader indirection

## Test plan
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [ ] Dev server starts without errors