### PR TITLE
Removed the erroneous get_queryset override on InventorySourceGroupsList

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -2248,9 +2248,6 @@ class InventorySourceGroupsList(SubListDestroyAPIView):
     relationship = 'groups'
     check_sub_obj_permission = False
 
-    def get_queryset(self):
-        return super().get_queryset().with_latest_summary_id()
-
     def perform_list_destroy(self, instance_list):
         inv_source = self.get_parent_object()
         with ignore_inventory_computed_fields():


### PR DESCRIPTION
##### SUMMARY

Accessing the API to query an Inventory Sources Groups throws an error. 

* `AttributeError: 'QuerySet' object has no attribute 'with_latest_summary_id'`

This is because we are improperly overriding the queryset

Found while reviewing another PR.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION
25.5.1


##### ADDITIONAL INFORMATION
