### PR TITLE
Stop coerce_naive_until crashing on an UNTIL it cannot read

### DIFF
--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -151,9 +151,11 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         #
 
         # Find the DTSTART rule or raise an error, its usually the first rule but that is not strictly enforced
-        start_date_rule = re.sub(r'^.*(DTSTART[^\s]+)\s.*$', r'\1', rrule)
-        if not start_date_rule:
+        # re.sub hands back the whole rrule when it does not match, so the DTSTART has to be searched for
+        start_date_match = re.search(r'DTSTART[^\s]+', rrule)
+        if not start_date_match:
             raise ValueError('A DTSTART field needs to be in the rrule')
+        start_date_rule = start_date_match.group(0)
 
         rules = re.split(r'\s+', rrule)
         for index in range(0, len(rules)):
@@ -162,6 +164,11 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
                 # if DTSTART;TZID= is used, coerce "naive" UNTIL values
                 # to the proper UTC date
                 match_until = re.match(r".*?(?P<until>UNTIL\=[0-9]+T[0-9]+)(?P<utcflag>Z?)", rule)
+                if match_until is None:
+                    # an UNTIL that is not a YYYYMMDDTHHMMSS datetime, the date only
+                    # form for instance, is nothing that can be coerced here. Leave
+                    # the rule alone so dateutil is the one that reports it.
+                    continue
                 if not len(match_until.group('utcflag')):
                     # rule = DTSTART;TZID=America/New_York:20200601T120000 RRULE:...;UNTIL=20200601T170000
 

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -163,7 +163,9 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
             if 'until=' in rule.lower():
                 # if DTSTART;TZID= is used, coerce "naive" UNTIL values
                 # to the proper UTC date
-                match_until = re.match(r".*?(?P<until>UNTIL\=[0-9]+T[0-9]+)(?P<utcflag>Z?)", rule)
+                # the check that gets here lowercases the rule, and RFC 5545 field names
+                # are case insensitive, so match the field the same way
+                match_until = re.match(r".*?(?P<until>UNTIL\=[0-9]+T[0-9]+)(?P<utcflag>Z?)", rule, re.IGNORECASE)
                 if match_until is None:
                     # an UNTIL that is not a YYYYMMDDTHHMMSS datetime, the date only
                     # form for instance, is nothing that can be coerced here. Leave
@@ -188,7 +190,7 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
 
                     # Make a datetime object with tzinfo=<the DTSTART timezone>
                     # localized_until = datetime.datetime(2020, 6, 1, 17, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York'))
-                    localized_until = make_aware(datetime.datetime.strptime(re.sub('^UNTIL=', '', naive_until), "%Y%m%dT%H%M%S"), local_tz)
+                    localized_until = make_aware(datetime.datetime.strptime(re.sub('^UNTIL=', '', naive_until, flags=re.IGNORECASE), "%Y%m%dT%H%M%S"), local_tz)
 
                     # Coerce the datetime to UTC and format it as a string w/ Zulu format
                     # utc_until = UNTIL=20200601T220000Z

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -183,6 +183,11 @@ def test_schedule_detail_returns_disabled_when_all_schedules_are_globally_disabl
         ("DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5", "A valid TZID must be provided"),  # noqa
         ("DTSTART:20300308T050000Z RRULE:FREQ=REGULARLY;INTERVAL=1", "rrule parsing failed validation: invalid 'FREQ': REGULARLY"),  # noqa
         ("DTSTART;TZID=America/New_York:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1", "rrule parsing failed validation"),
+        # an UNTIL without a time is not a value coerce_naive_until can convert, dateutil says why
+        (
+            "DTSTART;TZID=America/New_York:20300601T120000 RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20300701",
+            "rrule parsing failed validation: RRULE UNTIL values must be specified in UTC",
+        ),  # noqa
     ],
 )
 def test_invalid_rrules(post, admin_user, project, inventory, rrule, error):
@@ -217,7 +222,7 @@ def test_multiple_invalid_rrules(post, admin_user, project, inventory):
             "Multiple DTSTART is not supported.",
             "INTERVAL required in rrule: RULE:FREQ=SECONDLY",
             "RRULE may not contain both COUNT and UNTIL: RULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5;UNTIL=20220101",
-            "rrule parsing failed validation: 'NoneType' object has no attribute 'group'",
+            "rrule parsing failed validation: A valid TZID must be provided (e.g., America/New_York)",
         ]
     }
     assert expected_result == resp.data

--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -576,3 +576,18 @@ def test_rrule_without_a_dtstart_is_rejected():
     with pytest.raises(ValueError) as exc:
         Schedule.coerce_naive_until('RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20300701T120000Z')
     assert 'A DTSTART field needs to be in the rrule' in str(exc.value)
