### PR TITLE
Speed up OIDC login by reconciling org/team memberships in bulk

### DIFF
--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -54,8 +54,12 @@ __SWAGGER_REQUESTS__ = {}
 dab_rr_initial = importlib.import_module('ansible_base.resource_registry.migrations.0001_initial')
 
 
+def _dab_rr_create_service_id(**kwargs):
+    dab_rr_initial.create_service_id(apps, None)
+
+
 if is_testing():
-    post_migrate.connect(lambda **kwargs: dab_rr_initial.create_service_id(apps, None))
+    post_migrate.connect(_dab_rr_create_service_id, weak=False, dispatch_uid='dab-rr-create-service-id')
 
 
 @pytest.fixture(scope="session")

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -620,7 +620,7 @@ _SOCIAL_AUTH_PIPELINE_BASE = (
     'social_core.pipeline.user.user_details',
     'awx.sso.social_base_pipeline.prevent_inactive_login',
 )
-SOCIAL_AUTH_PIPELINE = _SOCIAL_AUTH_PIPELINE_BASE + ('awx.sso.social_pipeline.update_user_orgs', 'awx.sso.social_pipeline.update_user_teams')
+SOCIAL_AUTH_PIPELINE = _SOCIAL_AUTH_PIPELINE_BASE + ('awx.sso.social_pipeline.update_user_org_team_mappings',)
 SOCIAL_AUTH_SAML_PIPELINE = _SOCIAL_AUTH_PIPELINE_BASE + ('awx.sso.saml_pipeline.populate_user', 'awx.sso.saml_pipeline.update_user_flags')
 SAML_AUTO_CREATE_OBJECTS = True
 

--- a/awx/sso/common.py
+++ b/awx/sso/common.py
@@ -113,9 +113,6 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
         logger.debug(f"Adapter {adapter} is not allowed to create orgs/teams")
         return
 
-    # Get all of the IDs and names of orgs in the DB and create any new org defined in LDAP that does not exist in the DB
-    existing_orgs = get_orgs_by_ids()
-
     # Parse through orgs and teams provided and create a list of unique items we care about creating
     all_orgs = list(set(org_list))
     all_teams = []
@@ -134,6 +131,9 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
     if not all_orgs and not all_teams:
         return
 
+    # Get all of the IDs and names of orgs in the DB and create any new org defined in LDAP that does not exist in the DB
+    existing_orgs = get_orgs_by_ids()
+
     for org_name in all_orgs:
         if org_name and org_name not in existing_orgs:
             logger.info("{} adapter is creating org {}".format(adapter, org_name))
@@ -148,7 +148,10 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
     # Do the same for teams.  A team name may legitimately exist in more than
     # one organization, so the existence check must be scoped to the mapped
     # organization rather than the team name alone.
-    existing_teams = set(Team.objects.filter(organization_id__in=list(existing_orgs.values())).values_list('organization_id', 'name'))
+    referenced_org_ids = {existing_orgs[team_map[team_name]] for team_name in all_teams}
+    existing_teams = set(
+        Team.objects.filter(organization_id__in=referenced_org_ids, name__in=all_teams).values_list('organization_id', 'name')
+    )
     for team_name in all_teams:
         org_id = existing_orgs[team_map[team_name]]
         if (org_id, team_name) not in existing_teams:

--- a/awx/sso/common.py
+++ b/awx/sso/common.py
@@ -10,9 +10,18 @@ from awx.main.models import Organization, Team
 logger = logging.getLogger('awx.sso.common')
 
 
-def get_orgs_by_ids():
+def get_orgs_by_ids(names=None):
     existing_orgs = {}
-    for org_id, org_name in Organization.objects.all().values_list('id', 'name'):
+    if names is not None:
+        # Per-login hot path: only the orgs referenced by the configured
+        # maps are needed, and Organization.name is unique, so this hits
+        # the name index instead of scanning the whole table.
+        orgs = Organization.objects.filter(name__in=names)
+    else:
+        # Full scan, required when the caller must enumerate every org
+        # (the SAML attribute-based removal path does this).
+        orgs = Organization.objects.all()
+    for org_id, org_name in orgs.values_list('id', 'name'):
         existing_orgs[org_name] = org_id
     return existing_orgs
 
@@ -132,7 +141,7 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
         return
 
     # Get all of the IDs and names of orgs in the DB and create any new org defined in LDAP that does not exist in the DB
-    existing_orgs = get_orgs_by_ids()
+    existing_orgs = get_orgs_by_ids(names=all_orgs)
 
     for org_name in all_orgs:
         if org_name and org_name not in existing_orgs:

--- a/awx/sso/common.py
+++ b/awx/sso/common.py
@@ -161,9 +161,7 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
     # one organization, so the existence check must be scoped to the mapped
     # organization rather than the team name alone.
     referenced_org_ids = {existing_orgs[team_map[team_name]] for team_name in all_teams}
-    existing_teams = set(
-        Team.objects.filter(organization_id__in=referenced_org_ids, name__in=all_teams).values_list('organization_id', 'name')
-    )
+    existing_teams = set(Team.objects.filter(organization_id__in=referenced_org_ids, name__in=all_teams).values_list('organization_id', 'name'))
     for team_name in all_teams:
         org_id = existing_orgs[team_map[team_name]]
         if (org_id, team_name) not in existing_teams:

--- a/awx/sso/common.py
+++ b/awx/sso/common.py
@@ -77,7 +77,10 @@ def reconcile_users_org_team_mappings(user, desired_org_states, desired_team_sta
                             continue
                         if role_name not in roles:
                             roles.append(role_name)
-            model_roles = Team.objects.filter(name__in=team_names).values_list('name', 'organization__name', *roles, named=True)
+            model_roles = Team.objects.filter(
+                name__in=team_names,
+                organization__name__in=desired_states.keys(),
+            ).values_list('name', 'organization__name', *roles, named=True)
 
         for row in model_roles:
             for role_name in roles:

--- a/awx/sso/common.py
+++ b/awx/sso/common.py
@@ -131,6 +131,9 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
             #  although the rest of the login process might stack later on
             logger.error("{} adapter is attempting to create a team {} but it does not have an org".format(adapter, team_name))
 
+    if not all_orgs and not all_teams:
+        return
+
     for org_name in all_orgs:
         if org_name and org_name not in existing_orgs:
             logger.info("{} adapter is creating org {}".format(adapter, org_name))
@@ -142,13 +145,16 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
             # Add the org name to the existing orgs since we created it and we may need it to build the teams below
             existing_orgs[org_name] = new_org.id
 
-    # Do the same for teams
-    existing_team_names = list(Team.objects.all().values_list('name', flat=True))
+    # Do the same for teams.  A team name may legitimately exist in more than
+    # one organization, so the existence check must be scoped to the mapped
+    # organization rather than the team name alone.
+    existing_teams = set(Team.objects.filter(organization_id__in=list(existing_orgs.values())).values_list('organization_id', 'name'))
     for team_name in all_teams:
-        if team_name not in existing_team_names:
+        org_id = existing_orgs[team_map[team_name]]
+        if (org_id, team_name) not in existing_teams:
             logger.info("{} adapter is creating team {} in org {}".format(adapter, team_name, team_map[team_name]))
             try:
-                Team.objects.create(name=team_name, organization_id=existing_orgs[team_map[team_name]])
+                Team.objects.create(name=team_name, organization_id=org_id)
             except IntegrityError:
                 # If another process got here before us that is ok because we don't need the ID from this team or anything
                 pass

--- a/awx/sso/social_pipeline.py
+++ b/awx/sso/social_pipeline.py
@@ -47,13 +47,7 @@ def _update_m2m_from_expression(user, opts, remove=True):
     return None
 
 
-def update_user_org_team_mappings(
-    backend,
-    details,
-    user=None,
-    *args,
-    **kwargs
-):
+def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
     """
     Compute the desired organization/team membership state in memory and
     reconcile all memberships in bulk.
@@ -92,8 +86,7 @@ def update_user_org_team_mappings(
 
         if not organization:
             logger.error(
-                "Team named %s in social auth team map settings is "
-                "invalid due to missing organization",
+                "Team named %s in social auth team map settings is " "invalid due to missing organization",
                 team_name,
             )
             continue
@@ -142,20 +135,15 @@ def update_user_org_team_mappings(
                 )
             )
 
-            desired_org_states[organization_name][role_name] = (
-                _update_m2m_from_expression(
-                    user,
-                    opts,
-                    role_remove,
-                )
+            desired_org_states[organization_name][role_name] = _update_m2m_from_expression(
+                user,
+                opts,
+                role_remove,
             )
 
         # If no mapping actually manages this organization, don't make the
         # reconciliation query load it.
-        if all(
-            desired_org_states[organization_name][role_name] is None
-            for role_name in org_roles_and_expressions
-        ):
+        if all(desired_org_states[organization_name][role_name] is None for role_name in org_roles_and_expressions):
             del desired_org_states[organization_name]
 
     # ------------------------------------------------------------------
@@ -202,21 +190,15 @@ def update_user_org_team_mappings(
 # Kept for compatibility: a custom SOCIAL_AUTH_PIPELINE configured in
 # awx settings (e.g. NON_ROOT settings or an awx-manage shell) may still list
 # these legacy function names explicitly.
-# The default SOCIAL_AUTH_PIPELINE no longer calls these individually.
+#
+# NOTE: both wrappers delegate to the merged step.  Referencing either name
+# reconciles organization AND team memberships (and ensures mapped orgs/teams
+# exist) in one pass, so a custom pipeline listing only one of them behaves like
+# the merged step rather than the historical per-role behavior.  The merged
+# reconcile is idempotent, so a pipeline listing both simply runs it twice.
 def update_user_orgs(backend, details, user=None, *args, **kwargs):
-    return update_user_org_team_mappings(
-        backend,
-        details,
-        user=user,
-        *args,
-        **kwargs
-    )
+    return update_user_org_team_mappings(backend, details, user=user, *args, **kwargs)
+
 
 def update_user_teams(backend, details, user=None, *args, **kwargs):
-    return update_user_org_team_mappings(
-        backend,
-        details,
-        user=user,
-        *args,
-        **kwargs
-    )
+    return update_user_org_team_mappings(backend, details, user=user, *args, **kwargs)

--- a/awx/sso/social_pipeline.py
+++ b/awx/sso/social_pipeline.py
@@ -5,86 +5,218 @@
 import re
 import logging
 
-from awx.sso.common import get_or_create_org_with_default_galaxy_cred
+from awx.sso.common import (
+    create_org_and_teams,
+    reconcile_users_org_team_mappings,
+)
 
 logger = logging.getLogger('awx.sso.social_pipeline')
 
 
-def _update_m2m_from_expression(user, related, expr, remove=True):
+def _update_m2m_from_expression(user, opts, remove=True):
     """
-    Helper function to update m2m relationship based on user matching one or
-    more expressions.
+    Evaluate a social-auth organization/team mapping expression.
+
+    Returns:
+        True  - user should be added
+        False - user should be removed
+        None  - membership should not be changed
     """
-    should_add = False
-    if expr is None:
-        return
-    elif not expr:
+    if opts is None:
+        return None
+
+    if not opts:
         pass
-    elif expr is True:
-        should_add = True
+    elif isinstance(opts, bool) and opts is True:
+        return True
     else:
-        if isinstance(expr, (str, type(re.compile('')))):
-            expr = [expr]
-        for ex in expr:
-            if isinstance(ex, str):
-                if user.username == ex or user.email == ex:
-                    should_add = True
-            elif isinstance(ex, type(re.compile(''))):
-                if ex.match(user.username) or ex.match(user.email):
-                    should_add = True
-    if should_add:
-        related.add(user)
-    elif remove:
-        related.remove(user)
+        if isinstance(opts, (str, type(re.compile('')))):
+            opts = [opts]
+
+        for expression in opts:
+            if isinstance(expression, str):
+                if user.username == expression or user.email == expression:
+                    return True
+            elif isinstance(expression, type(re.compile(''))):
+                if expression.match(user.username) or expression.match(user.email):
+                    return True
+
+    if remove:
+        return False
+
+    return None
 
 
-def update_user_orgs(backend, details, user=None, *args, **kwargs):
+def update_user_org_team_mappings(
+    backend,
+    details,
+    user=None,
+    *args,
+    **kwargs
+):
     """
-    Update organization memberships for the given user based on mapping rules
-    defined in settings.
+    Compute the desired organization/team membership state in memory and
+    reconcile all memberships in bulk.
+
+    This follows the same desired-state approach used by LDAPBackend in
+    awx.sso.backends.
     """
     if not user:
         return
 
     org_map = backend.setting('ORGANIZATION_MAP') or {}
+    team_map_settings = backend.setting('TEAM_MAP') or {}
+
+    # ------------------------------------------------------------------
+    # Ensure mapped organizations and teams exist.
+    # ------------------------------------------------------------------
+
+    orgs_list = []
+    team_map = {}
+
     for org_name, org_opts in org_map.items():
         organization_alias = org_opts.get('organization_alias')
+
         if organization_alias:
             organization_name = organization_alias
         else:
             organization_name = org_name
-        org = get_or_create_org_with_default_galaxy_cred(name=organization_name)
 
-        # Update org admins from expression(s).
-        remove = bool(org_opts.get('remove', True))
-        admins_expr = org_opts.get('admins', None)
-        remove_admins = bool(org_opts.get('remove_admins', remove))
-        _update_m2m_from_expression(user, org.admin_role.members, admins_expr, remove_admins)
+        orgs_list.append(organization_name)
 
-        # Update org users from expression(s).
-        users_expr = org_opts.get('users', None)
-        remove_users = bool(org_opts.get('remove_users', remove))
-        _update_m2m_from_expression(user, org.member_role.members, users_expr, remove_users)
-
-
-def update_user_teams(backend, details, user=None, *args, **kwargs):
-    """
-    Update team memberships for the given user based on mapping rules defined
-    in settings.
-    """
-    if not user:
-        return
-    from awx.main.models import Team
-
-    team_map = backend.setting('TEAM_MAP') or {}
-    for team_name, team_opts in team_map.items():
-        # Get or create the org to update.
+    for team_name, team_opts in team_map_settings.items():
         if 'organization' not in team_opts:
             continue
-        org = get_or_create_org_with_default_galaxy_cred(name=team_opts['organization'])
 
-        # Update team members from expression(s).
-        team = Team.objects.get_or_create(name=team_name, organization=org)[0]
-        users_expr = team_opts.get('users', None)
+        organization = team_opts.get('organization')
+
+        if not organization:
+            logger.error(
+                "Team named %s in social auth team map settings is "
+                "invalid due to missing organization",
+                team_name,
+            )
+            continue
+
+        team_map[team_name] = organization
+
+    create_org_and_teams(
+        orgs_list,
+        team_map,
+        'Social Auth',
+    )
+
+    # ------------------------------------------------------------------
+    # Compute organization desired state in memory.
+    #
+    # This mirrors the LDAP implementation in awx.sso.backends.
+    # ------------------------------------------------------------------
+
+    desired_org_states = {}
+
+    for org_name, org_opts in org_map.items():
+        organization_alias = org_opts.get('organization_alias')
+
+        if organization_alias:
+            organization_name = organization_alias
+        else:
+            organization_name = org_name
+
+        remove = bool(org_opts.get('remove', True))
+
+        desired_org_states[organization_name] = {}
+
+        # Social auth currently supports organization admins and users.
+        org_roles_and_expressions = {
+            'admin_role': 'admins',
+            'member_role': 'users',
+        }
+
+        for role_name, expression_name in org_roles_and_expressions.items():
+            opts = org_opts.get(expression_name, None)
+
+            role_remove = bool(
+                org_opts.get(
+                    'remove_{}'.format(expression_name),
+                    remove,
+                )
+            )
+
+            desired_org_states[organization_name][role_name] = (
+                _update_m2m_from_expression(
+                    user,
+                    opts,
+                    role_remove,
+                )
+            )
+
+        # If no mapping actually manages this organization, don't make the
+        # reconciliation query load it.
+        if all(
+            desired_org_states[organization_name][role_name] is None
+            for role_name in org_roles_and_expressions
+        ):
+            del desired_org_states[organization_name]
+
+    # ------------------------------------------------------------------
+    # Compute team desired state in memory.
+    # ------------------------------------------------------------------
+
+    desired_team_states = {}
+
+    for team_name, team_opts in team_map_settings.items():
+        if 'organization' not in team_opts:
+            continue
+
+        organization = team_opts.get('organization')
+
+        if not organization:
+            continue
+
+        users_opts = team_opts.get('users', None)
         remove = bool(team_opts.get('remove', True))
-        _update_m2m_from_expression(user, team.member_role.members, users_expr, remove)
+
+        state = _update_m2m_from_expression(
+            user,
+            users_opts,
+            remove,
+        )
+
+        if state is not None:
+            if organization not in desired_team_states:
+                desired_team_states[organization] = {}
+
+            desired_team_states[organization][team_name] = {
+                'member_role': state,
+            }
+
+    # One reconciliation for all organization/team memberships.
+    reconcile_users_org_team_mappings(
+        user,
+        desired_org_states,
+        desired_team_states,
+        'Social Auth',
+    )
+
+
+# Kept for compatibility: a custom SOCIAL_AUTH_PIPELINE configured in
+# awx settings (e.g. NON_ROOT settings or an awx-manage shell) may still list
+# these legacy function names explicitly.
+# The default SOCIAL_AUTH_PIPELINE no longer calls these individually.
+def update_user_orgs(backend, details, user=None, *args, **kwargs):
+    return update_user_org_team_mappings(
+        backend,
+        details,
+        user=user,
+        *args,
+        **kwargs
+    )
+
+def update_user_teams(backend, details, user=None, *args, **kwargs):
+    return update_user_org_team_mappings(
+        backend,
+        details,
+        user=user,
+        *args,
+        **kwargs
+    )

--- a/awx/sso/social_pipeline.py
+++ b/awx/sso/social_pipeline.py
@@ -47,26 +47,17 @@ def _update_m2m_from_expression(user, opts, remove=True):
     return None
 
 
-def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
+def _compute_org_desired_states(org_map, user):
     """
-    Compute the desired organization/team membership state in memory and
-    reconcile all memberships in bulk.
+    Resolve the mapped organization names (honoring organization_alias) and
+    evaluate each organization's admins/users expressions into a desired state.
 
-    This follows the same desired-state approach used by LDAPBackend in
-    awx.sso.backends.
+    Returns a tuple of (orgs_list, desired_org_states):
+      orgs_list          - the organization names that should exist
+      desired_org_states - org name to {role_name: True/False/None}
     """
-    if not user:
-        return
-
-    org_map = backend.setting('ORGANIZATION_MAP') or {}
-    team_map_settings = backend.setting('TEAM_MAP') or {}
-
-    # ------------------------------------------------------------------
-    # Ensure mapped organizations and teams exist.
-    # ------------------------------------------------------------------
-
     orgs_list = []
-    team_map = {}
+    desired_org_states = {}
 
     for org_name, org_opts in org_map.items():
         organization_alias = org_opts.get('organization_alias')
@@ -77,43 +68,6 @@ def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
             organization_name = org_name
 
         orgs_list.append(organization_name)
-
-    for team_name, team_opts in team_map_settings.items():
-        if 'organization' not in team_opts:
-            continue
-
-        organization = team_opts.get('organization')
-
-        if not organization:
-            logger.error(
-                "Team named %s in social auth team map settings is " "invalid due to missing organization",
-                team_name,
-            )
-            continue
-
-        team_map[team_name] = organization
-
-    create_org_and_teams(
-        orgs_list,
-        team_map,
-        'Social Auth',
-    )
-
-    # ------------------------------------------------------------------
-    # Compute organization desired state in memory.
-    #
-    # This mirrors the LDAP implementation in awx.sso.backends.
-    # ------------------------------------------------------------------
-
-    desired_org_states = {}
-
-    for org_name, org_opts in org_map.items():
-        organization_alias = org_opts.get('organization_alias')
-
-        if organization_alias:
-            organization_name = organization_alias
-        else:
-            organization_name = org_name
 
         remove = bool(org_opts.get('remove', True))
 
@@ -146,10 +100,19 @@ def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
         if all(desired_org_states[organization_name][role_name] is None for role_name in org_roles_and_expressions):
             del desired_org_states[organization_name]
 
-    # ------------------------------------------------------------------
-    # Compute team desired state in memory.
-    # ------------------------------------------------------------------
+    return orgs_list, desired_org_states
 
+
+def _compute_team_desired_states(team_map_settings, user):
+    """
+    Resolve the mapped teams (declaring the organizations they belong to) and
+    evaluate each team's users expression into a desired state.
+
+    Returns a tuple of (team_map, desired_team_states):
+      team_map            - team name to organization name
+      desired_team_states - organization name to {team name: {'member_role': True/False/None}}
+    """
+    team_map = {}
     desired_team_states = {}
 
     for team_name, team_opts in team_map_settings.items():
@@ -159,7 +122,13 @@ def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
         organization = team_opts.get('organization')
 
         if not organization:
+            logger.error(
+                "Team named %s in social auth team map settings is " "invalid due to missing organization",
+                team_name,
+            )
             continue
+
+        team_map[team_name] = organization
 
         users_opts = team_opts.get('users', None)
         remove = bool(team_opts.get('remove', True))
@@ -178,6 +147,33 @@ def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
                 'member_role': state,
             }
 
+    return team_map, desired_team_states
+
+
+def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
+    """
+    Compute the desired organization/team membership state in memory and
+    reconcile all memberships in bulk.
+
+    This follows the same desired-state approach used by LDAPBackend in
+    awx.sso.backends.
+    """
+    if not user:
+        return
+
+    org_map = backend.setting('ORGANIZATION_MAP') or {}
+    team_map_settings = backend.setting('TEAM_MAP') or {}
+
+    orgs_list, desired_org_states = _compute_org_desired_states(org_map, user)
+    team_map, desired_team_states = _compute_team_desired_states(team_map_settings, user)
+
+    # Ensure mapped organizations and teams exist.
+    create_org_and_teams(
+        orgs_list,
+        team_map,
+        'Social Auth',
+    )
+
     # One reconciliation for all organization/team memberships.
     reconcile_users_org_team_mappings(
         user,
@@ -191,14 +187,63 @@ def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
 # awx settings (e.g. NON_ROOT settings or an awx-manage shell) may still list
 # these legacy function names explicitly.
 #
-# NOTE: both wrappers delegate to the merged step.  Referencing either name
-# reconciles organization AND team memberships (and ensures mapped orgs/teams
-# exist) in one pass, so a custom pipeline listing only one of them behaves like
-# the merged step rather than the historical per-role behavior.  The merged
-# reconcile is idempotent, so a pipeline listing both simply runs it twice.
+# Both entry points retain their original per-domain behavior:
+#   update_user_orgs  -> organizations only (admin_role/member_role)
+#   update_user_teams -> teams only (member_role)
+# Referencing one does NOT manage the other domain, matching the historical
+# behavior of the pre-merge pipeline.  Each still uses the same bulk
+# create_org_and_teams + reconcile_users_org_team_mappings helpers as the
+# merged step, so custom pipelines keep the bulk-reconciliation speedup.
 def update_user_orgs(backend, details, user=None, *args, **kwargs):
-    return update_user_org_team_mappings(backend, details, user=user, *args, **kwargs)
+    """
+    Update organization memberships for the given user based on mapping rules
+    defined in settings.  Teams are left untouched.
+    """
+    if not user:
+        return
+
+    org_map = backend.setting('ORGANIZATION_MAP') or {}
+
+    orgs_list, desired_org_states = _compute_org_desired_states(org_map, user)
+
+    # Ensure mapped organizations exist.  Teams (and the organizations only
+    # referenced by them) are managed by update_user_teams.
+    create_org_and_teams(
+        orgs_list,
+        {},
+        'Social Auth',
+    )
+
+    reconcile_users_org_team_mappings(
+        user,
+        desired_org_states,
+        {},
+        'Social Auth',
+    )
 
 
 def update_user_teams(backend, details, user=None, *args, **kwargs):
-    return update_user_org_team_mappings(backend, details, user=user, *args, **kwargs)
+    """
+    Update team memberships for the given user based on mapping rules defined
+    in settings.  Organization memberships are left untouched.
+    """
+    if not user:
+        return
+
+    team_map_settings = backend.setting('TEAM_MAP') or {}
+
+    team_map, desired_team_states = _compute_team_desired_states(team_map_settings, user)
+
+    # Ensure mapped teams (and the organizations they belong to) exist.
+    create_org_and_teams(
+        [],
+        team_map,
+        'Social Auth',
+    )
+
+    reconcile_users_org_team_mappings(
+        user,
+        {},
+        desired_team_states,
+        'Social Auth',
+    )

--- a/awx/sso/tests/functional/conftest.py
+++ b/awx/sso/tests/functional/conftest.py
@@ -11,5 +11,10 @@ from awx.main.utils import is_testing
 
 dab_rr_initial = importlib.import_module('ansible_base.resource_registry.migrations.0001_initial')
 
+
+def _dab_rr_create_service_id(**kwargs):
+    dab_rr_initial.create_service_id(apps, None)
+
+
 if is_testing():
-    post_migrate.connect(lambda **kwargs: dab_rr_initial.create_service_id(apps, None))
+    post_migrate.connect(_dab_rr_create_service_id, weak=False, dispatch_uid='dab-rr-create-service-id')

--- a/awx/sso/tests/functional/conftest.py
+++ b/awx/sso/tests/functional/conftest.py
@@ -1,0 +1,15 @@
+# HACK: the dab_resource_registry app requires ServiceID to be created in a
+# data migration, which is skipped under pytest's --nomigrations.  Mirror the
+# hack in awx/main/tests/functional/conftest.py so these SSO functional tests
+# can be run in isolation (without that conftest tree on the collection path).
+import importlib
+
+from django.apps import apps
+from django.db.models.signals import post_migrate
+
+from awx.main.utils import is_testing
+
+dab_rr_initial = importlib.import_module('ansible_base.resource_registry.migrations.0001_initial')
+
+if is_testing():
+    post_migrate.connect(lambda **kwargs: dab_rr_initial.create_service_id(apps, None))

--- a/awx/sso/tests/functional/test_common.py
+++ b/awx/sso/tests/functional/test_common.py
@@ -216,6 +216,28 @@ class TestCommonFunctions:
         assert user in team1.member_role
         assert user not in team2.member_role
 
+    def test_reconcile_team_query_scoped_to_mapped_orgs(self):
+        # Reconcile must only touch the teams in the orgs named in the desired
+        # state.  Same-named teams in other orgs (which the query previously
+        # read and no-op'd) must be left completely alone.
+        user = User.objects.create(username='user1@foo.com', last_name='foo', first_name='bar', email='user1@foo.com', is_active=True)
+        org = Organization.objects.create(name='Mapped Org')
+        team = Team.objects.create(name='Ops', organization=org)
+        team.member_role.members.add(user)
+
+        for i in range(3):
+            other_org = Organization.objects.create(name='Other Org {}'.format(i))
+            stray = Team.objects.create(name='Ops', organization=other_org)
+            stray.member_role.members.add(user)
+
+        reconcile_users_org_team_mappings(user, {}, {org.name: {'Ops': {'member_role': False}}}, 'py.test')
+
+        # The mapped org's team lost the membership...
+        assert user not in team.member_role
+        # ...while every same-named team in the non-mapped orgs kept it.
+        for stray in Team.objects.filter(name='Ops').exclude(organization=org):
+            assert user in stray.member_role
+
     @pytest.mark.parametrize(
         "org_list, team_map, can_create, org_count, team_count",
         [

--- a/awx/sso/tests/functional/test_common.py
+++ b/awx/sso/tests/functional/test_common.py
@@ -44,6 +44,12 @@ class TestCommonFunctions:
         assert Counter(orgs_and_ids.keys()) == Counter([o1.name, o2.name, o3.name])
         assert Counter(orgs_and_ids.values()) == Counter([o1.id, o2.id, o3.id])
 
+    def test_get_orgs_by_ids_scoped_to_names(self, orgs):
+        orgs_and_ids = get_orgs_by_ids(names=['Default1'])
+        assert set(orgs_and_ids.keys()) == {'Default1'}
+        o1, _, _ = orgs
+        assert orgs_and_ids['Default1'] == o1.id
+
     def test_reconcile_users_org_team_mappings(self):
         # Create objects for us to play with
         user = User.objects.create(username='user1@foo.com', last_name='foo', first_name='bar', email='user1@foo.com', is_active=True)

--- a/awx/sso/tests/functional/test_social_pipeline.py
+++ b/awx/sso/tests/functional/test_social_pipeline.py
@@ -204,15 +204,24 @@ class TestMergedPipelineStep:
         update_user_org_team_mappings(backend, None, user)
         assert Organization.objects.count() == 2
         assert Team.objects.count() == 1
-        assert user in Organization.objects.get(name='OrgOne').member_role
-        assert user in Organization.objects.get(name='OrgTwo').member_role
+        # The mapping only grants `users`, so assert on DIRECT member-role
+        # membership (Role.__contains__ would also match an org admin via the
+        # admin_role ancestor) and rule out an unintended admin grant.
+        org_one = Organization.objects.get(name='OrgOne')
+        org_two = Organization.objects.get(name='OrgTwo')
+        assert org_one.member_role.members.filter(pk=user.pk).exists()
+        assert org_two.member_role.members.filter(pk=user.pk).exists()
+        assert not org_one.admin_role.members.filter(pk=user.pk).exists()
+        assert not org_two.admin_role.members.filter(pk=user.pk).exists()
+        team_alpha = Team.objects.get(name='Alpha')
+        assert team_alpha.member_role.members.filter(pk=user.pk).exists()
 
     def test_alias_org_receives_membership(self):
         user = self._make_user()
         backend = FakeMergedBackend(ORGANIZATION_MAP={'Procurement': {'organization_alias': 'Acme Procurement', 'admins': 'alice'}})
         update_user_org_team_mappings(backend, None, user)
         org = Organization.objects.get(name='Acme Procurement')
-        assert user in org.admin_role
+        assert org.admin_role.members.filter(pk=user.pk).exists()
         assert not Organization.objects.filter(name='Procurement').exists()
 
     def test_unmapped_org_membership_is_untouched(self):
@@ -221,13 +230,15 @@ class TestMergedPipelineStep:
         org.admin_role.members.add(user)
         backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'remove': True}})
         update_user_org_team_mappings(backend, None, user)
-        assert user in org.admin_role
+        assert org.admin_role.members.filter(pk=user.pk).exists()
 
     def test_boolean_true_matches_everyone(self):
         user = self._make_user()
         backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'users': True}})
         update_user_org_team_mappings(backend, None, user)
-        assert user in Organization.objects.get(name='Default').member_role
+        default = Organization.objects.get(name='Default')
+        assert default.member_role.members.filter(pk=user.pk).exists()
+        assert not default.admin_role.members.filter(pk=user.pk).exists()
 
     def test_mismatched_expression_removes_membership(self):
         user = self._make_user()
@@ -235,7 +246,7 @@ class TestMergedPipelineStep:
         org.member_role.members.add(user)
         backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'users': 'bob', 'remove_users': True}})
         update_user_org_team_mappings(backend, None, user)
-        assert user not in org.member_role
+        assert not org.member_role.members.filter(pk=user.pk).exists()
 
     def test_remove_disabled_leaves_membership_untouched(self):
         user = self._make_user()
@@ -243,7 +254,7 @@ class TestMergedPipelineStep:
         org.member_role.members.add(user)
         backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'users': 'bob', 'remove_users': False}})
         update_user_org_team_mappings(backend, None, user)
-        assert user in org.member_role
+        assert org.member_role.members.filter(pk=user.pk).exists()
 
     def test_remove_applies_only_to_mismatched_role(self):
         user = self._make_user()
@@ -265,8 +276,8 @@ class TestMergedPipelineStep:
         team_two.member_role.members.add(user)
         backend = FakeMergedBackend(TEAM_MAP={'Support': {'organization': 'Org One', 'users': 'alice', 'remove': True}})
         update_user_org_team_mappings(backend, None, user)
-        assert user in team_one.member_role
-        assert user in team_two.member_role
+        assert team_one.member_role.members.filter(pk=user.pk).exists()
+        assert team_two.member_role.members.filter(pk=user.pk).exists()
 
     def test_same_named_team_elsewhere_is_created_in_mapped_org(self):
         user = self._make_user()
@@ -282,7 +293,7 @@ class TestMergedPipelineStep:
         assert Team.objects.filter(name='Support').count() == 2
         team_one = Team.objects.get(name='Support', organization=org_one)
         assert team_one.member_role.members.filter(pk=user.pk).exists()
-        assert user in team_two.member_role
+        assert team_two.member_role.members.filter(pk=user.pk).exists()
 
     def test_team_users_false_removes_membership(self):
         user = self._make_user()

--- a/awx/sso/tests/functional/test_social_pipeline.py
+++ b/awx/sso/tests/functional/test_social_pipeline.py
@@ -1,7 +1,7 @@
 import pytest
 import re
 
-from awx.sso.social_pipeline import update_user_orgs, update_user_teams
+from awx.sso.social_pipeline import _update_m2m_from_expression, update_user_org_team_mappings, update_user_orgs, update_user_teams
 from awx.main.models import User, Team, Organization
 
 
@@ -111,3 +111,198 @@ class TestSocialPipeline:
 
         assert Team.objects.get(name="Red").member_role.members.count() == 2
         assert Team.objects.get(name="Blue").member_role.members.count() == 2
+
+
+class SimpleUser:
+    def __init__(self, username, email):
+        self.username = username
+        self.email = email
+
+
+class FakeMergedBackend:
+    def __init__(self, **settings):
+        self._settings = settings
+
+    def setting(self, key):
+        return self._settings.get(key)
+
+
+class TestUpdateM2MFromExpression:
+    @pytest.mark.parametrize(
+        'opts, remove, expected',
+        [
+            (None, True, None),
+            (None, False, None),
+            ('', True, False),
+            ('', False, None),
+            ([], True, False),
+            (False, True, False),
+            (False, False, None),
+            (True, True, True),
+            (True, False, True),
+        ],
+    )
+    def test_return_values(self, opts, remove, expected):
+        user = SimpleUser('alice', 'alice@example.com')
+        assert _update_m2m_from_expression(user, opts, remove) is expected
+
+    @pytest.mark.parametrize(
+        'opts, matches',
+        [
+            ('alice', True),
+            ('alice@example.com', True),
+            ('bob', False),
+            (re.compile('alice@example.com'), True),
+            (re.compile('.*@example\\.com$'), True),
+            (re.compile('bob'), False),
+            (['charlie', re.compile('alice@example.com')], True),
+            (['charlie', 'dave'], False),
+        ],
+    )
+    def test_expression_matching(self, opts, matches):
+        user = SimpleUser('alice', 'alice@example.com')
+        assert _update_m2m_from_expression(user, opts, remove=True) is matches
+
+
+@pytest.mark.django_db
+class TestMergedPipelineStep:
+    def _make_user(self, username='alice', email='alice@example.com'):
+        return User.objects.create(username=username, last_name='foo', first_name='bar', email=email)
+
+    def test_org_and_team_membership_in_single_call(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={'Default': {'admins': 'alice', 'users': 'alice'}},
+            TEAM_MAP={'Operations': {'organization': 'Default', 'users': 'alice'}},
+        )
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Default')
+        team = Team.objects.get(name='Operations')
+        # The user is both an admin and a member, so `user in org.member_role`
+        # would also match through the admin_role ancestor.  Assert on DIRECT
+        # membership in both roles instead.
+        assert org.admin_role.members.filter(pk=user.pk).exists()
+        assert org.member_role.members.filter(pk=user.pk).exists()
+        assert team.member_role.members.filter(pk=user.pk).exists()
+
+    def test_empty_maps_are_a_noop(self):
+        user = self._make_user()
+        update_user_org_team_mappings(FakeMergedBackend(), None, user)
+        assert Organization.objects.count() == 0
+        assert Team.objects.count() == 0
+        assert list(user.roles.all()) == []
+
+    def test_no_user_returns_early(self):
+        update_user_org_team_mappings(FakeMergedBackend(), None, None)
+
+    def test_orgs_and_teams_created_from_maps(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={'OrgOne': {'users': 'alice'}, 'OrgTwo': {'users': 'alice'}},
+            TEAM_MAP={'Alpha': {'organization': 'OrgOne', 'users': 'alice'}},
+        )
+        update_user_org_team_mappings(backend, None, user)
+        assert Organization.objects.count() == 2
+        assert Team.objects.count() == 1
+        assert user in Organization.objects.get(name='OrgOne').member_role
+        assert user in Organization.objects.get(name='OrgTwo').member_role
+
+    def test_alias_org_receives_membership(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(ORGANIZATION_MAP={'Procurement': {'organization_alias': 'Acme Procurement', 'admins': 'alice'}})
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Acme Procurement')
+        assert user in org.admin_role
+        assert not Organization.objects.filter(name='Procurement').exists()
+
+    def test_unmapped_org_membership_is_untouched(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Default')
+        org.admin_role.members.add(user)
+        backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'remove': True}})
+        update_user_org_team_mappings(backend, None, user)
+        assert user in org.admin_role
+
+    def test_boolean_true_matches_everyone(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'users': True}})
+        update_user_org_team_mappings(backend, None, user)
+        assert user in Organization.objects.get(name='Default').member_role
+
+    def test_mismatched_expression_removes_membership(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Default')
+        org.member_role.members.add(user)
+        backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'users': 'bob', 'remove_users': True}})
+        update_user_org_team_mappings(backend, None, user)
+        assert user not in org.member_role
+
+    def test_remove_disabled_leaves_membership_untouched(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Default')
+        org.member_role.members.add(user)
+        backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'users': 'bob', 'remove_users': False}})
+        update_user_org_team_mappings(backend, None, user)
+        assert user in org.member_role
+
+    def test_remove_applies_only_to_mismatched_role(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'admins': 'alice', 'users': 'bob'}})
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Default')
+        # `user in role` (Role.__contains__) also matches ancestor roles, and
+        # org admin_role is a descendant of member_role, so an admin is always
+        # "in" member_role.  Assert on the DIRECT membership queryset instead.
+        assert org.admin_role.members.filter(pk=user.pk).exists()
+        assert not org.member_role.members.filter(pk=user.pk).exists()
+
+    def test_same_named_team_in_other_org_untouched(self):
+        user = self._make_user()
+        org_one = Organization.objects.create(name='Org One')
+        org_two = Organization.objects.create(name='Org Two')
+        team_one = Team.objects.create(name='Support', organization=org_one)
+        team_two = Team.objects.create(name='Support', organization=org_two)
+        team_two.member_role.members.add(user)
+        backend = FakeMergedBackend(TEAM_MAP={'Support': {'organization': 'Org One', 'users': 'alice', 'remove': True}})
+        update_user_org_team_mappings(backend, None, user)
+        assert user in team_one.member_role
+        assert user in team_two.member_role
+
+    def test_same_named_team_elsewhere_is_created_in_mapped_org(self):
+        user = self._make_user()
+        org_one = Organization.objects.create(name='Org One')
+        org_two = Organization.objects.create(name='Org Two')
+        team_two = Team.objects.create(name='Support', organization=org_two)
+        team_two.member_role.members.add(user)
+        backend = FakeMergedBackend(TEAM_MAP={'Support': {'organization': 'Org One', 'users': 'alice'}})
+        update_user_org_team_mappings(backend, None, user)
+        # A team name may exist in more than one org.  The mapped org has no
+        # 'Support' team yet, so it must be created there (and ONLY there).
+        assert Team.objects.filter(name='Support', organization=org_one).exists()
+        assert Team.objects.filter(name='Support').count() == 2
+        team_one = Team.objects.get(name='Support', organization=org_one)
+        assert team_one.member_role.members.filter(pk=user.pk).exists()
+        assert user in team_two.member_role
+
+    def test_team_users_false_removes_membership(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Default')
+        team = Team.objects.create(name='Operations', organization=org)
+        team.member_role.members.add(user)
+        backend = FakeMergedBackend(TEAM_MAP={'Operations': {'organization': 'Default', 'users': False}})
+        update_user_org_team_mappings(backend, None, user)
+        assert team.member_role.members.filter(pk=user.pk).exists() is False
+
+    def test_org_admins_false_removes_admin_membership(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Default')
+        org.admin_role.members.add(user)
+        backend = FakeMergedBackend(ORGANIZATION_MAP={'Default': {'admins': False}})
+        update_user_org_team_mappings(backend, None, user)
+        assert org.admin_role.members.filter(pk=user.pk).exists() is False
+
+    def test_team_without_organization_is_skipped(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(TEAM_MAP={'Floating': {'users': 'alice'}})
+        update_user_org_team_mappings(backend, None, user)
+        assert Team.objects.filter(name='Floating').count() == 0

--- a/awx/sso/tests/functional/test_social_pipeline.py
+++ b/awx/sso/tests/functional/test_social_pipeline.py
@@ -55,6 +55,10 @@ class TestSocialPipeline:
         assert org.admin_role.members.count() == 3
         assert org.member_role.members.count() == 3
 
+        # update_user_orgs manages organizations only, so the fixture's TEAM_MAP
+        # (Blue/Red) must neither be created nor reconciled.
+        assert Team.objects.count() == 0
+
         # Test remove feature enabled
         backend.setting('ORGANIZATION_MAP')['Default']['admins'] = ''
         backend.setting('ORGANIZATION_MAP')['Default']['users'] = ''
@@ -91,6 +95,14 @@ class TestSocialPipeline:
 
         assert Team.objects.get(name="Red").member_role.members.count() == 3
         assert Team.objects.get(name="Blue").member_role.members.count() == 3
+
+        # update_user_teams manages teams only: even matching org expressions
+        # must not grant (or revoke) any organization membership.
+        backend.setting('ORGANIZATION_MAP')['Default']['admins'] = re.compile('.*')
+        backend.setting('ORGANIZATION_MAP')['Default']['users'] = re.compile('.*')
+        update_user_teams(backend, None, u1)
+        assert Organization.objects.get(name="Default").admin_role.members.count() == 0
+        assert Organization.objects.get(name="Default").member_role.members.count() == 0
 
         # Test remove feature enabled
         backend.setting('TEAM_MAP')['Blue']['remove'] = True
@@ -317,3 +329,35 @@ class TestMergedPipelineStep:
         backend = FakeMergedBackend(TEAM_MAP={'Floating': {'users': 'alice'}})
         update_user_org_team_mappings(backend, None, user)
         assert Team.objects.filter(name='Floating').count() == 0
+
+    def test_update_user_orgs_does_not_touch_teams(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Default')
+        team = Team.objects.create(name='Ops', organization=org)
+        team.member_role.members.add(user)
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={'Default': {'users': user.username}},
+            TEAM_MAP={'Ops': {'organization': 'Default', 'users': 'nobody', 'remove': True}},
+        )
+        update_user_orgs(backend, None, user)
+        # update_user_orgs manages organizations only; the team mapping (which
+        # would otherwise remove the user) must be ignored...
+        assert team.member_role.members.filter(pk=user.pk).exists()
+        # ...while the org membership is still granted by the org-only step.
+        assert org.member_role.members.filter(pk=user.pk).exists()
+
+    def test_update_user_teams_does_not_touch_orgs(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Default')
+        org.admin_role.members.add(user)
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={'Default': {'admins': 'nobody', 'remove_admins': True}},
+            TEAM_MAP={'Ops': {'organization': 'Default', 'users': user.username}},
+        )
+        update_user_teams(backend, None, user)
+        # update_user_teams manages teams only; the org mapping (which would
+        # otherwise remove the admin) must be ignored...
+        assert org.admin_role.members.filter(pk=user.pk).exists()
+        # ...while the team membership is still granted by the team-only step.
+        team = Team.objects.get(name='Ops')
+        assert team.member_role.members.filter(pk=user.pk).exists()

--- a/awx/sso/tests/unit/test_pipelines.py
+++ b/awx/sso/tests/unit/test_pipelines.py
@@ -10,3 +10,25 @@ import pytest
 )
 def test_module_loads(lib):
     module = __import__("awx.sso." + lib)  # noqa
+
+
+# The default SOCIAL_AUTH_PIPELINE must use the merged step, NOT the legacy
+# per-role wrappers (update_user_orgs / update_user_teams).  The wrappers are
+# kept on purpose -- they delegate to the merged step -- because custom
+# pipelines outside the repo may still reference them.  Only the OIDC pipeline
+# was rewired; the SAML pipeline uses its own populate_user path and is
+# intentionally untouched.
+@pytest.mark.parametrize(
+    "pipeline_setting, func_name, expected",
+    [
+        ("SOCIAL_AUTH_PIPELINE", "update_user_org_team_mappings", True),
+        ("SOCIAL_AUTH_PIPELINE", "update_user_orgs", False),
+        ("SOCIAL_AUTH_PIPELINE", "update_user_teams", False),
+        ("SOCIAL_AUTH_SAML_PIPELINE", "update_user_org_team_mappings", False),
+    ],
+)
+def test_social_pipeline_uses_merged_step(pipeline_setting, func_name, expected):
+    from django.conf import settings
+
+    pipeline = getattr(settings, pipeline_setting)
+    assert any(func_name in entry for entry in pipeline) is expected


### PR DESCRIPTION
This aims at improving #661

##### SUMMARY
Unify the two per-mapping pipeline steps (`update_user_orgs`, `update_user_teams`) into a single
`update_user_org_team_mappings` step that follows the LDAP backend's desired-state approach:
- compute the desired org/team membership in memory, create missing orgs/teams once via `awx.sso.common.create_org_and_teams`, then apply every change via one bulk
- `reconcile_users_org_team_mappings` call. The default `SOCIAL_AUTH_PIPELINE`
(`awx/settings/defaults.py`) now runs the merged step only.

This removes the per-org/per-team `get_or_create` plus immediate m2m add/remove that ran on every
login, eliminating the noticeable login delay once more than a few orgs/teams are mapped.

##### Changes
- `_update_m2m_from_expression` now matches LDAP's `_update_m2m_from_groups`, evaluating a mapping
  expression to a tri-state (`True`/`False`/`None`).
- Desired-state computation is shared via `_compute_org_desired_states` / `_compute_team_desired_states`,
  keeping the merged default and the legacy entry points in lockstep.
- Per-login lookups are scoped to the configured maps instead of scanning whole tables:
  - `create_org_and_teams` returns early for empty maps and only reads referenced orgs
    (`get_orgs_by_ids(names=...)`, using the unique `Organization.name` index); the full scan is kept
    only for the SAML attribute-based removal path.
  - Team-existence checks are scoped to the mapped organization, so a team whose name exists in
    another org is still created where the mapping expects it.
  - `reconcile_users_org_team_mappings` scopes the team lookup by organization name, hitting the
    composite `(organization, name)` index instead of scanning the `Team` table.

##### Kept for backwards compatibility
- `update_user_orgs` and `update_user_teams` remain for custom `SOCIAL_AUTH_PIPELINE` settings that
  still reference them. They keep their original per-domain behavior - orgs only, teams only - so
  custom pipelines don't start managing the other domain, while still using the same bulk helpers
  and keeping the performance win.

##### Tests
- Unit test pins the default `SOCIAL_AUTH_PIPELINE` to the merged step (legacy entry points not part
  of it).
- Functional tests cover expression matching (`match()` start-anchored semantics), merged-step
  org/team membership cases, per-domain wrapper behavior, and the scoped lookups - using direct
  role-membership assertions to avoid `Role.__contains__` ancestor masking.
- The sso functional conftest replicates the DAB `resource_registry` `ServiceID` `post_migrate` hack
  so the tests run standalone with `--nomigrations`.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other (SSO login path in awx/sso)

##### ASCENDER VERSION
Tested with 25.5.1

##### ADDITIONAL INFO
There is more potential to increase performance (e.g. [mentioned here](https://github.com/2and3makes23/ascender/blob/2164ce87389d65bdc6a4453b0a2c1300b4e2b112/awx/sso/common.py#L108)), but these changes seemed to be the lowest hanging fruits with a large impact on OIDC login performance.

We experienced a delay of multiple seconds until forwarding to Ascender frontend. With this there is no noticable delay anymore.
