### PR TITLE
Upgrade cryptography to resolve CVE-2026-69247

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -11,7 +11,7 @@ botocore
 cachetools
 channels
 channels-valkey
-cryptography>=49.0.0  # CVE-2026-39892 GHSA-537c-gmf6-5ccf
+cryptography>=50.0.0  # CVE-2026-69247
 Cython>=3 # this is needed as a build dependency, one day we may have separated build deps; <3 cap removed once pyyaml>=6.0.1 supported Cython 3
 daphne>=4.2.2  # CVE-2026-44545 CVE-2026-44546
 distro
@@ -47,7 +47,7 @@ psycopg
 psutil
 pygerduty
 pygithub
-pyopenssl>=26.3.0  # tracks cryptography pin above (pyopenssl 26.3.0 requires cryptography>=49)
+pyopenssl>=26.4.0  # tracks cryptography pin above (pyopenssl 26.3.0 requires cryptography>=49)
 pyparsing==2.4.6  # Upgrading to v3 of pyparsing introduce errors on smart host filtering: Expected 'or' term, found 'or'  (at char 15), (line:1, col:16)
 python-daemon>3.0.0
 python-dsv-sdk>=1.0.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -77,7 +77,7 @@ click==8.1.7
     # via receptorctl
 constantly==23.10.4
     # via twisted
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   autobahn
@@ -321,7 +321,7 @@ pyjwt[crypto]==2.13.0
     #   twilio
 pynacl==1.6.2
     # via pygithub
-pyopenssl==26.3.0
+pyopenssl==26.4.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   twisted


### PR DESCRIPTION
Requires upgrading pyopenssl also, as they had an old pin for cryptography
