### PR TITLE
Resolve Host last_job filters against the latest job host summary

### DIFF
--- a/awx/api/filters.py
+++ b/awx/api/filters.py
@@ -1,23 +1,45 @@
 # Copyright (c) 2026 Ctrl IQ, Inc.
 # All Rights Reserved.
 
+# Python
+import functools
+import operator
+
 # Django
-from django.db.models import OuterRef, Subquery
+from django.db.models import Q
 
 # django-ansible-base
 from ansible_base.rest_filters.rest_framework.field_lookup_backend import FieldLookupBackend
 
-__all__ = ['HostFieldLookupBackend']
+__all__ = ['DERIVED_HOST_FIELDS', 'HostFieldLookupBackend']
 
+# Host field -> path from JobHostSummary that backs it; None is the summary itself.
 DERIVED_HOST_FIELDS = {'last_job': 'job', 'last_job_host_summary': None}
 
 
-def latest_summaries():
-    """The JobHostSummary rows that are the most recent one for their host."""
+def _annotated_hosts():
+    from awx.main.models.inventory import Host
+
+    return Host.objects.with_latest_summary_id()
+
+
+def hosts_matching_latest_summary(condition):
+    """
+    Hosts whose most recent JobHostSummary satisfies condition, a Q against JobHostSummary.
+
+    Recency comes from _latest_summary_id, the annotation the Host list views already carry
+    and that HostSerializer reads last_job/last_job_host_summary through, so a filter cannot
+    disagree with the values it serializes.
+    """
     from awx.main.models.jobs import JobHostSummary
 
-    newest = JobHostSummary.objects.filter(host_id=OuterRef('host_id')).order_by('-id')
-    return JobHostSummary.objects.filter(id=Subquery(newest.values('id')[:1]))
+    matching = JobHostSummary.objects.filter(condition).values('id')
+    return _annotated_hosts().filter(_latest_summary_id__in=matching).values('pk')
+
+
+def hosts_without_latest_summary(missing):
+    """Hosts that have never run when missing is True, those that have when it is False."""
+    return _annotated_hosts().filter(_latest_summary_id__isnull=missing).values('pk')
 
 
 class HostFieldLookupBackend(FieldLookupBackend):
@@ -36,16 +58,26 @@ class HostFieldLookupBackend(FieldLookupBackend):
             return super().value_to_python(model, lookup, value)
 
         prefix = DERIVED_HOST_FIELDS[field]
-        hosts_with_summary = latest_summaries().values('host_id')
 
         if remainder == 'isnull':
-            value, _, _ = super().value_to_python(JobHostSummary, 'id__isnull', value)
-            if value:
-                return Host.objects.exclude(pk__in=hosts_with_summary).values('pk'), 'pk__in', False
-            return hosts_with_summary, 'pk__in', False
+            missing, _, _ = super().value_to_python(JobHostSummary, 'id__isnull', value)
+            return hosts_without_latest_summary(missing), 'pk__in', False
 
         inner = remainder or 'id'
         if prefix:
             inner = '{}__{}'.format(prefix, inner)
+        elif inner == 'search':
+            # A summary holds none of the field names treated as searchable, which the
+            # parent expresses as an empty lookup list, and an empty list of ORs matches
+            # every row rather than none.
+            return Host.objects.none().values('pk'), ['pk__in'], False
+
         value, inner, _ = super().value_to_python(JobHostSummary, inner, value)
-        return latest_summaries().filter(**{inner: value}).values('host_id'), 'pk__in', False
+        if isinstance(inner, list):
+            # __search expands to several lookups, all relative to JobHostSummary, so the
+            # OR collapses here; left to the caller they would be applied against Host.
+            if not inner:
+                return Host.objects.none().values('pk'), ['pk__in'], False
+            condition = functools.reduce(operator.or_, (Q(**{one: value}) for one in inner))
+            return hosts_matching_latest_summary(condition), ['pk__in'], False
+        return hosts_matching_latest_summary(Q(**{inner: value})), 'pk__in', False

