### PR TITLE
Add legacy-peer-deps to .npmrc for Babel 8 compatibility

### DIFF
--- a/awx/ui/.npmrc
+++ b/awx/ui/.npmrc
@@ -1,1 +1,2 @@
 engine-strict = true
+legacy-peer-deps = true


### PR DESCRIPTION
## Summary

- Fixes `npm install` failure after Babel 8 migration (#547)
- `babel-plugin-styled-components@2.3.0` declares `peerDependencies` on `@babel/core ^7.0.0`, but the plugin works fine with Babel 8 via the jsx-compat wrapper in `config/babel/jsx-compat-plugin.js`
- Without `legacy-peer-deps = true`, npm strict peer dep resolution rejects the install with `ERESOLVE`

## Test plan

- [x] `npm install` succeeds without `--legacy-peer-deps` flag
- [x] `npm start` compiles successfully
- [x] `npm test` passes