### PR TITLE
fix: require superuser for the debug scheduler-trigger endpoints

### DIFF
--- a/awx/api/permissions.py
+++ b/awx/api/permissions.py
@@ -24,6 +24,7 @@ __all__ = [
     'InventoryInventorySourcesUpdatePermission',
     'UserPermission',
     'IsSystemAdminOrAuditor',
+    'IsSuperuser',
     'WorkflowApprovalPermission',
     'AnalyticsPermission',
 ]
@@ -246,6 +247,15 @@ class IsSystemAdminOrAuditor(permissions.BasePermission):
         if request.method == 'GET':
             return request.user.is_superuser or request.user.is_system_auditor
         return request.user.is_superuser
+
+
+class IsSuperuser(permissions.BasePermission):
+    """
+    Allows access only to system superusers.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_authenticated and request.user.is_superuser)
 
 
 class WebhookKeyPermission(permissions.BasePermission):

--- a/awx/api/views/debug.py
+++ b/awx/api/views/debug.py
@@ -2,9 +2,9 @@ from collections import OrderedDict
 
 from django.conf import settings
 
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from awx.api.generics import APIView
+from awx.api.permissions import IsSuperuser
 
 from awx.main.scheduler import TaskManager, DependencyManager, WorkflowManager
 
@@ -12,7 +12,7 @@ from awx.main.scheduler import TaskManager, DependencyManager, WorkflowManager
 class TaskManagerDebugView(APIView):
     _ignore_model_permissions = True
     exclude_from_schema = True
-    permission_classes = [AllowAny]
+    permission_classes = [IsSuperuser]
     prefix = 'Task'
 
     def get(self, request):
@@ -27,7 +27,7 @@ class TaskManagerDebugView(APIView):
 class DependencyManagerDebugView(APIView):
     _ignore_model_permissions = True
     exclude_from_schema = True
-    permission_classes = [AllowAny]
+    permission_classes = [IsSuperuser]
     prefix = 'Dependency'
 
     def get(self, request):
@@ -42,7 +42,7 @@ class DependencyManagerDebugView(APIView):
 class WorkflowManagerDebugView(APIView):
     _ignore_model_permissions = True
     exclude_from_schema = True
-    permission_classes = [AllowAny]
+    permission_classes = [IsSuperuser]
     prefix = 'Workflow'
 
     def get(self, request):
@@ -57,7 +57,7 @@ class WorkflowManagerDebugView(APIView):
 class DebugRootView(APIView):
     _ignore_model_permissions = True
     exclude_from_schema = True
-    permission_classes = [AllowAny]
+    permission_classes = [IsSuperuser]
 
     def get(self, request, format=None):
         '''List of available debug urls'''

--- a/awx/main/tests/functional/api/test_debug.py
+++ b/awx/main/tests/functional/api/test_debug.py
@@ -1,0 +1,22 @@
+import pytest
+
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('view_name', ['debug', 'task_manager', 'dependency_manager', 'workflow_manager'])
+def test_debug_endpoints_require_superuser(get, admin_user, alice, view_name):
+    """The /api/debug/ views trigger the schedulers and must not be anonymous.
+
+    They previously used AllowAny, so an unauthenticated request could run the
+    task/dependency/workflow managers.
+    """
+    url = reverse(f'api:{view_name}')
+
+    # unauthenticated is rejected (was 200 under AllowAny)
+    get(url, user=None, expect=401)
+    # an authenticated non-superuser is forbidden
+    get(url, user=alice, expect=403)
+    # a superuser is permitted
+    response = get(url, user=admin_user)
+    assert response.status_code not in (401, 403)


### PR DESCRIPTION

##### SUMMARY

The `/api/debug/` views (`task_manager`, `dependency_manager`, `workflow_manager`, and the debug root) each run a scheduler on GET but declare `permission_classes = [AllowAny]`, so an unauthenticated request can trigger the task, dependency and workflow managers. Verified against a running instance: an anonymous `GET /api/debug/task_manager/` executed `TaskManager().schedule()` end to end, spawning the pending job's project-update dependency, choosing controller and execution nodes, and moving it to waiting.

Impact: unauthenticated denial of service, since each `schedule()` scans pending work, computes capacity and takes a Postgres advisory lock with no auth and no rate limit. It also bypasses `AWX_DISABLE_TASK_MANAGERS`, which the views are documented as the only way around when an operator has disabled automatic scheduling.

Fix: add an `IsSuperuser` permission class and apply it to the four debug views, so the endpoints stay available to operators but require a superuser. This is preferred over gating the URLs to development-only settings so the operator capability is preserved and the change is directly testable. Adds a functional test.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION
```
25.5.1
```

##### ADDITIONAL INFORMATION

Reproduction, unauthenticated (no credentials):

Before:
```
$ curl -s -o /dev/null -w '%{http_code}\n' https://<ascender>/api/debug/task_manager/
200
```

After:
```
$ curl -s -o /dev/null -w '%{http_code}\n' https://<ascender>/api/debug/task_manager/
401
```