### PR TITLE
Upstream 16564 - Prefer scm_revision as the cache_id if available

### DIFF
--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -457,6 +457,14 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, RelatedJobsMixi
 
     @property
     def cache_id(self):
+        # Prefer scm_revision as the cache key if available. This guarantees that project changes are tracked correctly
+        # even over multiple nodes. The scm_revision is a hex string and thus safe to be used as a directory name.
+        if self.scm_revision:
+            return self.scm_revision
+
+        # If no scm_revision is available (e.g. non-scm projects), use last_job_id. It is a global ID in the
+        # database. This means that when a project sync runs on one node, all other nodes become outdated,
+        # resulting in unnecessary re-syncs.
         return str(self.last_job_id)
 
     @property
@@ -638,7 +646,7 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
 
     @property
     def cache_id(self):
-        if self.branch_override or self.job_type == 'check' or (not self.project):
+        if self.branch_override or (not self.project):
             return str(self.id)
         return self.project.cache_id
 

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -648,6 +648,11 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
     def cache_id(self):
         if self.branch_override or (not self.project):
             return str(self.id)
+        # Prefer the revision this update actually fetched. The project's scm_revision is only
+        # updated after the cache is written, so during post-run cache handling project.cache_id
+        # can still reflect the previous revision.
+        if self.scm_revision:
+            return self.scm_revision
         return self.project.cache_id
 
     def result_stdout_raw_limited(self, start_line=0, end_line=None, redact_sensitive=True):

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -704,7 +704,9 @@ class SourceControlMixin(BaseTask):
 
         has_cache = os.path.exists(os.path.join(project.get_cache_path(), project.cache_id))
         # Galaxy requirements are not supported for manual projects
-        if project.scm_type and ((not has_cache) or branch_override):
+        # If a source update is scheduled, always include roles/collections because
+        # the new revision may have different requirements.
+        if project.scm_type and ((not has_cache) or branch_override or source_update_tag in sync_needs):
             sync_needs.extend(['install_roles', 'install_collections'])
 
         return sync_needs

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1415,7 +1415,13 @@ class RunProjectUpdate(BaseTask):
             if status == 'successful' and 'install_' in instance.job_tags:
                 # Clear other caches before saving this one, and if branch is overridden
                 # do not clear cache for main branch, but do clear it for other branches
-                self.clear_project_cache(base_path, keep_value=instance.project.cache_id)
+                if instance.branch_override:
+                    keep_value = instance.project.cache_id
+                else:
+                    # Keep the directory about to be written; the project's scm_revision (and
+                    # therefore project.cache_id) is only updated further below.
+                    keep_value = instance.cache_id
+                self.clear_project_cache(base_path, keep_value=keep_value)
                 cache_path = os.path.join(base_path, instance.cache_id)
                 if os.path.exists(stage_path):
                     if os.path.exists(cache_path):

--- a/awx/main/tests/unit/models/test_project.py
+++ b/awx/main/tests/unit/models/test_project.py
@@ -2,6 +2,7 @@ import pytest
 import json
 from awx.main.models import (
     Project,
+    ProjectUpdate,
 )
 from django.core.exceptions import ValidationError
 
@@ -12,3 +13,28 @@ def test_clean_credential_insights():
         proj.clean_credential()
 
     assert json.dumps(str(e.value)) == json.dumps(str([u'Insights Credential is required for an Insights Project.']))
+
+
+def test_cache_id_prefers_scm_revision():
+    proj = Project(name="myproj", scm_type='git', scm_revision='34dbdd6bcbb99ee9ccb90a30ec0d7de17c9d0b3a')
+    proj.last_job_id = 42
+    assert proj.cache_id == '34dbdd6bcbb99ee9ccb90a30ec0d7de17c9d0b3a'
+
+
+def test_cache_id_falls_back_to_last_job_id():
+    proj = Project(name="myproj", scm_revision='')
+    proj.last_job_id = 42
+    assert proj.cache_id == '42'
+
+
+def test_project_update_cache_id_uses_project_cache_for_check_jobs():
+    proj = Project(name="myproj", scm_type='git', scm_branch='main', scm_revision='34dbdd6bcbb99ee9ccb90a30ec0d7de17c9d0b3a')
+    pu = ProjectUpdate(project=proj, job_type='check', scm_branch='main')
+    assert pu.cache_id == proj.cache_id
+
+
+def test_project_update_cache_id_branch_override_bypasses_cache():
+    proj = Project(name="myproj", scm_type='git', scm_branch='main', scm_revision='34dbdd6bcbb99ee9ccb90a30ec0d7de17c9d0b3a')
+    pu = ProjectUpdate(project=proj, job_type='run', scm_branch='other-branch')
+    pu.id = 7
+    assert pu.cache_id == '7'

--- a/awx/main/tests/unit/models/test_project.py
+++ b/awx/main/tests/unit/models/test_project.py
@@ -33,8 +33,16 @@ def test_project_update_cache_id_uses_project_cache_for_check_jobs():
     assert pu.cache_id == proj.cache_id
 
 
+def test_project_update_cache_id_prefers_own_scm_revision():
+    # After a check update fetches a new revision, the update's scm_revision is set before the
+    # project's is; the cache must be keyed on the newly fetched revision, not the stale one.
+    proj = Project(name="myproj", scm_type='git', scm_branch='main', scm_revision='34dbdd6bcbb99ee9ccb90a30ec0d7de17c9d0b3a')
+    pu = ProjectUpdate(project=proj, job_type='check', scm_branch='main', scm_revision='deadbeefcbb99ee9ccb90a30ec0d7de17c9d0b3a')
+    assert pu.cache_id == 'deadbeefcbb99ee9ccb90a30ec0d7de17c9d0b3a'
+
+
 def test_project_update_cache_id_branch_override_bypasses_cache():
     proj = Project(name="myproj", scm_type='git', scm_branch='main', scm_revision='34dbdd6bcbb99ee9ccb90a30ec0d7de17c9d0b3a')
-    pu = ProjectUpdate(project=proj, job_type='run', scm_branch='other-branch')
+    pu = ProjectUpdate(project=proj, job_type='run', scm_branch='other-branch', scm_revision='deadbeefcbb99ee9ccb90a30ec0d7de17c9d0b3a')
     pu.id = 7
     assert pu.cache_id == '7'


### PR DESCRIPTION
##### UPSTREAM SUMMARY

The PR changes the way the cache_id for project updates is created - if available it prefers to use the scm_revision. The cache_id is directly used as the directory name for the project contents on disk.

**Why?**

The other fields are global database IDs and that leads to a problem in multi node environments: if one node runs a project update, the ID is incremented. But now, all other nodes think that their projects are outdated, because the cache_id no longer matches their local directory names. This results in unnecessary project updates.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


** Note we added Unit Tests as the Upstream did not have any.  Also, the Upstream's logic was a bit flawed.  There is a failure sequence that will occur because when the cache update fetches a new revision, the cache_id is still the previous revision, so it is created under that.  Not until after the cache write does it update the cache_id to the new revision.  This in turn creates a double sync issue (next node looks for the project and can't find it, as its using a stale id) and it causes it to sync again.