### PR TITLE
Label social auth login buttons and allow a custom SAML label

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -708,6 +708,9 @@ class AuthView(APIView):
                 for idp in sorted(settings.SOCIAL_AUTH_SAML_ENABLED_IDPS.keys()):
                     saml_backend_data = dict(backend_data.items())
                     saml_backend_data['login_url'] = '%s?idp=%s' % (login_url, idp)
+                    label = settings.SOCIAL_AUTH_SAML_ENABLED_IDPS[idp].get('label')
+                    if label:
+                        saml_backend_data['label'] = label
                     full_backend_name = '%s:%s' % (name, idp)
                     if (err_backend == full_backend_name or err_backend == name) and err_message:
                         saml_backend_data['error'] = err_message

--- a/awx/sso/conf.py
+++ b/awx/sso/conf.py
@@ -1475,8 +1475,10 @@ register(
         'Configure the Entity ID, SSO URL and certificate for each identity'
         ' provider (IdP) in use. Multiple SAML IdPs are supported. Some IdPs'
         ' may provide user data using attribute names that differ from the'
-        ' default OIDs. Attribute names may be overridden for each IdP. Refer'
-        ' to the Ansible documentation for additional details and syntax.'
+        ' default OIDs. Attribute names may be overridden for each IdP. An'
+        ' optional label may be set for each IdP to control the text of its'
+        ' login button. Refer to the Ansible documentation for additional'
+        ' details and syntax.'
     ),
     category=_('SAML'),
     category_slug='saml',

--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -663,6 +663,7 @@ class SAMLIdPField(HybridDictField):
     attr_last_name = fields.CharField(required=False)
     attr_username = fields.CharField(required=False)
     attr_email = fields.CharField(required=False)
+    label = fields.CharField(required=False)
 
 
 class SAMLEnabledIdPsField(fields.DictField):

--- a/awx/ui/src/login.css
+++ b/awx/ui/src/login.css
@@ -105,3 +105,26 @@
 .ascender-login .pf-v6-c-alert.pf-m-warning .pf-v6-c-alert__title {
   color: var(--pf-v6-global--Color--100);
 }
+
+.ascender-login .ascender-login__sso {
+  margin-top: 1.5rem;
+}
+
+.ascender-login .ascender-login__sso-separator {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  color: var(--pf-v6-global--Color--300);
+}
+
+.ascender-login .ascender-login__sso-separator::before,
+.ascender-login .ascender-login__sso-separator::after {
+  flex: 1;
+  content: '';
+  border-top: 1px solid var(--pf-v6-global--BorderColor--100);
+}
+
+.ascender-login .ascender-login__sso .pf-v6-c-button + .pf-v6-c-button {
+  margin-top: 0.5rem;
+}

