### PR TITLE
Upstream 16554 - Replace OR with UNION in team list RBAC query

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1332,9 +1332,11 @@ class TeamAccess(BaseAccess):
     def filtered_queryset(self):
         if settings.ORG_ADMINS_CAN_SEE_ALL_USERS and (self.user.admin_of_organizations.exists() or self.user.auditor_of_organizations.exists()):
             return self.model.objects.all()
-        return self.model.objects.filter(
-            Q(organization__in=Organization.accessible_pk_qs(self.user, 'member_role')) | Q(pk__in=self.model.accessible_pk_qs(self.user, 'read_role'))
+        org_member_teams = (
+            self.model.objects.filter(organization__in=Organization.accessible_pk_qs(self.user, 'member_role')).order_by().values_list('pk', flat=True)
         )
+        direct_read_teams = self.model.objects.filter(pk__in=self.model.accessible_pk_qs(self.user, 'read_role')).order_by().values_list('pk', flat=True)
+        return self.model.objects.filter(pk__in=org_member_teams.union(direct_read_teams))
 
     @check_superuser
     def can_add(self, data):


### PR DESCRIPTION
## Upstream Summary

- Converts `TeamAccess.filtered_queryset()` from `Q(…) | Q(…)` (SQL OR) to UNION, allowing PostgreSQL to use the RoleEvaluation 3-column index independently for each access path (org membership vs direct read permission)
- Wraps the UNION in `pk__in=` so the outer queryset remains compatible with `BaseAccess.get_queryset()`'s `select_related()` call
- Scale Lab EXPLAIN ANALYZE confirmed 7-9x speedup and 101x disk read reduction at realistic RBAC density

Resolves: [AAP-83319](https://redhat.atlassian.net/browse/AAP-83319)

## Classification

New or Enhanced Feature
