### PR TITLE
Upstream 16527 - Eliminate LEFT OUTER JOINs in unified job RBAC query

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2513,7 +2513,7 @@ class UnifiedJobTemplateAccess(BaseAccess):
             Q(pk__in=self.model.accessible_pk_qs(self.user, 'read_role'))
             | Q(
                 pk__in=InventorySource.objects.filter(
-                    inventory__id__in=Inventory._accessible_pk_qs(Inventory, self.user, 'read_role'),
+                    inventory_id__in=Inventory._accessible_pk_qs(Inventory, self.user, 'read_role'),
                 ).values('unifiedjobtemplate_ptr_id')
             )
         )
@@ -2565,8 +2565,8 @@ class UnifiedJobAccess(BaseAccess):
         org_auditor_qs = Organization.objects.filter(Q(admin_role__members=self.user) | Q(auditor_role__members=self.user))
         qs = self.model.objects.filter(
             Q(unified_job_template_id__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'))
-            | Q(pk__in=InventoryUpdate.objects.filter(inventory_source__inventory__id__in=inv_pk_qs).values('pk'))
-            | Q(pk__in=AdHocCommand.objects.filter(inventory__id__in=inv_pk_qs).values('pk'))
+            | Q(pk__in=InventoryUpdate.objects.filter(inventory_source__inventory_id__in=inv_pk_qs).values('pk'))
+            | Q(pk__in=AdHocCommand.objects.filter(inventory_id__in=inv_pk_qs).values('pk'))
             | Q(organization__in=org_auditor_qs)
         )
         return qs

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2380,8 +2380,8 @@ class JobEventAccess(BaseAccess):
 
     def filtered_queryset(self):
         return self.model.objects.filter(
-            Q(host__inventory__in=Inventory.accessible_pk_qs(self.user, 'read_role'))
-            | Q(job__job_template__in=JobTemplate.accessible_pk_qs(self.user, 'read_role'))
+            Q(host_id__in=Host.objects.filter(inventory__in=Inventory.accessible_pk_qs(self.user, 'read_role')).values('pk'))
+            | Q(job_id__in=Job.objects.filter(job_template__in=JobTemplate.accessible_pk_qs(self.user, 'read_role')).values('pk'))
         )
 
     def can_add(self, data):
@@ -2511,7 +2511,11 @@ class UnifiedJobTemplateAccess(BaseAccess):
     def filtered_queryset(self):
         return self.model.objects.filter(
             Q(pk__in=self.model.accessible_pk_qs(self.user, 'read_role'))
-            | Q(inventorysource__inventory__id__in=Inventory._accessible_pk_qs(Inventory, self.user, 'read_role'))
+            | Q(
+                pk__in=InventorySource.objects.filter(
+                    inventory__id__in=Inventory._accessible_pk_qs(Inventory, self.user, 'read_role'),
+                ).values('unifiedjobtemplate_ptr_id')
+            )
         )
 
     def can_start(self, obj, validate_license=True):
@@ -2561,8 +2565,8 @@ class UnifiedJobAccess(BaseAccess):
         org_auditor_qs = Organization.objects.filter(Q(admin_role__members=self.user) | Q(auditor_role__members=self.user))
         qs = self.model.objects.filter(
             Q(unified_job_template_id__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'))
-            | Q(inventoryupdate__inventory_source__inventory__id__in=inv_pk_qs)
-            | Q(adhoccommand__inventory__id__in=inv_pk_qs)
+            | Q(pk__in=InventoryUpdate.objects.filter(inventory_source__inventory__id__in=inv_pk_qs).values('pk'))
+            | Q(pk__in=AdHocCommand.objects.filter(inventory__id__in=inv_pk_qs).values('pk'))
             | Q(organization__in=org_auditor_qs)
         )
         return qs
@@ -2685,8 +2689,12 @@ class LabelAccess(BaseAccess):
     def filtered_queryset(self):
         return self.model.objects.filter(
             Q(organization__in=Organization.accessible_pk_qs(self.user, 'read_role'))
-            | Q(unifiedjobtemplate_labels__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'))
-        ).distinct()
+            | Q(
+                pk__in=UnifiedJobTemplate.labels.through.objects.filter(
+                    unifiedjobtemplate_id__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'),
+                ).values('label_id')
+            )
+        )
 
     @check_superuser
     def can_add(self, data):


### PR DESCRIPTION
Upstream uses the new RBAC backend, but we can port the Upstream PR to fix the same issue on the older RBAC.

## Upstream Summary

- Replace field-traversal Q objects in `UnifiedJobAccess.filtered_queryset()` with `pk__in` subqueries, eliminating 3 LEFT OUTER JOINs that Django generates for the `inventoryupdate` and `adhoccommand` RBAC branches
- EXPLAIN ANALYZE on scale lab data (385K unified jobs) shows **28% execution time reduction** (496ms → 355ms), with larger gains expected under concurrent load due to reduced CPU contention

## Problem

Django translates `Q(inventoryupdate__inventory_source__inventory__id__in=...)` into LEFT OUTER JOINs, which are evaluated unconditionally for every row in `main_unifiedjob` before filtering. At scale, 99.84% of rows are scanned and discarded. The 4-way OR prevents PostgreSQL from using any column-specific index.

Under production concurrency (21 controller replicas), `pg_stat_statements` shows this query averages **3,959ms** per call across 29K+ calls, consuming **32.5 hours of DB time** — the single largest database workload.

## Fix

```python
# Before: field traversal → LEFT OUTER JOINs
Q(inventoryupdate__inventory_source__inventory__id__in=inv_pk_qs)
Q(adhoccommand__inventory__id__in=inv_pk_qs)

# After: explicit subqueries → IN (SELECT ...)
Q(pk__in=InventoryUpdate.objects.filter(
    inventory_source__inventory__id__in=inv_pk_qs,
).values('pk'))
Q(pk__in=AdHocCommand.objects.filter(
    inventory__id__in=inv_pk_qs,
).values('pk'))
```

Note: `Exists()` with `OuterRef` cannot be used here — django-polymorphic raises `AttributeError` on `Exists` nodes. The `pk__in` pattern is the polymorphic-compatible equivalent.

## Test plan

- [x] All 306 RBAC functional tests pass (`awx/main/tests/functional/rbac/`)
- [x] Verified generated SQL has zero LEFT OUTER JOINs via `str(qs.query)` in dev container
- [x] EXPLAIN ANALYZE confirms correct results (same 628 rows returned) with improved plan
- [ ] Scale lab A/B comparison after deployment to `aap26-next`


