### PR TITLE
Upstream 16522 - Refactor formatted raw SQL in unified_jobs result_stdout_raw_handle

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -23,6 +23,9 @@ from django.utils.timezone import now
 from django.utils.encoding import smart_str
 from django.contrib.contenttypes.models import ContentType
 
+# psycopg
+from psycopg import sql
+
 # REST Framework
 from rest_framework.exceptions import ParseError
 
@@ -1141,17 +1144,23 @@ class UnifiedJob(
                         raise StdoutMaxBytesExceeded(total, max_supported)
 
                 tbl = self._meta.db_table + 'event'
-                created_by_cond = ''
+                where_parts = [
+                    sql.SQL('{} = {}').format(sql.Identifier(self.event_parent_key), sql.Literal(self.id)),
+                    sql.SQL("stdout != ''"),
+                ]
                 if self.has_unpartitioned_events:
-                    tbl = f'_unpartitioned_{tbl}'
+                    tbl = '_unpartitioned_' + tbl
                 else:
-                    created_by_cond = f"job_created='{self.created.isoformat()}' AND "
+                    where_parts.insert(0, sql.SQL('job_created = {}').format(sql.Literal(self.created)))
 
-                sql = f"copy (select stdout from {tbl} where {created_by_cond}{self.event_parent_key}={self.id} and stdout != '' order by start_line) to stdout"  # nosql
+                copy_sql = sql.SQL('COPY (SELECT stdout FROM {} WHERE {} ORDER BY start_line) TO STDOUT').format(
+                    sql.Identifier(tbl),
+                    sql.SQL(' AND ').join(where_parts),
+                )
                 # psycopg3's copy writes bytes, but callers of this
                 # function assume a str-based fd will be returned; decode
                 # .write() calls on the fly to maintain this interface
-                with cursor.copy(sql) as copy:
+                with cursor.copy(copy_sql) as copy:
                     while data := copy.read():
                         fd.write(smart_str(bytes(data)))
 

--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -790,14 +790,13 @@ class MockCopy:
     events = []
     index = -1
 
-    def __init__(self, sql):
+    def __init__(self):
         self.events = []
-        parts = sql.split(' ')
-        tablename = parts[parts.index('from') + 1]
         for cls in (JobEvent, AdHocCommandEvent, ProjectUpdateEvent, InventoryUpdateEvent, SystemJobEvent):
-            if cls._meta.db_table == tablename:
-                for event in cls.objects.order_by('start_line').all():
-                    self.events.append(event.stdout)
+            events = list(cls.objects.order_by('start_line').values_list('stdout', flat=True))
+            if events:
+                self.events = events
+                break
 
     def read(self):
         self.index = self.index + 1
@@ -818,9 +817,8 @@ def sqlite_copy(request, mocker):
     # copy is postgres-specific, and SQLite doesn't support it; mock its
     # behavior to test that it writes a file that contains stdout from events
 
-    def write_stdout(self, sql):
-        mock_copy = MockCopy(sql)
-        return mock_copy
+    def write_stdout(self, sql, params=None):
+        return MockCopy()
 
     mocker.patch.object(SQLiteCursorWrapper, 'copy', write_stdout, create=True)
 


### PR DESCRIPTION
### Upstream Summary

Refactors `UnifiedJob.result_stdout_raw_handle()` in `awx/main/models/unified_jobs.py` to stop building PostgreSQL `COPY` SQL with f-strings.

The event-based stdout path previously interpolated table names, column names, `job_created`, and job ID directly into a query string (`# nosql`), which internal security scans flag as formatted raw SQL.

This change replaces that with `psycopg.sql` composables:

- `sql.Identifier()` for table and column names
- `sql.Literal()` for `job_created` and the parent FK value

Values are embedded via `sql.Literal()` rather than `%s` placeholders with a separate `params` list, because Django’s `cursor.copy()` only forwards the SQL statement to psycopg and does not pass bind parameters.

Behavior is unchanged: the method still streams stdout from job event tables via `COPY ... TO STDOUT`, ordered by `start_line`, with the same partitioned vs `_unpartitioned_` table selection and max-bytes checks. Django ORM is intentionally not used here to avoid loading large stdout blobs into memory.

The functional test `sqlite_copy` mock in `awx/main/tests/functional/conftest.py` was updated to load stdout from event tables directly instead of parsing SQL strings.

Related: AAP-77740 (discovered during AAP-76181)
## Issue type

Bug, Docs Fix or other nominal change

## Component

Other

## Before

```python
sql = f"copy (select stdout from {tbl} where {created_by_cond}{self.event_parent_key}={self.id} and stdout != '' order by start_line) to stdout"  # nosql
with cursor.copy(sql) as copy:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job stdout streaming reliability by using safer, parameterized database streaming for consistent output retrieval.
  * Kept the existing stdout size limit behavior and maintained the previous fallback flow when necessary.

* **Tests**
  * Updated functional test mocks to better emulate database COPY/stream behavior, including handling optional parameters.
  * Refined mock output selection to follow available event data rather than relying on query text parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->