--- a/awx/ui/src/screens/Login/Login.js
+++ b/awx/ui/src/screens/Login/Login.js
@@ -12,14 +12,13 @@ import DOMPurify from 'dompurify';
 import {
   Alert,
   Brand,
-  LoginMainFooterLinksItem, Button,
+  Button,
   LoginForm,
   Login as PFLogin,
   LoginHeader,
   LoginFooter,
   LoginMainBody,
   LoginMainFooter,
-  Tooltip,
 } from '@patternfly/react-core';
 
 import {
@@ -173,6 +172,86 @@ function AWXLogin({ alt, isAuthenticated }) {
     window.sessionStorage.setItem(SESSION_REDIRECT_URL, authRedirectTo);
   };
 
+  const socialAuthProviders = {
+    'azuread-oauth2': {
+      dataCy: 'social-auth-azure',
+      icon: AzureIcon,
+      label: t`Sign in with Azure AD`,
+    },
+    'azuread-tenant-oauth2': {
+      dataCy: 'social-auth-azure-tenant',
+      icon: AzureIcon,
+      label: t`Sign in with Azure AD Tenant`,
+    },
+    github: {
+      dataCy: 'social-auth-github',
+      icon: GithubIcon,
+      label: t`Sign in with GitHub`,
+    },
+    'github-org': {
+      dataCy: 'social-auth-github-org',
+      icon: GithubIcon,
+      label: t`Sign in with GitHub Organizations`,
+    },
+    'github-team': {
+      dataCy: 'social-auth-github-team',
+      icon: GithubIcon,
+      label: t`Sign in with GitHub Teams`,
+    },
+    'github-enterprise': {
+      dataCy: 'social-auth-github-enterprise',
+      icon: GithubIcon,
+      label: t`Sign in with GitHub Enterprise`,
+    },
+    'github-enterprise-org': {
+      dataCy: 'social-auth-github-enterprise-org',
+      icon: GithubIcon,
+      label: t`Sign in with GitHub Enterprise Organizations`,
+    },
+    'github-enterprise-team': {
+      dataCy: 'social-auth-github-enterprise-team',
+      icon: GithubIcon,
+      label: t`Sign in with GitHub Enterprise Teams`,
+    },
+    'google-oauth2': {
+      dataCy: 'social-auth-google',
+      icon: GoogleIcon,
+      label: t`Sign in with Google`,
+    },
+    oidc: {
+      dataCy: 'social-auth-oidc',
+      icon: UserCircleIcon,
+      label: t`Sign in with OIDC`,
+    },
+  };
+
+  const getSocialAuthProvider = (authKey) => {
+    if (!authKey.startsWith('saml')) {
+      return socialAuthProviders[authKey];
+    }
+    const samlIDP = authKey.split(':')[1] || null;
+    return {
+      dataCy: 'social-auth-saml',
+      icon: UserCircleIcon,
+      label: samlIDP ? t`Sign in with SAML ${samlIDP}` : t`Sign in with SAML`,
+    };
+  };
+
+  const socialAuthEntries = Object.keys(socialAuthOptions || {})
+    .map((authKey) => {
+      const provider = getSocialAuthProvider(authKey);
+      if (!provider) {
+        return null;
+      }
+      const { label } = socialAuthOptions[authKey];
+      return {
+        authKey,
+        ...provider,
+        label: label ? t`Sign in with ${label}` : provider.label,
+      };
+    })
+    .filter(Boolean);
+
   if (isCustomLoginInfoLoading) {
     return null;
   }
@@ -231,191 +310,27 @@ function AWXLogin({ alt, isAuthenticated }) {
             />
           )}
         </Formik>
+        {socialAuthEntries.length > 0 && (
+          <div className="ascender-login__sso">
+            <div className="ascender-login__sso-separator">{t`or`}</div>
+            {socialAuthEntries.map(({ authKey, dataCy, icon: Icon, label }) => (
+              <Button
+                key={authKey}
+                data-cy={dataCy}
+                variant="secondary"
+                component="a"
+                href={socialAuthOptions[authKey].login_url}
+                isBlock
+                icon={<Icon />}
+                onClick={setSessionRedirect}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+        )}
       </LoginMainBody>
-      <LoginMainFooter
-        socialMediaLoginContent={
-          <>
-            {socialAuthOptions &&
-              Object.keys(socialAuthOptions).map((authKey) => {
-                const loginUrl = socialAuthOptions[authKey].login_url;
-                if (authKey === 'azuread-oauth2') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-azure"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip content={t`Sign in with Azure AD`}>
-                        <AzureIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'azuread-tenant-oauth2') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-azure-tenant"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip
-                        content={t`Sign in with Azure AD Tenant`}
-                      >
-                        <AzureIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'github') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-github"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip content={t`Sign in with GitHub`}>
-                        <GithubIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'github-org') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-github-org"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip
-                        content={t`Sign in with GitHub Organizations`}
-                      >
-                        <GithubIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'github-team') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-github-team"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip content={t`Sign in with GitHub Teams`}>
-                        <GithubIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'github-enterprise') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-github-enterprise"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip
-                        content={t`Sign in with GitHub Enterprise`}
-                      >
-                        <GithubIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'github-enterprise-org') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-github-enterprise-org"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip
-                        content={t`Sign in with GitHub Enterprise Organizations`}
-                      >
-                        <GithubIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'github-enterprise-team') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-github-enterprise-team"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip
-                        content={t`Sign in with GitHub Enterprise Teams`}
-                      >
-                        <GithubIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'google-oauth2') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-google"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip content={t`Sign in with Google`}>
-                        <GoogleIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey === 'oidc') {
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-oidc"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip content={t`Sign in with OIDC`}>
-                        <UserCircleIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-                if (authKey.startsWith('saml')) {
-                  const samlIDP = authKey.split(':')[1] || null;
-                  return (
-                    <LoginMainFooterLinksItem data-codemods="true"
-                      data-cy="social-auth-saml"
-
-                      key={authKey}
-                      onClick={setSessionRedirect}
-                    ><Button variant="link" component="a" href={loginUrl}>
-                      <Tooltip
-                        content={
-                          samlIDP
-                            ? t`Sign in with SAML ${samlIDP}`
-                            : t`Sign in with SAML`
-                        }
-                      >
-                        <UserCircleIcon size="lg" />
-                      </Tooltip>
-                    </Button></LoginMainFooterLinksItem>
-                  );
-                }
-
-                return null;
-              })}
-              {Footer}
-          </>
-        }
-      />
+      <LoginMainFooter socialMediaLoginContent={<>{Footer}</>} />
     </Login>
   );
 }

