### PR TITLE
Give outgoing notification requests a timeout

### DIFF
--- a/awx/main/notifications/grafana_backend.py
+++ b/awx/main/notifications/grafana_backend.py
@@ -7,6 +7,7 @@ import logging
 import requests
 import dateutil.parser as dp
 
+from django.conf import settings
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext_lazy as _
 
@@ -97,7 +98,11 @@ class GrafanaBackend(AWXBaseEmailBackend, CustomNotificationBase):
             grafana_headers['Authorization'] = "Bearer {}".format(self.grafana_key)
             grafana_headers['Content-Type'] = "application/json"
             r = requests.post(
-                "{}/api/annotations".format(m.recipients()[0]), json=grafana_data, headers=grafana_headers, verify=(not self.grafana_no_verify_ssl)
+                "{}/api/annotations".format(m.recipients()[0]),
+                json=grafana_data,
+                headers=grafana_headers,
+                verify=(not self.grafana_no_verify_ssl),
+                timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             )
             if r.status_code >= 400:
                 logger.error(smart_str(_("Error sending notification grafana: {}").format(r.status_code)))

--- a/awx/main/notifications/mattermost_backend.py
+++ b/awx/main/notifications/mattermost_backend.py
@@ -4,6 +4,7 @@
 import logging
 import requests
 
+from django.conf import settings
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext_lazy as _
 
@@ -41,7 +42,12 @@ class MattermostBackend(AWXBaseEmailBackend, CustomNotificationBase):
 
             payload['text'] = m.subject
 
-            r = requests.post("{}".format(m.recipients()[0]), json=payload, verify=(not self.mattermost_no_verify_ssl))
+            r = requests.post(
+                "{}".format(m.recipients()[0]),
+                json=payload,
+                verify=(not self.mattermost_no_verify_ssl),
+                timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
+            )
             if r.status_code >= 400:
                 logger.error(smart_str(_("Error sending notification mattermost: {}").format(r.status_code)))
                 if not self.fail_silently:

--- a/awx/main/notifications/rocketchat_backend.py
+++ b/awx/main/notifications/rocketchat_backend.py
@@ -5,6 +5,7 @@ import logging
 import requests
 import json
 
+from django.conf import settings
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext_lazy as _
 
@@ -39,7 +40,11 @@ class RocketChatBackend(AWXBaseEmailBackend, CustomNotificationBase):
                     payload[optval] = optvalue.strip()
 
             r = requests.post(
-                "{}".format(m.recipients()[0]), data=json.dumps(payload), headers=get_awx_http_client_headers(), verify=(not self.rocketchat_no_verify_ssl)
+                "{}".format(m.recipients()[0]),
+                data=json.dumps(payload),
+                headers=get_awx_http_client_headers(),
+                verify=(not self.rocketchat_no_verify_ssl),
+                timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             )
 
             if r.status_code >= 400:

--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -6,6 +6,8 @@ import json
 import logging
 import requests
 
+from django.conf import settings
+
 from awx.main.notifications.base import AWXBaseEmailBackend
 from awx.main.utils import get_awx_http_client_headers
 from awx.main.notifications.custom_notification_base import CustomNotificationBase
@@ -89,6 +91,7 @@ class WebhookBackend(AWXBaseEmailBackend, CustomNotificationBase):
                     headers=headers,
                     verify=(not self.disable_ssl_verification),
                     allow_redirects=False,  # override default behaviour for redirects
+                    timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
                 )
 
                 # either success or error reached if this conditional fires

--- a/awx/main/tests/unit/notifications/test_grafana.py
+++ b/awx/main/tests/unit/notifications/test_grafana.py
@@ -1,5 +1,6 @@
 from unittest import mock
 import datetime as dt
+from django.conf import settings
 from django.core.mail.message import EmailMessage
 import pytest
 