--- a/awx/api/filters.py
+++ b/awx/api/filters.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Ctrl IQ, Inc.
+# All Rights Reserved.
+
+# Django
+from django.db.models import OuterRef, Subquery
+
+# django-ansible-base
+from ansible_base.rest_filters.rest_framework.field_lookup_backend import FieldLookupBackend
+
+__all__ = ['HostFieldLookupBackend']
+
+DERIVED_HOST_FIELDS = {'last_job': 'job', 'last_job_host_summary': None}
+
+
+def latest_summaries():
+    """The JobHostSummary rows that are the most recent one for their host."""
+    from awx.main.models.jobs import JobHostSummary
+
+    newest = JobHostSummary.objects.filter(host_id=OuterRef('host_id')).order_by('-id')
+    return JobHostSummary.objects.filter(id=Subquery(newest.values('id')[:1]))
+
+
+class HostFieldLookupBackend(FieldLookupBackend):
+    """
+    Resolves Host.last_job and Host.last_job_host_summary against the newest
+    JobHostSummary for each host. The columns of the same name are denormalized
+    caches that are no longer written, so a plain lookup matches nothing.
+    """
+
+    def value_to_python(self, model, lookup, value):
+        from awx.main.models.inventory import Host
+        from awx.main.models.jobs import JobHostSummary
+
+        field, _, remainder = lookup.partition('__')
+        if model is not Host or field not in DERIVED_HOST_FIELDS:
+            return super().value_to_python(model, lookup, value)
+
+        prefix = DERIVED_HOST_FIELDS[field]
+        hosts_with_summary = latest_summaries().values('host_id')
+
+        if remainder == 'isnull':
+            value, _, _ = super().value_to_python(JobHostSummary, 'id__isnull', value)
+            if value:
+                return Host.objects.exclude(pk__in=hosts_with_summary).values('pk'), 'pk__in', False
+            return hosts_with_summary, 'pk__in', False
+
+        inner = remainder or 'id'
+        if prefix:
+            inner = '{}__{}'.format(prefix, inner)
+        value, inner, _ = super().value_to_python(JobHostSummary, inner, value)
+        return latest_summaries().filter(**{inner: value}).values('host_id'), 'pk__in', False

--- a/awx/main/tests/functional/api/test_host_derived_filters.py
+++ b/awx/main/tests/functional/api/test_host_derived_filters.py
@@ -1,0 +1,90 @@
+import pytest
+
+from awx.api.versioning import reverse
+
+from awx.main.models import Host, Inventory, Job, JobEvent, Organization
+
+
+def run_job(inventory, ok=(), failures=()):
+    job = Job(inventory=inventory)
+    job.save()
+    host_map = dict(inventory.hosts.values_list('name', 'id'))
+    JobEvent.create_from_data(
+        job_id=job.pk,
+        parent_uuid='abc123',
+        event='playbook_on_stats',
+        event_data={
+            'ok': {name: 1 for name in ok},
+            'changed': {},
+            'dark': {},
+            'failures': {name: 1 for name in failures},
+            'ignored': {},
+            'processed': {},
+            'rescued': {},
+            'skipped': {},
+        },
+        host_map=host_map,
+    ).save()
+    return job
+
+
+@pytest.fixture
+def hosts():
+    org = Organization.objects.create(name='org')
+    inventory = Inventory.objects.create(name='inv', organization=org)
+    for name in ('failing', 'recovered', 'passing', 'never_run'):
+        Host.objects.create(name=name, inventory=inventory)
+    return inventory
+
+
+def names_from(response):
+    return sorted(host['name'] for host in response.data['results'])
+
+
+@pytest.mark.django_db
+def test_filter_by_latest_summary_failed(hosts, get, user):
+    run_job(hosts, ok=['passing'], failures=['failing', 'recovered'])
+    run_job(hosts, ok=['recovered'], failures=['failing'])
+
+    url = reverse('api:host_list')
+    response = get(url + '?last_job_host_summary__failed=true', user('admin', True))
+    assert names_from(response) == ['failing']
+
+    response = get(url + '?last_job_host_summary__failed=false', user('admin', True))
+    assert names_from(response) == ['passing', 'recovered']
+
+
+@pytest.mark.django_db
+def test_filter_by_last_job(hosts, get, user):
+    first = run_job(hosts, ok=['passing', 'recovered'])
+    second = run_job(hosts, ok=['recovered'])
+
+    url = reverse('api:host_list')
+    response = get(url + '?last_job=%d' % second.id, user('admin', True))
+    assert names_from(response) == ['recovered']
+
+    response = get(url + '?last_job=%d' % first.id, user('admin', True))
+    assert names_from(response) == ['passing']
+
+
+@pytest.mark.django_db
+def test_filter_by_summary_isnull(hosts, get, user):
+    run_job(hosts, ok=['passing'], failures=['failing'])
+
+    url = reverse('api:host_list')
+    response = get(url + '?last_job_host_summary__isnull=true', user('admin', True))
+    assert names_from(response) == ['never_run', 'recovered']
+
+    response = get(url + '?last_job_host_summary__isnull=false', user('admin', True))
+    assert names_from(response) == ['failing', 'passing']
+
+
+@pytest.mark.django_db
+def test_filter_matches_dashboard_count(hosts, get, user):
+    run_job(hosts, ok=['passing', 'recovered'], failures=['failing'])
+    run_job(hosts, failures=['failing'])
+
+    admin = user('admin', True)
+    listed = get(reverse('api:host_list') + '?last_job_host_summary__failed=true', admin)
+    dashboard = get(reverse('api:dashboard_view'), admin)
+    assert len(listed.data['results']) == dashboard.data['hosts']['failed']

