### PR TITLE
Remove user=root from the dev supervisor.conf so supervisord can start

### DIFF
--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -2,7 +2,6 @@
 umask = 022
 minfds = 4096
 nodaemon=true
-user=root
 
 [program:awx-dispatcher]
 command = awx-manage run_dispatcher


### PR DESCRIPTION
## Summary

Commit c8eeb60907 (#559, by @cigamit) added `user=root` to the `[supervisord]` section of `tools/docker-compose/supervisor.conf`. The docker-compose development container runs as the invoking user (`user: "1000"` in the generated compose file), not root, so supervisord refuses to start:

```
Error: Can't drop privilege as nonroot user
For help, use /usr/local/bin/supervisord -h
make: *** [Makefile:191: supervisor] Error 2
```

The awx container exits right after bootstrap and `make docker-compose` is broken on current main.

## Fix

Remove the `user=root` line. supervisord then runs as whatever user launched it, which is what the development container expects and matches the behavior before #559.

## Verification

With this line removed, `docker compose up` on the generated sources brings the environment up cleanly: supervisord starts all services, `/api/v2/ping/` returns 200 and the UI is reachable on port 8043.
