### PR TITLE
Fix dark mode colors

### DIFF
--- a/awx/ui/src/darkmode.css
+++ b/awx/ui/src/darkmode.css
@@ -293,6 +293,10 @@ html.pf-v6-theme-dark .pf-v6-c-menu-toggle {
   background-color: #1b1d21;
 }
 
+html.pf-v6-theme-dark .pf-v6-c-masthead .pf-v6-c-menu-toggle {
+  background-color: transparent;
+}
+
 html.pf-v6-theme-dark .pf-v6-c-menu-toggle.pf-m-primary {
   background-color: #17b26a;
 }

--- a/awx/ui/src/darkmode.css
+++ b/awx/ui/src/darkmode.css
@@ -60,18 +60,12 @@ html.pf-v6-theme-dark body {
 html.pf-v6-theme-dark .ascender-status-label.pf-v6-c-label.pf-m-green {
   --pf-v6-c-label--BackgroundColor: #17b26a;
 }
-html.pf-v6-theme-dark .ascender-status-label.pf-v6-c-label.pf-m-red {
-  --pf-v6-c-label--BackgroundColor: #f04438;
-}
 html.pf-v6-theme-dark .ascender-status-label.pf-v6-c-label.pf-m-blue {
   --pf-v6-c-label--BackgroundColor: #17b26a;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-label.pf-m-green {
   --pf-v6-c-label--BackgroundColor: #17b26a;
-}
-html.pf-v6-theme-dark .pf-v6-c-label.pf-m-red {
-  --pf-v6-c-label--BackgroundColor: #f04438;
 }
 html.pf-v6-theme-dark .pf-v6-c-label.pf-m-blue {
   --pf-v6-c-label--BackgroundColor: #17b26a;

--- a/awx/ui/src/darkmode.css
+++ b/awx/ui/src/darkmode.css
@@ -53,7 +53,6 @@ html.pf-v6-theme-dark body {
   --pf-v6-global--BoxShadow--lg: hsla(0,0%,100%,0);
   --pf-v6-global--BoxShadow--xl: hsla(0,0%,100%,0);
 
-
   --pf-t--global--color--status--success--default: #17b26a;
   --pf-t--global--color--status--danger--default: #f04438;
 }
@@ -84,14 +83,19 @@ html.pf-v6-theme-dark .pf-v6-c-title {
   font-weight: 500 !important;
 }
 
+html.pf-v6-theme-dark .pf-v6-c-data-list__item {
+  --pf-v6-c-data-list__item--BackgroundColor: #1a1e25;
+  background-color: #1a1e25;
+}
+
 html.pf-v6-theme-dark .pf-v6-c-table {
   --pf-v6-c-table__sort__button__text--Color: var(--pf-v6-global--Color--100);
   color: var(--pf-v6-global--Color--100);
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-table__expandable-row .pf-v6-c-table__expandable-row-content {
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-form-control {
@@ -211,9 +215,9 @@ html.pf-v6-theme-dark b {
 }
 
 html.pf-v6-theme-dark .pf-v6-c-page {
-  --pf-v6-c-page--BackgroundColor: #13161b;
-  --pf-v6-c-page__main-section--BackgroundColor: #13161b;
-  --pf-v6-c-page__header--BackgroundColor: #13161b;
+  --pf-v6-c-page--BackgroundColor: inherit;
+  --pf-v6-c-page__main-section--BackgroundColor: inherit;
+  --pf-v6-c-page__header--BackgroundColor: #000;
   --pf-v6-c-page__sidebar--BackgroundColor: #13161b;
 }
 
@@ -221,7 +225,7 @@ html.pf-v6-theme-dark .pf-v6-c-login {
   --pf-v6-c-login__main--BackgroundColor: var(--pf-v6-global--BackgroundColor--200);
 }
 html.pf-v6-theme-dark .pf-v6-c-masthead {
-  background-color: #13161b;
+  background-color: #000;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-breadcrumb__item-divider {
@@ -266,23 +270,23 @@ html.pf-v6-theme-dark .ascender-output-scroll {
 }
 
 html.pf-v6-theme-dark .pf-v6-c-page__main-section.pf-m-light {
-  background-color: #13161b;
+  background-color: #000;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-page__main-section {
-  background-color: #13161b;
+  background-color: #000;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-page__main-section:first-child {
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-toolbar {
-  --pf-v6-c-toolbar--BackgroundColor: #13161b;
+  --pf-v6-c-toolbar--BackgroundColor: #1a1e25;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-pagination.pf-m-bottom {
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-menu-toggle {
@@ -305,10 +309,9 @@ html.pf-v6-theme-dark .pf-v6-c-tabs__item-text {
 html.pf-v6-theme-dark .pf-v6-c-table thead {
   --pf-v6-c-table--cell--FontWeight: 500;
   border-bottom: 1px #373a41 solid;
-
 }
 html.pf-v6-theme-dark .pf-v6-c-table thead th {
-  background-color: #13161b !important;
+  background-color: #22262f !important;
 }
 html.pf-v6-theme-dark .pf-v6-c-table tr > * {
   color: inherit;
@@ -336,8 +339,7 @@ html.pf-v6-theme-dark .pf-v6-c-title {
 }
 
 html.pf-v6-theme-dark .pf-v6-c-card {
-  --pf-v6-c-card--BackgroundColor: #13161b;
-  --pf-v6-c-card--BorderStyle: none;
+  --pf-v6-c-card--BackgroundColor: #1a1e25;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-card__title {
@@ -347,7 +349,7 @@ html.pf-v6-theme-dark .pf-v6-c-card__title {
 
 html.pf-v6-theme-dark .pf-v6-c-data-list {
   --pf-v6-global--link--Color: inherit; 
-  --pf-v6-c-data-list__item--BackgroundColor: #13161b;
+  --pf-v6-c-data-list__item--BackgroundColor: var(--pf-v6-global--BackgroundColor--100);
   --pf-v6-c-data-list--BorderTopColor: var(--pf-v6-global--BorderColor--200);
   --pf-v6-c-data-list__item--BorderBottomColor: var(--pf-v6-global--BorderColor--200);
   --pf-v6-c-data-list__item--m-hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
@@ -698,7 +700,7 @@ html.pf-v6-theme-dark .pf-v6-c-switch__input:checked ~ .pf-v6-c-switch__toggle::
 }
 
 html.pf-v6-theme-dark [class*="FormLayout__SubFormLayout"] {
-  background-color: #13161b;
+  background-color: #000;
 }
 
 html.pf-v6-theme-dark #chart .nodes circle {
@@ -719,11 +721,11 @@ html.pf-v6-theme-dark #chart .nodes > g > text {
 }
 
 html.pf-v6-theme-dark .legend {
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
 
 html.pf-v6-theme-dark .tooltip {
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
 
 html.pf-v6-theme-dark polygon {
@@ -731,9 +733,10 @@ html.pf-v6-theme-dark polygon {
 }
 
 html.pf-v6-theme-dark .pf-v6-c-wizard__main-body {
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-wizard__header {
-  background-color: #13161b;
+  background-color: #1a1e25;
 }
+

--- a/awx/ui/src/darkmode.css
+++ b/awx/ui/src/darkmode.css
@@ -634,7 +634,6 @@ html.pf-v6-theme-dark .pf-v6-c-nav__toggle-icon {
 }
 
 html.pf-v6-theme-dark .pf-v6-c-pagination.pf-m-bottom {
-  justify-content: space-between;
 }
 
 html.pf-v6-theme-dark .pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled {


### PR DESCRIPTION
## Summary

- PR #541 (postcss-preset-env bump) included dark mode CSS changes that replaced the original color hierarchy with a uniform #13161b, causing cards, tables, toolbars, and page sections to blend into the background
- Restored the original values: #000 for page/masthead backgrounds, #1a1e25 for cards/tables/toolbars/pagination, #22262f for thead
- Kept valid new additions from #541: status label colors, menu-toggle styling, ace tag/markup highlighting, thead border, legend/tooltip backgrounds, wizard sections, polygon transparency

## Test plan

- [x] Dark mode: cards visually separate from page background (black page, dark gray cards)
- [x] Dark mode: dashboard stat cards and chart card have visible backgrounds
- [x] Dark mode: table headers distinguishable from table body
- [x] Light mode: no regressions (file only affects `html.pf-v6-theme-dark` selectors)