### PR TITLE
Reconcile social auth org and team memberships in bulk

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -620,7 +620,7 @@ _SOCIAL_AUTH_PIPELINE_BASE = (
     'social_core.pipeline.user.user_details',
     'awx.sso.social_base_pipeline.prevent_inactive_login',
 )
-SOCIAL_AUTH_PIPELINE = _SOCIAL_AUTH_PIPELINE_BASE + ('awx.sso.social_pipeline.update_user_orgs', 'awx.sso.social_pipeline.update_user_teams')
+SOCIAL_AUTH_PIPELINE = _SOCIAL_AUTH_PIPELINE_BASE + ('awx.sso.social_pipeline.populate_user',)
 SOCIAL_AUTH_SAML_PIPELINE = _SOCIAL_AUTH_PIPELINE_BASE + ('awx.sso.saml_pipeline.populate_user', 'awx.sso.saml_pipeline.update_user_flags')
 SAML_AUTO_CREATE_OBJECTS = True
 

--- a/awx/sso/common.py
+++ b/awx/sso/common.py
@@ -10,9 +10,17 @@ from awx.main.models import Organization, Team
 logger = logging.getLogger('awx.sso.common')
 
 
-def get_orgs_by_ids():
+def get_orgs_by_ids(names=None):
+    #
+    # names - an optional iterable of organization names to restrict the query to.
+    #         Adapters that only care about the orgs they have mapped should pass this
+    #         instead of reading the whole organization table on every login.
+    #
     existing_orgs = {}
-    for org_id, org_name in Organization.objects.all().values_list('id', 'name'):
+    organizations = Organization.objects.all()
+    if names is not None:
+        organizations = organizations.filter(name__in=names)
+    for org_id, org_name in organizations.values_list('id', 'name'):
         existing_orgs[org_name] = org_id
     return existing_orgs
 
@@ -113,9 +121,6 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
         logger.debug(f"Adapter {adapter} is not allowed to create orgs/teams")
         return
 
-    # Get all of the IDs and names of orgs in the DB and create any new org defined in LDAP that does not exist in the DB
-    existing_orgs = get_orgs_by_ids()
-
     # Parse through orgs and teams provided and create a list of unique items we care about creating
     all_orgs = list(set(org_list))
     all_teams = []
@@ -131,6 +136,9 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
             #  although the rest of the login process might stack later on
             logger.error("{} adapter is attempting to create a team {} but it does not have an org".format(adapter, team_name))
 
+    # Get the IDs and names of the orgs we care about and create any mapped org that does not exist in the DB
+    existing_orgs = get_orgs_by_ids(names=all_orgs)
+
     for org_name in all_orgs:
         if org_name and org_name not in existing_orgs:
             logger.info("{} adapter is creating org {}".format(adapter, org_name))
@@ -142,10 +150,10 @@ def create_org_and_teams(org_list, team_map, adapter, can_create=True):
             # Add the org name to the existing orgs since we created it and we may need it to build the teams below
             existing_orgs[org_name] = new_org.id
 
-    # Do the same for teams
-    existing_team_names = list(Team.objects.all().values_list('name', flat=True))
+    # Do the same for teams, a team is only unique within its organization so we have to match on both fields
+    existing_teams = set(Team.objects.filter(name__in=all_teams).values_list('name', 'organization__name'))
     for team_name in all_teams:
-        if team_name not in existing_team_names:
+        if (team_name, team_map[team_name]) not in existing_teams:
             logger.info("{} adapter is creating team {} in org {}".format(adapter, team_name, team_map[team_name]))
             try:
                 Team.objects.create(name=team_name, organization_id=existing_orgs[team_map[team_name]])

--- a/awx/sso/social_pipeline.py
+++ b/awx/sso/social_pipeline.py
@@ -5,20 +5,31 @@
 import re
 import logging
 
-from awx.sso.common import get_or_create_org_with_default_galaxy_cred
+from awx.sso.common import create_org_and_teams, reconcile_users_org_team_mappings
 
 logger = logging.getLogger('awx.sso.social_pipeline')
 
 
-def _update_m2m_from_expression(user, related, expr, remove=True):
+def _get_adapter_name(backend):
+    # The backend name is only used to label log messages, the test backends do not always have one
+    return getattr(backend, 'name', 'social')
+
+
+def _desired_state_from_expression(user, expr, remove=True):
     """
-    Helper function to update m2m relationship based on user matching one or
-    more expressions.
+    Helper function to evaluate the organization/team map expressions to determine if the user
+    should be a member of the role.
+
+    Returns:
+        True - User should be added
+        False - User should be removed
+        None - Users membership should not be changed
     """
