### PR TITLE
fix: prevent notification template render errors from crashing the error formatter

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -492,13 +492,13 @@ class JobNotificationMixin(object):
             try:
                 msg = env.from_string(msg_template).render(**context)
             except (TemplateSyntaxError, UndefinedError, SecurityError) as e:
-                msg = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__).replace('\n', '\r\n'))])
+                msg = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__)).replace('\n', '\r\n')])
 
         if body_template:
             try:
                 body = env.from_string(body_template).render(**context)
             except (TemplateSyntaxError, UndefinedError, SecurityError) as e:
-                body = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__).replace('\n', '\r\n'))])
+                body = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__)).replace('\n', '\r\n')])
 
         # Only replace the body when the template renders to nothing
         # (empty or whitespace-only). Short single-line bodies, such as a

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -5,7 +5,7 @@ import datetime
 import pytest
 
 # from awx.main.models import NotificationTemplates, Notifications, JobNotificationMixin
-from awx.main.models import AdHocCommand, InventoryUpdate, Job, JobNotificationMixin, ProjectUpdate, Schedule, SystemJob, WorkflowJob
+from awx.main.models import AdHocCommand, InventoryUpdate, Job, JobNotificationMixin, NotificationTemplate, ProjectUpdate, Schedule, SystemJob, WorkflowJob
 from awx.api.serializers import UnifiedJobSerializer
 
 
@@ -141,6 +141,20 @@ class TestJobNotificationMixin(object):
         job_serialization = UnifiedJobSerializer(job).to_representation(job)
         context = job.context(job_serialization)
         assert '批量安装项目' in context['job_metadata']
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize('bad_template', ['{% badtag %}', 'Job {{ name '])
+    def test_build_notification_message_handles_template_render_error(self, bad_template):
+        """A custom template with a Jinja syntax error must yield a readable error
+        message, not raise. traceback.format_exception returns a list, so the .replace
+        must apply to the joined string."""
+        job = Job.objects.create(name='fake-job')
+        nt = NotificationTemplate(name='broken', notification_type='webhook', messages={'started': {'message': bad_template, 'body': ''}})
+
+        msg, body = job.build_notification_message(nt, 'running')
+
+        assert isinstance(msg, str)
+        assert 'Traceback' in msg
 
     def test_context_stub(self):
         """The context stub is a fake context used to validate custom notification messages. Ensure that


### PR DESCRIPTION
##### SUMMARY

`JobNotificationMixin.build_notification_message()` catches Jinja `TemplateSyntaxError` / `UndefinedError` / `SecurityError` so it can render the error into the notification message/body. The except block calls `str.replace()` on the value returned by `traceback.format_exception()`, which is a list, so the error handler itself raises:

    AttributeError: 'list' object has no attribute 'replace'

Trigger: an admin saves a custom notification message or body template containing a Jinja syntax error (an unknown tag, an unclosed expression). Any job that fires that notification then hits the except block.

Impact: on the callback path the AttributeError is swallowed by an outer `except Exception` and logged misleadingly as "Worker failed to save stats or emit notifications", so the notification silently never sends and the operator never receives the error message this code exists to produce. On the job post-run path (`tasks/jobs.py`) the call is not wrapped, so it propagates.

Fix: `format_exception` returns a list; join it into a string first, then replace newlines with CRLF. One misplaced parenthesis, applied to the message and body paths. Adds a regression test.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION
```
25.5.1
```

##### ADDITIONAL INFORMATION

Reproduction (before the fix), via `awx-manage shell`:

```python
from awx.main.models import Job, NotificationTemplate
job = Job.objects.create(name='fake-job')
nt = NotificationTemplate(name='broken', notification_type='webhook',
                          messages={'started': {'message': '{% badtag %}', 'body': ''}})
job.build_notification_message(nt, 'running')
```

Before:
```
AttributeError: 'list' object has no attribute 'replace'
```

After:
```
("Encountered unknown tag 'badtag'.\r\nTraceback (most recent call last): ...", '')
```

Note: a static type checker flags this directly, whereas the current flake8 rule selection does no type inference and cannot:
```
$ mypy sample.py
error: "list[str]" has no attribute "replace"  [attr-defined]
```