### PR TITLE
Set additionalProperties once in the injector schema

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -810,7 +810,6 @@ class CredentialTypeInjectorField(JSONSchemaField):
     def schema(self, model_instance):
         return {
             'type': 'object',
-            'additionalProperties': False,
             'properties': {
                 'file': {
                     'type': 'object',


### PR DESCRIPTION
## Problem

`CredentialTypeInjectorField.schema()` sets the same key twice in one dict literal (`fields.py:813` and `fields.py:849`):

```python
return {
    'type': 'object',
    'additionalProperties': False,   # line 813
    'properties': {
        ...
    },
    'additionalProperties': False,   # line 849
}
```

Both hold `False`, so the schema that comes out is the one it looks like and nothing validates differently. Only the second assignment survives the literal though, and a duplicate key is the kind of thing that quietly stops meaning what it says the moment one of the two is edited.

flake8 does not report it, pyflakes only reports repeated keys when the values differ, so nothing in the linters would have caught this.

## Fix

Keep the one after `properties`, which is where the nested `file`, `env` and `extra_vars` schemas in the same literal put theirs.

## Tests

No behaviour change, so no new tests. The existing credential and field tests pass:

```
py.test awx/main/tests/unit/test_fields.py awx/main/tests/unit/models/test_credential.py awx/main/tests/functional/models/test_job_options.py
76 passed
```
