### PR TITLE
Suppress i18next/no-literal-string for pre-i18n loading text

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -205,6 +205,7 @@ function App() {
     return (
       // Don't render I18nProvider until i18n is activated
 
+      // eslint-disable-next-line i18next/no-literal-string
       <div>Loading...</div>
     );
   }


### PR DESCRIPTION
## Summary

- Adds an eslint-disable-next-line for the `i18next/no-literal-string` rule on the loading text in `App.js` (line 208)
- This text renders before `I18nProvider` is active, so it cannot use the `t` macro for translation
- Fixes the new lint violation introduced by eslint-plugin-i18next 6.1.5 (#537)

## Test plan

- [x] `npm run lint` passes in `awx/ui`