### PR TITLE
fix: survey question edit link resolves to a doubled survey/ segment

### DIFF
--- a/awx/ui/src/screens/Template/Survey/SurveyListItem.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyListItem.js
@@ -44,7 +44,7 @@ function SurveyListItem({ canEdit, question, isChecked, onSelect, rowIndex }) {
       >
         <>
           <Link
-            to={`survey/edit?question_variable=${encodeURIComponent(
+            to={`edit?question_variable=${encodeURIComponent(
               question.variable
             )}`}
           >
@@ -98,7 +98,7 @@ function SurveyListItem({ canEdit, question, isChecked, onSelect, rowIndex }) {
               ouiaId={`edit-survey-${question.variable}`}
               variant="plain"
               component={Link}
-              to={`survey/edit?question_variable=${encodeURIComponent(
+              to={`edit?question_variable=${encodeURIComponent(
                 question.variable
               )}`}
              />

--- a/awx/ui/src/screens/Template/Survey/SurveyListItem.test.js
+++ b/awx/ui/src/screens/Template/Survey/SurveyListItem.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
+import { Routes, Route } from 'react-router';
+import { createMemoryHistory } from 'history';
 import { renderWithContexts } from '../../../../testUtils/rtlContexts';
 import SurveyListItem from './SurveyListItem';
 
@@ -8,6 +10,40 @@ const renderInTable = (ui) =>
     <table>
       <tbody>{ui}</tbody>
     </table>
+  );
+
+// Mirrors how the app mounts the list: Template.js routes "survey/*" to
+// TemplateSurvey, which renders SurveyList from its own index route. Relative
+// link targets resolve against that route path, so hrefs are only meaningful
+// when the item is mounted at the same depth.
+const renderAtSurveyRoute = (ui) =>
+  renderWithContexts(
+    <Routes>
+      <Route
+        path="/templates/:templateType/:id/survey/*"
+        element={
+          <Routes>
+            <Route
+              index
+              element={
+                <table>
+                  <tbody>{ui}</tbody>
+                </table>
+              }
+            />
+          </Routes>
+        }
+      />
+    </Routes>,
+    {
+      context: {
+        router: {
+          history: createMemoryHistory({
+            initialEntries: ['/templates/job_template/59/survey'],
+          }),
+        },
+      },
+    }
   );
 
 describe('<SurveyListItem />', () => {
@@ -145,7 +181,7 @@ describe('<SurveyListItem />', () => {
   });
 
   test('edit button shown to users with edit capabilities', () => {
-    renderInTable(
+    renderAtSurveyRoute(
       <SurveyListItem
         question={item}
         isFirst
@@ -161,7 +197,24 @@ describe('<SurveyListItem />', () => {
     expect(editLink).toBeInTheDocument();
     expect(editLink).toHaveAttribute(
       'href',
-      '/survey/edit?question_variable=buzz'
+      '/templates/job_template/59/survey/edit?question_variable=buzz'
+    );
+  });
+
+  test('question name links to the edit form for that question', () => {
+    renderAtSurveyRoute(
+      <SurveyListItem
+        question={item}
+        isFirst
+        isLast
+        isChecked={false}
+        canEdit
+      />
+    );
+
+    expect(screen.getByRole('link', { name: 'Foo' })).toHaveAttribute(
+      'href',
+      '/templates/job_template/59/survey/edit?question_variable=buzz'
     );
   });
 });


### PR DESCRIPTION
##### SUMMARY

Opening a survey question, either by clicking the question name or the pencil action,
navigates to a path containing `survey/` twice and renders an empty card. No error is
shown and nothing is logged.

```
expected: /templates/job_template/1/survey/edit?question_variable=example
actual:   /templates/job_template/1/survey/survey/edit?question_variable=example
```

`SurveyListItem` builds a relative link target:

```jsx
to={`survey/edit?question_variable=${encodeURIComponent(question.variable)}`}
```

This was correct under react-router v5, which resolved a relative target with
`resolvePathname`. That treats the last segment of the current path as a file and drops
it, so from `/templates/job_template/1/survey` the target became
`/templates/job_template/1/survey/edit`.

v6 resolves a relative target against the current route path treated as a directory, so
the same string now appends instead of replacing. The link has been broken since the v5 to
v6 migration; it was missed when the Template route trees were converted in #427.

The fix drops the `survey/` prefix from both targets. The list renders from the index route
of `survey/*`, so a plain `edit?...` resolves to `<template>/survey/edit`.

Design note: the prefix could instead have been made absolute, matching `SurveyToolbar`,
which builds `pathname.substr(0, pathname.indexOf('survey')) + 'survey'` and is why adding
a question still works today. The relative form was kept because it is the idiom the rest
of the converted route trees use, and it stays correct if the survey routes are ever
mounted at a different depth.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### ASCENDER VERSION
```
awx: 25.5.2.dev2+g43994d8be
```

##### ADDITIONAL INFORMATION

Affects job templates and workflow job templates, since `Template.js` and
`WorkflowJobTemplate.js` both mount `TemplateSurvey` at `survey/*`.

`TemplateSurvey` registers `add`, `edit` and an index route with no `path="*"` fallback, so
the unmatched `survey/edit` remainder renders nothing. `Template.js` also hides the tabs
whenever the path contains `survey/`. That combination is why the failure presents as a
blank card rather than a not-found.

**Why the existing test did not catch it.** `SurveyListItem.test.js` mounted the component
at the router root, with no `/templates/:templateType/:id/survey` route above it, and
asserted the href was `/survey/edit?question_variable=buzz`. Relative resolution had
nothing to append to, so the assertion passed while the real screen was broken. The test
helper now mounts the item inside the same nesting the app uses, a `survey/*` parent with
an index child, so the assertions exercise real relative resolution. The question-name link
had no coverage at all and now has some.

**Steps to reproduce**

1. Open a job template that has at least one survey question.
2. Go to the Survey tab.
3. Click a question name, or its pencil icon.
4. Before: the URL gains a second `survey/` segment and the card is empty.
   After: the edit form loads.

**Before** — new tests against the unfixed component:

```
  ● <SurveyListItem /> › edit button shown to users with edit capabilities

    Expected the element to have attribute:
      href="/templates/job_template/59/survey/edit?question_variable=buzz"
    Received:
      href="/templates/job_template/59/survey/survey/edit?question_variable=buzz"

  ● <SurveyListItem /> › question name links to the edit form for that question

    Expected the element to have attribute:
      href="/templates/job_template/59/survey/edit?question_variable=buzz"
    Received:
      href="/templates/job_template/59/survey/survey/edit?question_variable=buzz"

Test Suites: 1 failed, 1 total
Tests:       2 failed, 7 passed, 9 total
```

**After** — same tests with the fix, then the full Template suite:

```
PASS src/screens/Template/Survey/SurveyListItem.test.js
  <SurveyListItem />
    ✓ edit button shown to users with edit capabilities
    ✓ question name links to the edit form for that question

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
```

```
$ node scripts/test.js --watchAll=false --testPathPatterns "screens/Template"

Test Suites: 48 passed, 48 total
Tests:       264 passed, 264 total
```

**Not addressed here.** Two adjacent issues, left out to keep this reviewable:

- The question-name link renders regardless of `canEdit`, but `TemplateSurvey` only
  registers the `edit` route when `canEdit` is true, so a user without edit or delete
  capability on the template gets a dead link. This predates the router migration and is
  unchanged by this PR.
- `TemplateSurvey` has no `path="*"` fallback, so any future route mismatch will also fail
  silently instead of rendering `ContentError`.

Happy to fold either in if you would prefer them here.