### PR TITLE
Point the docs at the Ascender client and drop leftover AWX names

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -263,7 +263,7 @@ class APIView(views.APIView):
         # `WWW-Authenticate: Basic ...`, your browser will prompt you for an
         # HTTP basic auth username+password and will store it _in the browser_
         # for subsequent requests.  Because basic auth does not require CSRF
-        # validation (because it's commonly used with e.g., tower-cli and other
+        # validation (because it's commonly used with e.g., the Ascender CLI and other
         # non-browser clients), browsers that save basic auth in this way are
         # vulnerable to cross-site request forgery:
         #

--- a/docs/docsite/rst/administration/ent_auth.rst
+++ b/docs/docsite/rst/administration/ent_auth.rst
@@ -511,7 +511,7 @@ For transparent logins to work, you must first get IdP-initiated logins to work.
 
     The above is a sample of a typical IdP format, but may not be the correct format for your particular case. You may need to reach out to your IdP for the correct transparent redirect URL as that URL is not the same for all IdPs.
 
-3. After transparent SAML login is configured, to log in using local credentials or a different SSO, go directly to ``https://<your-awx-server>/login``.  This provides the standard Ascender login page, including SSO authentication buttons, and allows you to log in with any configured method.
+3. After transparent SAML login is configured, to log in using local credentials or a different SSO, go directly to ``https://<your-ascender-server>/login``.  This provides the standard Ascender login page, including SSO authentication buttons, and allows you to log in with any configured method.
 
 
 Enabling Logging for SAML

--- a/docs/docsite/rst/administration/metrics.rst
+++ b/docs/docsite/rst/administration/metrics.rst
@@ -17,7 +17,7 @@ To set up and use Prometheus, you will need to install Prometheus on a virtual m
 
 .. _`Prometheus documentation`: https://prometheus.io/docs/introduction/first_steps/
 
-1. In the Prometheus config file (typically ``prometheus.yml``), specify a ``<token_value>``, a valid user/password for an Ascender user you have created, and a ``<awx_host>``. 
+1. In the Prometheus config file (typically ``prometheus.yml``), specify a ``<token_value>``, a valid user/password for an Ascender user you have created, and a ``<ascender_host>``. 
 
     .. note:: Alternatively, you can provide an OAuth2 token (which can be generated at ``/api/v2/users/N/personal_tokens/``). By default, the config assumes a user with username=admin and password=password.
 
@@ -39,7 +39,7 @@ To set up and use Prometheus, you will need to install Prometheus on a virtual m
         #   password: password
         static_configs:
             - targets: 
-                - <awx_host>
+                - <ascender_host>
 
  For help configuring other aspects of Prometheus, such as alerts and service discovery configurations, refer to the `Prometheus configuration docs`_.
 

--- a/docs/docsite/rst/administration/tipsandtricks.rst
+++ b/docs/docsite/rst/administration/tipsandtricks.rst
@@ -106,7 +106,7 @@ To view the Ansible outputs, browse to:
 
 ::
 
-   https://<awx server name>/api/v2/jobs/<job_id>/job_events/   
+   https://<ascender server name>/api/v2/jobs/<job_id>/job_events/   
 
 
 Locate and configure the Ansible configuration file

--- a/docs/docsite/rst/rest_api/authentication.rst
+++ b/docs/docsite/rst/rest_api/authentication.rst
@@ -30,7 +30,7 @@ Using the curl tool, you can see the activity that occurs when you log into Asce
 
 .. code-block:: text
 
-	curl -k -c - https://<awx-host>/api/login/
+	curl -k -c - https://<ascender-host>/api/login/
 
 	localhost	FALSE	/	FALSE	0   csrftoken
 	AswSFn5p1qQvaX4KoRZN6A5yer0Pq0VG2cXMTzZnzuhaY0L4tiidYqwf5PXZckuj
@@ -40,11 +40,11 @@ Using the curl tool, you can see the activity that occurs when you log into Asce
 .. code-block:: text
 
 	curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
-  	--referer https://<awx-host>/api/login/ \
+  	--referer https://<ascender-host>/api/login/ \
   	-H 'X-CSRFToken: K580zVVm0rWX8pmNylz5ygTPamgUJxifrdJY0UDtMMoOis5Q1UOxRmV9918BUBIN' \
   	--data 'username=root&password=reverse' \
   	--cookie 'csrftoken=K580zVVm0rWX8pmNylz5ygTPamgUJxifrdJY0UDtMMoOis5Q1UOxRmV9918BUBIN' \
-  	https://<awx-host>/api/login/ -k -D - -o /dev/null
+  	https://<ascender-host>/api/login/ -k -D - -o /dev/null
 
 All of this is done by the Ascender when you log in to the UI or API in the browser, and should only be used when authenticating in the browser. For programmatic integration with Ascender, see :ref:`api_oauth2_auth`.
 
@@ -90,7 +90,7 @@ Example with curl:
 .. code-block:: text
 
    # the --user flag adds this Authorization header for us
-   curl -X GET --user 'user:password' https://<awx-host>/api/v2/credentials -k -L
+   curl -X GET --user 'user:password' https://<ascender-host>/api/v2/credentials -k -L
 
 For more information about the Basic HTTP Authentication scheme, see `RFC 7617 <https://datatracker.ietf.org/doc/html/rfc7617>`_.
 
@@ -135,7 +135,7 @@ Token authentication is best used for any programmatic use of the Ascender API, 
 
 .. code-block:: text
 
