### PR TITLE
Expose the job's host list to custom notification templates

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -245,6 +245,9 @@ class Notification(CreatedModifiedModel):
 
 class JobNotificationMixin(object):
     STATUS_TO_TEMPLATE_TYPE = {'succeeded': 'success', 'running': 'started', 'failed': 'error'}
+    # Maximum number of host names exposed in the notification context to keep
+    # payloads bounded for jobs run against very large inventories.
+    HOST_LIST_MAX = 1000
     # Tree of fields that can be safely referenced in a notification message
     JOB_FIELDS_ALLOWED_LIST = [
         'id',
@@ -334,6 +337,7 @@ class JobNotificationMixin(object):
                 'force_handlers': False,
                 'forks': 0,
                 'host_status_counts': {'skipped': 1, 'ok': 5, 'changed': 3, 'failures': 0, 'dark': 0, 'failed': False, 'processed': 0, 'rescued': 0},
+                'hosts': ['host1', 'host2'],
                 'id': 42,
                 'job_explanation': 'Sample job explanation',
                 'job_slice_count': 1,
@@ -444,6 +448,11 @@ class JobNotificationMixin(object):
                     node[safe_field] = fields[safe_field]
 
         build_context(context['job'], serialized_job, self.JOB_FIELDS_ALLOWED_LIST)
+
+        # Expose the list of hosts the job ran against. Only jobs that track
+        # per-host results (i.e. real Jobs) have job_host_summaries.
+        if hasattr(self, 'job_host_summaries'):
+            context['job']['hosts'] = list(self.job_host_summaries.values_list('host_name', flat=True).order_by('host_name')[: self.HOST_LIST_MAX])
 
         return context
 

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -25,6 +25,7 @@ class TestJobNotificationMixin(object):
             'force_handlers': bool,
             'forks': int,
             'host_status_counts': {'skipped': int, 'ok': int, 'changed': int, 'failures': int, 'dark': int, 'processed': int, 'rescued': int, 'failed': bool},
+            'hosts': list,
             'id': int,
             'job_explanation': str,
             'job_slice_count': int,
@@ -122,6 +123,17 @@ class TestJobNotificationMixin(object):
 
         context = job.context(job_serialization)
         self.check_structure(TestJobNotificationMixin.CONTEXT_STRUCTURE, context)
+
+    @pytest.mark.django_db
+    def test_context_hosts(self):
+        job = Job.objects.create(name='fake-job')
+        job.job_host_summaries.create(host_name='host-b', failed=False, ok=1, changed=0, failures=0)
+        job.job_host_summaries.create(host_name='host-a', failed=False, ok=1, changed=0, failures=0)
+
+        job_serialization = UnifiedJobSerializer(job).to_representation(job)
+        context = job.context(job_serialization)
+
+        assert context['job']['hosts'] == ['host-a', 'host-b']
 
     @pytest.mark.django_db
     def test_context_job_metadata_with_unicode(self):

--- a/docs/docsite/rst/userguide/notification_parameters_supported.rst
+++ b/docs/docsite/rst/userguide/notification_parameters_supported.rst
@@ -52,6 +52,7 @@ This section describes the list of supported job attributes and the proper synta
    - ``rescued`` (integer)
    - ``ignored`` (integer)
    - ``failed`` (boolean)
+- ``hosts`` - (list) names of the hosts the job ran against, sorted alphabetically. Only populated for jobs that track per-host results; the list is capped at 1000 entries to keep notification payloads bounded for very large inventories.
 - ``summary_fields``:
    - ``inventory``
       - ``id`` - (integer) database ID for inventory


### PR DESCRIPTION
This adds a hosts data point (limited the 1st 1000) for the notifications to utilize.  Minor change, most everything was already in place for it.

Resolves #612