--- a/awx/main/tests/functional/api/test_host_derived_filters.py
+++ b/awx/main/tests/functional/api/test_host_derived_filters.py
@@ -132,6 +132,15 @@ def test_smart_inventory_host_filter(inventory_with_hosts, get, admin):
 
 
 @pytest.mark.django_db
+def test_smart_inventory_rejects_search(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, name='nightly build', ok=['passing'])
+
+    for lookup in ('last_job__search=nightly', 'last_job_host_summary__search=nightly'):
+        response = get(host_list('?host_filter=%s' % urllib.parse.quote(lookup, safe='')), admin)
+        assert response.status_code == 400
+
+
+@pytest.mark.django_db
 def test_other_models_filter_their_own_column(job_template, get, admin):
     job = Job.objects.create(job_template=job_template, name='template run')
     job_template.last_job = job

--- a/awx/main/tests/functional/api/test_host_derived_filters.py
+++ b/awx/main/tests/functional/api/test_host_derived_filters.py
@@ -1,3 +1,5 @@
+import urllib.parse
+
 import pytest
 
 from awx.api.versioning import reverse
@@ -5,8 +7,8 @@ from awx.api.versioning import reverse
 from awx.main.models import Host, Inventory, Job, JobEvent, Organization
 
 
-def run_job(inventory, ok=(), failures=()):
-    job = Job(inventory=inventory)
+def run_job(inventory, name='job', ok=(), failures=()):
+    job = Job(inventory=inventory, name=name)
     job.save()
     host_map = dict(inventory.hosts.values_list('name', 'id'))
     JobEvent.create_from_data(
@@ -29,7 +31,7 @@ def run_job(inventory, ok=(), failures=()):
 
 
 @pytest.fixture
-def hosts():
+def inventory_with_hosts():
     org = Organization.objects.create(name='org')
     inventory = Inventory.objects.create(name='inv', organization=org)
     for name in ('failing', 'recovered', 'passing', 'never_run'):
@@ -41,50 +43,112 @@ def names_from(response):
     return sorted(host['name'] for host in response.data['results'])
 
 
-@pytest.mark.django_db
-def test_filter_by_latest_summary_failed(hosts, get, user):
-    run_job(hosts, ok=['passing'], failures=['failing', 'recovered'])
-    run_job(hosts, ok=['recovered'], failures=['failing'])
+def host_list(query=''):
+    return reverse('api:host_list') + query
 
-    url = reverse('api:host_list')
-    response = get(url + '?last_job_host_summary__failed=true', user('admin', True))
+
+@pytest.mark.django_db
+def test_filter_by_latest_summary_failed(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, ok=['passing'], failures=['failing', 'recovered'])
+    run_job(inventory_with_hosts, ok=['recovered'], failures=['failing'])
+
+    response = get(host_list('?last_job_host_summary__failed=true'), admin)
     assert names_from(response) == ['failing']
 
-    response = get(url + '?last_job_host_summary__failed=false', user('admin', True))
+    response = get(host_list('?last_job_host_summary__failed=false'), admin)
     assert names_from(response) == ['passing', 'recovered']
 
 
 @pytest.mark.django_db
-def test_filter_by_last_job(hosts, get, user):
-    first = run_job(hosts, ok=['passing', 'recovered'])
-    second = run_job(hosts, ok=['recovered'])
+def test_filter_by_last_job(inventory_with_hosts, get, admin):
+    first = run_job(inventory_with_hosts, ok=['passing', 'recovered'])
+    second = run_job(inventory_with_hosts, ok=['recovered'])
 
-    url = reverse('api:host_list')
-    response = get(url + '?last_job=%d' % second.id, user('admin', True))
+    response = get(host_list('?last_job=%d' % second.id), admin)
     assert names_from(response) == ['recovered']
 
-    response = get(url + '?last_job=%d' % first.id, user('admin', True))
+    response = get(host_list('?last_job=%d' % first.id), admin)
     assert names_from(response) == ['passing']
 
 
 @pytest.mark.django_db
-def test_filter_by_summary_isnull(hosts, get, user):
-    run_job(hosts, ok=['passing'], failures=['failing'])
+def test_filter_by_last_job_in(inventory_with_hosts, get, admin):
+    first = run_job(inventory_with_hosts, ok=['passing'])
+    second = run_job(inventory_with_hosts, ok=['recovered'])
 
-    url = reverse('api:host_list')
-    response = get(url + '?last_job_host_summary__isnull=true', user('admin', True))
+    response = get(host_list('?last_job__in=%d,%d' % (first.id, second.id)), admin)
+    assert names_from(response) == ['passing', 'recovered']
+
+
+@pytest.mark.django_db
+def test_filter_by_summary_isnull(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, ok=['passing'], failures=['failing'])
+
+    response = get(host_list('?last_job_host_summary__isnull=true'), admin)
     assert names_from(response) == ['never_run', 'recovered']
 
-    response = get(url + '?last_job_host_summary__isnull=false', user('admin', True))
+    response = get(host_list('?last_job_host_summary__isnull=false'), admin)
     assert names_from(response) == ['failing', 'passing']
 
 
 @pytest.mark.django_db
-def test_filter_matches_dashboard_count(hosts, get, user):
-    run_job(hosts, ok=['passing', 'recovered'], failures=['failing'])
-    run_job(hosts, failures=['failing'])
+def test_negated_filter_keeps_hosts_that_never_ran(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, ok=['passing'], failures=['failing'])
 
-    admin = user('admin', True)
-    listed = get(reverse('api:host_list') + '?last_job_host_summary__failed=true', admin)
+    response = get(host_list('?not__last_job_host_summary__failed=true'), admin)
+    assert names_from(response) == ['never_run', 'passing', 'recovered']
+
+
+@pytest.mark.django_db
+def test_search_across_last_job(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, name='nightly build', ok=['passing'])
+    run_job(inventory_with_hosts, name='adhoc patch', ok=['recovered'])
+
+    response = get(host_list('?last_job__search=nightly'), admin)
+    assert names_from(response) == ['passing']
+
+
+@pytest.mark.django_db
+def test_search_across_summary_matches_nothing(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, ok=['passing'])
+
+    response = get(host_list('?last_job_host_summary__search=passing'), admin)
+    assert response.status_code == 200
+    assert names_from(response) == []
+
+
+@pytest.mark.django_db
+def test_smart_inventory_host_filter(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, ok=['passing'], failures=['failing'])
+    last = run_job(inventory_with_hosts, ok=['recovered'])
+
+    query = urllib.parse.quote('last_job_host_summary__failed=true', safe='')
+    response = get(host_list('?host_filter=%s' % query), admin)
+    assert names_from(response) == ['failing']
+
+    query = urllib.parse.quote('last_job=%d' % last.id, safe='')
+    response = get(host_list('?host_filter=%s' % query), admin)
+    assert names_from(response) == ['recovered']
+
+
+@pytest.mark.django_db
+def test_other_models_filter_their_own_column(job_template, get, admin):
+    job = Job.objects.create(job_template=job_template, name='template run')
+    job_template.last_job = job
+    job_template.save()
+
+    response = get(reverse('api:job_template_list') + '?last_job=%d' % job.id, admin)
+    assert [item['id'] for item in response.data['results']] == [job_template.id]
+
+    response = get(reverse('api:job_template_list') + '?last_job=%d' % (job.id + 1), admin)
+    assert response.data['results'] == []
+
+
+@pytest.mark.django_db
+def test_filter_matches_dashboard_count(inventory_with_hosts, get, admin):
+    run_job(inventory_with_hosts, ok=['passing', 'recovered'], failures=['failing'])
+    run_job(inventory_with_hosts, failures=['failing'])
+
+    listed = get(host_list('?last_job_host_summary__failed=true'), admin)
     dashboard = get(reverse('api:dashboard_view'), admin)
-    assert len(listed.data['results']) == dashboard.data['hosts']['failed']
+    assert listed.data['count'] == dashboard.data['hosts']['failed']

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -161,11 +161,18 @@ class SmartFilter(object):
                 q = reduce(lambda x, y: x | y, [models.Q(**{u'%s__icontains' % _k: _v}) for _k, _v in kwargs.items()])
                 self.result = Host.objects.filter(q)
             else:
-                # detect loops and restrict access to sensitive fields
                 # this import is intentional here to avoid a circular import
-                from ansible_base.rest_filters.rest_framework.field_lookup_backend import FieldLookupBackend
+                from awx.api.filters import DERIVED_HOST_FIELDS, HostFieldLookupBackend
 
-                FieldLookupBackend().get_field_from_lookup(Host, k)
+                # both branches resolve through get_fields_from_path, which is what detects
+                # loops and restricts access to sensitive fields
+                backend = HostFieldLookupBackend()
+                if k.partition('__')[0] in DERIVED_HOST_FIELDS:
+                    # these columns hold nothing, so resolve them the way the REST filters
+                    # do and keep smart inventories agreeing with /api/v2/hosts/
+                    v, k, _ = backend.value_to_python(Host, k, v)
+                else:
+                    backend.get_field_from_lookup(Host, k)
                 kwargs[k] = v
                 self.result = Host.objects.filter(**kwargs)
 

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -170,7 +170,12 @@ class SmartFilter(object):
                 if k.partition('__')[0] in DERIVED_HOST_FIELDS:
                     # these columns hold nothing, so resolve them the way the REST filters
                     # do and keep smart inventories agreeing with /api/v2/hosts/
-                    v, k, _ = backend.value_to_python(Host, k, v)
+                    v, lookup, _ = backend.value_to_python(Host, k, v)
+                    if isinstance(lookup, list):
+                        # a __search key resolves to several lookups; _expand_search turns
+                        # those away first, and the grammar cannot express the OR anyway
+                        raise ParseException('%s is not supported in host filters' % k)
+                    k = lookup
                 else:
                     backend.get_field_from_lookup(Host, k)
                 kwargs[k] = v

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1234,3 +1234,9 @@ from ansible_base.lib import dynamic_config  # noqa: E402
 
 settings_file = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_settings.py')
 include(settings_file)
+
+# dynamic_settings sets DEFAULT_FILTER_BACKENDS. Swap the generic field lookup backend for the
+# one that resolves the Host fields derived from JobHostSummary.
+REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS'] = tuple(
+    'awx.api.filters.HostFieldLookupBackend' if backend.endswith('.FieldLookupBackend') else backend for backend in REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS']
+)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -14,6 +14,11 @@ from datetime import timedelta
 
 # python-ldap
 import ldap
