### PR TITLE
Lightmode fixes and restructure css files

### DIFF
--- a/awx/ui/src/ascender.css
+++ b/awx/ui/src/ascender.css
@@ -243,7 +243,6 @@ input[type="checkbox"] {
   box-sizing: border-box;
 }
 
-
 /* Remove content area card chrome */
 .pf-v6-c-page__main-container {
   border: none !important;

--- a/awx/ui/src/darkmode.css
+++ b/awx/ui/src/darkmode.css
@@ -6,859 +6,870 @@
 * to maintain consistent theming across the application.
 */
 
-html.pf-v6-theme-dark body {
-  /* === Typography === */
-  /* Font families */
-  --pf-v6-global--FontFamily--sans-serif: Inter,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
-  --pf-v6-global--FontFamily--heading--sans-serif: Satoshi,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
-  --pf-v6-global--FontFamily--text: Inter,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
-
-  /* === Colors === */
-  /* Text colors */
-  color: #e0e0e0;
-  background-color: #13161b;
-  --pf-v6-global--Color--100: #e0e0e0;
-  --pf-v6-global--Color--200: #cecfd2;
-  --pf-v6-global--Color--300: #94979c;
-  --pf-v6-global--disabled-color--100: #85888e;
-  --pf-v6-global--link--Color: #12a66f;
-  --pf-v6-global--link--Color--hover: #cecfd2;
-
-  /* Background colors */
-  --pf-v6-global--BackgroundColor--100: #13161b;
-  --pf-v6-global--BackgroundColor--200: #1a1e25;
-  --ascender-workflow-node-bg: #1a1e25;
-  --ascender-workflow-graph-bg: #0d0f12;
-  --pf-v6-global--BackgroundColor--dark-100: #1a1e25;
-  --pf-v6-global--BackgroundColor--dark-200: #13161b;
-  
-  
-  
-  --pf-t--global--text--color--100: #f7f7f7;
-  --pf-t--global--border--color--default: #373a41;
-
-  /* === Borders === */
-  --pf-v6-global--BorderColor--100: #444548;
-  --pf-v6-global--BorderColor--200: #22262f;
-  --pf-v6-global--BorderColor--300: #22262f;
-  --pf-v6-global--BorderColor--disabled: #373a41;
-  
-  
-  /* === Focus === */
-  --pf-v6-global--focus-ring-color: #0b8759;
-  
-  /* === Shadows === */
-  --pf-v6-global--BoxShadow--sm: hsla(0,0%,100%,0);
-  --pf-v6-global--BoxShadow--md: hsla(0,0%,100%,0);
-  --pf-v6-global--BoxShadow--lg: hsla(0,0%,100%,0);
-  --pf-v6-global--BoxShadow--xl: hsla(0,0%,100%,0);
-
-
-  --pf-t--global--color--status--success--default: #17b26a;
-  --pf-t--global--color--status--danger--default: #f04438;
-
-  --pf-v6-c-button--disabled--BackgroundColor: #22262f;
-  --pf-v6-c-button--disabled--Color: #12a66f;
-  --pf-v6-c-menu-toggle--BorderColor: #444548;
-  --pf-t--global--border--color--control--default: #444548;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-label.pf-m-filled {
-  --pf-v6-c-label--BackgroundColor: #1b1d21;
-  border: 1px solid #444548;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-link.pf-m-inline {
-  --pf-v6-c-button--TextDecorationStyle: unset;
-  --pf-v6-c-button--TextDecorationLine: none;
-  --pf-v6-c-button--m-link--m-inline--hover--TextDecorationLine: none;
-  padding: 0px 4px 0px 4px;
-  min-height: auto;
-  height: auto;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-link.pf-m-inline:hover {
-  --pf-v6-c-button--TextDecorationStyle: unset;
-  --pf-v6-c-button--TextDecorationLine: none;
-}
-
-html.pf-v6-theme-dark .ascender-status-label.pf-v6-c-label {
-  --pf-v6-c-label--BackgroundColor: #22262f;
-  --pf-v6-c-label--Color: #12a66f;
-  --pf-v6-c-label__icon--Color: #12a66f;
-  font-weight: 600;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-link {
-  --pf-v6-c-label--BackgroundColor: #22262f;
-  --pf-v6-c-label--Color: #12a66f;
-  --pf-v6-c-label__icon--Color: #12a66f;
-  color: #12a66f;
-  border: 1px solid #12a66f;
-  margin-left: 0px;
-}
-
-html.pf-v6-theme-dark .ascender-status-label.pf-v6-c-label.pf-m-green {
-  --pf-v6-c-label--BackgroundColor: #12a66f;
-  --pf-v6-c-label--Color: #22262f;
-  --pf-v6-c-label__icon--Color: #22262f;
-  font-weight: 600;
-}
-
-html.pf-v6-theme-dark .ascender-status-label.pf-v6-c-label.pf-m-red {
-  --pf-v6-c-label--BackgroundColor: #f04438;
-  --pf-v6-c-label--Color: #22262f;
-  --pf-v6-c-label__icon--Color: #22262f;
-  font-weight: 600;
-}
-
-/* We don't want any blue, so just change it to our branded green */
-html.pf-v6-theme-dark .ascender-status-label.pf-v6-c-label.pf-m-blue {
-  --pf-v6-c-label--BackgroundColor: #12a66f;
-  --pf-v6-c-label--Color: #22262f;
-  --pf-v6-c-label__icon--Color: #22262f;
-  font-weight: 600;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-label.pf-m-green {
-  --pf-v6-c-label--BackgroundColor: #12a66f;
-  --pf-v6-c-label--Color: #22262f;
-  --pf-v6-c-label__icon--Color: #22262f;
-}
-html.pf-v6-theme-dark .pf-v6-c-label.pf-m-red {
-  --pf-v6-c-label--BackgroundColor: #f04438;
-}
-html.pf-v6-theme-dark .pf-v6-c-label.pf-m-blue {
-  --pf-v6-c-label--BackgroundColor: #12a66f;
-  --pf-v6-c-label--Color: #22262f;
-  --pf-v6-c-label__icon--Color: #22262f;
-  font-weight: 600;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-title {
-  color: var(--pf-v6-global--Color--100);
-  font-family: Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif !important;
-  font-weight: 500 !important;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-table {
-  --pf-v6-c-table__sort__button__text--Color: var(--pf-v6-global--Color--100);
-  color: var(--pf-v6-global--Color--100);
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-table__expandable-row .pf-v6-c-table__expandable-row-content {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-form-control {
-  --pf-v6-c-form-control--BackgroundColor: #1b1d21;
-  --pf-v6-c-form-control--disabled--BackgroundColor: var(--pf-v6-global--BorderColor--200);
-  --pf-v6-c-form-control--BorderColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-form-control--Color: var(--pf-v6-global--Color--100);
-  --pf-v6-c-form-control--PlaceholderColor: var(--pf-v6-global--disabled-color--100);
-
-  --pf-v6-c-form-control--BorderTopColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-form-control--BorderRightColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-form-control--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-form-control--BorderLeftColor: var(--pf-v6-global--BorderColor--100);
-
-  --pf-v6-c-form-control--PaddingTop: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-form-control--PaddingRight: var(--pf-v6-global--spacer--md);
-  --pf-v6-c-form-control--PaddingBottom: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-form-control--focus--PaddingBottom: var(--pf-v6-global--spacer--sm);
-
-  --pf-v6-c-button--BorderRadius: var(--pf-v6-global--BorderRadius--sm);
-  
-  --pf-v6-c-form-control--focus--BorderBottomWidth: 1px;
-  --pf-v6-c-form-control--PaddingLeft: var(--pf-v6-global--spacer--md);
-
-  border-radius: var(--pf-v6-global--BorderRadius--sm);
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-radio {
-  --pf-v6-c-radio--AccentColor: #12a66f;
-}
-
-html.pf-v6-theme-dark .ace_editor {
-  background-color: #13161b !important;
-  color: #f8f8f8 !important;
-}
-
-html.pf-v6-theme-dark .ace_editor .ace_gutter {
-  background: #1a1e25 !important;
-  color: #94979c !important;
-}
-
-html.pf-v6-theme-dark .ace_editor .ace_paren {
-  color: #f8f8f8 !important;
-}
-
-html.pf-v6-theme-dark .ace_editor .ace_string {
-  color: #8f9d6a !important;
-}
-
-html.pf-v6-theme-dark .ace_editor .ace_constant {
-  color: #cf6a4c !important;
-}
-
-html.pf-v6-theme-dark .ace_editor .ace_keyword {
-  color: #cda869 !important;
-}
-
-html.pf-v6-theme-dark .ace_editor .ace_tag {
-  color: #cda869 !important;
-}
-
-html.pf-v6-theme-dark .ace_editor .ace_markup {
-  color: #8f9d6a !important;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button {
-  --pf-v6-c-button--m-primary--BackgroundColor: #12a66f;
-  --pf-v6-c-button--m-primary--Color: #13161b;
-  --pf-v6-c-button--m-primary--hover--BackgroundColor: #0e8c5d;
-  --pf-v6-c-button--m-primary--focus--Color: #13161b;
-  --pf-v6-c-button--m-link--Color: #12a66f;
-  --pf-v6-c-button--disabled--BackgroundColor: #22262f;
-  --pf-v6-c-button--disabled--Color: #12a66f;
-  font-weight: 600;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-primary:not(:disabled) {
-  background-color: #12a66f;
-  --pf-v6-c-button--Color: #22262f !important;
-  color: #22262f !important;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-secondary:not(:disabled) {
-  background-color: transparent;
-  border-color: #12a66f;
-  color: #12a66f;
-  --pf-v6-global--Color--200: #12a66f;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-secondary:not(:disabled):hover {
-  border-color: #0e8c5d;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-danger {
-  --pf-v6-c-button--m-danger--BackgroundColor: var(--pf-v6-global--danger-color--100);
-  --pf-v6-c-button--m-danger--Color: #fff;
-  --pf-v6-c-button--m-danger--hover--BackgroundColor: var(--pf-v6-global--danger-color--200);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-control {
-  vertical-align: middle;
-  background-color: #12a66f;
-  color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-control:disabled {
-  background-color: #12a66f;
-  color: #22262f;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-control:disabled .pf-v6-svg {
-  color: #22262f;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-control:hover:not(:disabled) {
-  background-color: #0e8c5d;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-control:not(:disabled) .pf-v6-c-button__icon {
-  color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-control:not(:disabled) .pf-v6-svg {
-  color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-menu-toggle__status-icon {
-  --pf-v6-c-menu-toggle__status-icon--Color: #f04438;
-}
-
-html.pf-v6-theme-dark b {
-  font-weight: normal;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-page {
-  --pf-v6-c-page--BackgroundColor: #13161b;
-  --pf-v6-c-page__main-section--BackgroundColor: #13161b;
-  --pf-v6-c-page__header--BackgroundColor: #13161b;
-  --pf-v6-c-page__sidebar--BackgroundColor: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-login {
-  --pf-v6-c-login__main--BackgroundColor: var(--pf-v6-global--BackgroundColor--200);
-}
-html.pf-v6-theme-dark .pf-v6-c-masthead {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-breadcrumb__item-divider {
-  color: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-page__sidebar.pf-m-expanded {
-  box-shadow: none;
-  border-right: 1px solid var(--pf-v6-global--BorderColor--200);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-nav {
-  --pf-v6-c-nav--BackgroundColor: transparent;
-  --pf-v6-c-nav__link--Color: var(--pf-v6-global--Color--200);
-  --pf-v6-c-nav__link--m-current--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-nav__link--m-current--Color: var(--pf-v6-global--Color--100);
-  --pf-v6-c-nav__link--m-current--after--BorderColor: transparent;
-}
-
 html.pf-v6-theme-dark {
-  --ascender-output-bg: #000;
-  --ascender-gutter-bg: #13161b;
-  --ascender-status-running-color: #53b1fd;
-  --ascender-status-canceled-color: var(--pf-t--global--color--nonstatus--orange--100);
-  --ansi-color-0: #b0b0b0;
-  --ansi-color-4: #7aa2f7;
-  --ansi-color-12: #8cb4ff;
-}
+  & body {
+    /* === Typography === */
+    /* Font families */
+    --pf-v6-global--FontFamily--sans-serif: Inter,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+    --pf-v6-global--FontFamily--heading--sans-serif: Satoshi,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
+    --pf-v6-global--FontFamily--text: Inter,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif;
 
-html.pf-v6-theme-dark #job_output-toolbar {
-  border-top: 1px solid var(--pf-v6-global--BorderColor--100);
-  border-bottom: 1px solid var(--pf-v6-global--BorderColor--100);
-}
+    /* === Colors === */
+    /* Text colors */
+    color: #e0e0e0;
+    background-color: #13161b;
+    --pf-v6-global--Color--100: #e0e0e0;
+    --pf-v6-global--Color--200: #cecfd2;
+    --pf-v6-global--Color--300: #94979c;
+    --pf-v6-global--disabled-color--100: #85888e;
+    --pf-v6-global--link--Color: #12a66f;
+    --pf-v6-global--link--Color--hover: #cecfd2;
 
-html.pf-v6-theme-dark .ascender-output-wrapper {
-  border-top: 1px solid var(--pf-v6-global--BorderColor--100);
-  border-bottom: 1px solid var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .ascender-output-scroll {
-  background-image: linear-gradient(to right, #13161b 85px, transparent 85px);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-page__main-section.pf-m-light {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-page__main-section {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-page__main-section:first-child {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-toolbar {
-  --pf-v6-c-toolbar--BackgroundColor: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-pagination.pf-m-bottom {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-menu-toggle {
-  background-color: #1b1d21;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-menu-toggle::before {
-  border: var(--pf-v6-c-menu-toggle--BorderWidth) solid #444548;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-menu-toggle:hover {
-  --pf-v6-c-menu-toggle--BorderColor: #444548;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-pagination__page-menu > .pf-v6-c-menu-toggle {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark :focus-visible {
-  outline: 1px solid #373a41;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-menu-toggle.pf-m-primary {
-  background-color: #12a66f;
-  text-transform: uppercase;
-  font-weight: 600;
-}
-
-html.pf-v6-theme-dark .ace-tm .ace_gutter-active-line {
-  background-color: #000;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-tabs__item-text {
-  display: flex;
-  align-items: center;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-table thead {
-  --pf-v6-c-table--cell--FontWeight: 500;
-  border-bottom: 1px #373a41 solid;
-
-}
-html.pf-v6-theme-dark .pf-v6-c-table thead th {
-  background-color: #13161b !important;
-}
-html.pf-v6-theme-dark .pf-v6-c-table tr > * {
-  color: inherit;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-table {
-  --pf-v6-global--Color--100: inherit;
-  --pf-v6-global--Color--200: inherit;
-  --pf-v6-global--BorderColor--100: var(--pf-v6-global--BorderColor--200);
-  --pf-v6-global--primary-color--100: inherit;
-  --pf-v6-global--link--Color: inherit;
-  --pf-v6-global--link--Color--hover: inherit;
-  --pf-v6-global--BackgroundColor--100: inherit;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-empty-state {
-  --pf-v6-c-empty-state--PaddingTop: 4rem;
-  --pf-v6-c-empty-state__body--Color: var(--pf-v6-global--Color--300);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-title {
-  --pf-v6-c-title--m-2xl--FontWeight: var(--pf-v6-global--FontWeight--semi-bold);
-  --pf-v6-c-title--m-xl--FontWeight: var(--pf-v6-global--FontWeight--semi-bold);
-  --pf-v6-c-title--m-lg--FontWeight: var(--pf-v6-global--FontWeight--semi-bold);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-card {
-  --pf-v6-c-card--BackgroundColor: #13161b;
-  --pf-v6-c-card--BorderStyle: none;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-card__title {
-  --pf-v6-c-card__title--FontSize: var(--pf-v6-global--FontSize--lg);
-  margin-bottom: 0.25rem;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-data-list {
-  --pf-v6-global--link--Color: inherit; 
-  --pf-v6-c-data-list__item--BackgroundColor: #13161b;
-  --pf-v6-c-data-list--BorderTopColor: var(--pf-v6-global--BorderColor--200);
-  --pf-v6-c-data-list__item--BorderBottomColor: var(--pf-v6-global--BorderColor--200);
-  --pf-v6-c-data-list__item--m-hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-dropdown {
-  --pf-v6-c-dropdown__menu--BackgroundColor: #1a1e25;
-  --pf-v6-c-dropdown__menu-item--Color: var(--pf-v6-global--Color--100);
-  --pf-v6-c-dropdown__menu-item--FontSize: 0.875rem;
-  --pf-v6-c-dropdown__menu-item--hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-dropdown__menu-item--hover--Color: var(--pf-v6-global--Color--100);
-  --pf-v6-c-dropdown__menu-item--PaddingRight: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-dropdown__menu-item--PaddingLeft: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-dropdown__menu-item--PaddingTop: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-dropdown__menu-item--PaddingBottom: var(--pf-v6-global--spacer--sm);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-dropdown__menu {
-  border: 1px solid var(--pf-v6-global--BorderColor--100);
-  border-radius: var(--pf-v6-global--BorderRadius--md);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-menu {
-  --pf-v6-c-menu--BackgroundColor: #1a1e25;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-divider {
-  --pf-v6-c-divider--Color: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-dropdown__toggle-icon {
-  color: var(--pf-v6-global--Color--300);
-  opacity: .6;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-dropdown__toggle.pf-m-plain:not(.pf-m-text)  {
-  display: inline-flex;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-dropdown__toggle-text{
-  display: flex;
-  align-items: center;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-select {
-  --pf-v6-c-select__toggle--PaddingTop: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-select__toggle--PaddingBottom: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-select__toggle--BackgroundColor: var(--pf-v6-global--BackgroundColor--100);
-  --pf-v6-c-select__toggle--BorderColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-select__toggle--Color: var(--pf-v6-global--Color--100);
-  --pf-v6-c-select__toggle--PaddingRight: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-select__toggle--PaddingLeft: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-select__toggle--FontSize: var(--pf-v6-global--FontSize--sm);
-  --pf-v6-c-select__toggle--disabled--BackgroundColor: var(--pf-v6-global--BorderColor--200);
-  --pf-v6-c-select__toggle-arrow--Color: var(--pf-v6-global--Color--300);
+    /* Background colors */
+    --pf-v6-global--BackgroundColor--100: #13161b;
+    --pf-v6-global--BackgroundColor--200: #1a1e25;
+    --ascender-workflow-node-bg: #1a1e25;
+    --ascender-workflow-graph-bg: #0d0f12;
+    --pf-v6-global--BackgroundColor--dark-100: #1a1e25;
+    --pf-v6-global--BackgroundColor--dark-200: #13161b;
   
-  --pf-v6-c-select__menu--BackgroundColor: var(--pf-v6-global--BackgroundColor--100);
-  --pf-v6-c-select__menu-item--focus--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-select__menu-item--hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-select__menu-item--Color: var(--pf-v6-global--Color--100);
-  --pf-v6-c-select__menu-item--PaddingTop: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-select__menu-item--PaddingRight: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-select__menu-item--PaddingBottom: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-select__menu-item--PaddingLeft: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-select__menu-item--FontSize: var(--pf-v6-global--FontSize--sm);
-
-  --pf-v6-c-select__toggle--before--BorderTopWidth: 1px;
-  --pf-v6-c-select__toggle--before--BorderRightWidth: 1px;
-  --pf-v6-c-select__toggle--before--BorderBottomWidth: 1px;
-  --pf-v6-c-select__toggle--before--BorderLeftWidth: 1px;
-  --pf-v6-c-select__toggle--before--BorderWidth: 1px;
-  --pf-v6-c-select__toggle--before--BorderTopColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-select__toggle--before--BorderRightColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-select__toggle--before--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-select__toggle--before--BorderLeftColor: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-select__toggle {
-  border-radius: var(--pf-v6-global--BorderRadius--sm);
-  height: 42px;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-select__toggle:before {
-  --pf-v6-c-select__toggle--before--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-select__toggle--before--BorderBottomWidth: 1px;
-  border-radius: var(--pf-v6-global--BorderRadius--sm);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-select__toggle:focus {
-  --pf-v6-c-select__toggle--before--BorderBottomColor: inherit;
-  border-bottom: inherit;
-  outline: 2px solid var(--pf-v6-global--focus-ring-color);
-  outline-offset: 2px;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-select__menu {
-  border: 1px solid var(--pf-v6-global--BorderColor--100);
-  border-radius: var(--pf-v6-global--BorderRadius--md);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-options-menu {
-  --pf-v6-c-options-menu__menu-item--PaddingLeft: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-options-menu__menu-item--PaddingRight: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-options-menu__menu-item--PaddingTop: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-options-menu__menu-item--PaddingBottom: var(--pf-v6-global--spacer--sm);
-  --pf-v6-c-options-menu__menu-item--FontSize: var(--pf-v6-global--FontSize--sm);
-  --pf-v6-c-options-menu__menu-item-icon--Color: var(--pf-v6-global--Color--300);
-  --pf-v6-c-options-menu__menu-item--hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-options-menu__menu--BackgroundColor: var(--pf-v6-global--BackgroundColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-options-menu__menu {
-  border: 1px solid var(--pf-v6-global--BorderColor--100);
-  border-radius: var(--pf-v6-global--BorderRadius--md);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-form {
-  --pf-v6-c-form--GridGap: var(--pf-v6-global--spacer--md);
-  --pf-v6-c-form__label-text--FontWeight: var(--pf-v6-global--FontWeight--normal);
-  --pf-v6-c-form__group--m-action--MarginTop: var(--pf-v6-global--spacer--sm);
-}
-html.pf-v6-theme-dark .pf-v6-c-form__group.pf-m-action {
-  overflow: visible;
-}
-
-
-html.pf-v6-theme-dark .pf-v6-c-tooltip {
-  --pf-v6-c-tooltip--MaxWidth: inherit;
-  --pf-v6-c-tooltip--BoxShadow: inherit;
-  --pf-v6-c-tooltip_content--PaddingTop: inherit;
-  --pf-v6-c-tooltip_content--PaddingRight: inherit;
-  --pf-v6-c-tooltip_content--PaddingBottom: inherit;
-  --pf-v6-c-tooltip_content--PaddingLeft: inherit;
-  --pf-v6-c-tooltip_content--Color: #fff;
-  --pf-v6-c-tooltip__content--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-tooltip__content--PaddingTop: var(--pf-v6-global--spacer--xs);
-  --pf-v6-c-tooltip__content--PaddingRight: var(--pf-v6-global--spacer--md);
-  --pf-v6-c-tooltip__content--PaddingBottom: var(--pf-v6-global--spacer--xs);
-  --pf-v6-c-tooltip__content--PaddingLeft: var(--pf-v6-global--spacer--md);
-  --pf-v6-c-tooltip_content--FontSize: inherit;
-  --pf-v6-c-tooltip_arrow--Width: inherit;
-  --pf-v6-c-tooltip_arrow--Height: inherit;
-  --pf-v6-c-tooltip_arrow--m-top--TranslateX: inherit;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-tooltip__content {
-  border-radius: 0.25rem;
-  color: #fff;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-popover {
-  --pf-v6-c-popover__content--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-popover__arrow--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-popover__content {
-  border-radius: var(--pf-v6-global--BorderRadius--sm);
-  --pf-v6-c-popover__content--PaddingRight: var(--pf-v6-global--spacer--xl);
-  --pf-v6-c-popover__content--PaddingLeft: var(--pf-v6-global--spacer--xl);
-  --pf-v6-c-popover__content--PaddingTop: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-popover__content--PaddingBottom: var(--pf-v6-global--spacer--xl);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-popover.pf-m-top {
-  --pf-v6-c-popover__arrow--m-top--TranslateY: 0.25rem;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-form-control.pf-m-expanded {
-  --pf-v6-c-form-control--after--BorderColor: inherit;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-form-control:not(.ace_editor) {
-  transition: all 0.15s ease-in-out;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-control:hover {
-  --pf-v6-c-button--m-control--BackgroundColor: var(--pf-v6-global--primary-color--200);
-  --pf-v6-c-button--m-control--Color: var(--pf-v6-global--BorderColor--200);
-}
-
-html.pf-v6-theme-dark .pf-m-control.pf-v6-c-button::after {
-  display: none;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-plain,
-html.pf-v6-theme-dark .pf-v6-c-button.pf-m-plain:hover {
-  --pf-v6-c-button--m-plain--Color: var(--pf-v6-global--Color--200);
-  --pf-v6-c-button--m-plain--disabled--Color: var(--pf-t--color--gray--30);
-}
-
-html.pf-v6-theme-dark .pf-m-small {
-  font-size: 10px;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-notification-badge {
-  --pf-v6-c-notification-badge--PaddingRight: 1rem;
-  --pf-v6-c-notification-badge--PaddingLeft: 1rem;
-  --pf-v6-c-notification-badge--MarginTop: calc(-1 * 0.375rem);
-  --pf-v6-c-notification-badge--MarginRight: calc(-1 * 1rem);
-  --pf-v6-c-notification-badge--MarginBottom: calc(-1 * 0.375rem);
-  --pf-v6-c-notification-badge--MarginLeft: calc(-1 * 1rem);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-form-control:focus {
-  --pf-v6-c-form-control--BorderColor: var(--pf-v6-global--focus-ring-color);
-  --pf-v6-c-form-control--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
-
-  outline: 2px solid var(--pf-v6-global--focus-ring-color);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-form-control:hover {
-  --pf-v6-c-form-control--after--BorderColor: #444548;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-input-group {
-  /* Hardcoding the color here, as for some reason the gap doesn't proper change color
-     when using the var */
-  --pf-v6-c-input-group--BackgroundColor: #13161b;
-  border-radius: var(--pf-v6-global--BorderRadius--sm);
-  gap: var(--pf-v6-global--spacer--sm);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-input-group > * + * {
-  margin-left: 0;
-  border-left: none;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-progress {
-  --pf-v6-c-progress__bar--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-progress__bar,
-html.pf-v6-theme-dark .pf-v6-c-progress__bar::before,
-html.pf-v6-theme-dark .pf-v6-c-progress__indicator {
-  border-radius: 0.25rem;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-label-group {
-  color: var(--pf-v6-global--Color--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-alert {
-  --pf-v6-c-alert--BorderTopColor: var(--pf-v6-global--focus-ring-color);
-  --pf-v6-c-alert__title--Color: var(--pf-v6-global--Color--200);
-  --pf-v6-c-alert__icon--Color: var(--pf-v6-global--focus-ring-color);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-modal-box {
-  --pf-v6-c-modal-box--BackgroundColor: #13161b;
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-wizard {
-  --pf-v6-c-wizard--BackgroundColor: #13161b;
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-wizard__nav {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-wizard__main {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-wizard__footer {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-modal-box__header {
-  --pf-v6-c-modal-box__header--PaddingTop: var(--pf-v6-global--spacer--3xl);
-  --pf-v6-c-modal-box__header--PaddingBottom: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-modal-box__header--PaddingRight: var(--pf-v6-global--spacer--3xl);
-  --pf-v6-c-modal-box__header--PaddingLeft: var(--pf-v6-global--spacer--3xl);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-modal-box__footer {
-  --pf-v6-c-modal-box__footer--PaddingTop: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-modal-box__footer--PaddingBottom: var(--pf-v6-global--spacer--2xl);
-  --pf-v6-c-modal-box__footer--PaddingRight: var(--pf-v6-global--spacer--3xl);
-  --pf-v6-c-modal-box__footer--PaddingLeft: var(--pf-v6-global--spacer--3xl);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-modal-box__header + .pf-v6-c-modal-box__body {
-  --pf-v6-c-modal-box__body--PaddingTop: var(--pf-v6-global--spacer--3xl);
-  --pf-v6-c-modal-box__body--PaddingBottom: 4rem;
-  --pf-v6-c-modal-box__body--last-child--PaddingBottom: 3rem;
-  --pf-v6-c-modal-box__body--PaddingRight: var(--pf-v6-global--spacer--3xl);
-  --pf-v6-c-modal-box__body--PaddingLeft: var(--pf-v6-global--spacer--3xl);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-nav__toggle-icon {
-  color: var(--pf-v6-global--Color--300);
-  opacity: .6;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-pagination.pf-m-bottom {
-  justify-content: space-between;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled {
-  --pf-v6-c-button--disabled--BackgroundColor: transparent;
-  --pf-v6-c-button--m-plain--disabled--Color: var(--pf-t--color--gray--30);
-  --pf-v6-c-button--disabled--Color: var(--pf-t--color--gray--30);
-  border-color: #444548;
-  color: var(--pf-t--color--gray--30) !important;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled .pf-v6-svg {
-  color: var(--pf-t--color--gray--40) !important;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-slider {
-  --pf-v6-c-slider__thumb--Height: var(--pf-v6-global--spacer--md);
-  --pf-v6-c-slider__thumb--Width: var(--pf-v6-global--spacer--md);
-  --pf-v6-c-slider__steps--FontSize: var(--pf-v6-global--FontSize--xs);
-  --pf-v6-c-slider__thumb--BoxShadow: none;
-  /* --pf-v6-c-slider__rail-track--before--base--BackgroundColor: var(--pf-v6-global--primary-color--100); */
-  --pf-v6-c-slider__rail-track--before--fill--BackgroundColor: var(--pf-v6-global--primary-color--100); 
-  /* --pf-v6-c-slider__rail-track--before--fill--BackgroundColor--gradient-stop: transparent; */
-}
-
-html.pf-v6-theme-dark .pf-v6-c-nav__link:hover {
-  background-color: #26292d;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-nav__link:focus {
-  background-color: #444548;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-nav__link:active {
-  background-color: transparent;
-}
-
-html.pf-v6-theme-dark .ace-twilight .ace_gutter {
-  background: var(--pf-v6-global--BackgroundColor--200);
-  color: var(--pf-v6-global--Color--300);
-}
-
-html.pf-v6-theme-dark .ace-twilight .ace_marker-layer .ace_active-line {
-  background: var(--pf-v6-global--BackgroundColor--200);
-  color: var(--pf-v6-global--Color--200);
-}
-
-html.pf-v6-theme-dark .ace-twilight .ace_gutter-active-line {
-  background-color: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-switch {
-  --pf-v6-c-switch__toggle--before--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-  --pf-v6-c-switch__toggle--before--Top: 1px;
-  --pf-v6-c-switch__toggle--before--Width: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-switch__toggle--before--Height: var(--pf-v6-global--spacer--lg);
-  --pf-v6-c-switch__toggle--Width: 40px;
-  --pf-v6-c-switch__toggle--BorderRadius: 16px;
-  --pf-v6-c-switch__toggle--Height: 18px;
-  --pf-v6-c-switch__input--focus__toggle--OutlineColor: none;
-  --pf-v6-c-switch__toggle--before--Left: 3px;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-switch__input:checked ~ .pf-v6-c-switch__toggle::before {
-  --pf-v6-c-switch__toggle--before--BackgroundColor: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark [class*="FormLayout__SubFormLayout"] {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark #chart .nodes circle {
-  fill: #000;
-}
-
-html.pf-v6-theme-dark #chart .node-state-label rect {
-  fill: #000;
-  stroke: var(--pf-v6-global--BorderColor--100);
-}
-
-html.pf-v6-theme-dark #chart .node-state-label text {
-  fill: var(--pf-v6-global--Color--100);
-}
-
-html.pf-v6-theme-dark #chart .nodes > g > text {
-  fill: var(--pf-v6-global--Color--100);
-}
-
-html.pf-v6-theme-dark .legend {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .tooltip {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark polygon {
-  --pf-t--global--background--color--200: rgba(0,0,0,0);
-}
-
-html.pf-v6-theme-dark .pf-v6-c-wizard__main-body {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-wizard__header {
-  background-color: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-alert.pf-m-warning {
-  --pf-v6-c-alert--BackgroundColor: #1a1e25;
-  --pf-v6-c-alert--m-warning--BorderColor: #444548;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-about-modal-box {
-  --pf-v6-c-about-modal-box--BackgroundColor: #13161b;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-helper-text__item-icon {
-  --pf-v6-c-helper-text__item-icon--Color: #f04438;
-}
-
-html.pf-v6-theme-dark .pf-v6-c-wizard__nav-link {
-  --pf-v6-c-wizard__nav-link--Color: #13161b;
+  
+  
+    --pf-t--global--text--color--100: #f7f7f7;
+    --pf-t--global--border--color--default: #373a41;
+
+    /* === Borders === */
+    --pf-v6-global--BorderColor--100: #444548;
+    --pf-v6-global--BorderColor--200: #22262f;
+    --pf-v6-global--BorderColor--300: #22262f;
+    --pf-v6-global--BorderColor--disabled: #373a41;
+  
+  
+    /* === Focus === */
+    --pf-v6-global--focus-ring-color: #0b8759;
+  
+    /* === Shadows === */
+    --pf-v6-global--BoxShadow--sm: hsla(0,0%,100%,0);
+    --pf-v6-global--BoxShadow--md: hsla(0,0%,100%,0);
+    --pf-v6-global--BoxShadow--lg: hsla(0,0%,100%,0);
+    --pf-v6-global--BoxShadow--xl: hsla(0,0%,100%,0);
+
+
+    --pf-t--global--color--status--success--default: #17b26a;
+    --pf-t--global--color--status--danger--default: #f04438;
+
+    --pf-v6-c-button--disabled--BackgroundColor: #22262f;
+    --pf-v6-c-button--disabled--Color: #12a66f;
+    --pf-v6-c-menu-toggle--BorderColor: #444548;
+    --pf-t--global--border--color--control--default: #444548;
+  }
+
+  & .pf-v6-c-label.pf-m-filled {
+    --pf-v6-c-label--BackgroundColor: #1b1d21;
+    border: 1px solid #444548;
+  }
+
+  & .pf-v6-c-button.pf-m-link.pf-m-inline {
+    --pf-v6-c-button--TextDecorationStyle: unset;
+    --pf-v6-c-button--TextDecorationLine: none;
+    --pf-v6-c-button--m-link--m-inline--hover--TextDecorationLine: none;
+    padding: 0px 4px 0px 4px;
+    min-height: auto;
+    height: auto;
+  }
+
+  & .pf-v6-c-button.pf-m-link.pf-m-inline:hover {
+    --pf-v6-c-button--TextDecorationStyle: unset;
+    --pf-v6-c-button--TextDecorationLine: none;
+  }
+
+  & .ascender-status-label.pf-v6-c-label {
+    --pf-v6-c-label--BackgroundColor: #22262f;
+    --pf-v6-c-label--Color: #12a66f;
+    --pf-v6-c-label__icon--Color: #12a66f;
+    font-weight: 600;
+  }
+
+  & .pf-v6-c-button.pf-m-link {
+    --pf-v6-c-label--BackgroundColor: #22262f;
+    --pf-v6-c-label--Color: #12a66f;
+    --pf-v6-c-label__icon--Color: #12a66f;
+    color: #12a66f;
+    border: 1px solid #12a66f;
+    margin-left: 0px;
+  }
+
+  & .ascender-status-label.pf-v6-c-label.pf-m-green {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #22262f;
+    --pf-v6-c-label__icon--Color: #22262f;
+    font-weight: 600;
+  }
+
+  & .ascender-status-label.pf-v6-c-label.pf-m-red {
+    --pf-v6-c-label--BackgroundColor: #f04438;
+    --pf-v6-c-label--Color: #22262f;
+    --pf-v6-c-label__icon--Color: #22262f;
+    font-weight: 600;
+  }
+
+  & .ascender-status-label.pf-v6-c-label.pf-m-orange {
+    --pf-v6-c-label--BackgroundColor: #f79009;
+    --pf-v6-c-label--Color: #22262f;
+    --pf-v6-c-label__icon--Color: #22262f;
+    font-weight: 600;
+  }
+
+  /* We don't want any blue, so just change it to our branded green */
+  & .ascender-status-label.pf-v6-c-label.pf-m-blue {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #22262f;
+    --pf-v6-c-label__icon--Color: #22262f;
+    font-weight: 600;
+  }
+
+  & .pf-v6-c-label.pf-m-green {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #22262f;
+    --pf-v6-c-label__icon--Color: #22262f;
+  }
+
+  & .pf-v6-c-label.pf-m-red {
+    --pf-v6-c-label--BackgroundColor: #f04438;
+  }
+
+  & .pf-v6-c-label.pf-m-blue {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #22262f;
+    --pf-v6-c-label__icon--Color: #22262f;
+    font-weight: 600;
+  }
+
+  & .pf-v6-c-title {
+    color: var(--pf-v6-global--Color--100);
+    font-family: Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif !important;
+    font-weight: 500 !important;
+  }
+
+  & .pf-v6-c-table {
+    --pf-v6-c-table__sort__button__text--Color: var(--pf-v6-global--Color--100);
+    color: var(--pf-v6-global--Color--100);
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-table__expandable-row .pf-v6-c-table__expandable-row-content {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-form-control {
+    --pf-v6-c-form-control--BackgroundColor: #1b1d21;
+    --pf-v6-c-form-control--disabled--BackgroundColor: var(--pf-v6-global--BorderColor--200);
+    --pf-v6-c-form-control--BorderColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-form-control--Color: var(--pf-v6-global--Color--100);
+    --pf-v6-c-form-control--PlaceholderColor: var(--pf-v6-global--disabled-color--100);
+
+    --pf-v6-c-form-control--BorderTopColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-form-control--BorderRightColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-form-control--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-form-control--BorderLeftColor: var(--pf-v6-global--BorderColor--100);
+
+    --pf-v6-c-form-control--PaddingTop: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-form-control--PaddingRight: var(--pf-v6-global--spacer--md);
+    --pf-v6-c-form-control--PaddingBottom: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-form-control--focus--PaddingBottom: var(--pf-v6-global--spacer--sm);
+
+    --pf-v6-c-button--BorderRadius: var(--pf-v6-global--BorderRadius--sm);
+  
+    --pf-v6-c-form-control--focus--BorderBottomWidth: 1px;
+    --pf-v6-c-form-control--PaddingLeft: var(--pf-v6-global--spacer--md);
+
+    border-radius: var(--pf-v6-global--BorderRadius--sm);
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+
+  & .pf-v6-c-radio {
+    --pf-v6-c-radio--AccentColor: #12a66f;
+  }
+
+  & .ace_editor {
+    background-color: #13161b !important;
+    color: #f8f8f8 !important;
+  }
+
+  & .ace_editor .ace_gutter {
+    background: #1a1e25 !important;
+    color: #94979c !important;
+  }
+
+  & .ace_editor .ace_paren {
+    color: #f8f8f8 !important;
+  }
+
+  & .ace_editor .ace_string {
+    color: #8f9d6a !important;
+  }
+
+  & .ace_editor .ace_constant {
+    color: #cf6a4c !important;
+  }
+
+  & .ace_editor .ace_keyword {
+    color: #cda869 !important;
+  }
+
+  & .ace_editor .ace_tag {
+    color: #cda869 !important;
+  }
+
+  & .ace_editor .ace_markup {
+    color: #8f9d6a !important;
+  }
+
+  & .pf-v6-c-button {
+    --pf-v6-c-button--m-primary--BackgroundColor: #12a66f;
+    --pf-v6-c-button--m-primary--Color: #13161b;
+    --pf-v6-c-button--m-primary--hover--BackgroundColor: #0e8c5d;
+    --pf-v6-c-button--m-primary--focus--Color: #13161b;
+    --pf-v6-c-button--m-link--Color: #12a66f;
+    --pf-v6-c-button--disabled--BackgroundColor: #22262f;
+    --pf-v6-c-button--disabled--Color: #12a66f;
+    font-weight: 600;
+  }
+
+  & .pf-v6-c-button.pf-m-primary:not(:disabled) {
+    background-color: #12a66f;
+    --pf-v6-c-button--Color: #22262f !important;
+    color: #22262f !important;
+  }
+
+  & .pf-v6-c-button.pf-m-secondary:not(:disabled) {
+    background-color: transparent;
+    border-color: #12a66f;
+    color: #12a66f;
+    --pf-v6-global--Color--200: #12a66f;
+  }
+
+  & .pf-v6-c-button.pf-m-secondary:not(:disabled):hover {
+    border-color: #0e8c5d;
+  }
+
+  & .pf-v6-c-button.pf-m-danger {
+    --pf-v6-c-button--m-danger--BackgroundColor: var(--pf-v6-global--danger-color--100);
+    --pf-v6-c-button--m-danger--Color: #fff;
+    --pf-v6-c-button--m-danger--hover--BackgroundColor: var(--pf-v6-global--danger-color--200);
+  }
+
+  & .pf-v6-c-button.pf-m-control {
+    vertical-align: middle;
+    background-color: #12a66f;
+    color: #13161b;
+  }
+
+  & .pf-v6-c-button.pf-m-control:disabled {
+    background-color: #12a66f;
+    color: #22262f;
+  }
+
+  & .pf-v6-c-button.pf-m-control:disabled .pf-v6-svg {
+    color: #22262f;
+  }
+
+  & .pf-v6-c-button.pf-m-control:hover:not(:disabled) {
+    background-color: #0e8c5d;
+  }
+
+  & .pf-v6-c-button.pf-m-control:not(:disabled) .pf-v6-c-button__icon {
+    color: #13161b;
+  }
+
+  & .pf-v6-c-button.pf-m-control:not(:disabled) .pf-v6-svg {
+    color: #13161b;
+  }
+
+  & .pf-v6-c-menu-toggle__status-icon {
+    --pf-v6-c-menu-toggle__status-icon--Color: #f04438;
+  }
+
+  & b {
+    font-weight: normal;
+  }
+
+  & .pf-v6-c-page {
+    --pf-v6-c-page--BackgroundColor: #13161b;
+    --pf-v6-c-page__main-section--BackgroundColor: #13161b;
+    --pf-v6-c-page__header--BackgroundColor: #13161b;
+    --pf-v6-c-page__sidebar--BackgroundColor: #13161b;
+  }
+
+  & .pf-v6-c-login {
+    --pf-v6-c-login__main--BackgroundColor: var(--pf-v6-global--BackgroundColor--200);
+  }
+  & .pf-v6-c-masthead {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-breadcrumb__item-divider {
+    color: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .pf-v6-c-page__sidebar.pf-m-expanded {
+    box-shadow: none;
+    border-right: 1px solid var(--pf-v6-global--BorderColor--200);
+  }
+
+  & .pf-v6-c-nav {
+    --pf-v6-c-nav--BackgroundColor: transparent;
+    --pf-v6-c-nav__link--Color: var(--pf-v6-global--Color--200);
+    --pf-v6-c-nav__link--m-current--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-nav__link--m-current--Color: var(--pf-v6-global--Color--100);
+    --pf-v6-c-nav__link--m-current--after--BorderColor: transparent;
+  }
+
+  & {
+    --ascender-output-bg: #000;
+    --ascender-gutter-bg: #13161b;
+    --ascender-status-running-color: #12a66f;
+    --ascender-status-canceled-color: #f79009;
+    --ansi-color-0: #b0b0b0;
+    --ansi-color-4: #7aa2f7;
+    --ansi-color-12: #8cb4ff;
+  }
+
+  & #job_output-toolbar {
+    border-top: 1px solid var(--pf-v6-global--BorderColor--100);
+    border-bottom: 1px solid var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .ascender-output-wrapper {
+    border-top: 1px solid var(--pf-v6-global--BorderColor--100);
+    border-bottom: 1px solid var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .ascender-output-scroll {
+    background-image: linear-gradient(to right, #13161b 85px, transparent 85px);
+  }
+
+  & .pf-v6-c-page__main-section.pf-m-light {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-page__main-section {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-page__main-section:first-child {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-toolbar {
+    --pf-v6-c-toolbar--BackgroundColor: #13161b;
+  }
+
+  & .pf-v6-c-pagination.pf-m-bottom {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-menu-toggle {
+    background-color: #1b1d21;
+  }
+
+  & .pf-v6-c-menu-toggle::before {
+    border: var(--pf-v6-c-menu-toggle--BorderWidth) solid #444548;
+  }
+
+  & .pf-v6-c-menu-toggle:hover {
+    --pf-v6-c-menu-toggle--BorderColor: #444548;
+  }
+
+  & .pf-v6-c-pagination__page-menu > .pf-v6-c-menu-toggle {
+    background-color: #13161b;
+  }
+
+  & :focus-visible {
+    outline: 1px solid #373a41;
+  }
+
+  & .pf-v6-c-menu-toggle.pf-m-primary {
+    background-color: #12a66f;
+    text-transform: uppercase;
+    font-weight: 600;
+  }
+
+  & .ace-tm .ace_gutter-active-line {
+    background-color: #000;
+  }
+
+  & .pf-v6-c-tabs__item-text {
+    display: flex;
+    align-items: center;
+  }
+
+  & .pf-v6-c-table thead {
+    --pf-v6-c-table--cell--FontWeight: 500;
+    border-bottom: 1px #373a41 solid;
+
+  }
+  & .pf-v6-c-table thead th {
+    background-color: #13161b !important;
+  }
+  & .pf-v6-c-table tr > * {
+    color: inherit;
+  }
+
+  & .pf-v6-c-table {
+    --pf-v6-global--Color--100: inherit;
+    --pf-v6-global--Color--200: inherit;
+    --pf-v6-global--BorderColor--100: var(--pf-v6-global--BorderColor--200);
+    --pf-v6-global--primary-color--100: inherit;
+    --pf-v6-global--link--Color: inherit;
+    --pf-v6-global--link--Color--hover: inherit;
+    --pf-v6-global--BackgroundColor--100: inherit;
+  }
+
+  & .pf-v6-c-empty-state {
+    --pf-v6-c-empty-state--PaddingTop: 4rem;
+    --pf-v6-c-empty-state__body--Color: var(--pf-v6-global--Color--300);
+  }
+
+  & .pf-v6-c-title {
+    --pf-v6-c-title--m-2xl--FontWeight: var(--pf-v6-global--FontWeight--semi-bold);
+    --pf-v6-c-title--m-xl--FontWeight: var(--pf-v6-global--FontWeight--semi-bold);
+    --pf-v6-c-title--m-lg--FontWeight: var(--pf-v6-global--FontWeight--semi-bold);
+  }
+
+  & .pf-v6-c-card {
+    --pf-v6-c-card--BackgroundColor: #13161b;
+    --pf-v6-c-card--BorderStyle: none;
+  }
+
+  & .pf-v6-c-card__title {
+    --pf-v6-c-card__title--FontSize: var(--pf-v6-global--FontSize--lg);
+    margin-bottom: 0.25rem;
+  }
+
+  & .pf-v6-c-data-list {
+    --pf-v6-global--link--Color: inherit; 
+    --pf-v6-c-data-list__item--BackgroundColor: #13161b;
+    --pf-v6-c-data-list--BorderTopColor: var(--pf-v6-global--BorderColor--200);
+    --pf-v6-c-data-list__item--BorderBottomColor: var(--pf-v6-global--BorderColor--200);
+    --pf-v6-c-data-list__item--m-hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .pf-v6-c-dropdown {
+    --pf-v6-c-dropdown__menu--BackgroundColor: #1a1e25;
+    --pf-v6-c-dropdown__menu-item--Color: var(--pf-v6-global--Color--100);
+    --pf-v6-c-dropdown__menu-item--FontSize: 0.875rem;
+    --pf-v6-c-dropdown__menu-item--hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-dropdown__menu-item--hover--Color: var(--pf-v6-global--Color--100);
+    --pf-v6-c-dropdown__menu-item--PaddingRight: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-dropdown__menu-item--PaddingLeft: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-dropdown__menu-item--PaddingTop: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-dropdown__menu-item--PaddingBottom: var(--pf-v6-global--spacer--sm);
+  }
+
+  & .pf-v6-c-dropdown__menu {
+    border: 1px solid var(--pf-v6-global--BorderColor--100);
+    border-radius: var(--pf-v6-global--BorderRadius--md);
+  }
+
+  & .pf-v6-c-menu {
+    --pf-v6-c-menu--BackgroundColor: #1a1e25;
+  }
+
+  & .pf-v6-c-divider {
+    --pf-v6-c-divider--Color: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .pf-v6-c-dropdown__toggle-icon {
+    color: var(--pf-v6-global--Color--300);
+    opacity: .6;
+  }
+
+  & .pf-v6-c-dropdown__toggle.pf-m-plain:not(.pf-m-text)  {
+    display: inline-flex;
+  }
+
+  & .pf-v6-c-dropdown__toggle-text{
+    display: flex;
+    align-items: center;
+  }
+
+  & .pf-v6-c-select {
+    --pf-v6-c-select__toggle--PaddingTop: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-select__toggle--PaddingBottom: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-select__toggle--BackgroundColor: var(--pf-v6-global--BackgroundColor--100);
+    --pf-v6-c-select__toggle--BorderColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-select__toggle--Color: var(--pf-v6-global--Color--100);
+    --pf-v6-c-select__toggle--PaddingRight: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-select__toggle--PaddingLeft: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-select__toggle--FontSize: var(--pf-v6-global--FontSize--sm);
+    --pf-v6-c-select__toggle--disabled--BackgroundColor: var(--pf-v6-global--BorderColor--200);
+    --pf-v6-c-select__toggle-arrow--Color: var(--pf-v6-global--Color--300);
+  
+    --pf-v6-c-select__menu--BackgroundColor: var(--pf-v6-global--BackgroundColor--100);
+    --pf-v6-c-select__menu-item--focus--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-select__menu-item--hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-select__menu-item--Color: var(--pf-v6-global--Color--100);
+    --pf-v6-c-select__menu-item--PaddingTop: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-select__menu-item--PaddingRight: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-select__menu-item--PaddingBottom: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-select__menu-item--PaddingLeft: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-select__menu-item--FontSize: var(--pf-v6-global--FontSize--sm);
+
+    --pf-v6-c-select__toggle--before--BorderTopWidth: 1px;
+    --pf-v6-c-select__toggle--before--BorderRightWidth: 1px;
+    --pf-v6-c-select__toggle--before--BorderBottomWidth: 1px;
+    --pf-v6-c-select__toggle--before--BorderLeftWidth: 1px;
+    --pf-v6-c-select__toggle--before--BorderWidth: 1px;
+    --pf-v6-c-select__toggle--before--BorderTopColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-select__toggle--before--BorderRightColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-select__toggle--before--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-select__toggle--before--BorderLeftColor: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .pf-v6-c-select__toggle {
+    border-radius: var(--pf-v6-global--BorderRadius--sm);
+    height: 42px;
+  }
+
+  & .pf-v6-c-select__toggle:before {
+    --pf-v6-c-select__toggle--before--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-select__toggle--before--BorderBottomWidth: 1px;
+    border-radius: var(--pf-v6-global--BorderRadius--sm);
+  }
+
+  & .pf-v6-c-select__toggle:focus {
+    --pf-v6-c-select__toggle--before--BorderBottomColor: inherit;
+    border-bottom: inherit;
+    outline: 2px solid var(--pf-v6-global--focus-ring-color);
+    outline-offset: 2px;
+  }
+
+  & .pf-v6-c-select__menu {
+    border: 1px solid var(--pf-v6-global--BorderColor--100);
+    border-radius: var(--pf-v6-global--BorderRadius--md);
+  }
+
+  & .pf-v6-c-options-menu {
+    --pf-v6-c-options-menu__menu-item--PaddingLeft: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-options-menu__menu-item--PaddingRight: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-options-menu__menu-item--PaddingTop: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-options-menu__menu-item--PaddingBottom: var(--pf-v6-global--spacer--sm);
+    --pf-v6-c-options-menu__menu-item--FontSize: var(--pf-v6-global--FontSize--sm);
+    --pf-v6-c-options-menu__menu-item-icon--Color: var(--pf-v6-global--Color--300);
+    --pf-v6-c-options-menu__menu-item--hover--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-options-menu__menu--BackgroundColor: var(--pf-v6-global--BackgroundColor--100);
+  }
+
+  & .pf-v6-c-options-menu__menu {
+    border: 1px solid var(--pf-v6-global--BorderColor--100);
+    border-radius: var(--pf-v6-global--BorderRadius--md);
+  }
+
+  & .pf-v6-c-form {
+    --pf-v6-c-form--GridGap: var(--pf-v6-global--spacer--md);
+    --pf-v6-c-form__label-text--FontWeight: var(--pf-v6-global--FontWeight--normal);
+    --pf-v6-c-form__group--m-action--MarginTop: var(--pf-v6-global--spacer--sm);
+  }
+  & .pf-v6-c-form__group.pf-m-action {
+    overflow: visible;
+  }
+
+
+  & .pf-v6-c-tooltip {
+    --pf-v6-c-tooltip--MaxWidth: inherit;
+    --pf-v6-c-tooltip--BoxShadow: inherit;
+    --pf-v6-c-tooltip_content--PaddingTop: inherit;
+    --pf-v6-c-tooltip_content--PaddingRight: inherit;
+    --pf-v6-c-tooltip_content--PaddingBottom: inherit;
+    --pf-v6-c-tooltip_content--PaddingLeft: inherit;
+    --pf-v6-c-tooltip_content--Color: #fff;
+    --pf-v6-c-tooltip__content--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-tooltip__content--PaddingTop: var(--pf-v6-global--spacer--xs);
+    --pf-v6-c-tooltip__content--PaddingRight: var(--pf-v6-global--spacer--md);
+    --pf-v6-c-tooltip__content--PaddingBottom: var(--pf-v6-global--spacer--xs);
+    --pf-v6-c-tooltip__content--PaddingLeft: var(--pf-v6-global--spacer--md);
+    --pf-v6-c-tooltip_content--FontSize: inherit;
+    --pf-v6-c-tooltip_arrow--Width: inherit;
+    --pf-v6-c-tooltip_arrow--Height: inherit;
+    --pf-v6-c-tooltip_arrow--m-top--TranslateX: inherit;
+  }
+
+  & .pf-v6-c-tooltip__content {
+    border-radius: 0.25rem;
+    color: #fff;
+  }
+
+  & .pf-v6-c-popover {
+    --pf-v6-c-popover__content--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-popover__arrow--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .pf-v6-c-popover__content {
+    border-radius: var(--pf-v6-global--BorderRadius--sm);
+    --pf-v6-c-popover__content--PaddingRight: var(--pf-v6-global--spacer--xl);
+    --pf-v6-c-popover__content--PaddingLeft: var(--pf-v6-global--spacer--xl);
+    --pf-v6-c-popover__content--PaddingTop: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-popover__content--PaddingBottom: var(--pf-v6-global--spacer--xl);
+  }
+
+  & .pf-v6-c-popover.pf-m-top {
+    --pf-v6-c-popover__arrow--m-top--TranslateY: 0.25rem;
+  }
+
+  & .pf-v6-c-form-control.pf-m-expanded {
+    --pf-v6-c-form-control--after--BorderColor: inherit;
+  }
+
+  & .pf-v6-c-form-control:not(.ace_editor) {
+    transition: all 0.15s ease-in-out;
+  }
+
+  & .pf-v6-c-button.pf-m-control:hover {
+    --pf-v6-c-button--m-control--BackgroundColor: var(--pf-v6-global--primary-color--200);
+    --pf-v6-c-button--m-control--Color: var(--pf-v6-global--BorderColor--200);
+  }
+
+  & .pf-m-control.pf-v6-c-button::after {
+    display: none;
+  }
+
+  & .pf-v6-c-button.pf-m-plain,
+  & .pf-v6-c-button.pf-m-plain:hover {
+    --pf-v6-c-button--m-plain--Color: var(--pf-v6-global--Color--200);
+    --pf-v6-c-button--m-plain--disabled--Color: var(--pf-t--color--gray--30);
+  }
+
+  & .pf-m-small {
+    font-size: 10px;
+  }
+
+  & .pf-v6-c-notification-badge {
+    --pf-v6-c-notification-badge--PaddingRight: 1rem;
+    --pf-v6-c-notification-badge--PaddingLeft: 1rem;
+    --pf-v6-c-notification-badge--MarginTop: calc(-1 * 0.375rem);
+    --pf-v6-c-notification-badge--MarginRight: calc(-1 * 1rem);
+    --pf-v6-c-notification-badge--MarginBottom: calc(-1 * 0.375rem);
+    --pf-v6-c-notification-badge--MarginLeft: calc(-1 * 1rem);
+  }
+
+  & .pf-v6-c-form-control:focus {
+    --pf-v6-c-form-control--BorderColor: var(--pf-v6-global--focus-ring-color);
+    --pf-v6-c-form-control--BorderBottomColor: var(--pf-v6-global--BorderColor--100);
+
+    outline: 2px solid var(--pf-v6-global--focus-ring-color);
+  }
+
+  & .pf-v6-c-form-control:hover {
+    --pf-v6-c-form-control--after--BorderColor: #444548;
+  }
+
+  & .pf-v6-c-input-group {
+    /* Hardcoding the color here, as for some reason the gap doesn't proper change color
+       when using the var */
+    --pf-v6-c-input-group--BackgroundColor: #13161b;
+    border-radius: var(--pf-v6-global--BorderRadius--sm);
+    gap: var(--pf-v6-global--spacer--sm);
+  }
+
+  & .pf-v6-c-input-group > * + * {
+    margin-left: 0;
+    border-left: none;
+  }
+
+  & .pf-v6-c-progress {
+    --pf-v6-c-progress__bar--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .pf-v6-c-progress__bar,
+  & .pf-v6-c-progress__bar::before,
+  & .pf-v6-c-progress__indicator {
+    border-radius: 0.25rem;
+  }
+
+  & .pf-v6-c-label-group {
+    color: var(--pf-v6-global--Color--100);
+  }
+
+  & .pf-v6-c-alert {
+    --pf-v6-c-alert--BorderTopColor: var(--pf-v6-global--focus-ring-color);
+    --pf-v6-c-alert__title--Color: var(--pf-v6-global--Color--200);
+    --pf-v6-c-alert__icon--Color: var(--pf-v6-global--focus-ring-color);
+  }
+
+  & .pf-v6-c-modal-box {
+    --pf-v6-c-modal-box--BackgroundColor: #13161b;
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-wizard {
+    --pf-v6-c-wizard--BackgroundColor: #13161b;
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-wizard__nav {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-wizard__main {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-wizard__footer {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-modal-box__header {
+    --pf-v6-c-modal-box__header--PaddingTop: var(--pf-v6-global--spacer--3xl);
+    --pf-v6-c-modal-box__header--PaddingBottom: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-modal-box__header--PaddingRight: var(--pf-v6-global--spacer--3xl);
+    --pf-v6-c-modal-box__header--PaddingLeft: var(--pf-v6-global--spacer--3xl);
+  }
+
+  & .pf-v6-c-modal-box__footer {
+    --pf-v6-c-modal-box__footer--PaddingTop: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-modal-box__footer--PaddingBottom: var(--pf-v6-global--spacer--2xl);
+    --pf-v6-c-modal-box__footer--PaddingRight: var(--pf-v6-global--spacer--3xl);
+    --pf-v6-c-modal-box__footer--PaddingLeft: var(--pf-v6-global--spacer--3xl);
+  }
+
+  & .pf-v6-c-modal-box__header + .pf-v6-c-modal-box__body {
+    --pf-v6-c-modal-box__body--PaddingTop: var(--pf-v6-global--spacer--3xl);
+    --pf-v6-c-modal-box__body--PaddingBottom: 4rem;
+    --pf-v6-c-modal-box__body--last-child--PaddingBottom: 3rem;
+    --pf-v6-c-modal-box__body--PaddingRight: var(--pf-v6-global--spacer--3xl);
+    --pf-v6-c-modal-box__body--PaddingLeft: var(--pf-v6-global--spacer--3xl);
+  }
+
+  & .pf-v6-c-nav__toggle-icon {
+    color: var(--pf-v6-global--Color--300);
+    opacity: .6;
+  }
+
+  & .pf-v6-c-pagination.pf-m-bottom {
+    justify-content: space-between;
+  }
+
+  & .pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled {
+    --pf-v6-c-button--disabled--BackgroundColor: transparent;
+    --pf-v6-c-button--m-plain--disabled--Color: var(--pf-t--color--gray--30);
+    --pf-v6-c-button--disabled--Color: var(--pf-t--color--gray--30);
+    border-color: #444548;
+    color: var(--pf-t--color--gray--30) !important;
+  }
+
+  & .pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled .pf-v6-svg {
+    color: var(--pf-t--color--gray--40) !important;
+  }
+
+  & .pf-v6-c-slider {
+    --pf-v6-c-slider__thumb--Height: var(--pf-v6-global--spacer--md);
+    --pf-v6-c-slider__thumb--Width: var(--pf-v6-global--spacer--md);
+    --pf-v6-c-slider__steps--FontSize: var(--pf-v6-global--FontSize--xs);
+    --pf-v6-c-slider__thumb--BoxShadow: none;
+    /* --pf-v6-c-slider__rail-track--before--base--BackgroundColor: var(--pf-v6-global--primary-color--100); */
+    --pf-v6-c-slider__rail-track--before--fill--BackgroundColor: var(--pf-v6-global--primary-color--100); 
+    /* --pf-v6-c-slider__rail-track--before--fill--BackgroundColor--gradient-stop: transparent; */
+  }
+
+  & .pf-v6-c-nav__link:hover {
+    background-color: #26292d;
+  }
+
+  & .pf-v6-c-nav__link:focus {
+    background-color: #444548;
+  }
+
+  & .pf-v6-c-nav__link:active {
+    background-color: transparent;
+  }
+
+  & .ace-twilight .ace_gutter {
+    background: var(--pf-v6-global--BackgroundColor--200);
+    color: var(--pf-v6-global--Color--300);
+  }
+
+  & .ace-twilight .ace_marker-layer .ace_active-line {
+    background: var(--pf-v6-global--BackgroundColor--200);
+    color: var(--pf-v6-global--Color--200);
+  }
+
+  & .ace-twilight .ace_gutter-active-line {
+    background-color: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & .pf-v6-c-switch {
+    --pf-v6-c-switch__toggle--before--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+    --pf-v6-c-switch__toggle--before--Top: 1px;
+    --pf-v6-c-switch__toggle--before--Width: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-switch__toggle--before--Height: var(--pf-v6-global--spacer--lg);
+    --pf-v6-c-switch__toggle--Width: 40px;
+    --pf-v6-c-switch__toggle--BorderRadius: 16px;
+    --pf-v6-c-switch__toggle--Height: 18px;
+    --pf-v6-c-switch__input--focus__toggle--OutlineColor: none;
+    --pf-v6-c-switch__toggle--before--Left: 3px;
+  }
+
+  & .pf-v6-c-switch__input:checked ~ .pf-v6-c-switch__toggle::before {
+    --pf-v6-c-switch__toggle--before--BackgroundColor: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & [class*="FormLayout__SubFormLayout"] {
+    background-color: #13161b;
+  }
+
+  & #chart .nodes circle {
+    fill: #000;
+  }
+
+  & #chart .node-state-label rect {
+    fill: #000;
+    stroke: var(--pf-v6-global--BorderColor--100);
+  }
+
+  & #chart .node-state-label text {
+    fill: var(--pf-v6-global--Color--100);
+  }
+
+  & #chart .nodes > g > text {
+    fill: var(--pf-v6-global--Color--100);
+  }
+
+  & .legend {
+    background-color: #13161b;
+  }
+
+  & .tooltip {
+    background-color: #13161b;
+  }
+
+  & polygon {
+    --pf-t--global--background--color--200: rgba(0,0,0,0);
+  }
+
+  & .pf-v6-c-wizard__main-body {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-wizard__header {
+    background-color: #13161b;
+  }
+
+  & .pf-v6-c-alert.pf-m-warning {
+    --pf-v6-c-alert--BackgroundColor: #1a1e25;
+    --pf-v6-c-alert--m-warning--BorderColor: #444548;
+  }
+
+  & .pf-v6-c-about-modal-box {
+    --pf-v6-c-about-modal-box--BackgroundColor: #13161b;
+  }
+
+  & .pf-v6-c-helper-text__item-icon {
+    --pf-v6-c-helper-text__item-icon--Color: #f04438;
+  }
+
+  & .pf-v6-c-wizard__nav-link {
+    --pf-v6-c-wizard__nav-link--Color: #13161b;
+  }
 }

--- a/awx/ui/src/lightmode.css
+++ b/awx/ui/src/lightmode.css
@@ -11,149 +11,258 @@ html:not(.pf-v6-theme-dark) {
   --pf-v6-global--BorderColor--100: #d2d2d2;
   --pf-v6-global--BorderColor--200: #e0e0e0;
   --pf-v6-global--BackgroundColor--200: #f5f5f5;
-}
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-page {
-  --pf-v6-c-page--BackgroundColor: #f0f0f0;
-}
+  & .pf-v6-c-page {
+    --pf-v6-c-page--BackgroundColor: #f0f0f0;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-page__main {
-  background-color: #f0f0f0;
-}
+  & .pf-v6-c-page__main {
+    background-color: #f0f0f0;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-page__main-section {
-  background-color: #f0f0f0;
-}
+  & .pf-v6-c-page__main-section {
+    background-color: #f0f0f0;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-page__main-section:first-child {
-  background-color: #fff;
-}
+  & .pf-v6-c-page__main-section:first-child {
+    background-color: #fff;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-card.pf-v6-c-card:not(.pf-m-clickable) {
-  background-color: #fff !important;
-  border-radius: 16px !important;
-  box-shadow: none !important;
-}
+  & .pf-v6-c-card.pf-v6-c-card:not(.pf-m-clickable) {
+    background-color: #fff !important;
+    border-radius: 16px !important;
+    box-shadow: none !important;
+  }
 
-/* Dark masthead (top bar) */
-html:not(.pf-v6-theme-dark) .pf-v6-c-masthead {
-  background-color: #151515;
-  color: #fff;
-}
+  /* Dark masthead (top bar) */
+  & .pf-v6-c-masthead {
+    background-color: #151515;
+    color: #fff;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-masthead .pf-v6-svg {
-  color: #fff;
-}
+  & .pf-v6-c-masthead .pf-v6-svg {
+    color: #fff;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-masthead .pf-v6-c-button.pf-m-plain {
-  color: #fff;
-}
+  & .pf-v6-c-masthead .pf-v6-c-button.pf-m-plain {
+    color: #fff;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-masthead .pf-v6-c-menu-toggle {
-  color: #fff;
-}
+  & .pf-v6-c-masthead .pf-v6-c-menu-toggle {
+    color: #fff;
+  }
 
-/* Dark sidebar — match dark mode */
-html:not(.pf-v6-theme-dark) .pf-v6-c-page__sidebar {
-  --pf-v6-c-page__sidebar--BackgroundColor: #13161b;
-  background-color: #13161b;
-}
+  /* Dark sidebar — match dark mode */
+  & .pf-v6-c-page__sidebar {
+    --pf-v6-c-page__sidebar--BackgroundColor: #13161b;
+    background-color: #13161b;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-page__sidebar.pf-m-expanded {
-  box-shadow: none;
-  border-right: 1px solid #22262f;
-}
+  & .pf-v6-c-page__sidebar.pf-m-expanded {
+    box-shadow: none;
+    border-right: 1px solid #22262f;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-nav {
-  --pf-v6-c-nav--BackgroundColor: transparent;
-  --pf-v6-c-nav__link--Color: #cecfd2;
-  --pf-v6-c-nav__link--hover--Color: #f7f7f7;
-  --pf-v6-c-nav__link--hover--BackgroundColor: #373a41;
-  --pf-v6-c-nav__link--m-current--Color: #f7f7f7;
-  --pf-v6-c-nav__link--m-current--BackgroundColor: #373a41;
-  --pf-v6-c-nav__link--m-current--after--BorderColor: transparent;
-}
+  & .pf-v6-c-nav {
+    --pf-v6-c-nav--BackgroundColor: transparent;
+    --pf-v6-c-nav__link--Color: #cecfd2;
+    --pf-v6-c-nav__link--hover--Color: #f7f7f7;
+    --pf-v6-c-nav__link--hover--BackgroundColor: #373a41;
+    --pf-v6-c-nav__link--m-current--Color: #f7f7f7;
+    --pf-v6-c-nav__link--m-current--BackgroundColor: #373a41;
+    --pf-v6-c-nav__link--m-current--after--BorderColor: transparent;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-nav__section-title {
-  color: #f7f7f7;
-}
+  & .pf-v6-c-nav__section-title {
+    color: #f7f7f7;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-nav__toggle-icon {
-  color: #94979c;
-  opacity: .6;
-}
+  & .pf-v6-c-nav__toggle-icon {
+    color: #94979c;
+    opacity: .6;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-nav__link:focus {
-  background-color: #373a41;
-}
+  & .pf-v6-c-nav__link:focus {
+    background-color: #373a41;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-nav__link:active {
-  background-color: transparent;
-}
+  & .pf-v6-c-nav__link:active {
+    background-color: transparent;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-toolbar {
-  --pf-v6-c-toolbar--BackgroundColor: #fff;
-}
+  & .pf-v6-c-toolbar {
+    --pf-v6-c-toolbar--BackgroundColor: #fff;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-button.pf-m-control:not(:disabled) {
-  background-color: #12a66f;
-  color: #fff;
-}
+  & .pf-v6-c-button.pf-m-control:disabled {
+    background-color: #12a66f;
+    color: var(--pf-t--color--gray--20);
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-button.pf-m-control:not(:disabled):hover {
-  background-color: #0e8c5d;
-}
+  & .pf-v6-c-button.pf-m-control:disabled .pf-v6-svg {
+    color: var(--pf-t--color--gray--20);
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-button.pf-m-control:not(:disabled) .pf-v6-svg {
-  color: #fff;
-}
+  & .pf-v6-c-button.pf-m-control:disabled .pf-v6-c-button__icon {
+    color: var(--pf-t--color--gray--20);
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-table thead th {
-  background-color: var(--pf-t--color--gray--20) !important;
-}
+  & .pf-v6-c-button.pf-m-control:not(:disabled) {
+    background-color: #12a66f;
+    color: #fff;
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-pagination.pf-m-bottom {
-  background-color: #fff;
-}
+  & .pf-v6-c-button.pf-m-control:not(:disabled):hover {
+    background-color: #0e8c5d;
+  }
 
-.pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled {
-  --pf-v6-c-button--disabled--BackgroundColor: transparent;
-  --pf-v6-c-button--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-  --pf-v6-c-button--m-plain--disabled--Color: var(--pf-t--global--text--color--on-disabled);
-}
+  & .pf-v6-c-button.pf-m-control:not(:disabled) .pf-v6-svg {
+    color: #fff;
+  }
 
-.pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled .pf-v6-svg {
-  color: var(--pf-t--color--gray--40);
-}
+  & .pf-v6-c-button.pf-m-control:not(:disabled) .pf-v6-c-button__icon {
+    color: #fff;
+  }
 
-#job_output-toolbar {
-  border-top: 1px solid var(--pf-t--color--gray--20);
-  border-bottom: 1px solid var(--pf-t--color--gray--20);
-}
+  & .pf-v6-c-table thead th {
+    background-color: #fff;
+    border-bottom: 1px solid var(--pf-v6-c-table__tr--BorderBlockEndColor);
+  }
 
-.ascender-output-wrapper {
-  border-top: 1px solid var(--pf-t--color--gray--20);
-  border-bottom: 1px solid var(--pf-t--color--gray--20);
-}
+  & .pf-v6-c-pagination.pf-m-bottom {
+    background-color: #fff;
+  }
 
-html:not(.pf-v6-theme-dark) .ascender-output-scroll {
-  background-image: linear-gradient(to right, #e8e8e8 85px, transparent 85px);
-}
+  & .pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled {
+    --pf-v6-c-button--disabled--BackgroundColor: transparent;
+    --pf-v6-c-button--disabled--Color: var(--pf-t--global--text--color--on-disabled);
+    --pf-v6-c-button--m-plain--disabled--Color: var(--pf-t--global--text--color--on-disabled);
+  }
 
-/* Secondary button — outline style (green border + text, transparent bg) */
-html:not(.pf-v6-theme-dark) .pf-v6-c-button.pf-m-secondary:not(:disabled) {
-  background-color: transparent;
-  border-color: #12a66f;
-  --pf-v6-c-button--Color: #12a66f;
-  --pf-v6-c-button--hover--Color: #fff;
-  --pf-v6-c-button--BorderColor: #12a66f;
-  --pf-v6-c-button--hover--BorderColor: #0e8c5d;
-  --pf-v6-c-button--m-clicked--BorderColor: #0e8c5d;
-  color: #12a66f;
-}
+  & .pf-v6-c-pagination__nav-control .pf-v6-c-button:disabled .pf-v6-svg {
+    color: var(--pf-t--color--gray--40);
+  }
 
-html:not(.pf-v6-theme-dark) .pf-v6-c-button.pf-m-secondary:not(:disabled):hover {
-  background-color: #0e8c5d;
-  border-color: #0e8c5d;
-  color: #fff;
+  & #job_output-toolbar {
+    border-top: 1px solid var(--pf-t--color--gray--20);
+    border-bottom: 1px solid var(--pf-t--color--gray--20);
+  }
+
+  & .ascender-output-wrapper {
+    border-top: 1px solid var(--pf-t--color--gray--20);
+    border-bottom: 1px solid var(--pf-t--color--gray--20);
+  }
+
+  & .ascender-output-scroll {
+    background-image: linear-gradient(to right, #e8e8e8 85px, transparent 85px);
+  }
+
+  & .pf-v6-c-button {
+    --pf-v6-c-button--m-primary--BackgroundColor: #12a66f;
+    --pf-v6-c-button--m-primary--Color: #fff;
+    --pf-v6-c-button--m-primary--hover--BackgroundColor: #0e8c5d;
+    --pf-v6-c-button--m-primary--focus--Color: var(--pf-t--global--text--color--on-disabled);
+    --pf-v6-c-button--m-link--Color: #12a66f;
+    --pf-v6-c-button--disabled--BackgroundColor: #e8e8e8;
+    --pf-v6-c-button--disabled--Color: #12a66f;
+    --pf-v6-c-button--disabled--BorderColor: #12a66f;
+    --pf-v6-c-button--disabled--BorderWidth: 1px;
+    font-weight: 600;
+  }
+
+  /* Secondary button — outline style (green border + text, transparent bg) */
+  & .pf-v6-c-button.pf-m-secondary:not(:disabled) {
+    background-color: transparent;
+    border-color: #12a66f;
+    --pf-v6-global--Color--200: #12a66f;
+    --pf-v6-c-button--Color: #12a66f;
+    --pf-v6-c-button--hover--Color: #fff;
+    --pf-v6-c-button--BorderColor: #12a66f;
+    --pf-v6-c-button--hover--BorderColor: #0e8c5d;
+    --pf-v6-c-button--m-clicked--BorderColor: #0e8c5d;
+    color: #12a66f;
+  }
+
+  & .pf-v6-c-button.pf-m-secondary:not(:disabled):hover {
+    border-color: #0e8c5d;
+  }
+
+  & .pf-v6-c-button.pf-m-secondary:disabled {
+    border: 1px solid #12a66f;
+  }
+
+  & .pf-v6-c-button.pf-m-link {
+    --pf-v6-c-label--BackgroundColor: #c7c7c7;
+    --pf-v6-c-label--Color: #12a66f;
+    --pf-v6-c-label__icon--Color: #12a66f;
+    color: #12a66f;
+    border: 1px solid #12a66f;
+    margin-left: 0px;
+  }
+
+  & .ascender-status-label.pf-v6-c-label.pf-m-green {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #fff;
+    --pf-v6-c-label__icon--Color: #fff;
+    font-weight: 600;
+  }
+
+  & .ascender-status-label.pf-v6-c-label.pf-m-red {
+    --pf-v6-c-label--BackgroundColor: #f04438;
+    --pf-v6-c-label--Color: #fff;
+    --pf-v6-c-label__icon--Color: #fff;
+    font-weight: 600;
+  }
+
+  & .ascender-status-label.pf-v6-c-label.pf-m-orange {
+    --pf-v6-c-label--BackgroundColor: #f79009;
+    --pf-v6-c-label--Color: #fff;
+    --pf-v6-c-label__icon--Color: #fff;
+    font-weight: 600;
+  }
+
+  /* We don't want any blue, so just change it to our branded green */
+  & .ascender-status-label.pf-v6-c-label.pf-m-blue {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #fff;
+    --pf-v6-c-label__icon--Color: #fff;
+    font-weight: 600;
+  }
+
+  & .pf-v6-c-label.pf-m-green {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #fff;
+    --pf-v6-c-label__icon--Color: #fff;
+  }
+
+  & .pf-v6-c-label.pf-m-red {
+    --pf-v6-c-label--BackgroundColor: #f04438;
+    --pf-v6-c-label--Color: #fff;
+    --pf-v6-c-label__icon--Color: #fff;
+  }
+
+  & .pf-v6-c-label.pf-m-blue {
+    --pf-v6-c-label--BackgroundColor: #12a66f;
+    --pf-v6-c-label--Color: #fff;
+    --pf-v6-c-label__icon--Color: #fff;
+    font-weight: 600;
+  }
+
+  & .pf-v6-c-button.pf-m-link.pf-m-inline {
+    --pf-v6-c-button--TextDecorationStyle: unset;
+    --pf-v6-c-button--TextDecorationLine: none;
+    --pf-v6-c-button--m-link--m-inline--hover--TextDecorationLine: none;
+    padding: 0px 4px 0px 4px;
+    min-height: auto !important;
+    height: auto !important;
+  }
+
+  & .pf-v6-c-button.pf-m-link.pf-m-inline:hover {
+    --pf-v6-c-button--TextDecorationStyle: unset;
+    --pf-v6-c-button--TextDecorationLine: none;
+  }
+
+  [class*="WorkflowActionTooltip__TooltipActions"] {
+    background-color: #fff;
+  }
 }

--- a/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.js
@@ -32,7 +32,7 @@ const HostStatusBar = ({ counts = {} }) => {
   const noData = Object.keys(counts).length === 0;
   const hostStatus = {
     ok: {
-      color: '#4CB140',
+      color: '#12a66f',
       label: t`OK`,
     },
     skipped: {
@@ -44,7 +44,7 @@ const HostStatusBar = ({ counts = {} }) => {
       label: t`Changed`,
     },
     failures: {
-      color: '#C9190B',
+      color: '#f04438',
       label: t`Failed`,
     },
     dark: {


### PR DESCRIPTION
Start tweaking lightmode to make it more consistent (I may end up going back to blue link text for it, because the green on white isn't the easiest to read).

Also start restructuring the files, so that we don't have to append `html:not(.pf-v6-theme-dark)` and `html.pf-v6-theme-dark` in front of everything.