### PR TITLE
Upstream 16467 - Reset orphaned waiting jobs when controller node is deprovisioned

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -687,6 +687,17 @@ class TaskManager(TaskBase):
                 logger.error(f'{j.execution_node} is not a registered instance; reaping {j.log_format}')
                 reap_job(j, 'failed')
 
+        # Reset waiting jobs whose controller_node was deprovisioned (e.g. K8s pod replaced).
+        # These jobs will never be picked up because no live node is listening for them.
+        registered_control_nodes = Instance.objects.filter(node_type__in=('control', 'hybrid')).values_list('hostname', flat=True)
+        orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node__in=registered_control_nodes)
+        for j in orphaned_waiting:
+            logger.warning(f'{j.controller_node} is not a registered instance; resetting {j.log_format} to pending')
+            j.status = 'pending'
+            j.controller_node = ''
+            j.execution_node = ''
+            j.save(update_fields=['status', 'controller_node', 'execution_node'])
+
     def process_tasks(self):
         # maintain a list of jobs that went to an early failure state,
         # meaning the dispatcher never got these jobs,

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -690,7 +690,7 @@ class TaskManager(TaskBase):
         # Reset waiting jobs whose controller_node was deprovisioned (e.g. K8s pod replaced).
         # These jobs will never be picked up because no live node is listening for them.
         registered_control_nodes = Instance.objects.filter(node_type__in=('control', 'hybrid')).values_list('hostname', flat=True)
-        orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node__in=registered_control_nodes)
+        orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node='').exclude(controller_node__in=registered_control_nodes)
         for j in orphaned_waiting:
             logger.warning(f'{j.controller_node} is not a registered instance; resetting {j.log_format} to pending')
             j.status = 'pending'

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -441,6 +441,39 @@ class TestJobReaper(object):
         assert job.status == 'running'
         assert job.job_explanation == ''
 
+    def test_waiting_job_reset_when_controller_node_deprovisioned(self):
+        """When a controller pod is replaced (e.g. K8s rollout), waiting jobs
+        assigned to the now-gone controller_node should be reset to pending
+        by the task manager so they can be re-dispatched."""
+        from awx.main.scheduler import TaskManager
+
+        Instance(hostname='awx-task-live', node_type='control').save()
+        # No instance record for 'awx-task-dead' — it was already deprovisioned
+        job = Job.objects.create(status='waiting', controller_node='awx-task-dead', execution_node='')
+
+        tm = TaskManager()
+        tm.reap_jobs_from_orphaned_instances()
+
+        job.refresh_from_db()
+        assert job.status == 'pending'
+        assert job.controller_node == ''
+        assert job.execution_node == ''
+
+    @pytest.mark.parametrize('node_type', ['control', 'hybrid'])
+    def test_waiting_job_not_reset_when_controller_node_alive(self, node_type):
+        """Waiting jobs on a live control or hybrid node should not be touched."""
+        from awx.main.scheduler import TaskManager
+
+        Instance(hostname='awx-task-live', node_type=node_type).save()
+        job = Job.objects.create(status='waiting', controller_node='awx-task-live', execution_node='')
+
+        tm = TaskManager()
+        tm.reap_jobs_from_orphaned_instances()
+
+        job.refresh_from_db()
+        assert job.status == 'waiting'
+        assert job.controller_node == 'awx-task-live'
+
 
 @pytest.mark.django_db
 class TestScheduler:

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -474,6 +474,20 @@ class TestJobReaper(object):
         assert job.status == 'waiting'
         assert job.controller_node == 'awx-task-live'
 
+    def test_waiting_job_not_reset_when_controller_node_unassigned(self):
+        """A waiting job with no controller_node assigned yet is not orphaned
+        and should not be swept by the deprovisioned-controller check."""
+        from awx.main.scheduler import TaskManager
+
+        Instance(hostname='awx-task-live', node_type='control').save()
+        job = Job.objects.create(status='waiting', controller_node='', execution_node='')
+
+        tm = TaskManager()
+        tm.reap_jobs_from_orphaned_instances()
+
+        job.refresh_from_db()
+        assert job.status == 'waiting'
+
 
 @pytest.mark.django_db
 class TestScheduler:


### PR DESCRIPTION
## Upstream Summary
- In K8s deployments, jobs can get permanently stuck in `waiting` status when the controller pod they were assigned to is replaced/deprovisioned
- The instance record gets deleted but the waiting jobs referencing that `controller_node` are never cleaned up — no existing reaper path catches them
- Extends `reap_jobs_from_orphaned_instances()` in the task manager to detect waiting jobs whose `controller_node` no longer matches any registered control/hybrid instance, and resets them to `pending` so they can be re-dispatched

## Why existing reaping paths don't catch this

1. **`reaper.reap()`** — only queries `status='running'`, so waiting jobs are invisible to it entirely.
2. **`startup_reaping()`** — also only queries `status='running'` on the current node at startup.
3. **`_heartbeat_handle_lost_instances()`** — correctly resets waiting jobs, but only for instances still in the DB. Once `AWX_AUTO_DEPROVISION_INSTANCES` deletes the Instance record (same function, a few lines later), future heartbeats have no record to match against — the dead hostname is gone.
4. **`reap_jobs_from_orphaned_instances()`** (before this fix) — checks `execution_node` against registered instances, but never checks `controller_node`. A waiting job with `controller_node='dead-pod'` and `execution_node=''` passes right through.
5. **Heartbeat `dispatch_waiting_jobs` re-check** — only looks for waiting jobs where `controller_node` matches the *current* node (`CLUSTER_HOST_ID`), not orphaned jobs on other nodes.

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- API
