### PR TITLE
Stop cleanup_jobs crashing on a batch window that holds no jobs

### DIFF
--- a/awx/main/management/commands/cleanup_jobs.py
+++ b/awx/main/management/commands/cleanup_jobs.py
@@ -307,7 +307,10 @@ class Command(BaseCommand):
 
                 _pre_delete_job_host_summaries(pk_list, self.logger)
                 _, results = qs_batch.delete()
-                deleted += results['main.Job']
+                # a window can hold no deletable Job at all: Job shares the
+                # UnifiedJob id sequence with the other job types, and windows
+                # overlap on their boundary id. Django reports {} for those.
+                deleted += results.get('main.Job', 0)
                 # Avoid dropping the job event table in case we have interacted with it already
                 self._delete_unpartitioned_events(Job, pk_list)
 

--- a/awx/main/tests/functional/commands/test_cleanup_jobs.py
+++ b/awx/main/tests/functional/commands/test_cleanup_jobs.py
@@ -1,0 +1,82 @@
+import logging
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+
+from django.utils.timezone import now
+
+from awx.main.management.commands.cleanup_jobs import Command
+from awx.main.models import Job
+
+
+@pytest.fixture(autouse=True)
+def no_postgres_only_sql():
+    """cleanup_jobs reaches PostgreSQL-only SQL on either side of the batch
+    loop: _pre_delete_job_host_summaries uses ANY(%s), and
+    has_unpartitioned_table reads pg_tables. The test database is SQLite, so
+    stub both out and let the batch loop itself run. The raw statements are
+    covered in awx/main/tests/unit/commands/test_cleanup_jobs.py."""
+    with mock.patch('awx.main.management.commands.cleanup_jobs._pre_delete_job_host_summaries'):
+        with mock.patch.object(Command, 'has_unpartitioned_table', return_value=False):
+            yield
+
+
+@pytest.fixture
+def old_jobs(inventory):
+    """Six finished jobs old enough for cleanup to pick up."""
+    created = now() - timedelta(days=400)
+    jobs = []
+    for i in range(6):
+        job = Job.objects.create(name='old-job-%d' % i, inventory=inventory, status='successful')
+        Job.objects.filter(pk=job.pk).update(created=created)
+        jobs.append(job)
+    return jobs
+
+
+def _command(batch_size):
+    command = Command()
+    command.logger = logging.getLogger('awx.main.commands.cleanup_jobs')
+    command.cutoff = now() - timedelta(days=1)
+    command.dry_run = False
+    command.batch_size = batch_size
+    return command
+
+
+@pytest.mark.django_db
+def test_cleanup_jobs_with_a_gap_in_the_id_range(old_jobs):
+    """A batch window covering only ids whose jobs are already gone must not fail.
+
+    Job shares the UnifiedJob id sequence with project updates, inventory
+    updates and workflow jobs, so a window of ids holding no deletable Job is
+    routine rather than exceptional.
+    """
+    Job.objects.filter(pk__in=[old_jobs[2].pk, old_jobs[3].pk]).delete()
+    expected = Job.objects.filter(pk__in=[job.pk for job in old_jobs]).count()
+
+    skipped, deleted = _command(batch_size=1).cleanup_jobs()
+
+    assert deleted == expected
+    assert not Job.objects.filter(pk__in=[job.pk for job in old_jobs]).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_jobs_when_the_id_span_is_a_multiple_of_the_batch_size(old_jobs):
+    """Batch windows overlap on their boundary id, so the highest job can be
+    swept up by the previous window and leave the final window empty."""
+    first, last = old_jobs[0].pk, old_jobs[-1].pk
+    batch_size = last - first
+    expected = len(old_jobs)
+
+    skipped, deleted = _command(batch_size=batch_size).cleanup_jobs()
+
+    assert deleted == expected
+    assert not Job.objects.filter(pk__in=[job.pk for job in old_jobs]).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_jobs_deletes_every_old_job(old_jobs):
+    skipped, deleted = _command(batch_size=100000).cleanup_jobs()
+
+    assert deleted == len(old_jobs)
+    assert not Job.objects.filter(pk__in=[job.pk for job in old_jobs]).exists()

