### PR TITLE
Let flake8 catch identity comparisons against literals

### DIFF
--- a/awx/main/tests/functional/models/test_workflow.py
+++ b/awx/main/tests/functional/models/test_workflow.py
@@ -756,7 +756,7 @@ class TestWorkflowJobTemplatePrompts:
         assert workflow_job.scm_branch is None
         assert workflow_job.job_tags is None
         assert workflow_job.skip_tags is None
-        assert len(workflow_job.labels.all()) is 0
+        assert len(workflow_job.labels.all()) == 0
 
         # fields from prompts used
         workflow_job = workflow_job_template.create_unified_job(**prompts_data)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
   yamllint -s .
 
 [flake8]
-select = F401,F402,F821,F823,F841,F811,E265,E266,F541,W605,E722,F822,F523,W291,F405
+select = F401,F402,F821,F823,F841,F811,E265,E266,F541,W605,E722,F822,F523,W291,F405,F632
 exclude = .git,__pycache__,.tox,awx/ui/node_modules,env
 
 [testenv:pip-compile-docs]


### PR DESCRIPTION
## Problem

`awx/main/tests/functional/models/test_workflow.py` asserted:

```python
assert len(workflow_job.labels.all()) is 0
```

That passes, but only because CPython interns small integers. The same expression against a count outside the interned range compares object identity and fails no matter what the number is, so the assertion is not testing what it reads as.

flake8 reports exactly this as `F632` ("use ==/!= to compare constant literals"), but `F632` was missing from the `select` list in `tox.ini`, so the `api-lint` job could not see it. I found it by running `flake8 --select=F` and diffing the output against the configured list.

## Changes

- Add `F632` to the `select` list in `tox.ini`.
- Fix the one existing violation.

`flake8 awx awxkit` is clean with the wider list, so nothing else needed changing:

```
$ flake8 awx awxkit
exit=0
```

The affected test file still passes:

```
py.test -q awx/main/tests/functional/models/test_workflow.py
................................................     [100%]
48 passed in 35.55s
```