-    should_add = False
     if expr is None:
-        return
-    elif not expr:
+        return None
+
+    should_add = False
+    if not expr:
         pass
     elif expr is True:
         should_add = True
@@ -32,20 +43,33 @@ def _update_m2m_from_expression(user, related, expr, remove=True):
             elif isinstance(ex, type(re.compile(''))):
                 if ex.match(user.username) or ex.match(user.email):
                     should_add = True
+
     if should_add:
-        related.add(user)
+        return True
     elif remove:
-        related.remove(user)
+        return False
+    return None
 
 
-def update_user_orgs(backend, details, user=None, *args, **kwargs):
+def _merge_desired_states(existing_state, new_state):
     """
-    Update organization memberships for the given user based on mapping rules
+    Helper function to combine the desired states of two map entries pointing at the same role.
+
+    Being a member of the role wins over not being a member of it, which in turn wins over
+    leaving the membership alone.
+    """
+    if new_state is None:
+        return existing_state
+    if existing_state is None:
+        return new_state
+    return existing_state or new_state
+
+
+def _update_user_orgs(backend, user, desired_org_state, orgs_to_create):
+    """
+    Compute the organization memberships for the given user based on mapping rules
     defined in settings.
     """
-    if not user:
-        return
-
     org_map = backend.setting('ORGANIZATION_MAP') or {}
     for org_name, org_opts in org_map.items():
         organization_alias = org_opts.get('organization_alias')
@@ -53,38 +77,102 @@ def update_user_orgs(backend, details, user=None, *args, **kwargs):
             organization_name = organization_alias
         else:
             organization_name = org_name
-        org = get_or_create_org_with_default_galaxy_cred(name=organization_name)
+        if organization_name not in orgs_to_create:
+            orgs_to_create.append(organization_name)
 
-        # Update org admins from expression(s).
+        if organization_name not in desired_org_state:
+            desired_org_state[organization_name] = {}
+
         remove = bool(org_opts.get('remove', True))
-        admins_expr = org_opts.get('admins', None)
-        remove_admins = bool(org_opts.get('remove_admins', remove))
-        _update_m2m_from_expression(user, org.admin_role.members, admins_expr, remove_admins)
+        for role_name, user_type in (('admin_role', 'admins'), ('member_role', 'users')):
+            remove_members = bool(org_opts.get('remove_{}'.format(user_type), remove))
+            state = _desired_state_from_expression(user, org_opts.get(user_type, None), remove_members)
+            desired_org_state[organization_name][role_name] = _merge_desired_states(desired_org_state[organization_name].get(role_name, None), state)
 
-        # Update org users from expression(s).
-        users_expr = org_opts.get('users', None)
-        remove_users = bool(org_opts.get('remove_users', remove))
-        _update_m2m_from_expression(user, org.member_role.members, users_expr, remove_users)
+
+def _update_user_teams(backend, user, desired_team_state, teams_to_create):
+    """
+    Compute the team memberships for the given user based on mapping rules defined
+    in settings.
+    """
+    team_map = backend.setting('TEAM_MAP') or {}
+    for team_name, team_opts in team_map.items():
+        # Get or create the org to update.
+        if 'organization' not in team_opts:
+            continue
+        organization_name = team_opts['organization']
+        teams_to_create[team_name] = organization_name
+
+        remove = bool(team_opts.get('remove', True))
+        state = _desired_state_from_expression(user, team_opts.get('users', None), remove)
+        if state is None:
+            continue
+
+        if organization_name not in desired_team_state:
+            desired_team_state[organization_name] = {}
+        desired_team_state[organization_name][team_name] = {'member_role': state}
+
+
+def populate_user(backend, details, user=None, *args, **kwargs):
+    """
+    Update organization and team memberships for the given user based on mapping
+    rules defined in settings.
+    """
+    if not user:
+        return
+
+    # Build the in-memory settings for how this user should be modeled
+    desired_org_state = {}
+    desired_team_state = {}
+    orgs_to_create = []
+    teams_to_create = {}
+    _update_user_orgs(backend, user, desired_org_state, orgs_to_create)
+    _update_user_teams(backend, user, desired_team_state, teams_to_create)
+
+    adapter = _get_adapter_name(backend)
+
+    # Create any mapped org/team which does not exist yet
+    create_org_and_teams(orgs_to_create, teams_to_create, adapter)
+
+    # Finally reconcile the user, this only writes the memberships which actually changed
+    reconcile_users_org_team_mappings(user, desired_org_state, desired_team_state, adapter)
+
+
+def update_user_orgs(backend, details, user=None, *args, **kwargs):
+    """
+    Update organization memberships for the given user based on mapping rules
+    defined in settings.
+
+    Kept for pipelines which reference the organization and team steps separately,
+    populate_user does both in a single pass.
+    """
+    if not user:
+        return
+
+    desired_org_state = {}
+    orgs_to_create = []
+    _update_user_orgs(backend, user, desired_org_state, orgs_to_create)
+
+    adapter = _get_adapter_name(backend)
+    create_org_and_teams(orgs_to_create, {}, adapter)
+    reconcile_users_org_team_mappings(user, desired_org_state, {}, adapter)
 
 
 def update_user_teams(backend, details, user=None, *args, **kwargs):
     """
     Update team memberships for the given user based on mapping rules defined
     in settings.
+
+    Kept for pipelines which reference the organization and team steps separately,
+    populate_user does both in a single pass.
     """
     if not user:
         return
