### PR TITLE
Fix container group TLS verification broken by the kubernetes 36 upgrade

### DIFF
--- a/awx/main/scheduler/kubernetes.py
+++ b/awx/main/scheduler/kubernetes.py
@@ -144,16 +144,24 @@ class PodManager(object):
         # this feels a little janky, but it's what k8s' own code does
         # internally when it reads kube config files from disk:
         # https://github.com/kubernetes-client/python-base/blob/0b208334ef0247aad9afcaae8003954423b61a0d/config/kube_config.py#L643
+        cfg = type.__call__(client.Configuration)
         if self.credential:
             loader = config.kube_config.KubeConfigLoader(config_dict=self.kube_config)
-            cfg = type.__call__(client.Configuration)
             loader.load_and_set(cfg)
-            api = client.CoreV1Api(api_client=client.ApiClient(configuration=cfg))
         else:
-            config.load_incluster_config()
-            api = client.CoreV1Api()
+            # pass an explicit configuration so the in-cluster loader does not
+            # mutate (and leak its bearer token into) the process-wide default
+            config.load_incluster_config(client_configuration=cfg)
 
-        return api
+        # kubernetes >= 34.1 picks HTTP_PROXY/HTTPS_PROXY up from the environment
+        # in Configuration.__init__. Container group API traffic was never proxied
+        # before that, and on OpenShift the injected cluster-wide proxy makes TLS
+        # verification against the cluster CA fail, so this stays opt-in.
+        if not settings.AWX_CONTAINER_GROUP_K8S_API_USE_PROXY:
+            cfg.proxy = None
+            cfg.proxy_headers = None
+
+        return client.CoreV1Api(api_client=client.ApiClient(configuration=cfg))
 
     @property
     def pod_name(self):
@@ -189,10 +197,24 @@ def generate_tmp_kube_config(credential, namespace):
         "current-context": host_input,
     }
 
