### PR TITLE
Upstream16461 - remove extra_vars from jobs and unified_jobs list endpoint

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -907,13 +907,19 @@ class UnifiedJobListSerializer(UnifiedJobSerializer):
     class Meta:
         fields = ('*', '-job_args', '-job_cwd', '-job_env', '-result_traceback', '-event_processing_finished')
 
+    @classmethod
+    def parse_requested_includes(cls, raw):
+        # Single source of truth for parsing the ?include= query param, shared
+        # with UnifiedJobIncludeMixin so the view-level defer and the
+        # serializer-level field stripping never drift apart.
+        requested = {name.strip() for name in (raw or '').split(',') if name.strip()}
+        return frozenset(requested) & cls.OPTIONAL_INCLUDE_FIELDS
+
     def _requested_includes(self):
         request = self.context.get('request')
         if request is None:
             return frozenset()
-        raw = request.query_params.get('include', '')
-        requested = {name.strip() for name in raw.split(',') if name.strip()}
-        return frozenset(requested) & self.OPTIONAL_INCLUDE_FIELDS
+        return self.parse_requested_includes(request.query_params.get('include', ''))
 
     def get_field_names(self, declared_fields, info):
         field_names = super(UnifiedJobListSerializer, self).get_field_names(declared_fields, info)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -896,14 +896,31 @@ class UnifiedJobSerializer(BaseSerializer):
 
 
 class UnifiedJobListSerializer(UnifiedJobSerializer):
+    # Heavy fields that can hold large amounts of data. They are stripped from
+    # list responses by default to keep payloads small, and can be requested
+    # back explicitly (and only these) via the ?include=<field>[,<field>] query
+    # param handled by UnifiedJobIncludeMixin.
+    OPTIONAL_INCLUDE_FIELDS = frozenset({'artifacts', 'extra_vars'})
+
+    _ALWAYS_STRIPPED_FIELDS = frozenset({'job_args', 'job_cwd', 'job_env', 'result_traceback', 'event_processing_finished'})
+
     class Meta:
-        fields = ('*', '-job_args', '-job_cwd', '-job_env', '-result_traceback', '-event_processing_finished', '-artifacts')
+        fields = ('*', '-job_args', '-job_cwd', '-job_env', '-result_traceback', '-event_processing_finished')
+
+    def _requested_includes(self):
+        request = self.context.get('request')
+        if request is None:
+            return frozenset()
+        raw = request.query_params.get('include', '')
+        requested = {name.strip() for name in raw.split(',') if name.strip()}
+        return frozenset(requested) & self.OPTIONAL_INCLUDE_FIELDS
 
     def get_field_names(self, declared_fields, info):
         field_names = super(UnifiedJobListSerializer, self).get_field_names(declared_fields, info)
         # Meta multiple inheritance and -field_name options don't seem to be
         # taking effect above, so remove the undesired fields here.
-        return tuple(x for x in field_names if x not in ('job_args', 'job_cwd', 'job_env', 'result_traceback', 'event_processing_finished', 'artifacts'))
+        strip = self._ALWAYS_STRIPPED_FIELDS | (self.OPTIONAL_INCLUDE_FIELDS - self._requested_includes())
+        return tuple(x for x in field_names if x not in strip)
 
     def get_types(self):
         if type(self) is UnifiedJobListSerializer:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -118,6 +118,7 @@ from awx.api.views.mixin import (
     RelatedJobsPreventDeleteMixin,
     UnifiedJobDeletionMixin,
     NoTruncateMixin,
+    UnifiedJobIncludeMixin,
 )
 from awx.api.pagination import UnifiedJobEventPagination
 from awx.main.utils import set_environ
