### PR TITLE
Allow assigning instance groups to inventory sources

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2516,6 +2516,7 @@ class InventorySourceSerializer(UnifiedJobTemplateSerializer, InventorySourceOpt
                 activity_stream=self.reverse('api:inventory_source_activity_stream_list', kwargs={'pk': obj.pk}),
                 hosts=self.reverse('api:inventory_source_hosts_list', kwargs={'pk': obj.pk}),
                 groups=self.reverse('api:inventory_source_groups_list', kwargs={'pk': obj.pk}),
+                instance_groups=self.reverse('api:inventory_source_instance_groups_list', kwargs={'pk': obj.pk}),
                 notification_templates_started=self.reverse('api:inventory_source_notification_templates_started_list', kwargs={'pk': obj.pk}),
                 notification_templates_success=self.reverse('api:inventory_source_notification_templates_success_list', kwargs={'pk': obj.pk}),
                 notification_templates_error=self.reverse('api:inventory_source_notification_templates_error_list', kwargs={'pk': obj.pk}),

--- a/awx/api/urls/inventory_source.py
+++ b/awx/api/urls/inventory_source.py
@@ -12,6 +12,7 @@ from awx.api.views import (
     InventorySourceSchedulesList,
     InventorySourceCredentialsList,
     InventorySourceGroupsList,
+    InventorySourceInstanceGroupsList,
     InventorySourceHostsList,
     InventorySourceNotificationTemplatesErrorList,
     InventorySourceNotificationTemplatesStartedList,
@@ -26,6 +27,7 @@ urls = [
     path('<int:pk>/activity_stream/', InventorySourceActivityStreamList.as_view(), name='inventory_source_activity_stream_list'),
     path('<int:pk>/schedules/', InventorySourceSchedulesList.as_view(), name='inventory_source_schedules_list'),
     path('<int:pk>/credentials/', InventorySourceCredentialsList.as_view(), name='inventory_source_credentials_list'),
+    path('<int:pk>/instance_groups/', InventorySourceInstanceGroupsList.as_view(), name='inventory_source_instance_groups_list'),
     path('<int:pk>/groups/', InventorySourceGroupsList.as_view(), name='inventory_source_groups_list'),
     path('<int:pk>/hosts/', InventorySourceHostsList.as_view(), name='inventory_source_hosts_list'),
     path(

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -2294,6 +2294,14 @@ class InventorySourceCredentialsList(SubListAttachDetachAPIView):
         return None
 
 
+class InventorySourceInstanceGroupsList(SubListAttachDetachAPIView):
+    model = models.InstanceGroup
+    serializer_class = serializers.InstanceGroupSerializer
+    parent_model = models.InventorySource
+    relationship = 'instance_groups'
+    filter_read_permission = False
+
+
 class InventorySourceUpdateView(RetrieveAPIView):
     model = models.InventorySource
     obj_permission_type = 'start'

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1117,6 +1117,20 @@ class InventorySourceAccess(NotificationAttachMixin, UnifiedCredentialsMixin, Ba
             return self.user in obj.inventory.update_role
         return False
 
+    @check_superuser
+    def can_attach(self, obj, sub_obj, relationship, data, skip_sub_obj_read_check=False):
+        if relationship == 'instance_groups':
+            if not obj.inventory:
+                return False
+            return self.user in sub_obj.use_role and self.user in obj.inventory.admin_role
+        return super(InventorySourceAccess, self).can_attach(obj, sub_obj, relationship, data, skip_sub_obj_read_check=skip_sub_obj_read_check)
+
+    @check_superuser
+    def can_unattach(self, obj, sub_obj, relationship, *args, **kwargs):
+        if relationship == 'instance_groups':
+            return self.can_attach(obj, sub_obj, relationship, *args, **kwargs)
+        return super(InventorySourceAccess, self).can_unattach(obj, sub_obj, relationship, *args, **kwargs)
+
 
 class InventoryUpdateAccess(BaseAccess):
     """

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1126,10 +1126,10 @@ class InventorySourceAccess(NotificationAttachMixin, UnifiedCredentialsMixin, Ba
         return super(InventorySourceAccess, self).can_attach(obj, sub_obj, relationship, data, skip_sub_obj_read_check=skip_sub_obj_read_check)
 
     @check_superuser
-    def can_unattach(self, obj, sub_obj, relationship, *args, **kwargs):
+    def can_unattach(self, obj, sub_obj, relationship, data=None, skip_sub_obj_read_check=False):
         if relationship == 'instance_groups':
-            return self.can_attach(obj, sub_obj, relationship, *args, **kwargs)
-        return super(InventorySourceAccess, self).can_unattach(obj, sub_obj, relationship, *args, **kwargs)
+            return self.can_attach(obj, sub_obj, relationship, data, skip_sub_obj_read_check=skip_sub_obj_read_check)
+        return super(InventorySourceAccess, self).can_unattach(obj, sub_obj, relationship, data)
 
 
 class InventoryUpdateAccess(BaseAccess):

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1424,8 +1424,11 @@ class InventoryUpdate(UnifiedJob, InventorySourceOptions, JobNotificationMixin, 
     @property
     def preferred_instance_groups(self):
         selected_groups = []
+        # Instance groups set directly on the inventory source take precedence over the inventory's
+        for instance_group in self.inventory_source.instance_groups.all():
+            selected_groups.append(instance_group)
         if self.inventory_source.inventory is not None:
-            # Add the inventory sources IG to the selected IGs first
+            # Add the inventory's IGs to the selected IGs next
             for instance_group in self.inventory_source.inventory.instance_groups.all():
                 selected_groups.append(instance_group)
             # If the inventory allows for fallback and we have an organization then also append the orgs IGs to the end of the list

--- a/awx/main/tests/functional/api/test_instance_group.py
+++ b/awx/main/tests/functional/api/test_instance_group.py
@@ -137,7 +137,7 @@ def test_delete_rename_tower_instance_group_prevented(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('source_model', ['job_template', 'inventory', 'organization'], indirect=True)
+@pytest.mark.parametrize('source_model', ['job_template', 'inventory', 'organization', 'inventory_source'], indirect=True)
 def test_instance_group_order_persistence(get, post, admin, source_model):
     # create several instance groups in random order
     total = 5
@@ -165,6 +165,20 @@ def test_instance_group_order_persistence(get, post, admin, source_model):
         resp = get(url, admin)
         assert resp.data['count'] == total
         assert [ig['name'] for ig in resp.data['results']] == [ig.name for ig in before]
+
+
+@pytest.mark.django_db
+def test_inventory_source_instance_group_attach_permissions(get, post, rando, inventory_source, instance_group):
+    url = reverse('api:inventory_source_instance_groups_list', kwargs={'pk': inventory_source.pk})
+    inventory_source.inventory.admin_role.members.add(rando)
+    # inventory admin without use permission on the instance group cannot attach it
+    post(url, {'associate': True, 'id': instance_group.id}, rando, expect=403)
+    assert list(inventory_source.instance_groups.all()) == []
+    instance_group.use_role.members.add(rando)
+    post(url, {'associate': True, 'id': instance_group.id}, rando, expect=204)
+    assert list(inventory_source.instance_groups.all()) == [instance_group]
+    post(url, {'disassociate': True, 'id': instance_group.id}, rando, expect=204)
+    assert list(inventory_source.instance_groups.all()) == []
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/test_instances.py
+++ b/awx/main/tests/functional/test_instances.py
@@ -423,9 +423,11 @@ class TestInstanceGroupOrdering:
         inventory_source.inventory.instance_groups.add(ig_inv)
         assert iu.preferred_instance_groups == [ig_inv, ig_org]
         inventory_source.instance_groups.add(ig_tmp)
-        # API does not allow setting IGs on inventory source, so ignore those
-        assert iu.preferred_instance_groups == [ig_inv, ig_org]
+        # Instance groups on the inventory source take precedence over the inventory's
+        assert iu.preferred_instance_groups == [ig_tmp, ig_inv, ig_org]
         inventory_source.inventory.prevent_instance_group_fallback = True
+        assert iu.preferred_instance_groups == [ig_tmp, ig_inv]
+        inventory_source.instance_groups.remove(ig_tmp)
         assert iu.preferred_instance_groups == [ig_inv]
 
     def test_job_instance_groups(self, instance_group_factory, inventory, project, default_instance_group):

--- a/awx/main/tests/functional/test_rbac_instance_groups.py
+++ b/awx/main/tests/functional/test_rbac_instance_groups.py
@@ -55,6 +55,8 @@ def test_ig_inventory_source_associability(default_instance_group, rando, invent
 
     assert allowed == InventorySourceAccess(rando).can_attach(inventory_source, default_instance_group, 'instance_groups', None)
     assert allowed == InventorySourceAccess(rando).can_unattach(inventory_source, default_instance_group, 'instance_groups', None)
+    # data is optional for unattach checks, callers are allowed to omit it
+    assert allowed == InventorySourceAccess(rando).can_unattach(inventory_source, default_instance_group, 'instance_groups')
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/test_rbac_instance_groups.py
+++ b/awx/main/tests/functional/test_rbac_instance_groups.py
@@ -4,6 +4,7 @@ from awx.main.access import (
     InstanceGroupAccess,
     OrganizationAccess,
     InventoryAccess,
+    InventorySourceAccess,
     JobTemplateAccess,
 )
 
@@ -39,6 +40,21 @@ def test_ig_role_based_associability(default_instance_group, rando, organization
     assert allowed == JobTemplateAccess(rando).can_attach(objects.job_template, default_instance_group, 'instance_groups', None)
     assert allowed == InventoryAccess(rando).can_attach(objects.inventory, default_instance_group, 'instance_groups', None)
     assert allowed == OrganizationAccess(rando).can_attach(objects.organization, default_instance_group, 'instance_groups', None)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "obj_perm,subobj_perm,allowed",
+    [('admin_role', 'use_role', True), ('admin_role', 'read_role', False), ('use_role', 'use_role', False), ('admin_role', 'admin_role', True)],
+)
+def test_ig_inventory_source_associability(default_instance_group, rando, inventory_source, obj_perm, subobj_perm, allowed):
+    if obj_perm:
+        getattr(inventory_source.inventory, obj_perm).members.add(rando)
+    if subobj_perm:
+        getattr(default_instance_group, subobj_perm).members.add(rando)
+
+    assert allowed == InventorySourceAccess(rando).can_attach(inventory_source, default_instance_group, 'instance_groups', None)
+    assert allowed == InventorySourceAccess(rando).can_unattach(inventory_source, default_instance_group, 'instance_groups', None)
 
 
 @pytest.mark.django_db

--- a/awx/ui/src/api/models/InventorySources.js
+++ b/awx/ui/src/api/models/InventorySources.js
@@ -2,9 +2,10 @@ import Base from '../Base';
 import NotificationsMixin from '../mixins/Notifications.mixin';
 import LaunchUpdateMixin from '../mixins/LaunchUpdate.mixin';
 import SchedulesMixin from '../mixins/Schedules.mixin';
+import InstanceGroupsMixin from '../mixins/InstanceGroups.mixin';
 
-class InventorySources extends LaunchUpdateMixin(
-  NotificationsMixin(SchedulesMixin(Base))
+class InventorySources extends InstanceGroupsMixin(
+  LaunchUpdateMixin(NotificationsMixin(SchedulesMixin(Base)))
 ) {
   constructor(http) {
     super(http);

--- a/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.js
@@ -11,8 +11,14 @@ function InventorySourceAdd({ inventory }) {
   const { id, organization } = inventory;
 
   const { error, request, result } = useRequest(
-    useCallback(async (values) => {
+    useCallback(async ({ instanceGroups, ...values }) => {
       const { data } = await InventorySourcesAPI.create(values);
+      /* eslint-disable no-await-in-loop, no-restricted-syntax */
+      // Resolve Promises sequentially to maintain order and avoid race condition
+      for (const group of instanceGroups || []) {
+        await InventorySourcesAPI.associateInstanceGroup(data.id, group.id);
+      }
+      /* eslint-enable no-await-in-loop, no-restricted-syntax */
       return data;
     }, [])
   );
@@ -34,6 +40,7 @@ function InventorySourceAdd({ inventory }) {
       source_project,
       source_script,
       execution_environment,
+      instanceGroups,
       ...remainingForm
     } = form;
 
@@ -50,6 +57,7 @@ function InventorySourceAdd({ inventory }) {
       inventory: id,
       source_script: source_script?.id || null,
       execution_environment: execution_environment?.id || null,
+      instanceGroups,
       ...sourcePath,
       ...sourceProject,
       ...remainingForm,

--- a/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.test.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceAdd/InventorySourceAdd.test.js
@@ -20,6 +20,7 @@ const invSourceData = {
   update_cache_timeout: 0,
   update_on_launch: false,
   verbosity: 1,
+  instanceGroups: [{ id: 100 }, { id: 200 }],
 };
 
 const mockInventory = {
@@ -94,6 +95,30 @@ describe('<InventorySourceAdd />', () => {
       update_on_launch: false,
       verbosity: 1,
     });
+  });
+
+  test('should associate instance groups after creation', async () => {
+    InventorySourcesAPI.create.mockResolvedValue({ data: { id: 55 } });
+    const { user } = renderWithContexts(
+      <InventorySourceAdd inventory={mockInventory} />
+    );
+    await user.click(await screen.findByRole('button', { name: 'mock-submit' }));
+
+    await waitFor(() =>
+      expect(InventorySourcesAPI.associateInstanceGroup).toHaveBeenCalledTimes(
+        2
+      )
+    );
+    expect(InventorySourcesAPI.associateInstanceGroup).toHaveBeenNthCalledWith(
+      1,
+      55,
+      100
+    );
+    expect(InventorySourcesAPI.associateInstanceGroup).toHaveBeenNthCalledWith(
+      2,
+      55,
+      200
+    );
   });
 
   test('successful form submission should trigger redirect', async () => {

--- a/awx/ui/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceDetail/InventorySourceDetail.js
@@ -14,6 +14,7 @@ import CredentialChip from 'components/CredentialChip';
 import DeleteButton from 'components/DeleteButton';
 import ErrorDetail from 'components/ErrorDetail';
 import ExecutionEnvironmentDetail from 'components/ExecutionEnvironmentDetail';
+import InstanceGroupLabels from 'components/InstanceGroupLabels';
 import JobCancelButton from 'components/JobCancelButton';
 import StatusLabel from 'components/StatusLabel';
 import { CardBody, CardActionsRow } from 'components/Card';
@@ -51,6 +52,20 @@ function InventorySourceDetail({ inventorySource }) {
       );
     }, [])
   );
+
+  const { result: instanceGroups, request: fetchInstanceGroups } = useRequest(
+    useCallback(async () => {
+      const { data } = await InventorySourcesAPI.readInstanceGroups(
+        inventorySource.id
+      );
+      return data.results;
+    }, [inventorySource.id]),
+    []
+  );
+
+  useEffect(() => {
+    fetchInstanceGroups();
+  }, [fetchInstanceGroups]);
 
   const {
     created,
@@ -218,6 +233,13 @@ function InventorySourceDetail({ inventorySource }) {
         <ExecutionEnvironmentDetail
           executionEnvironment={execution_environment}
         />
+        {instanceGroups && instanceGroups.length > 0 && (
+          <Detail
+            fullWidth
+            label={t`Instance Groups`}
+            value={<InstanceGroupLabels labels={instanceGroups} isLinkable />}
+          />
+        )}
         {source_project && (
           <Detail
             label={t`Project`}

--- a/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.js
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { Card } from '@patternfly/react-core';
 import { CardBody } from 'components/Card';
+import ContentError from 'components/ContentError';
+import ContentLoading from 'components/ContentLoading';
 import useRequest from 'hooks/useRequest';
 import { InventorySourcesAPI } from 'api';
 import InventorySourceForm from '../shared/InventorySourceForm';
@@ -11,13 +13,35 @@ function InventorySourceEdit({ source, inventory }) {
   const { id, organization } = inventory;
   const detailsUrl = `/inventories/inventory/${id}/sources/${source.id}/details`;
 
+  const {
+    isLoading: isInstanceGroupsLoading,
+    error: instanceGroupsError,
+    request: fetchInstanceGroups,
+    result: associatedInstanceGroups,
+  } = useRequest(
+    useCallback(async () => {
+      const { data } = await InventorySourcesAPI.readInstanceGroups(source.id);
+      return data.results;
+    }, [source.id]),
+    null
+  );
+
+  useEffect(() => {
+    fetchInstanceGroups();
+  }, [fetchInstanceGroups]);
+
   const { error, request, result } = useRequest(
     useCallback(
-      async (values) => {
+      async ({ instanceGroups, ...values }) => {
         const { data } = await InventorySourcesAPI.replace(source.id, values);
+        await InventorySourcesAPI.orderInstanceGroups(
+          source.id,
+          instanceGroups,
+          associatedInstanceGroups
+        );
         return data;
       },
-      [source.id]
+      [source.id, associatedInstanceGroups]
     ),
     null
   );
@@ -37,6 +61,7 @@ function InventorySourceEdit({ source, inventory }) {
       source_project,
       source_script,
       execution_environment,
+      instanceGroups,
       ...remainingForm
     } = form;
 
@@ -53,6 +78,7 @@ function InventorySourceEdit({ source, inventory }) {
       inventory: id,
       source_script: source_script?.id || null,
       execution_environment: execution_environment?.id || null,
+      instanceGroups,
       ...sourcePath,
       ...sourceProject,
       ...remainingForm,
@@ -63,11 +89,32 @@ function InventorySourceEdit({ source, inventory }) {
     navigate(detailsUrl);
   };
 
+  if (instanceGroupsError) {
+    return (
+      <Card>
+        <CardBody>
+          <ContentError error={instanceGroupsError} />
+        </CardBody>
+      </Card>
+    );
+  }
+
+  if (isInstanceGroupsLoading || !associatedInstanceGroups) {
+    return (
+      <Card>
+        <CardBody>
+          <ContentLoading />
+        </CardBody>
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <CardBody>
         <InventorySourceForm
           source={source}
+          instanceGroups={associatedInstanceGroups}
           onCancel={handleCancel}
           onSubmit={handleSubmit}
           submitError={error}

--- a/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.test.js
+++ b/awx/ui/src/screens/Inventory/InventorySourceEdit/InventorySourceEdit.test.js
@@ -37,7 +37,9 @@ jest.mock(
           <button
             type="button"
             aria-label="mock-submit"
-            onClick={() => onSubmit(mockInvSrc)}
+            onClick={() =>
+              onSubmit({ ...mockInvSrc, instanceGroups: [{ id: 100 }] })
+            }
           />
           <button type="button" aria-label="mock-cancel" onClick={onCancel} />
           {submitError ? <div data-testid="mock-submit-error" /> : null}
@@ -46,6 +48,12 @@ jest.mock(
 );
 
 describe('<InventorySourceEdit />', () => {
+  beforeEach(() => {
+    InventorySourcesAPI.readInstanceGroups.mockResolvedValue({
+      data: { results: [] },
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -85,6 +93,11 @@ describe('<InventorySourceEdit />', () => {
       update_on_launch: false,
       verbosity: 1,
     });
+    expect(InventorySourcesAPI.orderInstanceGroups).toHaveBeenCalledWith(
+      23,
+      [{ id: 100 }],
+      []
+    );
   });
 
   test('should navigate to inventory source detail after successful submission', async () => {

--- a/awx/ui/src/screens/Inventory/shared/InventorySourceForm.js
+++ b/awx/ui/src/screens/Inventory/shared/InventorySourceForm.js
@@ -15,7 +15,10 @@ import FormActionGroup from 'components/FormActionGroup/FormActionGroup';
 import FormField, { FormSubmitError } from 'components/FormField';
 import { FormColumnLayout, SubFormLayout } from 'components/FormLayout';
 
-import { ExecutionEnvironmentLookup } from 'components/Lookup';
+import {
+  ExecutionEnvironmentLookup,
+  InstanceGroupsLookup,
+} from 'components/Lookup';
 import {
   AzureSubForm,
   EC2SubForm,
@@ -89,6 +92,8 @@ const InventorySourceFormFields = ({
     executionEnvironmentMeta,
     executionEnvironmentHelpers,
   ] = useField('execution_environment');
+  const [instanceGroupsField, , instanceGroupsHelpers] =
+    useField('instanceGroups');
 
   const resetSubFormFields = (sourceType) => {
     if (sourceType === initialValues.source) {
@@ -143,6 +148,12 @@ const InventorySourceFormFields = ({
         onChange={handleExecutionEnvironmentUpdate}
         globallyAvailable
         organizationId={organizationId}
+      />
+      <InstanceGroupsLookup
+        value={instanceGroupsField.value}
+        onChange={(value) => instanceGroupsHelpers.setValue(value)}
+        tooltip={t`Select the Instance Groups this inventory source sync should run on. If unset, the sync runs on the instance groups of the inventory or its organization.`}
+        fieldName="instanceGroups"
       />
       <FormGroup
         fieldId="source"
@@ -271,11 +282,13 @@ const InventorySourceForm = ({
   onCancel,
   onSubmit,
   source,
+  instanceGroups = [],
   submitError = null,
   organizationId,
 }) => {
   const initialValues = {
     credential: source?.summary_fields?.credential || null,
+    instanceGroups: instanceGroups || [],
     description: source?.description || '',
     name: source?.name || '',
     overwrite: source?.overwrite || false,

--- a/docs/inventory_source_instance_groups.md
+++ b/docs/inventory_source_instance_groups.md
@@ -1,0 +1,39 @@
+# Instance Groups on Inventory Sources
+
+An inventory update (source sync) is a real job: an execution node spawns an execution
+environment and runs the inventory plugin inside it. That means the node that executes the
+sync is the node that needs network access to the inventory source, not the control plane.
+
+Before this feature, the instance groups used for a sync were always taken from the
+inventory (falling back to the organization and then the global default). The
+`instance_groups` field on the inventory was doing double duty: it controlled both where
+playbooks that use the inventory run and where the syncs of that inventory run. If your
+hosts live in a remote network segment and you pin the inventory to an execution node
+registered there, the syncs also land on that node, which may have no route back to the
+system the inventory source pulls from.
+
+Now instance groups can be assigned directly to an inventory source, and they take
+precedence over the inventory's. The full resolution order for an inventory update is:
+
+1. `inventory_source.instance_groups`
+2. `inventory.instance_groups`
+3. `organization.instance_groups` (skipped when the inventory sets
+   `prevent_instance_group_fallback`)
+4. the global default instance group
+
+A source with no instance groups behaves exactly as before, so existing deployments are
+unaffected. A single inventory with several sources in different network segments can pin
+each source to the instance group that can actually reach it.
+
+## API
+
+`GET /api/v2/inventory_sources/N/instance_groups/` lists the instance groups of a source.
+POST `{"id": X}` to associate, `{"id": X, "disassociate": true}` to remove. The order of
+association is preserved and is the order the scheduler uses. Associating requires use
+permission on the instance group plus admin permission on the inventory, the same rule
+that applies to job templates and inventories.
+
+Container groups are valid targets, just as they are for the inventory level routing.
+
+Playbook jobs that use the inventory ignore this field entirely; it only affects inventory
+updates.


### PR DESCRIPTION
This comes from the forum thread https://forum.ascender-automation.org/d/17-feature-request-set-instance-group-of-inventory-sync (and upstream https://github.com/ansible/awx/issues/13995, open since 2023 with no movement).

## The problem

An inventory sync is a real job, the execution node spawns an EE and runs the inventory plugin inside it. So the node that runs the sync is the one that needs network access to the inventory source, not the control plane.

Today the only routing knob is `Inventory.instance_groups`, and it does double duty: it decides where playbook jobs using that inventory run AND where the syncs of that inventory run. The failure mode from the forum: your hosts live in a remote DC only reachable from an execution node registered there, so you pin the remote instance group on the inventory. As a side effect the syncs also get scheduled on that remote node, which has no route back to the central system the source pulls from, and the sync fails. There is no way to decouple the two.

You can work around it by setting the instance group on every job template and leaving the inventory alone, but that has to be repeated on every JT and a missed one silently falls back to a group that cannot reach the hosts.

## What this does

Lets you assign instance groups directly to an inventory source. The resolution order for an inventory update becomes:

```
inventory_source.instance_groups > inventory.instance_groups > organization.instance_groups > global default
```

I went with per source rather than per inventory (which is what the forum post originally asked for) because one inventory can have several sources pointing at systems in different network segments. Per source degrades to exactly the per inventory behaviour when left empty, so it covers both.

A source with no instance groups behaves exactly as before, nothing changes for existing deployments. Playbook jobs ignore the new field entirely, it only affects inventory updates.

## Implementation notes

The nice surprise is that `InventorySource` already inherits `instance_groups` from `UnifiedJobTemplate`, the field and the through table have been in the schema all along. The API just never exposed it and `InventoryUpdate.preferred_instance_groups` ignored it (there was even a comment in `test_instances.py` saying "API does not allow setting IGs on inventory source, so ignore those"). So this PR needs **no migration** at all.

- `InventoryUpdate.preferred_instance_groups` now consults the source first, then falls back to the existing chain. Same prepend semantics as job templates, and `prevent_instance_group_fallback` on the inventory keeps working as it did.
- New `/api/v2/inventory_sources/N/instance_groups/` sublist, mirroring `JobTemplateInstanceGroupsList`, wired into the related links. Association order is preserved.
- RBAC: attaching needs use permission on the instance group plus admin on the inventory, the same rule as job templates, inventories and organizations.
- UI: instance groups lookup on the inventory source form (add and edit), labels on the detail view.
- Docs: `docs/inventory_source_instance_groups.md`.

## Tests

- Updated the precedence test in `test_instances.py` (source set, source empty, and with `prevent_instance_group_fallback`).
- New parametrized RBAC test for `InventorySourceAccess` attach/unattach in `test_rbac_instance_groups.py`.
- Added `inventory_source` to the order persistence test in `api/test_instance_group.py`, plus an endpoint test checking the 403 without use permission and the 204 with it.
- Jest tests for the form, add, edit and detail screens.

Full functional suite and the UI tests pass, black/flake8 clean, `check_migrations` reports no changes.
