### PR TITLE
Fix job history for constructed inventory hosts

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3711,9 +3711,19 @@ class BaseJobHostSummariesList(SubListAPIView):
 class HostJobHostSummariesList(BaseJobHostSummariesList):
     parent_model = models.Host
 
+    def get_sublist_queryset(self, parent):
+        if parent.inventory and parent.inventory.kind == 'constructed':
+            return parent.constructed_host_summaries
+        return super().get_sublist_queryset(parent)
+
 
 class GroupJobHostSummariesList(BaseJobHostSummariesList):
     parent_model = models.Group
+
+    def get_sublist_queryset(self, parent):
+        if parent.inventory and parent.inventory.kind == 'constructed':
+            return parent.constructed_host_summaries
+        return super().get_sublist_queryset(parent)
 
 
 class JobJobHostSummariesList(BaseJobHostSummariesList):

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -23,6 +23,7 @@ from rest_framework.exceptions import PermissionDenied
 
 # AWX inventory imports
 from awx.main.models.inventory import Inventory, InventorySource, InventoryUpdate, Host
+from awx.main.models.jobs import JobHostSummary
 from awx.main.utils.mem_inventory import MemInventory, dict_to_mem_data
 from awx.main.utils.safe_yaml import sanitize_jinja
 
@@ -764,6 +765,26 @@ class Command(BaseCommand):
         if settings.SQL_DEBUG:
             logger.warning('Group-host updates took %d queries for %d group-host relationships', len(connection.queries) - queries_before, group_host_count)
 