--- a/awx/main/tests/functional/commands/test_cleanup_jobs.py
+++ b/awx/main/tests/functional/commands/test_cleanup_jobs.py
@@ -56,6 +56,7 @@ def test_cleanup_jobs_with_a_gap_in_the_id_range(old_jobs):
 
     skipped, deleted = _command(batch_size=1).cleanup_jobs()
 
+    assert skipped == 0
     assert deleted == expected
     assert not Job.objects.filter(pk__in=[job.pk for job in old_jobs]).exists()
 
@@ -70,6 +71,7 @@ def test_cleanup_jobs_when_the_id_span_is_a_multiple_of_the_batch_size(old_jobs)
 
     skipped, deleted = _command(batch_size=batch_size).cleanup_jobs()
 
+    assert skipped == 0
     assert deleted == expected
     assert not Job.objects.filter(pk__in=[job.pk for job in old_jobs]).exists()
 
@@ -78,5 +80,6 @@ def test_cleanup_jobs_when_the_id_span_is_a_multiple_of_the_batch_size(old_jobs)
 def test_cleanup_jobs_deletes_every_old_job(old_jobs):
     skipped, deleted = _command(batch_size=100000).cleanup_jobs()
 
+    assert skipped == 0
     assert deleted == len(old_jobs)
     assert not Job.objects.filter(pk__in=[job.pk for job in old_jobs]).exists()


### PR DESCRIPTION
## Problem

`cleanup_jobs` walks the id range in batches and adds up what each batch removed:

```python
_, results = qs_batch.delete()
deleted += results['main.Job']
```

Django returns `(0, {})` when a delete matches nothing, so an empty window raises `KeyError` and the command dies:

```
empty Job delete -> (0, {})
results['main.Job'] -> KeyError 'main.Job'
```

Driving the real command with a gap in the id range:

```
job ids [929, 930, 931, 932, 933, 934], deleted [931, 932] to leave a gap
cleanup_jobs -> CRASHED with KeyError 'main.Job'
```

Two ways to land on an empty window, both from the loop at `cleanup_jobs.py:304`:

- **Boundary overlap.** A window is `[start, start + batch_size]` and the next one begins at `start + batch_size`, so they share an id. The last window starts at `min + k*batch_size`; when the id span is an exact multiple of the batch size, the highest job is already removed by the previous window and the final window is empty.
- **Sparse id ranges.** `Job` shares the `UnifiedJob` id sequence with project updates, inventory updates and workflow jobs, so a window covering only ids belonging to other job types holds no deletable `Job`. That gets likelier the smaller the batch, and `--batch-size` is a documented option (`cleanup_jobs.py:191`).

This matters more than a management-command traceback suggests. `cleanup_jobs` is the built-in "Remove jobs older than a certain number of days" system job (`jobs.py:1253`), normally on a schedule, so a failure stops job cleanup and lets the database grow.

## Fix

Use `results.get('main.Job', 0)`. The sibling helper `_delete_unpartitioned_events` already guards its own empty list the same way at line 283, which is what makes this look like an oversight rather than an assumption.

## Tests

Three tests in `awx/main/tests/functional/commands/test_cleanup_jobs.py`: the gap case, the exact-multiple boundary case, and a control that deletes everything in one window.

Before the fix, the first two fail with the real `KeyError: 'main.Job'` and the control passes. After, all pass along with the existing unit tests:

```
py.test -q awx/main/tests/functional/commands/test_cleanup_jobs.py awx/main/tests/unit/commands/test_cleanup_jobs.py
............                                         [100%]
12 passed in 1.15s
```

One thing worth flagging separately: the tests have to stub `_pre_delete_job_host_summaries` and `has_unpartitioned_table`. Both issue PostgreSQL-only SQL (`ANY(%s)` and a read of `pg_tables`) while the suite runs against SQLite (`awx/main/tests/settings_for_test.py:16`), so `cleanup_jobs()` cannot be called end to end in a test at all. That is why this went unnoticed, and it is worth its own look.

## Upstream

`devel` carries the identical line, so the same fix is proposed there.
