### PR TITLE
Cover the PostgreSQL-only paths of cleanup_jobs with real tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Run smoke test
         run: ansible-playbook tools/docker-compose/ansible/smoke-test.yml -v
 
+      # The api-test job runs against SQLite, so any PostgreSQL-only SQL is
+      # unreachable there. This environment already has a real database, so the
+      # tests guarded by a vendor check get to run here instead of skipping.
+      - name: Run the PostgreSQL-backed tests
+        run: |
+          docker exec tools_postgres_1 psql -U postgres -c 'ALTER ROLE awx CREATEDB;'
+          docker exec --workdir /awx_devel tools_awx_1 make test-postgres
+
       - name: Get logs from the development environment on failure
         if: failure()
         run: docker logs tools_awx_1 || true

--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,15 @@ test:
 	cd awxkit && $(VENV_BASE)/awx/bin/tox -re py3
 	awx-manage check_migrations --dry-run --check -n 'missing_migration_file'
 
+## Run the tests that need a real PostgreSQL, which the SQLite suite skips.
+PG_TEST_DIRS ?= awx/main/tests/functional/commands/test_cleanup_jobs_postgres.py
+test-postgres:
+	if [ "$(VENV_BASE)" ]; then \
+		. $(VENV_BASE)/awx/bin/activate; \
+	fi; \
+	PYTHONDONTWRITEBYTECODE=1 DJANGO_SETTINGS_MODULE=awx.main.tests.settings_for_test_pg \
+		py.test -p no:cacheprovider -v $(PG_TEST_DIRS)
+
 ## Run all API unit tests without parallel execution (safer but slower).
 test-serial:
 	if [ "$(VENV_BASE)" ]; then \

--- a/awx/main/tests/functional/commands/test_cleanup_jobs_postgres.py
+++ b/awx/main/tests/functional/commands/test_cleanup_jobs_postgres.py
@@ -56,6 +56,7 @@ def test_cleanup_jobs_clears_host_summary_references(inventory):
 
     skipped, deleted = _command().cleanup_jobs()
 
+    assert skipped == 0
     assert deleted == 1
     assert not Job.objects.filter(pk=job.pk).exists()
     assert JobHostSummary.objects.filter(job_id=job.pk).count() == 0
@@ -104,6 +105,7 @@ def test_pre_delete_job_host_summaries_spans_chunks(inventory):
     with mock.patch('awx.main.management.commands.cleanup_jobs.JHS_CHUNK_SIZE', 2):
         skipped, deleted = _command().cleanup_jobs()
 
+    assert skipped == 0
     assert deleted == len(jobs)
     assert JobHostSummary.objects.filter(job__in=jobs).count() == 0
     assert not Host.objects.filter(last_job_host_summary__isnull=False, inventory=inventory).exists()