--- a/awx/ui/src/screens/Login/Login.test.js
+++ b/awx/ui/src/screens/Login/Login.test.js
@@ -440,4 +440,60 @@ describe('<Login />', () => {
       container.querySelectorAll('[data-cy="social-auth-google"]')
     ).toHaveLength(0);
   });
+
+  test('SAML button uses the configured label', async () => {
+    AuthAPI.read.mockResolvedValue({
+      data: {
+        'saml:entra': {
+          login_url: '/sso/login/saml/?idp=entra',
+          complete_url: 'https://localhost:8043/sso/complete/saml/',
+          metadata_url: '/sso/metadata/saml/',
+          label: 'Entra ID',
+        },
+      },
+    });
+
+    const { container } = renderWithContexts(
+      <AWXLogin isAuthenticated={() => false} />
+    );
+    await waitForLoginForm(container);
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll('[data-cy="social-auth-saml"]')
+      ).toHaveLength(1)
+    );
+    expect(
+      container.querySelector('[data-cy="social-auth-saml"]').textContent
+    ).toEqual('Sign in with Entra ID');
+  });
+
+  test('SAML button falls back to the IdP key when no label is set', async () => {
+    AuthAPI.read.mockResolvedValue({
+      data: {
+        saml: {
+          login_url: '/sso/login/saml/',
+          complete_url: 'https://localhost:8043/sso/complete/saml/',
+          metadata_url: '/sso/metadata/saml/',
+        },
+        'saml:onelogin': {
+          login_url: '/sso/login/saml/?idp=onelogin',
+          complete_url: 'https://localhost:8043/sso/complete/saml/',
+          metadata_url: '/sso/metadata/saml/',
+        },
+      },
+    });
+
+    const { container } = renderWithContexts(
+      <AWXLogin isAuthenticated={() => false} />
+    );
+    await waitForLoginForm(container);
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll('[data-cy="social-auth-saml"]')
+      ).toHaveLength(2)
+    );
+    const buttons = container.querySelectorAll('[data-cy="social-auth-saml"]');
+    expect(buttons[0].textContent).toEqual('Sign in with SAML');
+    expect(buttons[1].textContent).toEqual('Sign in with SAML onelogin');
+  });
 });


### PR DESCRIPTION
##### SUMMARY

Social auth providers render as icon-only links in the login card's footer row, with the provider name only in a hover tooltip. With a single SAML IdP configured, the login screen shows one unlabelled circle and no text.

This moves the buttons into the card below the credential form as full-width secondary buttons with visible labels, and lets a SAML IdP set its own label.

Design notes:

- The ten near-identical provider branches collapse into a lookup table. The  `data-cy` attributes are unchanged, so the existing social auth tests pass untouched.
- `SAMLIdPField` gains an optional `label`, surfaced through `/api/v2/auth/`. SAML is the only multi-instance backend and the only one whose display name the code cannot know, so it is the only one that needs this. The other providers ship correct fixed names.
- The UI applies `label` for any backend that supplies one, not just SAML, so other providers can adopt it later with no UI change.
- Existing message IDs are unchanged, so current translations keep working. Without a label the derived text applies, so existing installs are unchanged apart from the layout.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
 - UI

##### ASCENDER VERSION
awx: 25.4.1.dev225+gad4c43395

##### ADDITIONAL INFORMATION

With a label configured:

```json
"entra": {
  "entity_id": "...",
  "url": "...",
  "x509cert": "...",
  "label": "Entra ID"
}
```

the button reads Sign in with Entra ID. Remove label and it reads Sign in with SAML entra, exactly as before this change.

PASS src/screens/Login/Login.test.js
  ✓ GitHub auth buttons shown
  ✓ Google auth button shown
  ✓ Azure AD auth button shown
  ✓ SAML auth buttons shown
  ✓ SAML button uses the configured label
  ✓ SAML button falls back to the IdP key when no label is set