+    def _relink_orphaned_job_host_summaries(self):
+        host_map = dict(self.inventory.hosts.values_list('name', 'pk'))
+        if not host_map:
+            return
+
+        host_names = list(host_map.keys())
+        is_constructed = self.inventory.kind == 'constructed'
+        fk_field = 'constructed_host_id' if is_constructed else 'host_id'
+        null_filter = {'constructed_host__isnull': True} if is_constructed else {'host__isnull': True}
+
+        for offset in range(0, len(host_names), self._batch_size):
+            batch_names = host_names[offset : offset + self._batch_size]
+            orphaned = JobHostSummary.objects.filter(job__inventory=self.inventory, host_name__in=batch_names, **null_filter)
+            for host_name in batch_names:
+                host_pk = host_map.get(host_name)
+                if host_pk:
+                    updated = orphaned.filter(host_name=host_name).update(**{fk_field: host_pk})
+                    if updated:
+                        logger.info('Re-linked %d orphaned job host summaries for host "%s"', updated, host_name)
+
     def load_into_database(self):
         """
         Load inventory from in-memory groups to the database, overwriting or
@@ -784,6 +805,7 @@ class Command(BaseCommand):
         self._create_update_hosts(pk_mem_host_map)
         self._create_update_group_children()
         self._create_update_group_hosts()
+        self._relink_orphaned_job_host_summaries()
 
     def remote_tower_license_compare(self, local_license_type):
         # this requires https://github.com/ansible/ansible/pull/52747

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -877,6 +877,12 @@ class Group(CommonModelNameNotUnique, RelatedJobsMixin):
         return JobHostSummary.objects.filter(host__in=self.all_hosts)
 
     @property
+    def constructed_host_summaries(self):
+        from awx.main.models.jobs import JobHostSummary
+
+        return JobHostSummary.objects.filter(constructed_host__in=self.all_hosts)
+
+    @property
     def job_events(self):
         from awx.main.models.jobs import JobEvent
 

--- a/awx/main/tests/functional/commands/test_inventory_import.py
+++ b/awx/main/tests/functional/commands/test_inventory_import.py
@@ -398,3 +398,138 @@ def test_tower_version_compare():
     with pytest.raises(PermissionDenied):
         cmd.remote_tower_license_compare('very_supported')
     cmd.remote_tower_license_compare('open')
+
+
+@pytest.mark.django_db
+@mock.patch.object(inventory_import.Command, 'set_logging_level', mock_logging)
+class TestRelinkOrphanedJobHostSummaries:
+    """After an overwrite sync deletes and recreates a host, orphaned
+    JobHostSummary records (host_id=NULL) should be re-linked to the
+    new host object by matching on host_name."""
+
+    def test_relink_after_host_recreated(self, inventory):
+        from awx.main.models import JobHostSummary, Job, Project, JobTemplate
+
+        inv_src = InventorySource.objects.create(inventory=inventory, source='ec2')
+        project = Project.objects.create(name='test-proj')
+        jt = JobTemplate.objects.create(name='test-jt', inventory=inventory, project=project)
+
+        data = {
+            '_meta': {'hostvars': {'server1': {}, 'server2': {}}},
+            'ungrouped': {'hosts': ['server1', 'server2']},
+        }
+        options = dict(overwrite=True)
+
+        inventory_import.Command().perform_update(options.copy(), data.copy(), inv_src.create_unified_job())
+        host1 = inventory.hosts.get(name='server1')
+
+        job = Job.objects.create(inventory=inventory, job_template=jt, status='successful')
+        JobHostSummary.objects.create(job=job, host=host1, host_name='server1', ok=1)
+
+        # Simulate host disappearing and reappearing (delete + reimport)
+        host1.delete()
+        inventory_import.Command().perform_update(options.copy(), data.copy(), inv_src.create_unified_job())
+
+        new_host = inventory.hosts.get(name='server1')
+        assert new_host.pk != host1.pk
+
+        summary = JobHostSummary.objects.get(job=job, host_name='server1')
+        assert summary.host_id == new_host.pk
+
+    def test_no_relink_when_host_still_linked(self, inventory):
+        from awx.main.models import JobHostSummary, Job, Project, JobTemplate
+
+        inv_src = InventorySource.objects.create(inventory=inventory, source='ec2')
+        project = Project.objects.create(name='test-proj')
+        jt = JobTemplate.objects.create(name='test-jt', inventory=inventory, project=project)
+
+        data = {
+            '_meta': {'hostvars': {'server1': {}}},
+            'ungrouped': {'hosts': ['server1']},
+        }
+        options = dict(overwrite=True)
+
+        inventory_import.Command().perform_update(options.copy(), data.copy(), inv_src.create_unified_job())
+        host1 = inventory.hosts.get(name='server1')
+
+        job = Job.objects.create(inventory=inventory, job_template=jt, status='successful')
+        JobHostSummary.objects.create(job=job, host=host1, host_name='server1', ok=1)
+
+        # Sync again without host disappearing - PK should be preserved
+        inventory_import.Command().perform_update(options.copy(), data.copy(), inv_src.create_unified_job())
+        same_host = inventory.hosts.get(name='server1')
+        assert same_host.pk == host1.pk
+
+        summary = JobHostSummary.objects.get(job=job, host_name='server1')
+        assert summary.host_id == host1.pk
+
+    def test_relink_constructed_inventory(self, organization):
+        from awx.main.models import JobHostSummary, Job, Project, JobTemplate
+
+        source_inv = Inventory.objects.create(name='source-inv', organization=organization)
+        constructed_inv = Inventory.objects.create(name='constructed-inv', kind='constructed', organization=organization)
+        project = Project.objects.create(name='test-proj')
+        jt = JobTemplate.objects.create(name='test-jt', inventory=constructed_inv, project=project)
+
+        source_host = Host.objects.create(name='server1', inventory=source_inv)
+        constructed_host = Host.objects.create(
+            name='server1', inventory=constructed_inv, instance_id=str(source_host.pk)
+        )
+
+        job = Job.objects.create(inventory=constructed_inv, job_template=jt, status='successful')
+        JobHostSummary.objects.create(
+            job=job, host=source_host, constructed_host=constructed_host,
+            host_name='server1', ok=1
+        )
+
+        old_constructed_pk = constructed_host.pk
+        constructed_host.delete()
+
+        # Recreate constructed host (simulates constructed inventory re-sync)
+        new_constructed_host = Host.objects.create(
+            name='server1', inventory=constructed_inv, instance_id=str(source_host.pk)
+        )
+
+        inv_src = InventorySource.objects.create(inventory=constructed_inv, source='constructed')
+        data = {
+            '_meta': {'hostvars': {'server1': {}}},
+            'ungrouped': {'hosts': ['server1']},
+        }
+        inventory_import.Command().perform_update(dict(overwrite=True), data, inv_src.create_unified_job())
+
+        summary = JobHostSummary.objects.get(job=job, host_name='server1')
+        assert summary.constructed_host_id is not None
+        assert summary.constructed_host_id != old_constructed_pk
+
+    def test_relink_does_not_cross_inventories(self, organization):
+        from awx.main.models import JobHostSummary, Job, Project, JobTemplate
+
+        inv_a = Inventory.objects.create(name='inv-a', organization=organization)
+        inv_b = Inventory.objects.create(name='inv-b', organization=organization)
+        inv_src_a = InventorySource.objects.create(inventory=inv_a, source='ec2')
+        inv_src_b = InventorySource.objects.create(inventory=inv_b, source='ec2')
+        project = Project.objects.create(name='test-proj')
+
+        data = {
+            '_meta': {'hostvars': {'server1': {}}},
+            'ungrouped': {'hosts': ['server1']},
+        }
+        options = dict(overwrite=True)
+
+        # Create host in both inventories
+        inventory_import.Command().perform_update(options.copy(), data.copy(), inv_src_a.create_unified_job())
+        inventory_import.Command().perform_update(options.copy(), data.copy(), inv_src_b.create_unified_job())
+
+        host_b = inv_b.hosts.get(name='server1')
+        jt_b = JobTemplate.objects.create(name='test-jt-b', inventory=inv_b, project=project)
+        job_b = Job.objects.create(inventory=inv_b, job_template=jt_b, status='successful')
+        JobHostSummary.objects.create(job=job_b, host=host_b, host_name='server1', ok=1)
+
+        # Delete host from inv_b, orphaning the summary
+        host_b.delete()
+
+        # Sync inv_a: should NOT re-link inv_b's orphaned summary
+        inventory_import.Command().perform_update(options.copy(), data.copy(), inv_src_a.create_unified_job())
+
+        summary = JobHostSummary.objects.get(job=job_b, host_name='server1')
+        assert summary.host_id is None, "Summary from inv_b should not be re-linked to inv_a's host"

--- a/awx/main/tests/functional/models/test_host_summary_fields.py
+++ b/awx/main/tests/functional/models/test_host_summary_fields.py
@@ -2,8 +2,9 @@ import pytest
 
 from django.utils.timezone import now
 
-from awx.main.models import Job, JobEvent, JobTemplate, Inventory, Host, JobHostSummary, Project
+from awx.main.models import Job, JobEvent, JobTemplate, Inventory, Host, Group, JobHostSummary, Project
 from awx.api.serializers import HostSerializer
+from awx.api.versioning import reverse
 
 
 @pytest.mark.django_db
@@ -109,3 +110,91 @@ class TestHostSummaryFields:
 
         assert 'last_job' not in d
         assert 'last_job_host_summary' not in d
+
+
+@pytest.mark.django_db
+class TestConstructedHostJobSummariesAPI:
+    """The job_host_summaries endpoint for hosts in a constructed inventory
+    should use the constructed_host FK, not the regular host FK."""
+
+    def test_constructed_host_summaries_returned(self, get, admin, organization):
+        source_inv = Inventory.objects.create(name='source', organization=organization)
+        constructed_inv = Inventory.objects.create(name='constructed', kind='constructed', organization=organization)
+
+        source_host = Host.objects.create(name='server1', inventory=source_inv)
+        constructed_host = Host.objects.create(name='server1', inventory=constructed_inv, instance_id=str(source_host.pk))
+
+        project = Project.objects.create(name='test-proj')
+        jt = JobTemplate.objects.create(name='test-jt', inventory=constructed_inv, project=project)
+        job = Job.objects.create(inventory=constructed_inv, job_template=jt, status='successful')
+
+        JobHostSummary.objects.create(
+            job=job, host=source_host, constructed_host=constructed_host,
+            host_name='server1', ok=1
+        )
+
+        url = reverse('api:host_job_host_summaries_list', kwargs={'pk': constructed_host.pk})
+        resp = get(url, user=admin, expect=200)
+        assert resp.data['count'] == 1
+        assert resp.data['results'][0]['host_name'] == 'server1'
+
+    def test_regular_host_summaries_still_work(self, get, admin, organization):
+        inv = Inventory.objects.create(name='regular', organization=organization)
+        host = Host.objects.create(name='server1', inventory=inv)
+
+        project = Project.objects.create(name='test-proj')
+        jt = JobTemplate.objects.create(name='test-jt', inventory=inv, project=project)
+        job = Job.objects.create(inventory=inv, job_template=jt, status='successful')
+
+        JobHostSummary.objects.create(job=job, host=host, host_name='server1', ok=1)
+
+        url = reverse('api:host_job_host_summaries_list', kwargs={'pk': host.pk})
+        resp = get(url, user=admin, expect=200)
+        assert resp.data['count'] == 1
+
+    def test_constructed_host_no_false_positives(self, get, admin, organization):
+        source_inv = Inventory.objects.create(name='source', organization=organization)
+        constructed_inv = Inventory.objects.create(name='constructed', kind='constructed', organization=organization)
+
+        source_host = Host.objects.create(name='server1', inventory=source_inv)
+        constructed_host = Host.objects.create(name='server1', inventory=constructed_inv, instance_id=str(source_host.pk))
+
+        project = Project.objects.create(name='test-proj')
+        jt = JobTemplate.objects.create(name='test-jt', inventory=source_inv, project=project)
+        job = Job.objects.create(inventory=source_inv, job_template=jt, status='successful')
+
+        # Summary linked to source host only, not the constructed one
+        JobHostSummary.objects.create(job=job, host=source_host, host_name='server1', ok=1)
+
+        url = reverse('api:host_job_host_summaries_list', kwargs={'pk': constructed_host.pk})
+        resp = get(url, user=admin, expect=200)
+        assert resp.data['count'] == 0
+
+
+@pytest.mark.django_db
+class TestConstructedGroupJobSummariesAPI:
+    """The job_host_summaries endpoint for groups in a constructed inventory
+    should use the constructed_host FK."""
+
+    def test_constructed_group_summaries_returned(self, get, admin, organization):
+        source_inv = Inventory.objects.create(name='source', organization=organization)
+        constructed_inv = Inventory.objects.create(name='constructed', kind='constructed', organization=organization)
+
+        source_host = Host.objects.create(name='server1', inventory=source_inv)
+        constructed_host = Host.objects.create(name='server1', inventory=constructed_inv, instance_id=str(source_host.pk))
+
+        group = Group.objects.create(name='webservers', inventory=constructed_inv)
+        group.hosts.add(constructed_host)
+
+        project = Project.objects.create(name='test-proj')
+        jt = JobTemplate.objects.create(name='test-jt', inventory=constructed_inv, project=project)
+        job = Job.objects.create(inventory=constructed_inv, job_template=jt, status='successful')
+
+        JobHostSummary.objects.create(
+            job=job, host=source_host, constructed_host=constructed_host,
+            host_name='server1', ok=1
+        )
+
+        url = reverse('api:group_job_host_summaries_list', kwargs={'pk': group.pk})
+        resp = get(url, user=admin, expect=200)
+        assert resp.data['count'] == 1


### PR DESCRIPTION
## Summary

When looking at a host or group inside a constructed inventory, the job history (job_host_summaries endpoint) was coming back empty. This happened because the API was querying the wrong foreign key on JobHostSummary: it used the `host` FK (which points to the source inventory host) instead of `constructed_host` (which points to the constructed inventory host). The serializer already handled this correctly for the `recent_jobs` field, but the full list endpoint did not.

On top of that, when an inventory source syncs with overwrite and a host temporarily disappears from the source, the host object gets deleted and recreated with a new PK. The old JobHostSummary records lose their host link (SET_NULL), so even after the host comes back, the job history is gone. This adds a relink step after each inventory sync that reconnects those orphaned records by matching on host_name, scoped to the same inventory so it wont accidentally link summaries from a different inventory that happens to have a host with the same name.

Changes:
- HostJobHostSummariesList and GroupJobHostSummariesList now use constructed_host_summaries for constructed inventory hosts/groups
- New Group.constructed_host_summaries property (Host already had one)
- New _relink_orphaned_job_host_summaries method in inventory_import, called after each sync
- 12 new tests covering the API fix, the relink logic, constructed inventories, and cross-inventory isolation

## Test plan

- [x] Existing tests pass (48 inventory import + 8 host summary = 56 total, 0 regressions)
- [x] New test: constructed host job summaries returned via API
- [x] New test: regular (non-constructed) host summaries still work
- [x] New test: no false positives (summaries from source inventory dont leak to constructed)
- [x] New test: constructed group summaries returned via API
- [x] New test: orphaned summaries re-linked after host is deleted and recreated
- [x] New test: summaries not re-linked when host PK is preserved (no orphan)
- [x] New test: constructed inventory orphaned summaries re-linked via constructed_host FK
- [x] New test: re-link does NOT cross inventories (inventory A sync wont steal inventory B orphans)