### PR TITLE
fix: SSO login buttons hidden when custom login info is empty

### DIFF
--- a/awx/ui/src/login.css
+++ b/awx/ui/src/login.css
@@ -90,7 +90,7 @@
   outline: none;
 }
 
-.ascender-login .pf-v6-c-login__main-footer:has(.pf-v6-c-login__footer:empty) {
+.ascender-login .pf-v6-c-login__footer:empty {
   display: none;
 }
 


### PR DESCRIPTION
##### SUMMARY
Since 25.5.0, the login page hides all SSO login buttons whenever `CUSTOM_LOGIN_INFO` is empty, which is the default. The rule added in #519  uses `:has(.pf-v6-c-login__footer:empty)` on `login__main-footer`, but that container also holds the SSO button list, so the rule hides the buttons along with the empty footer.

This change hides only the empty `login__footer` element. `login__main-footer` has no padding or margin of its own, so an install with neither SSO buttons nor custom login info still renders nothing there, same as before.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
25.5.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Reproduce: configure any social auth backend, leave Settings > User Interface > Custom Login Info empty, and load `/#/login`. The button markup is in the DOM but inside a `display:none` container. 25.4.0 is unaffected (rule absent).


