### PR TITLE
Authorize subscriptions to all event channels (CVE-2026-16544)

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -204,8 +204,19 @@ def consumer_access(group_name):
     """
     consumer_access returns the proper Access class based on group_name
     for a channels consumer.
+
+    Every group name produced by awx.main.models.events.emit_event_detail
+    must be represented here, otherwise the consumer has no way to
+    authorize a subscription to that event stream.
     """
-    class_map = {'job_events': JobAccess, 'workflow_events': WorkflowJobAccess, 'ad_hoc_command_events': AdHocCommandAccess}
+    class_map = {
+        'job_events': JobAccess,
+        'workflow_events': WorkflowJobAccess,
+        'ad_hoc_command_events': AdHocCommandAccess,
+        'project_update_events': ProjectUpdateAccess,
+        'inventory_update_events': InventoryUpdateAccess,
+        'system_job_events': SystemJobAccess,
+    }
     return class_map.get(group_name)
 
 

--- a/awx/main/consumers.py
+++ b/awx/main/consumers.py
@@ -179,7 +179,16 @@ class EventConsumer(AsyncJsonWebsocketConsumer):
                     for oid in v:
                         name = '{}-{}'.format(group_name, oid)
                         access_cls = consumer_access(group_name)
-                        if access_cls is not None:
+                        if access_cls is None:
+                            # Event streams are scoped to a single object, so subscribing to one
+                            # without an authorization check would expose another user's stdout.
+                            # Deny instead of falling through, so that adding a new event type
+                            # cannot silently reintroduce unauthorized access.
+                            if group_name.endswith('_events'):
+                                logger.error(f"access denied to channel {group_name}, no access class registered, for {user.username}")
+                                await self.send_json({"error": "access denied to channel {0} for resource id {1}".format(group_name, oid)})
+                                continue
+                        else:
                             user_access = access_cls(user)
                             if not await self.user_can_see_object_id(user_access, oid):
                                 await self.send_json({"error": "access denied to channel {0} for resource id {1}".format(group_name, oid)})

--- a/awx/main/consumers.py
+++ b/awx/main/consumers.py
@@ -185,7 +185,9 @@ class EventConsumer(AsyncJsonWebsocketConsumer):
                             # Deny instead of falling through, so that adding a new event type
                             # cannot silently reintroduce unauthorized access.
                             if group_name.endswith('_events'):
-                                logger.error(f"access denied to channel {group_name}, no access class registered, for {user.username}")
+                                # group_name comes from the client payload, so %r keeps a
+                                # crafted value from forging additional log lines.
+                                logger.error("access denied to channel %r, no access class registered, for %s", group_name, user.username)
                                 await self.send_json({"error": "access denied to channel {0} for resource id {1}".format(group_name, oid)})
                                 continue
                         else:

--- a/awx/main/tests/unit/test_access.py
+++ b/awx/main/tests/unit/test_access.py
@@ -250,3 +250,17 @@ def test_system_job_template_can_start(mocker):
     user.is_superuser = True
     access = SystemJobTemplateAccess(user)
     assert access.can_start(None)
+
+
+def test_consumer_access_covers_all_event_groups():
+    """
+    Every group name emitted by emit_event_detail must map to an Access class,
+    otherwise the websocket consumer cannot authorize a subscription to it.
+    """
+    from awx.main.access import consumer_access
+    from awx.main.models.events import AdHocCommandEvent, InventoryUpdateEvent, JobEvent, ProjectUpdateEvent, SystemJobEvent
+    from awx.main.utils import camelcase_to_underscore
+
+    for cls in (JobEvent, AdHocCommandEvent, ProjectUpdateEvent, InventoryUpdateEvent, SystemJobEvent):
+        group_name = camelcase_to_underscore(cls.__name__) + 's'
+        assert consumer_access(group_name) is not None, f'no Access class registered for websocket group {group_name}'

--- a/awx/main/tests/unit/test_access.py
+++ b/awx/main/tests/unit/test_access.py
@@ -254,13 +254,22 @@ def test_system_job_template_can_start(mocker):
 
 def test_consumer_access_covers_all_event_groups():
     """
-    Every group name emitted by emit_event_detail must map to an Access class,
-    otherwise the websocket consumer cannot authorize a subscription to it.
+    Every object scoped event group must map to an Access class, otherwise the
+    websocket consumer cannot authorize a subscription to it.
+
+    There are two producers of such groups:
+      - emit_event_detail in awx.main.models.events, which derives the name from
+        the event class, so those names are derived here rather than restated
+      - UnifiedJob._websocket_emit_status, which emits the literal
+        'workflow_events' group, so that one is asserted explicitly
     """
     from awx.main.access import consumer_access
     from awx.main.models.events import AdHocCommandEvent, InventoryUpdateEvent, JobEvent, ProjectUpdateEvent, SystemJobEvent
     from awx.main.utils import camelcase_to_underscore
 