+
+# Django
+from django.core.exceptions import ImproperlyConfigured
+
+# django-split-settings
 from split_settings.tools import include
 
 DEBUG = True
@@ -1236,7 +1241,13 @@ settings_file = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_
 include(settings_file)
 
 # dynamic_settings sets DEFAULT_FILTER_BACKENDS. Swap the generic field lookup backend for the
-# one that resolves the Host fields derived from JobHostSummary.
+# one that resolves the Host fields derived from JobHostSummary. A miss here would put the
+# derived filters back to matching nothing, which is silent, so refuse to start instead.
+generic_field_lookup_backend = 'ansible_base.rest_filters.rest_framework.field_lookup_backend.FieldLookupBackend'
+if generic_field_lookup_backend not in REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS']:
+    raise ImproperlyConfigured(
+        'Expected {} in REST_FRAMEWORK["DEFAULT_FILTER_BACKENDS"], found {}.'.format(generic_field_lookup_backend, REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS'])
+    )
 REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS'] = tuple(
-    'awx.api.filters.HostFieldLookupBackend' if backend.endswith('.FieldLookupBackend') else backend for backend in REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS']
+    'awx.api.filters.HostFieldLookupBackend' if backend == generic_field_lookup_backend else backend for backend in REST_FRAMEWORK['DEFAULT_FILTER_BACKENDS']
 )


