### PR TITLE
Emit every activity stream entry of an m2m change, not the last one

### DIFF
--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -535,7 +535,9 @@ def activity_stream_associate(sender, instance, **kwargs):
                 activity_entry.role.add(role)
                 activity_entry.object_relationship_type = obj_rel
                 activity_entry.save()
-            connection.on_commit(lambda: emit_activity_stream_change(activity_entry))
+            # bind the entry to the callback: the loop rebinds activity_entry, and
+            # on_commit defers every callback until the whole loop has finished
+            connection.on_commit(lambda entry=activity_entry: emit_activity_stream_change(entry))
 
 
 @receiver(current_user_getter)

--- a/awx/main/tests/functional/models/test_activity_stream.py
+++ b/awx/main/tests/functional/models/test_activity_stream.py
@@ -4,7 +4,7 @@ from unittest import mock
 import json
 
 # AWX models
-from awx.main.models import ActivityStream, Organization, JobTemplate, Credential, CredentialType, Inventory, InventorySource, Project, User
+from awx.main.models import ActivityStream, Organization, JobTemplate, Credential, CredentialType, Inventory, InventorySource, Label, Project, User
 
 # other AWX
 from awx.main.utils import model_to_dict, model_instance_diff
@@ -278,3 +278,21 @@ def test_credential_defaults_idempotency():
     CredentialType.setup_tower_managed_defaults()
     assert CredentialType.objects.get(name='CIQ Ascender Automation Platform', kind='cloud').inputs == old_inputs
     assert ActivityStream.objects.count() == prior_count
+
+
+@pytest.mark.django_db
+def test_associate_emits_every_entry(organization, job_template, django_capture_on_commit_callbacks):
+    """One m2m change can hold several objects, and each gets its own entry.
+
+    The emit is deferred to commit, so a callback that closes over the loop
+    variable rather than the entry reports the last one over and over.
+    """
+    labels = [Label.objects.create(name='label-%d' % i, organization=organization) for i in range(3)]
+
+    with mock.patch('awx.main.signals.emit_activity_stream_change') as emit:
+        with django_capture_on_commit_callbacks(execute=True):
+            job_template.labels.add(*labels)
+
+    entries = ActivityStream.objects.filter(operation='associate', object1='job_template', object2='label')
+    assert entries.count() == len(labels)
+    assert sorted(call.args[0].pk for call in emit.call_args_list) == sorted(entries.values_list('pk', flat=True))


### PR DESCRIPTION
## Problem

`activity_stream_associate()` walks the `pk_set` of an m2m change and creates one entry per object, then hands each entry to the websocket and the external logger (`signals.py:538`):

```python
for entity_acted in kwargs['pk_set']:
    activity_entry = get_activity_stream_class()(...)
    activity_entry.save()
    ...
    connection.on_commit(lambda: emit_activity_stream_change(activity_entry))
```

The lambda closes over the variable, not over the entry it was created for. `ATOMIC_REQUESTS` is on (`settings/defaults.py:39`), so the callbacks never run inline, they all run after the request commits, which is after the loop has finished. Every callback then reads the same `activity_entry`, the one from the last iteration.

Adding three labels to a job template in one call emits the third entry three times and never emits the first two:

```
entries in the database: [114, 115, 116]
entries emitted:         [116, 116, 116]
```

Anything that changes several objects in one m2m call hits this: `ig.instances.set(...)` in `apply_cluster_membership_policies`, bulk `group.hosts.add(*hosts)` during inventory import, assigning several credentials or labels at once. The rows in the activity stream are correct, what is wrong is what goes out over the websocket and to the external log aggregator, which is what dashboards and audit pipelines consume.

## Fix

Bind the entry as a default argument so each callback keeps its own:

```python
connection.on_commit(lambda entry=activity_entry: emit_activity_stream_change(entry))
```

`send_notification_templates()` already does this in `models/notifications.py:539`, with the same "force late-binding" note.

## Tests

`test_associate_emits_every_entry` in `awx/main/tests/functional/models/test_activity_stream.py` adds three labels to a job template in one call, runs the commit callbacks, and compares what was emitted against what was written.

Before the fix:

```
AssertionError: assert [116, 116, 116] == [114, 115, 116]
```

After, the module passes:

```
py.test awx/main/tests/functional/models/test_activity_stream.py
25 passed
```
