### PR TITLE
Skip related endpoints without NATURAL_KEY during awxkit export

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -124,6 +124,12 @@ class ApiV2(base.Base):
             if rel_endpoint.__item_class__.__name__ == 'WorkflowApprovalTemplate':
                 continue
 
+            # Skip related objects (e.g. write_only fields like webhook_key)
+            # that have no NATURAL_KEY defined.
+            if not getattr(rel_endpoint, 'NATURAL_KEY', None):
+                log.warning("Unable to construct a natural key for %r of object %s, skipping.", key, _page.endpoint)
+                continue
+
             rel_natural_key = rel_endpoint.get_natural_key(self._cache)
             if rel_natural_key is None:
                 log.error("Unable to construct a natural key for foreign key %r of object %s.", key, _page.endpoint)


### PR DESCRIPTION
## Summary

When exporting resources (e.g. job_templates), the awxkit export code iterates over POST fields from the OPTIONS response. For write_only fields like `webhook_key` (added to projects in #563, and already present on job templates and workflow job templates), the key appears in both `post_fields` and `_page.related`, but the resolved endpoint (e.g. `/api/v2/job_templates/N/webhook_key/`) is served by a view whose page class (`Base`) has no `NATURAL_KEY` defined. This caused the awxkit export to log an ERROR, set `_has_error=True`, and return `None` for every affected resource, producing empty asset lists (for example zero job templates in an awxkit collection export).

## Fix

When the resolved related endpoint has no `NATURAL_KEY` attribute, log a warning and skip the field instead of erroring out and dropping the whole resource. A missing `NATURAL_KEY` means the page class does not participate in natural key resolution at all, which is a different situation from a failed natural key construction, and it should not be fatal.

This fixes the `test_export_simple` failure in ctrliq/ascender-collection#165, where every JobTemplate was silently dropped from the awxkit export output.

## Verification

I ran the ascender-collection unit test suite against this branch (ascender_devel image, `pytest tests/unit/`): 149 passed, including `test_export_simple`.