### PR DESCRIPTION
##### SUMMARY

`Host.last_job` and `Host.last_job_host_summary` are denormalized caches that are no longer written. The serializer, `DashboardView` and `Inventory.update_computed_fields` all derive the value from `JobHostSummary`, but filtering goes to the columns, which are NULL for every host. Those lookups therefore return an empty set rather than an error.

Three visible effects:

- The dashboard's "Failed hosts" tile links to `/hosts?host.last_job_host_summary__failed=true` (`Dashboard.js:107`). The count beside it is correct, the list it opens is always empty.
- `HostFilterLookup.js:145` offers "Last job" as a host-filter key for smart inventories. A smart inventory built on it silently matches nothing, and unlike the dashboard there is no count to contradict it.
- Any API client filtering `last_job` or `last_job_host_summary` gets a silently wrong answer instead of an error. Compare `?has_active_failures=true`, which fails loudly with `Host has no field named 'has_active_failures'`.

Both entry points are covered. `HostFieldLookupBackend` resolves the two fields for the REST filters, and `SmartFilter` routes them through the same code so a smart inventory's `host_filter` agrees with `/api/v2/hosts/`; `SmartFilter` validates the lookup with the backend but then builds its own queryset, so it needs handling of its own. `__search` is included: the parent expands it to a list of lookups relative to the related model, so the OR is collapsed against `JobHostSummary` rather than applied to `Host`. A smart inventory cannot express that OR, and `SmartFilter` rejects such keys as a parse error.