@@ -32,6 +33,7 @@ def test_send_messages():
             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer testapikey'},
             json={'text': 'test subject', 'isRegion': True, 'timeEnd': 120000, 'time': 60000},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1
 
@@ -62,6 +64,7 @@ def test_send_messages_with_no_verify_ssl():
             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer testapikey'},
             json={'text': 'test subject', 'isRegion': True, 'timeEnd': 120000, 'time': 60000},
             verify=False,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1
 
@@ -93,6 +96,7 @@ def test_send_messages_with_dashboardid(dashboardId):
             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer testapikey'},
             json={'text': 'test subject', 'isRegion': True, 'timeEnd': 120000, 'time': 60000, 'dashboardId': dashboardId},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1
 
@@ -124,6 +128,7 @@ def test_send_messages_with_panelid(panelId):
             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer testapikey'},
             json={'text': 'test subject', 'isRegion': True, 'timeEnd': 120000, 'panelId': int(panelId), 'time': 60000},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1
 
@@ -154,6 +159,7 @@ def test_send_messages_with_bothids():
             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer testapikey'},
             json={'text': 'test subject', 'isRegion': True, 'timeEnd': 120000, 'panelId': 42, 'time': 60000, 'dashboardId': 42},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1
 
@@ -184,6 +190,7 @@ def test_send_messages_with_emptyids():
             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer testapikey'},
             json={'text': 'test subject', 'isRegion': True, 'timeEnd': 120000, 'time': 60000},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1
 
@@ -214,5 +221,6 @@ def test_send_messages_with_tags():
             headers={'Content-Type': 'application/json', 'Authorization': 'Bearer testapikey'},
             json={'tags': ['ansible'], 'text': 'test subject', 'isRegion': True, 'timeEnd': 120000, 'time': 60000},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1

--- a/awx/main/tests/unit/notifications/test_mattermost.py
+++ b/awx/main/tests/unit/notifications/test_mattermost.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+from django.conf import settings
+from django.core.mail.message import EmailMessage
+
+import awx.main.notifications.mattermost_backend as mattermost_backend
+
+
+def test_send_messages():
+    with mock.patch('awx.main.notifications.mattermost_backend.requests') as requests_mock:
+        requests_mock.post.return_value.status_code = 200
+        backend = mattermost_backend.MattermostBackend()
+        message = EmailMessage(
+            'test subject',
+            'test body',
+            [],
+            [
+                'http://example.com',
+            ],
+        )
+
+        sent_messages = backend.send_messages(
+            [
+                message,
+            ]
+        )
+
+        requests_mock.post.assert_called_once_with(
+            'http://example.com',
+            json={'text': 'test subject'},
+            verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
+        )
+        assert sent_messages == 1

--- a/awx/main/tests/unit/notifications/test_rocketchat.py
+++ b/awx/main/tests/unit/notifications/test_rocketchat.py
@@ -1,6 +1,7 @@
 import json
 
 from unittest import mock
+from django.conf import settings
 from django.core.mail.message import EmailMessage
 
 import awx.main.notifications.rocketchat_backend as rocketchat_backend
@@ -31,6 +32,7 @@ def test_send_messages():
             data='{"text": "test subject"}',
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1
 
@@ -116,5 +118,6 @@ def test_send_messages_with_no_verify_ssl():
             data='{"text": "test subject"}',
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=False,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
         )
         assert sent_messages == 1

--- a/awx/main/tests/unit/notifications/test_webhook.py
+++ b/awx/main/tests/unit/notifications/test_webhook.py
@@ -1,6 +1,7 @@
 import json
 
 from unittest import mock
+from django.conf import settings
 from django.core.mail.message import EmailMessage
 
 import awx.main.notifications.webhook_backend as webhook_backend
