### PR TITLE
Describe the locale lists accurately and pin them to the files on disk

### DIFF
--- a/awx/main/tests/unit/test_locales.py
+++ b/awx/main/tests/unit/test_locales.py
@@ -1,0 +1,39 @@
+import os
+
+import pytest
+
+from django.conf import settings
+
+import awx
+from awx.api.serializers import SUPPORTED_UI_LOCALES
+
+AWX_ROOT = os.path.dirname(os.path.abspath(awx.__file__))
+BACKEND_CATALOG_DIR = os.path.join(AWX_ROOT, 'locale')
+UI_BUNDLE_DIR = os.path.join(AWX_ROOT, 'ui', 'src', 'locales')
+
+# 'en' is declared without a backend catalog on purpose: the UI ships its bundle
+# under that code, and a request that resolves to 'en' falls through to the
+# source strings, which are already English.
+LANGUAGES_WITHOUT_CATALOG = {'en'}
+
+
+def _subdirectories(path):
+    return {name for name in os.listdir(path) if os.path.isdir(os.path.join(path, name))}
+
+
+def test_languages_match_the_backend_catalogs():
+    """Every LANGUAGES code except 'en' must have a catalog we actually ship."""
+    declared = {code for code, _label in settings.LANGUAGES}
+    assert declared - LANGUAGES_WITHOUT_CATALOG == _subdirectories(BACKEND_CATALOG_DIR)
+
+
+def test_default_language_has_a_catalog():
+    assert settings.LANGUAGE_CODE in _subdirectories(BACKEND_CATALOG_DIR)
+
+
+@pytest.mark.skipif(not os.path.isdir(UI_BUNDLE_DIR), reason='UI sources are not present in this layout')
+def test_supported_ui_locales_match_the_ui_bundles():
+    """preferred_language is validated against the locales the UI can load, which
+    is a different set from LANGUAGES: the UI names its English bundle 'en' while
+    the backend catalog is 'en-us'."""
+    assert SUPPORTED_UI_LOCALES - {''} == _subdirectories(UI_BUNDLE_DIR)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -93,13 +93,23 @@ TIME_ZONE = 'UTC'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 
-# Languages that have translation catalogs under awx/locale/<code>/. Declaring
-# this explicitly (rather than relying on Django's full global LANGUAGES list)
-# ensures LocaleMiddleware selects the exact catalog code we ship. In
-# particular Django's global list only has 'zh-hans'/'zh-hant', so without this
-# a request asking for 'zh' would resolve to 'zh-hans' (which has no catalog)
-# and fall back to English. These codes must match SUPPORTED_UI_LOCALES in
-# awx/api/serializers.py and the directory names under awx/locale/.
+# Languages LocaleMiddleware is allowed to activate: the catalog directories
+# under awx/locale/<code>/, plus 'en'. Declaring this explicitly (rather than
+# relying on Django's full global LANGUAGES list) ensures LocaleMiddleware
+# selects the exact catalog code we ship. In particular Django's global list
+# only has 'zh-hans'/'zh-hant', so without this a request asking for 'zh' would
+# resolve to 'zh-hans' (which has no catalog) and fall back to English.
+#
+# 'en' is the one entry with no catalog of its own: the UI names its English
+# bundle 'en' while the backend catalog is 'en-us', so a preferred_language of
+# 'en' has to resolve to something here. It falls through to the source strings,
+# which are already English.
+#
+# This is NOT the same list as SUPPORTED_UI_LOCALES in awx/api/serializers.py.
+# That one mirrors the bundles under awx/ui/src/locales/ and therefore contains
+# 'en' but not 'en-us'. awx/main/tests/unit/test_locales.py pins both sets
+# against the directories on disk, so adding a language means adding it to
+# whichever of the two lists actually gained a catalog.
 LANGUAGES = [
     ('en-us', 'English (US)'),
     ('en', 'English'),


### PR DESCRIPTION
## Problem

The comment above `LANGUAGES` states that its codes "must match `SUPPORTED_UI_LOCALES` in `awx/api/serializers.py` and the directory names under `awx/locale/`". Neither half holds:

| Source | Codes |
|---|---|
| `LANGUAGES` (`defaults.py`) | ar, **en**, **en-us**, es, fr, hi, ja, ko, nl, zh |
| `SUPPORTED_UI_LOCALES` (`serializers.py:982`) | ar, **en**, es, fr, hi, ja, ko, nl, zh |
| `awx/locale/` | ar, **en-us**, es, fr, hi, ja, ko, nl, zh |
| `awx/ui/src/locales/` | ar, **en**, es, fr, hi, ja, ko, nl, zh |

Against a running instance:

```
preferred_language=en       -> 200   (accepted, but there is no awx/locale/en/)
preferred_language=en-us    -> 400   (rejected, yet it is the only English catalog shipped)
preferred_language=zh       -> 200
preferred_language=zh-hans  -> 400
```

## Why this is a comment fix and not a behaviour fix

The behaviour is correct once you see that the two lists answer different questions:

- `LANGUAGES` is what `LocaleMiddleware` may activate. It tracks `awx/locale/`, and must contain `en-us` because `LANGUAGE_CODE = 'en-us'`.
- `SUPPORTED_UI_LOCALES` is what the UI can load. It tracks `awx/ui/src/locales/`, which names its English bundle `en`.
- `en` is carried in `LANGUAGES` so that a `preferred_language` of `en` resolves to something. It has no catalog and falls through to the source strings, which are already English.

Accepting `en-us` for `preferred_language` would hand the UI a bundle name it does not ship, so the 400 is right. No behaviour changes here.

The risk is the comment: following it when adding a language means putting the new code in both lists, and one of those two is guaranteed to be wrong. The `zh` entry it describes is exactly a case where getting this wrong resolves to a code with no catalog.

## Changes

- Rewrite the comment to describe what each list tracks and why `en` is the odd one out.
- Add `awx/main/tests/unit/test_locales.py` asserting each list against the directories it tracks, plus that `LANGUAGE_CODE` has a catalog, so the relationship cannot drift again.

```
py.test -q awx/main/tests/unit/test_locales.py
...                                                  [100%]
3 passed in 0.03s
```