-   curl -u user:password -k -X POST https://<awx-host>/api/v2/tokens/
+   curl -u user:password -k -X POST https://<ascender-host>/api/v2/tokens/
 
 
 This call will return JSON data like:
@@ -149,7 +149,7 @@ The value of the ``token`` property is what you can now use to perform a GET req
 	curl -k -X POST \
   	  -H “Content-Type: application/json”
   	  -H “Authorization: Bearer <oauth2-token-value>” \
-  	  https://<awx-host>/api/v2/hosts/ 
+  	  https://<ascender-host>/api/v2/hosts/ 
 
 Similarly, you can launch a job by making a POST to the job template that you want to launch.
 
@@ -159,13 +159,13 @@ Similarly, you can launch a job by making a POST to the job template that you wa
   	  -H "Authorization: Bearer <oauth2-token-value>" \
   	  -H "Content-Type: application/json" \
   	  --data '{"limit" : "ansible"}' \
-  	  https://<awx-host>/api/v2/job_templates/14/launch/ 
+  	  https://<ascender-host>/api/v2/job_templates/14/launch/ 
 
 
 **Python Example**
 
-`awxkit <https://pypi.org/project/awxkit/>`_ is an open source tool that makes it easy to use HTTP requests to access the Ascender API. 
-You can have awxkit acquire a PAT on your behalf by using the ``awxkit login`` command. Refer to the :ref:`api_start` for more detail.
+`Ascender Kit <https://pypi.org/project/ascender-kit/>`_ is an open source tool that makes it easy to use HTTP requests to access the Ascender API. 
+You can have it acquire a PAT on your behalf by using the ``ascender login`` command. Refer to the `Ascender Kit documentation <https://github.com/ctrliq/ascender-kit>`_ for more detail.
 
 For more information on how to use OAuth 2 in Ascender in the context of integrating external applications, see :ref:`ag_oauth2_token_auth` in the |ata|. 
 
@@ -175,15 +175,15 @@ If you need to write custom requests, you can write a Python script using `Pytho
 
 	import requests
 	oauth2_token_value = 'y1Q8ye4hPvT61aQq63Da6N1C25jiA'   # your token value from Ascender
-	url = 'https://<awx-host>/api/v2/users/'
+	url = 'https://<ascender-host>/api/v2/users/'
 	payload = {}
 	headers = {'Authorization': 'Bearer ' + oauth2_token_value,}
 
-	# makes request to awx user endpoint
+	# makes request to Ascender user endpoint
 	response = requests.request('GET', url, headers=headers, data=payload,
 	allow_redirects=False, verify=False)
 
-	# prints json returned from awx with formatting
+	# prints json returned from Ascender with formatting
 	print(json.dumps(response.json(), indent=4, sort_keys=True))
 
 

--- a/docs/docsite/rst/rest_api/filtering.rst
+++ b/docs/docsite/rst/rest_api/filtering.rst
@@ -12,25 +12,25 @@ For example, to find the groups that contain the name "foo":
 
 ::
 
-    http://<awx server name>/api/v2/groups/?name__contains=foo
+    http://<ascender server name>/api/v2/groups/?name__contains=foo
 
 To find an exact match:
 
 ::
 
-    http://<awx server name>/api/v2/groups/?name=foo
+    http://<ascender server name>/api/v2/groups/?name=foo
 
 If a resource is of an integer type, you must add ``\_\_int`` to the end to cast your string input value to an integer, like so:
 
 ::
 
-    http://<awx server name>/api/v2/arbitrary_resource/?x__int=5
+    http://<ascender server name>/api/v2/arbitrary_resource/?x__int=5
 
 Related resources can also be queried, like so:
 
 ::
 
-    http://<awx server name>/api/v2/users/?first_name__icontains=kim
+    http://<ascender server name>/api/v2/users/?first_name__icontains=kim
 
 This will return all users with names that include the string "Kim" in them.
 
@@ -38,7 +38,7 @@ You can also filter against multiple fields at once:
 
 ::
 
-    http://<awx server name>/api/v2/groups/?name__icontains=test&has_active_failures=false
+    http://<ascender server name>/api/v2/groups/?name__icontains=test&has_active_failures=false
 
 This finds all groups containing the name "test" that has no active failures.
 

--- a/docs/docsite/rst/userguide/job_templates.rst
+++ b/docs/docsite/rst/userguide/job_templates.rst
@@ -705,7 +705,7 @@ You can find the API endpoint for fact caching at:
 
 .. code-block::
    
-   http://<awx server name>/api/v2/hosts/x/ansible_facts
+   http://<ascender server name>/api/v2/hosts/x/ansible_facts
 
 .. _ug_CloudCredentials:
 


### PR DESCRIPTION
The API auth docs still told people to install awxkit and run `awxkit login` to get a token. That client is ascender-kit now and its command is `ascender`, so the documented one does not exist. The paragraph now names Ascender Kit, links its PyPI page and points at the repo for the CLI reference. The old `api_start` link went to the REST API index, which has no CLI content, so it is gone.

Also swapped the AWX branded host placeholders in the examples for Ascender ones across six files, `<awx-host>`, `<awx server name>`, `<awx_host>` and `<your-awx-server>`, keeping the shape each file already used. Fixed two comments in the Python example that said awx, and a tower-cli mention in the basic auth comment in generics.py.

Left alone anything that is a real name: the AWX Operator, `awx-manage`, `/etc/awx/conf.d`, `awx_sessionid`, the css asset and the `configure-awx-*.png` screenshot filenames.