### PR TITLE
Defer loading of ansible_facts in HostLatestSummaryQuerySet

### DIFF
--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -50,7 +50,7 @@ class HostLatestSummaryQuerySet(models.QuerySet):
         latest_summary = JobHostSummary.objects.filter(host_id=OuterRef('pk')).order_by('-id')
         return self.annotate(
             _latest_summary_id=Subquery(latest_summary.values('id')[:1]),
-        )
+        ).defer('ansible_facts')
 
     def _fetch_all(self):
         super()._fetch_all()


### PR DESCRIPTION
##### SUMMARY

I was seeing performance issues loading a fairly small number of hosts in my environment,  on the order of 5-8 seconds just for the page to load. I asked Claude to look into it, and it found that the full `ansible_facts` JSON blob was being loaded from the database for every host on every list/detail request, even though it's never rendered in the response. 

The fix defers loading of the `ansible_facts` column in `HostLatestSummaryQuerySet.with_latest_summary_id()`.

I tested this in my own environment and didn't see any regressions.

##### ISSUE TYPE

 - Bug Fix

##### COMPONENT NAME
 - API

##### ASCENDER VERSION
```
25.5.1
```