### PR TITLE
Fix: use singular form ANSIBLE_COLLECTIONS_PATH

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -193,7 +193,7 @@
     # additional_galaxy_env contains environment variables are used for installing roles and collections and will take precedence over items in galaxy_task_env
     additional_galaxy_env:
       # These paths control where ansible-galaxy installs collections and roles on top the filesystem
-      ANSIBLE_COLLECTIONS_PATHS: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_collections"
+      ANSIBLE_COLLECTIONS_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_collections"
       ANSIBLE_ROLES_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_roles"
       # Put the local tmp directory in same volume as collection destination
       # otherwise, files cannot be moved accross volumes and will cause error


### PR DESCRIPTION
## Summary

`ANSIBLE_COLLECTIONS_PATHS` was deprecated in ansible-core 2.10 and removed in 2.19.

Only the singular `ANSIBLE_COLLECTIONS_PATH` works on newer versions.

The plural form is silently ignored on ansible-core >= 2.19, causing `ansible-galaxy` to install collections into `~/.ansible/collections` instead of the project cache directory. As a result, jobs can't find the collections.

This fix changes the var in `project_update.yml` to the singular form so collections are installed into the correct cache path.

Note: `awx/main/tasks/jobs.py` already uses `ANSIBLE_COLLECTIONS_PATH` and only sets the plural form for the `ENABLE_ANSIBLE_29` backward-compat path.

Fixes #567

## ISSUE TYPE

- Bugfix Pull Request

## COMPONENT NAME

- API

## ADDITIONAL INFORMATION

Backport of upstream fix https://github.com/ansible/awx/pull/15841