-    for cls in (JobEvent, AdHocCommandEvent, ProjectUpdateEvent, InventoryUpdateEvent, SystemJobEvent):
-        group_name = camelcase_to_underscore(cls.__name__) + 's'
+    event_classes = (JobEvent, AdHocCommandEvent, ProjectUpdateEvent, InventoryUpdateEvent, SystemJobEvent)
+    group_names = [camelcase_to_underscore(cls.__name__) + 's' for cls in event_classes]
+    group_names.append('workflow_events')
+
+    for group_name in group_names:
         assert consumer_access(group_name) is not None, f'no Access class registered for websocket group {group_name}'


### PR DESCRIPTION
##### SUMMARY

`consumer_access()` in `awx/main/access.py` mapped only three of the six websocket
event groups to an Access class. `emit_event_detail()` in `awx/main/models/events.py`
derives the group name as `camelcase_to_underscore(cls.__name__) + 's'`, which yields:

| Event class | Group name | Mapped before |
|---|---|---|
| `JobEvent` | `job_events` | yes |
| `AdHocCommandEvent` | `ad_hoc_command_events` | yes |
| `ProjectUpdateEvent` | `project_update_events` | **no** |
| `InventoryUpdateEvent` | `inventory_update_events` | **no** |
| `SystemJobEvent` | `system_job_events` | **no** |

`EventConsumer.receive_json()` treated a missing Access class as "no authorization
required" and subscribed the client anyway:

```python
access_cls = consumer_access(group_name)
if access_cls is not None:
    ...permission check...
new_groups.add(name)     # also reached when access_cls is None
```

So any authenticated user could subscribe to `project_update_events-<id>`,
`inventory_update_events-<id>` or `system_job_events-<id>` and receive the stdout of
jobs they cannot otherwise read. This is CVE-2026-16544 / GHSA-2jx7-9fh6-5m74.

**Design decisions**

1. The three missing groups are registered with the existing Access classes. Their
   querysets already restrict correctly, so no new authorization logic is introduced:
   `ProjectUpdateAccess.filtered_queryset()` filters by projects readable via
   `read_role`, `InventoryUpdateAccess.filtered_queryset()` by readable inventories,
   and `SystemJobAccess` has no `filtered_queryset` override, so `BaseAccess` returns
   `objects.none()` for anyone who is not a superuser or system auditor.

2. The consumer no longer falls through when no Access class is registered for a group
   whose name ends in `_events`. The advisory notes this is an incomplete fix of
   CVE-2020-10698, and the fall-through is the reason it could be reintroduced —
   adding a sixth event type would have had the same effect. Filling in the map alone
   does not address that.

   The guard is deliberately narrow. `jobs` (subscribed as
   `{jobs: ['summary', 'status_changed']}`), `inventories`, `schedules` and `control`
   are not object scoped, have no Access class by design, and keep working unchanged.

3. The regression test derives the group names from the event classes rather than
   restating them, so a future event type without a mapping fails the test. There was
   no existing test for `consumer_access()`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION
```
25.5.0 (deployed from ghcr.io/ctrliq/ascender:25.5.0; branch based on main @ 4ed44f9)
```

##### ADDITIONAL INFORMATION

Reproduced against a running 25.5.0 instance before the change:

```
$ awx-manage shell -c "..."
job_events                 -> <class 'awx.main.access.JobAccess'>
ad_hoc_command_events      -> <class 'awx.main.access.AdHocCommandAccess'>
project_update_events      -> None
inventory_update_events    -> None
system_job_events          -> None
```

Verified for this change: syntax of all three files, longest added line 139 characters
(under the 160 limit in `pyproject.toml`), the import path of `camelcase_to_underscore`
against `awx/main/models/events.py`, and that the three Access classes resolve to
`ProjectUpdate`, `InventoryUpdate` and `SystemJob` respectively in a live container.

Not verified by me: an end-to-end differential subscription test with real objects. I
could not create a `ProjectUpdate` on 25.5.0 because `Fernet256.__init__` in
`awx/main/utils/encryption.py` does not set the `_aes` attribute that
`cryptography` 50.0.0 introduced in `Fernet`, so every `encrypt_field()` call raises
`AttributeError`. That is unrelated to this change and I will open a separate issue/PR
for it. Tag 25.4.0 pins `cryptography==46.0.7` and is not affected.
