### PR TITLE
Report the Twilio error instead of a bare reraise

### DIFF
--- a/awx/main/notifications/twilio_backend.py
+++ b/awx/main/notifications/twilio_backend.py
@@ -39,7 +39,7 @@ class TwilioBackend(AWXBaseEmailBackend, CustomNotificationBase):
             logger.error(smart_str(_("Exception connecting to Twilio: {}").format(e)))
 
         for m in messages:
-            failed = False
+            failure = None
             for dest in m.to:
                 try:
                     logger.debug(smart_str(_("FROM: {} / TO: {}").format(m.from_email, dest)))
@@ -47,7 +47,10 @@ class TwilioBackend(AWXBaseEmailBackend, CustomNotificationBase):
                     sent_messages += 1
                 except Exception as e:
                     logger.error(smart_str(_("Exception sending messages: {}").format(e)))
-                    failed = True
-            if not self.fail_silently and failed:
-                raise
+                    if failure is None:
+                        failure = e
+            # a bare raise here would be outside the handler that caught this,
+            # so the exception has to be kept to report what actually failed
+            if not self.fail_silently and failure is not None:
+                raise failure
         return sent_messages

--- a/awx/main/tests/unit/notifications/test_twilio.py
+++ b/awx/main/tests/unit/notifications/test_twilio.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+import pytest
+
+from django.core.mail.message import EmailMessage
+
+import awx.main.notifications.twilio_backend as twilio_backend
+
+
+class TwilioError(Exception):
+    pass
+
+
+def test_send_messages():
+    with mock.patch('awx.main.notifications.twilio_backend.Client') as client_mock:
+        backend = twilio_backend.TwilioBackend('account-sid', 'account-token')
+        message = EmailMessage('test subject', 'test body', '+15005550006', ['+15005550001', '+15005550002'])
+
+        sent_messages = backend.send_messages([message])
+
+        assert sent_messages == 2
+        assert client_mock.return_value.messages.create.call_count == 2
+
+
+def test_send_messages_reports_the_twilio_error():
+    """A failed send has to surface what Twilio said.
+
+    The handler that caught it has already exited by the time the backend
+    reports the failure, so a bare raise would report a RuntimeError about
+    there being no active exception instead.
+    """
+    with mock.patch('awx.main.notifications.twilio_backend.Client') as client_mock:
+        client_mock.return_value.messages.create.side_effect = TwilioError('is not a valid phone number')
+        backend = twilio_backend.TwilioBackend('account-sid', 'account-token')
+        message = EmailMessage('test subject', 'test body', '+15005550006', ['+15005550009'])
+
+        with pytest.raises(TwilioError) as exc:
+            backend.send_messages([message])
+
+        assert 'is not a valid phone number' in str(exc.value)
+
+
+def test_send_messages_fail_silently():
+    with mock.patch('awx.main.notifications.twilio_backend.Client') as client_mock:
+        client_mock.return_value.messages.create.side_effect = TwilioError('is not a valid phone number')
+        backend = twilio_backend.TwilioBackend('account-sid', 'account-token', fail_silently=True)
+        message = EmailMessage('test subject', 'test body', '+15005550006', ['+15005550009'])
+
+        assert backend.send_messages([message]) == 0


### PR DESCRIPTION
## Problem

`TwilioBackend.send_messages()` logs a failed send inside the handler and reraises after it (`twilio_backend.py:41-53`):

```python
except Exception as e:
    logger.error(smart_str(_("Exception sending messages: {}").format(e)))
    failed = True
if not self.fail_silently and failed:
    raise
```

The handler has already exited at that point, so there is no active exception and the bare `raise` produces:

```
RuntimeError: No active exception to reraise
```

That is the live path, not an edge case. `NotificationTemplate.send()` builds the backend without passing `fail_silently` (`models/notifications.py:182`), so it keeps the `False` default, and `send_notifications()` writes whatever comes out into the notification record (`tasks/system.py:351`):

```python
except Exception as e:
    notification.status = "failed"
    notification.error = smart_str(e)
```

So a Twilio rejection like "The 'To' number +15005550009 is not a valid phone number" reaches the user as "No active exception to reraise" in the notification list and in the API, and the real reason only exists in the service log.

## Fix

Keep the exception that was caught and raise it. The first failure of the message is the one reported, later ones are still logged, and `fail_silently=True` keeps returning the count as before.

`PagerDutyBackend` and the other backends do not share this bug, they raise from inside their handler.

## Tests

`awx/main/tests/unit/notifications/test_twilio.py`, three cases: a normal send, a failing send, and a failing send with `fail_silently`.

Before the fix the failing send test fails with the real traceback:

```
File "/awx_devel/awx/main/notifications/twilio_backend.py", line 52, in send_messages
    raise
RuntimeError: No active exception to reraise
```

After it, the whole notification unit suite passes:

```
py.test awx/main/tests/unit/notifications
32 passed
```