-    from awx.main.models import Team
 
-    team_map = backend.setting('TEAM_MAP') or {}
-    for team_name, team_opts in team_map.items():
-        # Get or create the org to update.
-        if 'organization' not in team_opts:
-            continue
-        org = get_or_create_org_with_default_galaxy_cred(name=team_opts['organization'])
+    desired_team_state = {}
+    teams_to_create = {}
+    _update_user_teams(backend, user, desired_team_state, teams_to_create)
 
-        # Update team members from expression(s).
-        team = Team.objects.get_or_create(name=team_name, organization=org)[0]
-        users_expr = team_opts.get('users', None)
-        remove = bool(team_opts.get('remove', True))
-        _update_m2m_from_expression(user, team.member_role.members, users_expr, remove)
+    adapter = _get_adapter_name(backend)
+    create_org_and_teams([], teams_to_create, adapter)
+    reconcile_users_org_team_mappings(user, {}, desired_team_state, adapter)

--- a/awx/sso/tests/functional/test_common.py
+++ b/awx/sso/tests/functional/test_common.py
@@ -269,6 +269,14 @@ class TestCommonFunctions:
         assert Organization.objects.count() == org_count
         assert Team.objects.count() == team_count
 
+    def test_create_org_and_teams_same_team_name_in_different_orgs(self, galaxy_credential):
+        # A team is only unique within its organization so the same team name has to be
+        # creatable in more than one org
+        create_org_and_teams([], {"team1": "org1"}, 'py.test')
+        create_org_and_teams([], {"team1": "org2"}, 'py.test')
+
+        assert Counter(Team.objects.filter(name="team1").values_list('organization__name', flat=True)) == Counter(["org1", "org2"])
+
     def test_get_or_create_org_with_default_galaxy_cred_add_galaxy_cred(self, galaxy_credential):
         # If this method creates the org it should get the default galaxy credential
         num_orgs = 4

--- a/awx/sso/tests/functional/test_social_pipeline.py
+++ b/awx/sso/tests/functional/test_social_pipeline.py
@@ -1,8 +1,8 @@
 import pytest
 import re
 
-from awx.sso.social_pipeline import update_user_orgs, update_user_teams
-from awx.main.models import User, Team, Organization
+from awx.sso.social_pipeline import populate_user, update_user_orgs, update_user_teams
+from awx.main.models import ActivityStream, User, Team, Organization
 
 
 @pytest.fixture
@@ -111,3 +111,50 @@ class TestSocialPipeline:
 
         assert Team.objects.get(name="Red").member_role.members.count() == 2
         assert Team.objects.get(name="Blue").member_role.members.count() == 2
