### PR TITLE
Upstream 16558 - Set PostgreSQL statement_timeout on web worker DB connections

### DIFF
--- a/awx/main/tests/unit/settings/test_statement_timeout.py
+++ b/awx/main/tests/unit/settings/test_statement_timeout.py
@@ -1,0 +1,93 @@
+import types
+from unittest import mock
+
+from awx.settings.statement_timeout import set_statement_timeout
+
+PG_ENGINE = "django.db.backends.postgresql"
+SQLITE_ENGINE = "django.db.backends.sqlite3"
+
+
+def _make_databases(engine=PG_ENGINE, existing_options=None):
+    databases = {"default": {"ENGINE": engine}}
+    if existing_options:
+        databases["default"]["OPTIONS"] = {"options": existing_options}
+    return databases
+
+
+def _options(databases):
+    return databases["default"].get("OPTIONS", {}).get("options")
+
+
+def _fake_uwsgi(harakiri):
+    mod = types.ModuleType('uwsgi')
+    mod.opt = {b'harakiri': str(harakiri).encode()}
+    return mod
+
+
+class TestSetStatementTimeout:
+    def test_derives_from_uwsgi_harakiri(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': _fake_uwsgi(115)}):
+            set_statement_timeout(databases)
+        assert _options(databases) == "-c statement_timeout=110000"
+
+    def test_no_op_without_uwsgi_or_setting(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': None}):
+            set_statement_timeout(databases)
+        assert _options(databases) is None
+
+    def test_falls_back_to_setting(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': None}):
+            set_statement_timeout(databases, 60000)
+        assert _options(databases) == "-c statement_timeout=60000"
+
+    def test_uwsgi_takes_precedence_over_setting(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': _fake_uwsgi(115)}):
+            set_statement_timeout(databases, 60000)
+        assert _options(databases) == "-c statement_timeout=110000"
+
+    def test_harakiri_zero_falls_back_to_setting(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': _fake_uwsgi(0)}):
+            set_statement_timeout(databases, 90000)
+        assert _options(databases) == "-c statement_timeout=90000"
+
+    def test_harakiri_very_low_clamps_to_one_second(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': _fake_uwsgi(1)}):
+            set_statement_timeout(databases)
+        assert _options(databases) == "-c statement_timeout=1000"
+
+    def test_harakiri_midrange_uses_proportional_margin(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': _fake_uwsgi(30)}):
+            # margin = min(5, max(1, int(30*0.1))) = 3 → timeout = 27s
+            set_statement_timeout(databases)
+        assert _options(databases) == "-c statement_timeout=27000"
+
+    def test_skips_sqlite(self):
+        databases = _make_databases(engine=SQLITE_ENGINE)
+        set_statement_timeout(databases, 60000)
+        assert _options(databases) is None
+
+    def test_skips_empty_databases(self):
+        databases = {}
+        set_statement_timeout(databases, 60000)
+        assert databases == {}
+
+    def test_appends_to_existing_options(self):
+        databases = _make_databases(existing_options="-c lock_timeout=5000")
+        with mock.patch.dict('sys.modules', {'uwsgi': None}):
+            set_statement_timeout(databases, 60000)
+        assert _options(databases) == "-c lock_timeout=5000 -c statement_timeout=60000"
+
+    def test_preserves_other_options_keys(self):
+        databases = _make_databases()
+        databases["default"]["OPTIONS"] = {"sslmode": "require"}
+        with mock.patch.dict('sys.modules', {'uwsgi': None}):
+            set_statement_timeout(databases, 60000)
+        assert databases["default"]["OPTIONS"]["sslmode"] == "require"
+        assert _options(databases) == "-c statement_timeout=60000"

--- a/awx/main/tests/unit/settings/test_statement_timeout.py
+++ b/awx/main/tests/unit/settings/test_statement_timeout.py
@@ -19,6 +19,14 @@ def _options(databases):
 
 
 def _fake_uwsgi(harakiri):
+    # Real uwsgi builds expose opt with str keys and bytes values
+    mod = types.ModuleType('uwsgi')
+    mod.opt = {'harakiri': str(harakiri).encode()}
+    return mod
+
+
+def _fake_uwsgi_bytes_keys(harakiri):
+    # Some uwsgi versions/builds use bytes keys instead
     mod = types.ModuleType('uwsgi')
     mod.opt = {b'harakiri': str(harakiri).encode()}
     return mod
@@ -28,6 +36,12 @@ class TestSetStatementTimeout:
     def test_derives_from_uwsgi_harakiri(self):
         databases = _make_databases()
         with mock.patch.dict('sys.modules', {'uwsgi': _fake_uwsgi(115)}):
+            set_statement_timeout(databases)
+        assert _options(databases) == "-c statement_timeout=110000"
+
+    def test_derives_from_uwsgi_harakiri_bytes_keys(self):
+        databases = _make_databases()
+        with mock.patch.dict('sys.modules', {'uwsgi': _fake_uwsgi_bytes_keys(115)}):
             set_statement_timeout(databases)
         assert _options(databases) == "-c statement_timeout=110000"
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -44,6 +44,11 @@ DATABASES = {
     }
 }
 
+# Optional manual override for statement_timeout (ms) on web worker DB
+# connections.  When running under uwsgi, the timeout is auto-derived from
+# the harakiri value.  Set this for non-uwsgi deployments or to override.
+DATABASE_STATEMENT_TIMEOUT = None
+
 # Special database overrides for dispatcher connections listening to pg_notify
 LISTENER_DATABASES = {
     'default': {

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1110,6 +1110,7 @@ RECEPTOR_LOG_LEVEL = 'info'
 
 MIDDLEWARE = [
     'django_guid.middleware.guid_middleware',
+    'ansible_base.lib.middleware.logging.log_request.LogTracebackMiddleware',
     'awx.main.middleware.SettingsCacheMiddleware',
     'awx.main.middleware.TimingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -115,3 +115,9 @@ from .application_name import set_application_name
 set_application_name(DATABASES, CLUSTER_HOST_ID)  # NOQA
 
 del set_application_name
+
+from .statement_timeout import set_statement_timeout
+
+set_statement_timeout(DATABASES, DATABASE_STATEMENT_TIMEOUT)  # NOQA
+
+del set_statement_timeout

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -100,3 +100,9 @@ from .application_name import set_application_name
 set_application_name(DATABASES, CLUSTER_HOST_ID)  # NOQA
 
 del set_application_name
+
+from .statement_timeout import set_statement_timeout
+
+set_statement_timeout(DATABASES, DATABASE_STATEMENT_TIMEOUT)  # NOQA
+
+del set_statement_timeout

--- a/awx/settings/statement_timeout.py
+++ b/awx/settings/statement_timeout.py
@@ -1,0 +1,39 @@
+def set_statement_timeout(DATABASES, DATABASE_STATEMENT_TIMEOUT=None):
+    '''
+    Set PostgreSQL statement_timeout on web worker DB connections.
+
+    Under uwsgi, derives the timeout from the harakiri value with a safety
+    margin so PostgreSQL cancels the query before uwsgi kills the worker.
+    The margin is 10% of harakiri, clamped to [1s, 5s].  Falls back to the
+    DATABASE_STATEMENT_TIMEOUT setting (ms) for non-uwsgi deployments.
+    Outside uwsgi with no setting defined, no timeout is applied so
+    legitimate long-running queries (task workers, migrations) are unaffected.
+    '''
+    # If settings files were not properly passed DATABASES could be {} at which point we don't need to set the timeout.
+    if not DATABASES or 'default' not in DATABASES:
+        return
+
+    if 'sqlite3' in DATABASES['default']['ENGINE']:
+        return
+
+    timeout_ms = None
+    try:
+        import uwsgi
+
+        harakiri = int(uwsgi.opt.get(b'harakiri', 0))
+        if harakiri > 0:
+            margin = min(5, max(1, int(harakiri * 0.1)))
+            timeout_ms = max(1000, (harakiri - margin) * 1000)
+    except (ImportError, ValueError):
+        pass
+
+    if timeout_ms is None:
+        timeout_ms = DATABASE_STATEMENT_TIMEOUT
+
+    if timeout_ms is None:
+        return
+
+    options_dict = DATABASES['default'].setdefault('OPTIONS', dict())
+    existing = options_dict.get('options', '')
+    new_opt = f'-c statement_timeout={timeout_ms}'
+    options_dict['options'] = f'{existing} {new_opt}'.strip() if existing else new_opt

--- a/awx/settings/statement_timeout.py
+++ b/awx/settings/statement_timeout.py
@@ -20,11 +20,12 @@ def set_statement_timeout(DATABASES, DATABASE_STATEMENT_TIMEOUT=None):
     try:
         import uwsgi
 
-        harakiri = int(uwsgi.opt.get(b'harakiri', 0))
+        # uwsgi.opt key type (str vs bytes) varies across uwsgi versions/builds
+        harakiri = int(uwsgi.opt.get('harakiri', uwsgi.opt.get(b'harakiri', 0)) or 0)
         if harakiri > 0:
             margin = min(5, max(1, int(harakiri * 0.1)))
             timeout_ms = max(1000, (harakiri - margin) * 1000)
-    except (ImportError, ValueError):
+    except (ImportError, ValueError, TypeError):
         pass
 
     if timeout_ms is None:

--- a/tools/ansible/roles/dockerfile/files/uwsgi.ini
+++ b/tools/ansible/roles/dockerfile/files/uwsgi.ini
@@ -10,6 +10,11 @@ master-fifo = /var/lib/awx/awxfifo
 max-requests = 1000
 buffer-size = 32768
 
+harakiri = 115
+harakiri-graceful-timeout = 110
+harakiri-graceful-signal = 6
+py-call-osafterfork = true
+
 if-env = UWSGI_MOUNT_PATH
 mount = %(_)=awx.wsgi:application
 endif =


### PR DESCRIPTION

Adapted from https://github.com/ansible/awx/pull/16558 (AAP-84057).

When uwsgi's harakiri kills a worker, the corresponding PostgreSQL backend keeps executing the query indefinitely. These abandoned queries accumulate, consuming CPU and shared_buffers and inflating all other query times.

Under uwsgi, the statement_timeout is auto-derived from the harakiri value with a safety margin (10% of harakiri, clamped to [1s, 5s]) so PostgreSQL cancels runaway queries before uwsgi kills the worker. Outside uwsgi (task workers, migrations), no timeout is applied. A DATABASE_STATEMENT_TIMEOUT setting (ms) is available as a manual override for non-uwsgi deployments.

Upstream implements this as a dynaconf merge function; Ascender predates the dynaconf settings migration, so this is adapted to the same pattern as set_application_name: a helper applied to DATABASES at the bottom of production.py and development.py, after conf.d files are loaded.

### Bug found in the upstream code while verifying: 
live testing showed web workers were still getting statement_timeout=0. The cause: upstream's uwsgi.opt.get(b'harakiri', 0) uses a bytes key, but our uwsgi build exposes uwsgi.opt with str keys — so the lookup silently always missed and harakiri was never read. Key type varies by uwsgi version/build, so I made ours check both ([statement_timeout.py:26](vscode-webview://12jj7jki7c4mg4h4q1r8fhg1mr4lb00bhb6h402sinjiimhjoeia/awx/settings/statement_timeout.py#L26)) and added tests for both shapes. This is likely broken in upstream AWX too