--- a/awx/main/tests/functional/commands/test_cleanup_jobs_postgres.py
+++ b/awx/main/tests/functional/commands/test_cleanup_jobs_postgres.py
@@ -1,0 +1,109 @@
+"""cleanup_jobs against a real PostgreSQL, with nothing stubbed out.
+
+The default test settings use SQLite, which leaves every PostgreSQL-only
+statement in this command unreachable from a test: _pre_delete_job_host_summaries
+issues ANY(%s) and has_unpartitioned_table reads pg_tables. Both are skipped by
+the SQLite suite in test_cleanup_jobs.py, so the statements themselves are only
+ever asserted as strings against a mock cursor.
+
+Run these with `make test-postgres`.
+"""
+
+import logging
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+
+from django.db import connection
+from django.utils.timezone import now
+
+from awx.main.management.commands.cleanup_jobs import Command
+from awx.main.models import Job, Host, JobHostSummary
+
+pytestmark = pytest.mark.skipif(connection.vendor != 'postgresql', reason='exercises PostgreSQL-only SQL')
+
+
+def _command(batch_size=100000):
+    command = Command()
+    command.logger = logging.getLogger('awx.main.commands.cleanup_jobs')
+    command.cutoff = now() - timedelta(days=1)
+    command.dry_run = False
+    command.batch_size = batch_size
+    return command
+
+
+def _old_job_with_hosts(inventory, name, host_count):
+    job = Job.objects.create(name=name, inventory=inventory, status='successful')
+    Job.objects.filter(pk=job.pk).update(created=now() - timedelta(days=400))
+    hosts = []
+    for i in range(host_count):
+        host = Host.objects.create(name='%s-host-%d' % (name, i), inventory=inventory)
+        summary = JobHostSummary.objects.create(job=job, host=host, host_name=host.name)
+        host.last_job_host_summary = summary
+        host.last_job = job
+        host.save()
+        hosts.append(host)
+    return job, hosts
+
+
+@pytest.mark.django_db
+def test_cleanup_jobs_clears_host_summary_references(inventory):
+    """The raw UPDATE has to null Host.last_job_host_summary before the DELETE,
+    otherwise the foreign key blocks it."""
+    job, hosts = _old_job_with_hosts(inventory, 'pg-clears', 3)
+    assert JobHostSummary.objects.filter(job=job).count() == 3
+
+    skipped, deleted = _command().cleanup_jobs()
+
+    assert deleted == 1
+    assert not Job.objects.filter(pk=job.pk).exists()
+    assert JobHostSummary.objects.filter(job_id=job.pk).count() == 0
+    for host in hosts:
+        host.refresh_from_db()
+        assert host.last_job_host_summary_id is None
+
+
+@pytest.mark.django_db
+def test_cleanup_jobs_keeps_hosts_themselves(inventory):
+    """Only the summary rows go; the hosts they pointed at must survive."""
+    job, hosts = _old_job_with_hosts(inventory, 'pg-keeps', 3)
+
+    _command().cleanup_jobs()
+
+    for host in hosts:
+        assert Host.objects.filter(pk=host.pk).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_jobs_leaves_recent_jobs_and_their_summaries(inventory):
+    recent = Job.objects.create(name='pg-recent', inventory=inventory, status='successful')
+    host = Host.objects.create(name='pg-recent-host', inventory=inventory)
+    summary = JobHostSummary.objects.create(job=recent, host=host, host_name=host.name)
+    host.last_job_host_summary = summary
+    host.save()
+
+    _command().cleanup_jobs()
+
+    assert Job.objects.filter(pk=recent.pk).exists()
+    assert JobHostSummary.objects.filter(pk=summary.pk).exists()
+    host.refresh_from_db()
+    assert host.last_job_host_summary_id == summary.pk
+
+
+@pytest.mark.django_db
+def test_pre_delete_job_host_summaries_spans_chunks(inventory):
+    """The helper chunks its job pks; drive it across more than one chunk so the
+    loop runs against the database rather than a mock cursor."""
+    jobs = []
+    for i in range(5):
+        job, _ = _old_job_with_hosts(inventory, 'pg-chunk-%d' % i, 2)
+        jobs.append(job)
+    assert JobHostSummary.objects.filter(job__in=jobs).count() == 10
+
+    with mock.patch('awx.main.management.commands.cleanup_jobs.JHS_CHUNK_SIZE', 2):
+        skipped, deleted = _command().cleanup_jobs()
+
+    assert deleted == len(jobs)
+    assert JobHostSummary.objects.filter(job__in=jobs).count() == 0
+    assert not Host.objects.filter(last_job_host_summary__isnull=False, inventory=inventory).exists()

--- a/awx/main/tests/settings_for_test_pg.py
+++ b/awx/main/tests/settings_for_test_pg.py
@@ -1,0 +1,19 @@
+# Python
+import copy
+import os
+
+# Load the standard test settings, then put the database back on PostgreSQL.
+from awx.main.tests.settings_for_test import *  # NOQA
+from awx.settings.development import DATABASES as DEVELOPMENT_DATABASES
+
+# settings_for_test swaps the database for SQLite so the suite runs with no
+# services attached. That leaves the PostgreSQL-only SQL in AWX unreachable from
+# a test: cleanup_jobs alone reaches ANY(%s), pg_tables and pg_catalog.pg_inherits.
+# Point at the development database instead and let Django build its own test_
+# database next to it, so those statements execute for real.
+#
+# Opt in with DJANGO_SETTINGS_MODULE=awx.main.tests.settings_for_test_pg, or use
+# `make test-postgres`. Tests that need this guard themselves with a skipif on
+# connection.vendor, so they stay inert under the default SQLite settings.
+DATABASES = copy.deepcopy(DEVELOPMENT_DATABASES)
+DATABASES['default']['TEST'] = {'NAME': os.getenv('AWX_TEST_DATABASE_NAME', 'test_awx_pg')}


