### PR TITLE
Add some overrides to suppress a few NPM peer-dependency warnings

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -8603,9 +8603,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8620,9 +8617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8637,9 +8631,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8654,9 +8645,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9944,9 +9932,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9961,9 +9946,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9978,9 +9960,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9995,9 +9974,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10012,9 +9988,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10029,9 +10002,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10046,9 +10016,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10063,9 +10030,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10080,9 +10044,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10097,9 +10058,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -110,6 +110,51 @@
     },
     "babel-plugin-styled-components": {
       "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-bigint": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-class-static-block": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-import-attributes": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-private-property-in-object": {
+      "@babel/core": "$@babel/core"
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "@babel/core": "$@babel/core"
     }
   },
   "scripts": {


### PR DESCRIPTION
This suppresses 15 warnings, such as
```
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @babel/plugin-syntax-top-level-await@7.14.5
npm warn Found: @babel/core@8.0.1
npm warn node_modules/@babel/core
npm warn   dev @babel/core@"^8.0.1" from the root project
npm warn   82 more (@babel/eslint-parser, @babel/eslint-plugin, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer @babel/core@"^7.0.0-0" from @babel/plugin-syntax-top-level-await@7.14.5
npm warn node_modules/babel-preset-current-node-syntax/node_modules/@babel/plugin-syntax-top-level-await
npm warn   @babel/plugin-syntax-top-level-await@"^7.14.5" from babel-preset-current-node-syntax@1.2.0
npm warn   node_modules/babel-preset-current-node-syntax
npm warn
npm warn Conflicting peer dependency: @babel/core@7.29.7
npm warn node_modules/@babel/core
npm warn   peer @babel/core@"^7.0.0-0" from @babel/plugin-syntax-top-level-await@7.14.5
npm warn   node_modules/babel-preset-current-node-syntax/node_modules/@babel/plugin-syntax-top-level-await
npm warn     @babel/plugin-syntax-top-level-await@"^7.14.5" from babel-preset-current-node-syntax@1.2.0
npm warn     node_modules/babel-preset-current-node-syntax
```