+
+
+def test_lowercase_until_is_coerced_like_the_uppercase_one():
+    """RFC 5545 field names are case insensitive.
+
+    The check that reaches the coercion lowercases the rule first, so a
+    lowercase UNTIL gets that far and has to be treated the same way.
+    """
+    upper = 'DTSTART;TZID=America/New_York:20300601T120000 RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20300701T170000'
+    lower = upper.replace('UNTIL=', 'until=')
+
+    assert Schedule.coerce_naive_until(upper).endswith('UNTIL=20300701T210000Z')
+    assert Schedule.coerce_naive_until(lower) == Schedule.coerce_naive_until(upper)
+
+    assert Schedule.rrulestr(lower)._rrule[0]._until == Schedule.rrulestr(upper)._rrule[0]._until

--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -554,3 +554,25 @@ def test_skip_sundays():
 def test_get_end_date(rrule, expected_result):
     ruleset = Schedule.rrulestr(rrule)
     assert expected_result == Schedule.get_end_date(ruleset)
+
+
+def test_date_only_until_is_left_for_dateutil_to_report():
+    """UNTIL without a time is not a value coerce_naive_until can convert.
+
+    It used to assume its own regex had matched, so the schedule endpoint
+    answered with "'NoneType' object has no attribute 'group'".
+    """
+    rrule = 'DTSTART;TZID=America/New_York:20300601T120000 RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20300701'
+
+    assert Schedule.coerce_naive_until(rrule) == rrule
+
+    with pytest.raises(ValueError) as exc:
+        Schedule.rrulestr(rrule)
+    assert 'UNTIL values must be specified in UTC' in str(exc.value)
+
+
+def test_rrule_without_a_dtstart_is_rejected():
+    """The check for this used re.sub, which hands back the whole rrule when it does not match."""
+    with pytest.raises(ValueError) as exc:
+        Schedule.coerce_naive_until('RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20300701T120000Z')
+    assert 'A DTSTART field needs to be in the rrule' in str(exc.value)


### PR DESCRIPTION
## Problem

`Schedule.coerce_naive_until()` turns a naive `UNTIL` into UTC. It finds the value with a regex that only matches the `YYYYMMDDTHHMMSS` form, then reads the match without checking it (`schedules.py:164`):

```python
match_until = re.match(r".*?(?P<until>UNTIL\=[0-9]+T[0-9]+)(?P<utcflag>Z?)", rule)
if not len(match_until.group('utcflag')):
```

An `UNTIL` with no time in it gets past the `'until=' in rule.lower()` check and arrives here as `None`:

```
POST /api/v2/job_templates/N/schedules/
rrule: DTSTART;TZID=America/New_York:20300601T120000 RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20300701

400 {"rrule": ["rrule parsing failed validation: 'NoneType' object has no attribute 'group'"]}
```

`validate_rrule` catches everything, so it comes back as a 400 rather than a 500, but the message says nothing about the rule. `test_multiple_invalid_rrules` has been asserting that exact string, which is how a Python internal error became the documented answer.

The DTSTART check right above has the same shape of problem (`schedules.py:154`):

```python
start_date_rule = re.sub(r'^.*(DTSTART[^\s]+)\s.*$', r'\1', rrule)
if not start_date_rule:
    raise ValueError('A DTSTART field needs to be in the rrule')
```

`re.sub` returns the subject unchanged when the pattern does not match, so `start_date_rule` is never empty and that `ValueError` can never be raised. What it holds when there is no DTSTART is the whole rrule, which then goes into the temporary rule built for timezone detection.

## Fix

Skip a value that cannot be coerced and let dateutil report it:

```
rrule parsing failed validation: RRULE UNTIL values must be specified in UTC when DTSTART is timezone-aware
```

And search for the DTSTART field so the check that is already written actually runs. This is a behaviour change for an rrule with no DTSTART, which now raises instead of parsing with whatever dateutil defaults to, but `validate_rrule` already rejects those with "Valid DTSTART required in rrule", so the API answer does not change.

## Tests

Two cases in `awx/main/tests/functional/models/test_schedule.py`, one for the date only UNTIL and one for the missing DTSTART, plus a case in the `test_invalid_rrules` table for what a client now gets back.

`test_multiple_invalid_rrules` asserted the old `'NoneType' object has no attribute 'group'` message, and now asserts what that rrule really has wrong with it, an invalid TZID.

```
py.test awx/main/tests/functional/api/test_schedules.py awx/main/tests/functional/models/test_schedule.py
114 passed
```
