### PR TITLE
Drop partition names cleanup_jobs cannot read a date out of

### DIFF
--- a/awx/main/management/commands/cleanup_jobs.py
+++ b/awx/main/management/commands/cleanup_jobs.py
@@ -143,8 +143,10 @@ class DeleteMeta:
             cursor.execute(query)
             partitions_from_db = [r[0] for r in cursor.fetchall()]
 
-        partitions_dt = [partition_name_dt(p) for p in partitions_from_db if not None]
-        partitions_dt = [p for p in partitions_dt if not None]
+        # partition_name_dt returns None for a name it cannot read a date out of,
+        # and dt_to_partition_name would fail on that below
+        partitions_dt = [partition_name_dt(p) for p in partitions_from_db]
+        partitions_dt = [p for p in partitions_dt if p is not None]
 
         # convert datetime partition back to string partition
         partitions_maybe_drop = {dt_to_partition_name(tbl_name, dt) for dt in partitions_dt}

--- a/awx/main/tests/unit/commands/test_cleanup_jobs.py
+++ b/awx/main/tests/unit/commands/test_cleanup_jobs.py
@@ -1,6 +1,11 @@
+import logging
+from datetime import timedelta
 from unittest import mock
 
-from awx.main.management.commands.cleanup_jobs import _pre_delete_job_host_summaries, JHS_CHUNK_SIZE
+from django.utils.timezone import now
+
+from awx.main.management.commands.cleanup_jobs import DeleteMeta, _pre_delete_job_host_summaries, JHS_CHUNK_SIZE
+from awx.main.models import Job
 
 
 class TestPreDeleteJobHostSummaries:
@@ -135,3 +140,34 @@ class TestDeleteMetaPreDelete:
         dm.delete_jobs()
 
         mock_pre_delete.assert_not_called()
+
+
+class TestFindPartitionsToDrop:
+    """The partition list comes back as table names that have to be read as dates."""
+
+    def _delete_meta(self, children):
+        delete_meta = DeleteMeta(logging.getLogger('awx.main.commands.cleanup_jobs'), Job, now() - timedelta(days=1), dry_run=False)
+        cursor = mock.MagicMock()
+        cursor.fetchall.return_value = [(name,) for name in children]
+        connection = mock.MagicMock()
+        connection.cursor.return_value.__enter__ = mock.Mock(return_value=cursor)
+        connection.cursor.return_value.__exit__ = mock.Mock(return_value=False)
+        return delete_meta, connection
+
+    def test_partitions_are_collected(self):
+        delete_meta, connection = self._delete_meta(['main_jobevent_20210318_09', 'main_jobevent_20210318_11'])
+
+        with mock.patch('awx.main.management.commands.cleanup_jobs.connection', connection):
+            delete_meta.find_partitions_to_drop()
+
+        assert delete_meta.parts_to_drop == {'main_jobevent_20210318_09', 'main_jobevent_20210318_11'}
+
+    def test_a_name_without_a_date_is_skipped(self):
+        """partition_name_dt returns None for those, and dropping a None makes
+        the whole cleanup run fail on dt_to_partition_name."""
+        delete_meta, connection = self._delete_meta(['main_jobevent_20210318_09', 'main_jobevent_default'])
+
+        with mock.patch('awx.main.management.commands.cleanup_jobs.connection', connection):
+            delete_meta.find_partitions_to_drop()
+
+        assert delete_meta.parts_to_drop == {'main_jobevent_20210318_09'}


### PR DESCRIPTION
## Problem

`DeleteMeta.find_partitions_to_drop()` reads the event partitions of a job class out of `pg_inherits` and turns each name back into a date. Names it cannot read are meant to be dropped from the list (`cleanup_jobs.py:146`):

```python
partitions_dt = [partition_name_dt(p) for p in partitions_from_db if not None]
partitions_dt = [p for p in partitions_dt if not None]
```

Both filters test the literal `None`, and `not None` is `True`, so neither list is filtered. `partition_name_dt()` returns `None` for a name that does not match its regex and for anything holding `_unpartitioned`, and that `None` then reaches `dt_to_partition_name()` on the next line:

```
AttributeError: 'NoneType' object has no attribute 'strftime'
```

`find_partitions_to_drop()` runs inside `DeleteMeta.delete()`, so this takes down the whole `cleanup_jobs` run, which is the built in "Remove jobs older than a certain number of days" system job.

Today every child of a partitioned event table is named `<table>_<YYYYMMDD>_<HH>` by `create_partition()`, so nothing reaches the crash. The guard is still there for a reason, and it is not doing anything.

## Fix

Compare against `None`. The comprehension over `partitions_from_db` had no reason to filter at all, so the check happens once, on the parsed values.

## Tests

`TestFindPartitionsToDrop` in `awx/main/tests/unit/commands/test_cleanup_jobs.py`, one case for ordinary partition names and one for a name with no date in it, both driven through a mocked cursor the way the existing tests in that file do.

Before the fix the second one reproduces the crash:

```
AttributeError: 'NoneType' object has no attribute 'strftime'
```

After:

```
py.test awx/main/tests/unit/commands/test_cleanup_jobs.py awx/main/tests/functional/commands/test_cleanup_jobs.py
14 passed
```
