### PR TITLE
Add the check_instance_ready management command for k8s readiness probes

### DIFF
--- a/awx/main/management/commands/check_instance_ready.py
+++ b/awx/main/management/commands/check_instance_ready.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand, CommandError
+from awx.main.models.ha import Instance
+
+
+class Command(BaseCommand):
+    help = 'Check if the task manager instance is ready throw error if not ready, can be use as readiness probe for k8s.'
+
+    def handle(self, *args, **options):
+        if Instance.objects.me().node_state != Instance.States.READY:
+            raise CommandError('Instance is not ready')  # so that return code is not 0
+
+        return


### PR DESCRIPTION
## Summary

Fixes #571.

The task pod readiness probe runs `awx-manage check_instance_ready` when `task_readiness_period` is greater than 0, but `awx/main/management/commands/check_instance_ready.py` is missing from this repo, so the probe always errors and task pods never become ready.

This adds the command exactly as it exists in upstream AWX (the file is identical in 24.6.1 and devel): it exits non-zero unless the local instance `node_state` is `ready`, so it can be used directly as a k8s readiness probe.

## Verification

Everything the command depends on already exists here (`Instance.objects.me()` and `Instance.States.READY`). I ran it against a docker-compose development instance built from main:

```
$ awx-manage check_instance_ready
$ echo $?
0
```

with the instance registered and in the `ready` state.
