### PR TITLE
Re-attach latest job host summaries on clones of an evaluated queryset

### DIFF
--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -37,12 +37,12 @@ class HostLatestSummaryQuerySet(models.QuerySet):
     Not streaming-safe: relies on _result_cache existing after _fetch_all().
     """
 
+    # Guards against redoing the in_bulk() when _fetch_all() runs again on an
+    # already-populated queryset. Deliberately not carried over in _clone():
+    # a clone starts with an empty _result_cache and re-runs its query, so it
+    # has to bulk-attach again. Copying the flag would leave the clone's hosts
+    # without _latest_summary_cache and silently fall back to a query per host.
     _awx_latest_summary_attached = False
-
-    def _clone(self):
-        clone = super()._clone()
-        clone._awx_latest_summary_attached = self._awx_latest_summary_attached
-        return clone
 
     def with_latest_summary_id(self):
         from awx.main.models.jobs import JobHostSummary

--- a/awx/main/tests/functional/models/test_host_queryset.py
+++ b/awx/main/tests/functional/models/test_host_queryset.py
@@ -211,3 +211,25 @@ class TestHostLatestSummaryQuerySet:
         assert len(with_summary) == 2
         assert len(without_summary) == 3
         assert sorted([h.name for h in with_summary]) == ['host-0', 'host-1']
+
+    def test_clone_of_evaluated_queryset_still_bulk_attaches(self):
+        """A queryset chained off an already-evaluated one re-runs its query, so
+        it has to bulk-attach again rather than inherit the "done" flag."""
+        inventory = self._create_inventory_with_hosts(5)
+        self._run_job(inventory)
+
+        qs = Host.objects.filter(inventory=inventory).with_latest_summary_id()
+        list(qs)  # evaluate, which sets the guard flag on qs
+
+        clone = qs.filter(name__startswith='host-')
+        assert clone._result_cache is None, 'the clone must re-run its own query'
+
+        hosts = list(clone)
+        assert len(hosts) == 5
+        for host in hosts:
+            assert hasattr(host, '_latest_summary_cache')
+
+        with CaptureQueriesContext(connection) as ctx:
+            for host in hosts:
+                assert host.latest_summary is not None
+        assert len(ctx.captured_queries) == 0


### PR DESCRIPTION
## Problem

`HostLatestSummaryQuerySet` keeps `_awx_latest_summary_attached` so that a second `_fetch_all()` on an already-populated queryset does not repeat the `in_bulk()` lookup. `_clone()` copied that flag onto the new queryset:

```python
def _clone(self):
    clone = super()._clone()
    clone._awx_latest_summary_attached = self._awx_latest_summary_attached
    return clone
```

Django's `_clone()` deliberately does not copy `_result_cache`, so a clone always re-runs its own query. Inheriting the flag makes `_fetch_all()` take the early return and skip the bulk attach, so the hosts come back without `_latest_summary_cache` and `Host.latest_summary` falls back to one query per host, which is the exact cost this queryset exists to avoid.

Measured against the live ORM, five hosts with summaries:

```
fresh queryset          flag_after_eval=True   cache_attached=True
clone of that queryset  inherited_flag=True    result_cache=None
                        after re-query         cache_attached=False   <- attach skipped

queries touching latest_summary:  fresh=2   via-clone-of-evaluated=8
```

## Scope

Not a live regression. I instrumented `HostList` and no clone in that path ever inherits the flag (every clone happens before evaluation), so the query count is unchanged today. The reason to fix it is that the failure is silent: nothing errors, results stay correct, and the only symptom is the query count going linear.

While confirming that, I did find real per-host query growth on `/api/v2/hosts/` (26 queries for 20 hosts), but it comes from `recent_jobs` in `HostSerializer.get_summary_fields`, which slices `obj.job_host_summaries` once per host. That code is identical in upstream `devel` and is unrelated to this change.

## Fix

Drop the `_clone()` override so a clone picks up the class default of `False` and bulk-attaches after its own query. The guard still does its job on repeat `_fetch_all()` calls against the same queryset.

## Tests

`test_clone_of_evaluated_queryset_still_bulk_attaches` chains a filter off an evaluated queryset and asserts the clone re-queries, that every host carries `_latest_summary_cache`, and that reading `latest_summary` costs zero further queries.

Verified it is a real regression test: it fails on `main` and passes with the fix. Full file run in the dev container:

```
py.test -q awx/main/tests/functional/models/test_host_queryset.py
.................                                    [100%]
17 passed in 1.83s
```