Recency comes from the `_latest_summary_id` annotation in `HostLatestSummaryQuerySet`, which every Host list view already carries and which `HostSerializer` reads `last_job` and `last_job_host_summary` through. Reusing it keeps one definition of "latest summary" across the serializer, `DashboardView`, `Inventory.update_computed_fields` and the filters, and drives the scan off `Host` rather than the much larger `JobHostSummary`. `__isnull` maps to the annotation being null, so it means "the host has never run". Non-Host models fall through to the parent backend, which matters because `UnifiedJobTemplate.last_job` is a live column. Registration matches the generic backend by exact dotted path and raises `ImproperlyConfigured` if it is absent, since a silent miss would leave the derived filters matching nothing. No UI change is needed; the existing link and filter key work as written.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION
```
awx: 25.4.1.dev225+gcc4e6d337
```

##### ADDITIONAL INFORMATION

Reproduction on an instance where hosts have run jobs:

```
GET /api/v2/dashboard/                                -> hosts.failed = 4
GET /api/v2/hosts/?last_job_host_summary__failed=true -> count = 0
GET /api/v2/hosts/?last_job_host_summary__isnull=true -> count = 262 (every host)
```

A host serializing `last_job: 274` is not matched by `?last_job=274`, because the serialized value is derived while the filter reads the column.

Full suite, `make test` in the branch-built `ascender_devel` image:

```
3685 passed, 6 skipped, 3 failed in 329s
```

The three are `test_is_not_inventory[bad|bad_encoding|empty.txt]`, which key off file permissions and fail on any mount that reports every file as executable. They are unrelated to this change.

Negative control, with the derived-field resolution removed:

```
3 failed, 7 passed
  test_smart_inventory_host_filter             [] != ['failing']
  test_search_across_last_job                  400 != 200
  test_search_across_summary_matches_nothing   400 != 200
```

```
awx/main/tests/functional/api/test_host_derived_filters.py   11 passed
black --check, flake8                                        clean
```