-    if credential.get_input('verify_ssl') and 'ssl_ca_cert' in credential.inputs:
-        config["clusters"][0]["cluster"]["certificate-authority-data"] = b64encode(
+    apply_tls_verification(config, credential)
+    return config
+
+
+def apply_tls_verification(kube_config, credential):
+    """Set the cluster's TLS verification keys on a generated kube config.
+
+    The "Certificate Authority data" input is optional, so it can be present but
+    empty. Testing for the key rather than its value used to leave verification
+    enabled with no CA at all, which silently fell back to whatever bundle the
+    client happened to default to. Leaving both keys unset is the honest way to
+    express "verify against the container's system trust store", which is what
+    the operator's bundle_cacert_secret populates.
+    """
+    cluster = kube_config["clusters"][0]["cluster"]
+    if not credential.get_input('verify_ssl'):
+        cluster["insecure-skip-tls-verify"] = True
+    elif credential.get_input('ssl_ca_cert', default=''):
+        cluster["certificate-authority-data"] = b64encode(
             credential.get_input('ssl_ca_cert').encode()  # encode to bytes
         ).decode()  # decode the base64 data into a str
-    else:
-        config["clusters"][0]["cluster"]["insecure-skip-tls-verify"] = True
-    return config

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -1,5 +1,4 @@
 # Python
-from base64 import b64encode
 from collections import namedtuple
 import concurrent.futures
 from enum import Enum
@@ -614,6 +613,8 @@ class AWXReceptorJob:
 
     @property
     def kube_config(self):
+        from awx.main.scheduler.kubernetes import apply_tls_verification  # prevent circular import
+
         host_input = self.credential.get_input('host')
         config = {
             "apiVersion": "v1",
@@ -625,12 +626,7 @@ class AWXReceptorJob:
             "current-context": host_input,
         }
 
-        if self.credential.get_input('verify_ssl') and 'ssl_ca_cert' in self.credential.inputs:
-            config["clusters"][0]["cluster"]["certificate-authority-data"] = b64encode(
-                self.credential.get_input('ssl_ca_cert').encode()  # encode to bytes
-            ).decode()  # decode the base64 data into a str
-        else:
-            config["clusters"][0]["cluster"]["insecure-skip-tls-verify"] = True
+        apply_tls_verification(config, self.credential)
         return config
 
 

--- a/awx/main/tests/functional/task_management/test_container_groups.py
+++ b/awx/main/tests/functional/task_management/test_container_groups.py
@@ -5,7 +5,10 @@ from collections import namedtuple
 from unittest import mock  # noqa
 import pytest
 
+from django.test.utils import override_settings
+
 from awx.main.tasks.receptor import AWXReceptorJob
+from awx.main.scheduler.kubernetes import PodManager
 from awx.main.utils import (
     create_temporary_fifo,
 )
@@ -101,3 +104,55 @@ def test_kubectl_ssl_verification(containerized_job, default_job_execution_envir
     receptor_job = AWXReceptorJob(rj, runner_params={'settings': {}})
     ca_data = receptor_job.kube_config['clusters'][0]['cluster']['certificate-authority-data']
     assert cert.stdout == base64.b64decode(ca_data.encode())
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'verify_ssl, ssl_ca_cert, expected',
+    [
+        # a CA was supplied, so pin verification to it
+        (True, 'my-ca-data', {'certificate-authority-data': base64.b64encode(b'my-ca-data').decode()}),
+        # verification is on but no CA was supplied, whether the input is absent
+        # or merely empty: neither key is set, so the client verifies against the
+        # container's system trust store instead of whichever bundle it happens
+        # to default to
+        (True, '', {}),
+        (True, None, {}),
+        (False, '', {'insecure-skip-tls-verify': True}),
+        # an explicitly disabled verify_ssl wins over a stored CA
+        (False, 'my-ca-data', {'insecure-skip-tls-verify': True}),
+    ],
+)
+def test_kube_config_tls_verification(containerized_job, default_job_execution_environment, verify_ssl, ssl_ca_cert, expected):
+    containerized_job.execution_environment = default_job_execution_environment
+    cred = containerized_job.instance_group.credential
+    cred.inputs['verify_ssl'] = verify_ssl
+    if ssl_ca_cert is None:
+        cred.inputs.pop('ssl_ca_cert', None)
+    else:
+        cred.inputs['ssl_ca_cert'] = ssl_ca_cert
+    cred.save()
+
+    RunJob = namedtuple('RunJob', ['instance', 'build_execution_environment_params'])
+    rj = RunJob(instance=containerized_job, build_execution_environment_params=lambda x: {})
+    cluster = AWXReceptorJob(rj, runner_params={'settings': {}}).kube_config['clusters'][0]['cluster']
+
+    assert {key: value for key, value in cluster.items() if key != 'server'} == expected
+
+
+@pytest.mark.django_db
+def test_kube_api_ignores_proxy_environment(containerized_job, default_job_execution_environment):
+    """HTTP(S)_PROXY must not divert cluster API calls unless explicitly opted into.
+
+    kubernetes >= 34.1 reads those variables in Configuration.__init__, which
+    silently routes API traffic through a proxy whose certificate the cluster CA
+    cannot validate.
+    """
+    pm = PodManager(containerized_job)
+
+    with mock.patch.dict('os.environ', {'HTTPS_PROXY': 'http://proxy.example.com:3128'}):
+        assert pm.kube_api.api_client.configuration.proxy is None
+
+        del pm.__dict__['kube_api']  # drop the cached_property
+        with override_settings(AWX_CONTAINER_GROUP_K8S_API_USE_PROXY=True):
+            assert pm.kube_api.api_client.configuration.proxy == 'http://proxy.example.com:3128'

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -69,6 +69,14 @@ LISTENER_DATABASES = {
 IS_K8S = False
 
 AWX_CONTAINER_GROUP_K8S_API_TIMEOUT = 10
+# Whether container group Kubernetes API calls should be routed through the
+# HTTP_PROXY/HTTPS_PROXY environment variables of the task container. The Python
+# Kubernetes client started honouring those on its own in 34.1, but this traffic
+# has never been proxied by AWX, and a TLS-terminating proxy breaks certificate
+# verification against the cluster CA (the client verifies against the cluster
+# credential's CA data or the service account CA, never the system trust store).
+# Leave disabled unless the cluster API really is only reachable through a proxy.
+AWX_CONTAINER_GROUP_K8S_API_USE_PROXY = False
 AWX_CONTAINER_GROUP_DEFAULT_NAMESPACE = os.getenv('MY_POD_NAMESPACE', 'default')
 AWX_CONTAINER_GROUP_DEFAULT_JOB_LABEL = os.getenv('AWX_CONTAINER_GROUP_DEFAULT_JOB_LABEL', 'ansible_job')
 # Timeout when waiting for pod to enter running state. If the pod is still in pending state , it will be terminated. Valid time units are "s", "m", "h". Example : "5m" , "10s".


### PR DESCRIPTION
Fixes #648.

## Problem

`25.5.1` bumped the Python Kubernetes client from `29.0.0` to `36.0.2`. No AWX code changed on this path between the two tags, the dependency bump alone is the regression:

```
awx.main.scheduler Failed to list pods for container group default-2
urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
unable to get local issuer certificate (_ssl.c:998)
```

Since client `34.1`, `Configuration.__init__` reads the proxy environment variables (`kubernetes/client/configuration.py`):

```python
self.no_proxy = None
if os.getenv("HTTPS_PROXY"): self.proxy = os.getenv("HTTPS_PROXY")
...
```

Container group API traffic was never proxied before that. On OpenShift the cluster-wide proxy is injected into the task pod, so those calls now go through it, and once TLS terminates at the proxy the chain no longer validates against the cluster CA. Building the `PodManager.kube_api` code path against both client versions with `HTTPS_PROXY` set:

| client | pool manager |
|---|---|
| `29.0.0` | `PoolManager` (proxy env ignored) |
| `36.0.2` | `ProxyManager` |

When `NO_PROXY` is unset or does not cover the API endpoint, even the in-cluster address is diverted:

```
https://172.30.0.1:443              bypass=False
https://kubernetes.default.svc:443  bypass=False
```

Adding the CA through the operator's `bundle_cacert_secret` does not help, because the client verifies against `configuration.ssl_ca_cert` (the cluster credential's CA data, or the service account CA), never the system trust store.

## Changes

- Clear `Configuration.proxy` for container group API calls, gated behind a new `AWX_CONTAINER_GROUP_K8S_API_USE_PROXY` setting that defaults to `False`. This restores the pre-`25.5.1` behaviour while leaving an escape hatch for clusters that genuinely are only reachable through a proxy.
- Stop deciding TLS verification on the *presence* of the `ssl_ca_cert` input rather than its value. That input is optional, so a credential with "Verify SSL" on and an empty CA left verification enabled with no CA configured at all, silently falling back to whichever bundle the client defaulted to (`certifi` before the upgrade, the system trust store after, since `36.0.2` also dropped the `certifi.where()` fallback in `rest.py`). Setting neither key expresses "verify against the system trust store" directly, which is what `bundle_cacert_secret` populates. The receptor kube config gets the same treatment through a shared `apply_tls_verification` helper.
- Hand `load_incluster_config` an explicit `Configuration` so it no longer mutates the process-wide default with its bearer token. Client `36` no longer deep-copies in `set_default()`.

## Verification

Replaying the patched code path against the real `kubernetes==36.0.2` with `HTTPS_PROXY` set and `NO_PROXY` unset:

```
verify + CA      proxy=None  pool=PoolManager  verify_ssl=True   ca_certs=<credential CA>  cert_reqs=CERT_REQUIRED
verify, no CA    proxy=None  pool=PoolManager  verify_ssl=True   ca_certs=None             cert_reqs=CERT_REQUIRED
verify_ssl off   proxy=None  pool=PoolManager  verify_ssl=False  ca_certs=None             cert_reqs=CERT_NONE
```

New tests cover the four TLS input combinations and both sides of the proxy setting. `black` and `flake8` are clean; the Django suite runs in CI.

Note that upstream AWX `devel` is also on `kubernetes==36.0.2` and carries the same regression.