+
+    def test_update_user_orgs_ignores_undefined_roles(self, org, backend, users):
+        u1, u2, u3 = users
+
+        # A map entry without an admins expression must not manage the admin role at all,
+        # even though remove_admins is set
+        del backend.setting('ORGANIZATION_MAP')['Default']['admins']
+        backend.setting('ORGANIZATION_MAP')['Default']['users'] = re.compile('.*')
+        org.admin_role.members.add(u1)
+
+        update_user_orgs(backend, None, u1)
+
+        assert list(org.admin_role.members.all()) == [u1]
+        assert list(org.member_role.members.all()) == [u1]
+
+    def test_populate_user_only_writes_when_the_membership_changes(self, users, django_assert_max_num_queries):
+        u1, u2, u3 = users
+
+        organization_map = {}
+        team_map = {}
+        for number in range(25):
+            organization_map[f"Org {number}"] = {'users': re.compile('.*'), 'admins': ''}
+            team_map[f"Team {number}"] = {'organization': f"Org {number}", 'users': re.compile('.*')}
+
+        class Backend:
+            s = {'ORGANIZATION_MAP': organization_map, 'TEAM_MAP': team_map}
+
+            def setting(self, key):
+                return self.s[key]
+
+        backend = Backend()
+
+        # The first login has to create every mapped org and team and grant the memberships
+        populate_user(backend, None, u1)
+        assert Organization.objects.count() == 25
+        assert Team.objects.count() == 25
+        granted_roles = set(u1.roles.values_list('pk', flat=True))
+        assert len(granted_roles) == 50
+
+        # A second login with an unchanged map must not write anything, and the number of
+        # queries it takes must not scale with the size of the map
+        activity_stream_entries = ActivityStream.objects.count()
+        with django_assert_max_num_queries(15):
+            populate_user(backend, None, u1)
+
+        assert set(u1.roles.values_list('pk', flat=True)) == granted_roles
+        assert ActivityStream.objects.count() == activity_stream_entries


### PR DESCRIPTION
Closes #661.

## The problem

Every non-SAML social login, OIDC included, runs `awx.sso.social_pipeline.update_user_orgs` and `update_user_teams`. Those are the last SSO adapters still walking the organization and team maps one entry at a time: a `get_or_create` per mapped org, a query for each role, then an unconditional `role.members.add(user)` or `.remove(user)`.

The removes are the expensive part. Django sends `pre_remove` with the pks it was asked to remove whether or not the user actually holds the role, and `rbac_activity_stream` records an entry for each one, so a login also wrote a `disassociate` for every mapped role the user was not a member of. None of this work depends on anything having changed.

With the ~100 mapped organizations and teams from the issue that is a couple of thousand queries and ~100 pointless activity stream rows on every login, which the user experiences as a multi second wait before the browser is redirected.

## The fix

Build the desired membership state in memory and hand it to `create_org_and_teams()` and `reconcile_users_org_team_mappings()`, the way the LDAP and SAML adapters have done since they were converted, so only the memberships that actually changed are written.

Measured on a repeat login with 25 mapped orgs and 25 mapped teams where nothing has changed:

| | queries | ActivityStream rows |
| --- | --- | --- |
| before | 550 | 25 |
| after | 7 | 0 |

Both numbers scaled linearly with map size before, and are now flat.

`populate_user()` does orgs and teams in a single pass and replaces the two entries in `SOCIAL_AUTH_PIPELINE`. `update_user_orgs()` and `update_user_teams()` remain as working entry points for anyone who pins the two steps separately in a custom pipeline.

### Undefined expressions keep their old meaning

`_desired_state_from_expression()` deliberately does not reuse the SAML helper of the same shape. SAML treats a missing key as a removal, the social maps have always left that role alone, and porting the SAML version verbatim would have started stripping users out of every org whose map entry has no `users` key. `test_update_user_orgs_ignores_undefined_roles` pins that.

### Two side fixes in `create_org_and_teams()`

Adopting the bulk helper unmodified would have introduced the whole table reads of `main_organization` and `main_team` that the issue complains about, so both are now restricted to the names being mapped. `get_orgs_by_ids()` keeps its unfiltered behaviour by default, which is what the SAML remove flag semantics need.

Existing teams are also matched on `(name, organization)` rather than name alone. A team is only unique within its organization, so the name only check meant a team named `Blue` in one org stopped `Blue` from ever being created in another.

## Notes for upgraders

Two changes are visible in behaviour, both in the direction the configuration always described:

* The team matching fix applies to LDAP and SAML as well, since the helper is shared. A team that was silently never created because its name existed in another org will be created on the next login and its mapped memberships granted.
* When `organization_alias` collapses several map keys onto one organization and those entries disagree, membership now wins over non membership instead of the result depending on map ordering.

## Testing

* `py.test awx/sso/` passes, 210 tests, 3 of them new.
* `py.test awx/sso/ awx/main/tests/functional/test_rbac_core.py awx/main/tests/functional/models/test_activity_stream.py` passes, 244 tests.
* `black --check` and `flake8` with the `tox.ini` select list are clean.
* Every entry of `SOCIAL_AUTH_PIPELINE` still resolves through `social_core.utils.module_member` against a running instance.

`test_populate_user_only_writes_when_the_membership_changes` is the regression guard: it asserts a repeat login stays under a fixed query count and adds no activity stream rows, which is exactly what the old code violated.
