### PR TITLE
Add typescript devDependency (required by eslint-config-airbnb-extended)

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -99,6 +99,7 @@
         "style-loader": "^4.0.0",
         "styled-components": "^6.4.3",
         "terser-webpack-plugin": "^5.6.1",
+        "typescript": "^6.0.3",
         "webpack": "^5.108.1",
         "webpack-dev-server": "^5.2.5",
         "webpack-manifest-plugin": "^6.0.1"
@@ -31032,6 +31033,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -99,6 +99,7 @@
     "style-loader": "^4.0.0",
     "styled-components": "^6.4.3",
     "terser-webpack-plugin": "^5.6.1",
+    "typescript": "^6.0.3",
     "webpack": "^5.108.1",
     "webpack-dev-server": "^5.2.5",
     "webpack-manifest-plugin": "^6.0.1"


### PR DESCRIPTION
## Summary

- Adds `typescript` as a devDependency (`^6.0.3`)
- `eslint-config-airbnb-extended` pulls in `typescript-eslint` -> `@typescript-eslint/parser`, which requires `typescript` as a peer dependency
- Without it, the webpack dev server fails to compile: `Cannot find module 'typescript'`