### PR TITLE
Fix multiple usability issues after PF6 upgrade

### DIFF
--- a/awx/ui/src/components/Lookup/ExecutionEnvironmentLookup.js
+++ b/awx/ui/src/components/Lookup/ExecutionEnvironmentLookup.js
@@ -29,7 +29,7 @@ function ExecutionEnvironmentLookup({
   globallyAvailable,
   helperTextInvalid,
   isDisabled,
-  isValid,
+  isValid = true,
   onBlur,
   onChange,
   organizationId = null,

--- a/awx/ui/src/components/Schedule/shared/FrequencyDetailSubform.js
+++ b/awx/ui/src/components/Schedule/shared/FrequencyDetailSubform.js
@@ -28,7 +28,7 @@ const RunOnRadio = styled(Radio)`
     width: 100%;
   }
 
-  :not(:last-of-type) {
+  &:not(:last-of-type) {
     margin-bottom: 10px;
   }
 
@@ -43,7 +43,7 @@ const RunEveryLabel = styled.p`
 `;
 
 const Checkbox = styled(_Checkbox)`
-  :not(:last-of-type) {
+  &:not(:last-of-type) {
     margin-right: 10px;
   }
 `;

--- a/awx/ui/src/darkmode.css
+++ b/awx/ui/src/darkmode.css
@@ -870,6 +870,6 @@ html.pf-v6-theme-dark {
   }
 
   & .pf-v6-c-wizard__nav-link {
-    --pf-v6-c-wizard__nav-link--Color: #13161b;
+    --pf-v6-c-wizard__nav-link--Color: var(--pf-t--global--text--color--subtle);
   }
 }

--- a/awx/ui/src/screens/Credential/shared/CredentialForm.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialForm.js
@@ -33,12 +33,19 @@ const StyledSelect = styled(Select)`
   ul {
     max-width: 495px;
   }
-`;
 
-const StyledSelectOption = styled(SelectOption)`
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  /*
+   * Truncate long credential type names, but scope the styles to the menu
+   * item's text span only. PatternFly applies the SelectOption className to
+   * both the flex <li> and the inner button, and setting overflow: hidden on
+   * the flex <li> (align-items: baseline) collapses its height, clipping the
+   * option so the text isn't visible.
+   */
+  .pf-v6-c-menu__item-text {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
 `;
 
 function CredentialFormFields({ initialTypeId, credentialTypes }) {
@@ -200,13 +207,13 @@ function CredentialFormFields({ initialTypeId, credentialTypes }) {
     >
       <SelectList style={{ maxHeight: '300px', overflowY: 'auto' }}>
         {filteredOptions.map((credType) => (
-          <StyledSelectOption
+          <SelectOption
             key={credType.value}
             value={credType.value}
             data-cy={`${credType.key}-credential-type-select-option`}
           >
             {credType.label}
-          </StyledSelectOption>
+          </SelectOption>
         ))}
         {filteredOptions.length === 0 && (
           <SelectOption isDisabled>

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/BecomeMethodField.js
@@ -79,6 +79,7 @@ function BecomeMethodField({ fieldOptions, isRequired = false }) {
           <MenuToggle
             ref={toggleRef}
             variant="typeahead"
+            isFullWidth
             onClick={() => setIsOpen(!isOpen)}
             isExpanded={isOpen}
           >

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.js
@@ -109,7 +109,7 @@ function CredentialInput({
       return (
         <InputGroup>
           {RevertReplaceButton}
-          <InputGroupItem><FileUpload
+          <InputGroupItem isFill><FileUpload
             {...fileUploadProps}
             {...rest}
           /></InputGroupItem>

--- a/awx/ui/src/screens/NotificationTemplate/shared/TypeInputsSubForm.js
+++ b/awx/ui/src/screens/NotificationTemplate/shared/TypeInputsSubForm.js
@@ -89,7 +89,7 @@ function SecretPasswordField({
       }
     >
       <InputGroup>
-        <InputGroupItem><PasswordInput
+        <InputGroupItem isFill><PasswordInput
           id={id}
           name={name}
           validate={validate}

--- a/awx/ui/src/screens/Setting/UI/UIDetail/UIDetail.js
+++ b/awx/ui/src/screens/Setting/UI/UIDetail/UIDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import { useLingui } from '@lingui/react/macro';
 import { Button } from '@patternfly/react-core';
 import { CaretLeftIcon } from '@patternfly/react-icons';
@@ -19,13 +19,18 @@ function UIDetail() {
   const { t } = useLingui();
   const { me } = useConfig();
   const { GET: options } = useSettings();
-  const navigate = useNavigate();
   const { state: locationState } = useLocation();
   const hardReload = locationState?.hardReload;
 
-  if (hardReload) {
-    navigate(0);
-  }
+  useEffect(() => {
+    if (hardReload) {
+      // Clear the hardReload flag from history state before reloading so that
+      // the post-reload render doesn't see it again and trigger the reload
+      // over and over (infinite loop).
+      window.history.replaceState(null, '');
+      window.location.reload();
+    }
+  }, [hardReload]);
 
   const {
     isLoading,

--- a/awx/ui/src/screens/Setting/shared/SharedFields.js
+++ b/awx/ui/src/screens/Setting/shared/SharedFields.js
@@ -227,7 +227,7 @@ const EncryptedField = ({ name, config, isRequired = false }) => {
       t={t}
     >
       <InputGroup>
-        <InputGroupItem><PasswordInput
+        <InputGroupItem isFill><PasswordInput
           id={name}
           name={name}
           label={config.label}

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeNextButton.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeNextButton.js
@@ -14,7 +14,11 @@ function NodeNextButton({
       return;
     }
     onNext();
-  }, [onNext, triggerNext]);
+    // `onNext` (the wizard's goToNextStep) gets a new identity on every render,
+    // so it must not be a dependency here — otherwise the effect re-fires on the
+    // next render and advances an extra step, triggering an unintended save.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [triggerNext]);
 
   return (
     <Button

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.js
@@ -431,7 +431,7 @@ function Visualizer({ template }) {
                 inventory: node.promptValues?.inventory?.id || null,
                 unified_job_template: node.fullUnifiedJobTemplate.id,
                 all_parents_must_converge: node.all_parents_must_converge,
-                ...(node.identifier && { identifier: node.identifier }),
+                identifier: node.identifier || undefined,
               }).then(({ data }) => {
                 node.originalNodeObject = data;
                 originalLinkMap[node.id] = {


### PR DESCRIPTION
These include

- Fix credential type dropdown options being clipped by scoping the truncation styles to the menu item text instead of the flex `<li>` (which collapsed under overflow: hidden). 
- Make the Machine credential's "Privilege Escalation Method" typeahead toggle full width by adding isFullWidth to its MenuToggle. 
- Make the Machine credential's "SSH Private Key" and "Signed SSH Certificate" file uploads full width by adding isFill to their InputGroupItem. 
- Fix workflow visualizer save error by omitting the blank identifier from the create-node payload so the API generates a UUID. 
- Fix add-node wizard skipping the "Node type" step and creating a DELETED node by removing the unstable onNext from the Next-button effect dependencies. 
- Fix wizard step nav labels being invisible in dark mode by pointing --pf-v6-c-wizard__nav-link--Color at the PatternFly subtle-text token instead of a hardcoded dark color. 
- Make the E-mail/IRC notification "Password" field full width by adding isFill to its InputGroupItem. 
- Fix schedule frequency field misalignment and missing checkbox spacing by adding the & self-reference to the RunOnRadio and Checkbox styled-component selectors. 
- Fix the infinite reload loop when saving UI settings by moving the hard reload into an effect and clearing the persistent hardReload history state. 
- Remove the spurious alert icon on the "Global default execution environment" settings field by defaulting isValid to true in ExecutionEnvironmentLookup. 
- Make the "OIDC Secret" (and other SSO/settings EncryptedField) secret input full width by adding isFill to its InputGroupItem.