@@ -3499,7 +3500,7 @@ class SystemJobTemplateNotificationTemplatesSuccessList(SystemJobTemplateNotific
     relationship = 'notification_templates_success'
 
 
-class JobList(ListAPIView):
+class JobList(UnifiedJobIncludeMixin, ListAPIView):
     model = models.Job
     serializer_class = serializers.JobListSerializer
 
@@ -4150,7 +4151,7 @@ class UnifiedJobTemplateList(ListAPIView):
     search_fields = ('description', 'name', 'jobtemplate__playbook')
 
 
-class UnifiedJobList(ListAPIView):
+class UnifiedJobList(UnifiedJobIncludeMixin, ListAPIView):
     model = models.UnifiedJob
     serializer_class = serializers.UnifiedJobListSerializer
     search_fields = ('description', 'name', 'job__playbook')

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3504,6 +3504,19 @@ class JobList(UnifiedJobIncludeMixin, ListAPIView):
     model = models.Job
     serializer_class = serializers.JobListSerializer
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+        # extra_vars/artifacts are large columns that JobListSerializer omits
+        # from list responses unless requested via ?include=. Defer the ones
+        # that won't be serialized so the DB doesn't read their (potentially
+        # TOAST-ed) values. Only safe here because Job is queried directly
+        # (unlike the polymorphic UnifiedJobList).
+        requested = self.serializer_class.parse_requested_includes(self.request.query_params.get('include', ''))
+        to_defer = self.serializer_class.OPTIONAL_INCLUDE_FIELDS - requested
+        if to_defer:
+            qs = qs.defer(*sorted(to_defer))
+        return qs
+
 
 class JobDetail(UnifiedJobDeletionMixin, RetrieveDestroyAPIView):
     model = models.Job

--- a/awx/api/views/mixin.py
+++ b/awx/api/views/mixin.py
@@ -216,3 +216,9 @@ class NoTruncateMixin(object):
         if self.request.query_params.get('no_truncate'):
             context.update(no_truncate=True)
         return context
+
+
+class UnifiedJobIncludeMixin(object):
+    # Reserve the name 'include' so we can use it as a query param. Otherwise, the rest-filters backend
+    # would treat it as a model field lookup.
+    rest_filters_reserved_names = ('include',)

--- a/awx/main/tests/functional/api/test_unified_jobs_view.py
+++ b/awx/main/tests/functional/api/test_unified_jobs_view.py
@@ -145,3 +145,122 @@ def test_delete_ad_hoc_command_in_active_state(ad_hoc_command_factory, delete, a
     adhoc = ad_hoc_command_factory(initial_state=status)
     url = reverse('api:ad_hoc_command_detail', kwargs={'pk': adhoc.pk})
     delete(url, None, admin, expect=403)
+
+
+@pytest.fixture
+def job_with_heavy_fields(job_factory):
+    job = job_factory()
+    job.extra_vars = '{"some_var": "some_value"}'
+    job.artifacts = {"some_artifact": "some_value"}
+    job.save()
+    return job
+
+
+def _job_result(response, job_id):
+    for row in response.data['results']:
+        if row['id'] == job_id:
+            return row
+    raise AssertionError('job {} not found in {}'.format(job_id, [r['id'] for r in response.data['results']]))
+
+
+@pytest.mark.django_db
+def test_unified_jobs_list_excludes_heavy_fields_by_default(get, admin, job_with_heavy_fields):
+    response = get(reverse('api:unified_job_list') + '?id={}'.format(job_with_heavy_fields.id), admin, expect=200)
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'artifacts' not in row
+    assert 'extra_vars' not in row
+
+
+@pytest.mark.django_db
+def test_unified_jobs_list_include_artifacts(get, admin, job_with_heavy_fields):
+    response = get(
+        reverse('api:unified_job_list') + '?id={}&include=artifacts'.format(job_with_heavy_fields.id),
+        admin,
+        expect=200,
+    )
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'artifacts' in row
+    assert 'extra_vars' not in row
+
+
+@pytest.mark.django_db
+def test_unified_jobs_list_include_extra_vars(get, admin, job_with_heavy_fields):
+    response = get(
+        reverse('api:unified_job_list') + '?id={}&include=extra_vars'.format(job_with_heavy_fields.id),
+        admin,
+        expect=200,
+    )
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'extra_vars' in row
+    assert 'artifacts' not in row
+
+
+@pytest.mark.django_db
+def test_unified_jobs_list_include_both(get, admin, job_with_heavy_fields):
+    response = get(
+        reverse('api:unified_job_list') + '?id={}&include=artifacts,extra_vars'.format(job_with_heavy_fields.id),
+        admin,
+        expect=200,
+    )
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'artifacts' in row
+    assert 'extra_vars' in row
+
+
+@pytest.mark.django_db
+def test_unified_jobs_list_include_tolerates_whitespace(get, admin, job_with_heavy_fields):
+    response = get(
+        reverse('api:unified_job_list') + '?id={}&include=%20artifacts%20,%20extra_vars%20'.format(job_with_heavy_fields.id),
+        admin,
+        expect=200,
+    )
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'artifacts' in row
+    assert 'extra_vars' in row
+
+
+@pytest.mark.django_db
+def test_unified_jobs_list_include_ignores_unknown(get, admin, job_with_heavy_fields):
+    response = get(
+        reverse('api:unified_job_list') + '?id={}&include=does_not_exist'.format(job_with_heavy_fields.id),
+        admin,
+        expect=200,
+    )
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'artifacts' not in row
+    assert 'extra_vars' not in row
+
+
+@pytest.mark.django_db
+def test_unified_jobs_list_include_does_not_honor_always_stripped(get, admin, job_with_heavy_fields):
+    # Always-stripped fields like event_processing_finished, job_args, result_traceback
+    # must remain stripped regardless of the ?include= param — they cannot be re-included.
+    response = get(
+        reverse('api:unified_job_list') + '?id={}&include=job_args,result_traceback,event_processing_finished'.format(job_with_heavy_fields.id),
+        admin,
+        expect=200,
+    )
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'event_processing_finished' not in row
+    assert 'job_args' not in row
+    assert 'result_traceback' not in row
+
+
+@pytest.mark.django_db
+def test_jobs_list_excludes_heavy_fields_by_default(get, admin, job_with_heavy_fields):
+    response = get(reverse('api:job_list') + '?id={}'.format(job_with_heavy_fields.id), admin, expect=200)
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'artifacts' not in row
+    assert 'extra_vars' not in row
+
+
+@pytest.mark.django_db
+def test_jobs_list_include_extra_vars(get, admin, job_with_heavy_fields):
+    response = get(
+        reverse('api:job_list') + '?id={}&include=extra_vars'.format(job_with_heavy_fields.id),
+        admin,
+        expect=200,
+    )
+    row = _job_result(response, job_with_heavy_fields.id)
+    assert 'extra_vars' in row
+    assert 'artifacts' not in row

--- a/awx/main/tests/functional/api/test_unified_jobs_view.py
+++ b/awx/main/tests/functional/api/test_unified_jobs_view.py
@@ -264,3 +264,46 @@ def test_jobs_list_include_extra_vars(get, admin, job_with_heavy_fields):
     row = _job_result(response, job_with_heavy_fields.id)
     assert 'extra_vars' in row
     assert 'artifacts' not in row
+
+
+def _deferred_field_names(qs):
+    # queryset.query.deferred_loading is (names, defer_flag). When defer_flag is
+    # True the names are deferred; when False (an .only() was applied) the
+    # deferred set is every concrete field not in names.
+    names, defer = qs.query.deferred_loading
+    if defer:
+        return set(names)
+    all_fields = {f.name for f in qs.model._meta.concrete_fields}
+    return all_fields - set(names)
+
+
+def _job_list_queryset(user, querystring=''):
+    from rest_framework.request import Request
+    from rest_framework.test import APIRequestFactory
+
+    from awx.api.views import JobList
+
+    view = JobList()
+    view.request = Request(APIRequestFactory().get('/api/v2/jobs/' + querystring))
+    view.request.user = user
+    return view.get_queryset()
+
+
+@pytest.mark.django_db
+def test_jobs_list_queryset_defers_heavy_columns_by_default(admin):
+    deferred = _deferred_field_names(_job_list_queryset(admin))
+    assert {'extra_vars', 'artifacts'} <= deferred
+
+
+@pytest.mark.django_db
+def test_jobs_list_queryset_defers_only_unrequested_heavy_columns(admin):
+    deferred = _deferred_field_names(_job_list_queryset(admin, '?include=extra_vars'))
+    assert 'artifacts' in deferred
+    assert 'extra_vars' not in deferred
+
+
+@pytest.mark.django_db
+def test_jobs_list_queryset_defers_nothing_when_all_included(admin):
+    deferred = _deferred_field_names(_job_list_queryset(admin, '?include=extra_vars,artifacts'))
+    assert 'extra_vars' not in deferred
+    assert 'artifacts' not in deferred

--- a/awx/main/tests/unit/api/serializers/test_unified_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_unified_serializers.py
@@ -39,7 +39,9 @@ def test_unified_job_detail_exclusive_fields():
     For each type, assert that the only fields allowed to be exclusive to
     detail view are the allowed types
     """
-    allowed_detail_fields = frozenset(('result_traceback', 'job_args', 'job_cwd', 'job_env', 'event_processing_finished', 'artifacts'))
+    allowed_detail_fields = frozenset(
+        ('result_traceback', 'job_args', 'job_cwd', 'job_env', 'event_processing_finished', 'artifacts', 'extra_vars', 'context_message')
+    )
     for cls in UnifiedJob.__subclasses__():
         list_serializer = getattr(serializers, '{}ListSerializer'.format(cls.__name__))
         detail_serializer = getattr(serializers, '{}Serializer'.format(cls.__name__))


### PR DESCRIPTION
This is adapted from the upstream PR https://github.com/ansible/awx/pull/16546 , but we have made some modifications to it to resolve a few issues.

Key fixes vs. the upstream version:

1. Renamed the param/mixin from exclude → include (mixin.py:219, reserved name updated). With fields stripped by default, "exclude" was semantically backwards; "include" (opt-in) is correct and matches the PR's payload-reduction intent.
2. Restored the default stripping of artifacts (the upstream code had unintentionally started returning it by default — a payload regression) and added extra_vars to the default-stripped set.
3. Rewrote the functional tests to assert the opt-in include behavior, and updated the unit test's allowed_detail_fields.
4. Add a defer to the JobList to save a bit of DB I/O.  All UI components load from the UnifiedJobList but this will help a little from anything that hits the api endpoint (awxkit, collections, etc...)

Also included in this is a unit test fix not related to this PR, but resolves an issue in the test that was created by a previous PR (adding 'context_message')..

### UPSTREAM SUMMARY

Adds a new query parameter (exclude) to those endpoints which allows to explicitly excluding those fields (and only those fields) in the response.

**Reason**: this field can hold large amounts of data that is not needed in  the list view. The fields are still returned in the details for a specific job

Verification steps:

1. Launch a few job templates
2. Open the jobs page in the UI, inspect the requests in the Browser dev tools
3. Look for the /api/v2/unified_jobs/ GET request and inspect the response
4. Make sure that extra_vars nor artifacts are present in the response
5. Open the API request in a separate browser tab (or navigate their via the API browser) and try the following URLs:

```
/api/v2/unified_jobs/?exclude=artifacts
/api/v2/unified_jobs/?exclude=artifacts,extra_vars
```

Make sure that the fields are included in the response when explicitly requested.