### PR DESCRIPTION
## Problem

`awx/main/tests/settings_for_test.py:16` swaps the database for SQLite so the suite runs with no services attached. That is a reasonable default, but it leaves every PostgreSQL-only statement in AWX unreachable from a test. `cleanup_jobs` alone reaches three:

| Location | Statement |
|---|---|
| `_pre_delete_job_host_summaries` | `... WHERE job_id = ANY(%s)` |
| `has_unpartitioned_table` | reads `pg_tables` |
| `find_partitions_to_drop` | reads `pg_catalog.pg_inherits`, `::regclass` |

The SQLite tests added alongside #654 have to stub the first two out just to reach the batch loop:

```python
with mock.patch('...cleanup_jobs._pre_delete_job_host_summaries'):
    with mock.patch.object(Command, 'has_unpartitioned_table', return_value=False):
```

So today those statements are only ever asserted as strings against a mock cursor (`test_cleanup_jobs.py` checks `'ANY(%s)' in call[0][0]`). A wrong column name, a reversed statement order or a broken chunk boundary would all pass.

## Changes

- **`awx/main/tests/settings_for_test_pg.py`** restores the development database so Django builds its `test_` database on PostgreSQL. `settings_for_test` already imports the development settings and then overrides `DATABASES`, and its own comment notes that removing that override puts tests back on PostgreSQL, so this is a small module rather than new plumbing.
- **`test_cleanup_jobs_postgres.py`** runs `cleanup_jobs` end to end with nothing stubbed: the raw `UPDATE` nulls `Host.last_job_host_summary` before the `DELETE` (otherwise the foreign key blocks it), the hosts themselves survive, recent jobs and their summaries are left alone, and the chunking loop is driven across more than one chunk with a patched `JHS_CHUNK_SIZE`.
- **`make test-postgres`** to run them.
- A step in the **`dev-env` CI job**, which already stands up the compose stack with a real database, so these run in CI rather than only on a developer's machine.

The tests guard on `connection.vendor`, so they skip under the default settings and the `api-test` job is unaffected.

## Verification

Against the dev compose PostgreSQL:

```
$ make test-postgres
test_cleanup_jobs_clears_host_summary_references PASSED     [ 25%]
test_cleanup_jobs_keeps_hosts_themselves PASSED             [ 50%]
test_cleanup_jobs_leaves_recent_jobs_and_their_summaries PASSED [ 75%]
test_pre_delete_job_host_summaries_spans_chunks PASSED      [100%]
4 passed
```

Under the default SQLite settings they skip rather than fail:

```
$ py.test -q -rs awx/main/tests/functional/commands/test_cleanup_jobs_postgres.py
ssss
SKIPPED [4] exercises PostgreSQL-only SQL
4 skipped in 0.18s
```

The exact commands in the CI step were run against the local compose stack:

```
$ docker exec tools_postgres_1 psql -U postgres -c 'ALTER ROLE awx CREATEDB;'
ALTER ROLE
$ docker exec --workdir /awx_devel tools_awx_1 make test-postgres
4 passed in 1.42s
```

The `ALTER ROLE` is needed because the compose database grants `awx` ownership of its database but not `CREATEDB`, which Django needs to build the test database. `yamllint -s` and `flake8` are clean.

One caveat worth stating plainly: the CI step itself is the part I could not execute in a real GitHub Actions run. The commands are verified locally and the job already refers to `tools_awx_1` by name for its log capture, so the container naming is not a guess, but this PR's own CI run is what will confirm it.

## Result

`cleanup_jobs` went from no executable coverage of its PostgreSQL SQL to four tests that exercise it for real. The statements pass as written, so this adds no fix, only the coverage that would have caught the crash in #654 and would catch a regression in the raw SQL from now on.
