### PR TITLE
Fix js-yaml 5.x imports (no default export)

### DIFF
--- a/awx/ui/src/components/LaunchPrompt/steps/PreviewStep.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/PreviewStep.js
@@ -5,7 +5,7 @@ import { Tooltip } from '@patternfly/react-core';
 import { useLingui } from '@lingui/react/macro';
 import { useFormikContext } from 'formik';
 
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import mergeExtraVars, { maskPasswords } from 'util/prompt/mergeExtraVars';
 import getSurveyValues from 'util/prompt/getSurveyValues';
 import PromptDetail from '../../PromptDetail';

--- a/awx/ui/src/components/Schedule/ScheduleAdd/ScheduleAdd.js
+++ b/awx/ui/src/components/Schedule/ScheduleAdd/ScheduleAdd.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Card } from '@patternfly/react-core';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { parseVariableField } from 'util/yaml';
 import { OrganizationsAPI, SchedulesAPI } from 'api';
 import mergeExtraVars from 'util/prompt/mergeExtraVars';

--- a/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
+++ b/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { Card } from '@patternfly/react-core';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { OrganizationsAPI, SchedulesAPI } from 'api';
 import { getAddedAndRemoved } from 'util/lists';
 import { parseVariableField } from 'util/yaml';

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
@@ -3,7 +3,7 @@ import React, { useContext, useState, useEffect, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Formik, useFormikContext } from 'formik';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import {
 	Button,
 	Form,

--- a/awx/ui/src/util/prompt/mergeExtraVars.js
+++ b/awx/ui/src/util/prompt/mergeExtraVars.js
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 export default function mergeExtraVars(extraVars = '', survey = {}) {
   const vars = (extraVars ? yaml.load(extraVars) : undefined) || {};

--- a/awx/ui/src/util/yaml.js
+++ b/awx/ui/src/util/yaml.js
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 export function yamlToJson(yamlString) {
   if (!yamlString || !yamlString.trim()) {


### PR DESCRIPTION
## Summary

- js-yaml 5.x (merged in #540) dropped its default export
- All six `import yaml from 'js-yaml'` call sites break at build time with `export 'default' was not found in 'js-yaml'`
- Changed to namespace imports (`import * as yaml from 'js-yaml'`) in all six files

## Files changed

- `awx/ui/src/util/yaml.js`
- `awx/ui/src/util/prompt/mergeExtraVars.js`
- `awx/ui/src/components/LaunchPrompt/steps/PreviewStep.js`
- `awx/ui/src/components/Schedule/ScheduleAdd/ScheduleAdd.js`
- `awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js`
- `awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js`

## Test plan

- [x] `npm start` compiles without js-yaml errors
- [x] Survey/schedule forms that use YAML extra vars still serialize/deserialize correctly