@@ -32,6 +33,7 @@ def test_send_messages_as_POST():
             data=json.dumps({'text': 'test body'}, ensure_ascii=False).encode('utf-8'),
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1
@@ -63,6 +65,7 @@ def test_send_messages_as_PUT():
             data=json.dumps({'text': 'test body 2'}, ensure_ascii=False).encode('utf-8'),
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1
@@ -94,6 +97,7 @@ def test_send_messages_with_username():
             data=json.dumps({'text': 'test body'}, ensure_ascii=False).encode('utf-8'),
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1
@@ -125,6 +129,7 @@ def test_send_messages_with_password():
             data=json.dumps({'text': 'test body'}, ensure_ascii=False).encode('utf-8'),
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1
@@ -156,6 +161,7 @@ def test_send_messages_with_username_and_password():
             data=json.dumps({'text': 'test body'}, ensure_ascii=False).encode('utf-8'),
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1
@@ -187,6 +193,7 @@ def test_send_messages_with_no_verify_ssl():
             data=json.dumps({'text': 'test body'}, ensure_ascii=False).encode('utf-8'),
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=False,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1
@@ -223,6 +230,7 @@ def test_send_messages_with_additional_headers():
                 'X-Test-Header2': 'test-content-2',
             },
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1
@@ -260,6 +268,7 @@ def test_send_messages_with_redirects_ok():
             data=json.dumps({'text': 'test body'}, ensure_ascii=False).encode('utf-8'),
             headers={'Content-Type': 'application/json', 'User-Agent': 'AWX 0.0.1.dev (open)'},
             verify=True,
+            timeout=settings.AWX_NOTIFICATION_REQUEST_TIMEOUT,
             allow_redirects=False,
         )
         assert sent_messages == 1

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -303,6 +303,12 @@ SUBSYSTEM_METRICS_TASK_MANAGER_RECORD_INTERVAL = 15
 # The maximum allowed jobs to start on a given task manager cycle
 START_TASK_LIMIT = 100
 
+# Number of seconds an outgoing notification waits on the service it posts to.
+# Without it the dispatcher worker running send_notifications is held for as
+# long as the far end keeps the connection open. Matches the default timeout of
+# the email backend.
+AWX_NOTIFICATION_REQUEST_TIMEOUT = 30
+
 # Time out task managers if they take longer than this many seconds, plus TASK_MANAGER_TIMEOUT_GRACE_PERIOD
 # We have the grace period so the task manager can bail out before the timeout.
 TASK_MANAGER_TIMEOUT = 300


### PR DESCRIPTION
## Problem

None of the HTTP notification backends passes a `timeout` to `requests`:

- `webhook_backend.py:84`
- `mattermost_backend.py:44`
- `rocketchat_backend.py:41`
- `grafana_backend.py:99`

`requests` has no default timeout, so a target that accepts the connection and then never answers keeps the call open for as long as the socket stays up. `send_notifications` runs as a dispatcher task (`tasks/system.py:333`), so the worker process handling it is held for that whole time and cannot pick up other work. The webhook backend makes it worse: it loops up to `MAX_RETRIES` times following redirects, so one notification can hang on five separate requests.

Nothing else bounds this. The notification job itself has no timeout, and the endpoint is user supplied, so a slow or hostile receiver is enough.

The email backend already takes a timeout and defaults it to 30 seconds (`email_backend.py:34`), which is the gap this closes for the HTTP ones.

## Fix

Add `AWX_NOTIFICATION_REQUEST_TIMEOUT` to settings, default 30 to match the email backend, and pass it from the four backends. It is a plain setting rather than a per template field, so no API or migration change, and an operator can still override it in a settings file the way `AWX_CONTAINER_GROUP_K8S_API_TIMEOUT` is overridden.

Not covered here: `credential_plugins/conjur.py` and `utils/licensing.py` have the same missing timeout in different subsystems.

## Tests

The existing webhook, Rocket.Chat and Grafana unit tests assert the full call, so they now assert the timeout too. Mattermost had no unit test at all, so this adds one.

```
py.test awx/main/tests/unit/notifications awx/main/tests/functional/test_notifications.py
41 passed
```
