### PR TITLE
Set Fernet256._aes so encryption works with cryptography 50

### DIFF
--- a/awx/main/utils/encryption.py
+++ b/awx/main/utils/encryption.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import algorithms
 from django.utils.encoding import smart_str, smart_bytes
 
 __all__ = ['get_encryption_key', 'encrypt_field', 'decrypt_field', 'encrypt_value', 'decrypt_value', 'encrypt_dict']
@@ -29,6 +30,10 @@ class Fernet256(Fernet):
 
         self._signing_key = key[:32]
         self._encryption_key = key[32:]
+        # Fernet._encrypt_from_parts and Fernet._decrypt_data build their Cipher from
+        # self._aes, which Fernet.__init__ sets as of cryptography 50.0.0. Overriding
+        # __init__ without setting it makes every encrypt/decrypt raise AttributeError.
+        self._aes = algorithms.AES(self._encryption_key)
         self._backend = backend
 
 


### PR DESCRIPTION
##### SUMMARY

`Fernet256` in `awx/main/utils/encryption.py` overrides `Fernet.__init__` and sets
`_signing_key`, `_encryption_key` and `_backend`. As of cryptography 50.0.0,
`Fernet.__init__` also precomputes the AES algorithm object:

```python
self._signing_key = key[:16]
self._encryption_key = key[16:]
self._aes = algorithms.AES(self._encryption_key)   # added in 50.0.0
```

`Fernet._encrypt_from_parts` and `Fernet._decrypt_data` both build their `Cipher` from
`self._aes`. Because `Fernet256.__init__` never sets it, every call raises:

```
AttributeError: 'Fernet256' object has no attribute '_aes'
```

`requirements/requirements.txt` on `main` pins `cryptography==50.0.0`, so this affects
`main` and the 25.5.0 images built from it. Tag 25.4.0 pins `cryptography==46.0.7`,
where the attribute does not exist yet, and is not affected.

**Impact**

`encrypt_field()` and `decrypt_field()` are the entry points for every encrypted model
field, so this is not limited to writes. Observed on a fresh 25.5.0 deployment:

- `POST /api/v2/projects/` returns `{"detail":"A server error has occurred."}`
- creating a `ProjectUpdate` fails in `UnifiedJob.signal_start` → `update_fields(start_args=...)` → `encrypt_field`
- decryption is affected as well, since `_decrypt_data` uses the same attribute, so
  reading existing credentials on an upgraded instance would fail too

Traceback tail from the running instance:

```
File ".../awx/main/utils/encryption.py", line 118, in encrypt_field
  encrypted = f.encrypt(smart_bytes(value))
File ".../cryptography/fernet.py", line 71, in _encrypt_from_parts
  encryptor = Cipher(self._aes, modes.CBC(iv)).encryptor()
AttributeError: 'Fernet256' object has no attribute '_aes'
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION
```
25.5.0 (ghcr.io/ctrliq/ascender:25.5.0, cryptography 50.0.0 in the image); branch based on main @ 4ed44f9
```

##### ADDITIONAL INFORMATION

The fix sets `_aes` from the 32 byte encryption key, so AES-256-CBC is preserved as the
class docstring promises rather than silently narrowing to AES-128.

Verified inside the 25.5.0 container against cryptography 50.0.0, comparing the current
implementation with the patched one:

```
cryptography: 50.0.0
without _aes : AttributeError: 'Fernet256' object has no attribute '_aes'
with    _aes : encrypt+decrypt OK, round trip correct = True, AES bits = 256
```

Two notes you may want to weigh:

1. The existing tests in `awx/main/tests/unit/utils/test_encryption.py`
   (`test_encrypt_field` and the others) do a full encrypt/decrypt round trip and should
   fail on `main` as it stands, so no new test is added here. It may be worth checking
   why the bump to cryptography 50.0.0 did not surface there.

2. This keeps depending on a private attribute of `Fernet`, so a future cryptography
   release can break it again the same way. A more durable option would be to implement
   the AES-256 variant without subclassing `Fernet`, or to constrain the dependency to a
   tested range. I kept this change minimal and did not attempt either.
