### PR TITLE
Write the round up note as a comment, not a noqa directive

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -323,7 +323,7 @@ class AutoscalePool(WorkerPool):
                 # There are 1073741824 bytes in a gigabyte. Convert bytes to gigabytes by dividing by 2**30
                 total_memory_gb = convert_mem_str_to_bytes(settings_absmem) // 2**30
             else:
-                total_memory_gb = (psutil.virtual_memory().total >> 30) + 1  # noqa: round up
+                total_memory_gb = (psutil.virtual_memory().total >> 30) + 1  # round up
 
             # Get same number as max forks based on memory, this function takes memory as bytes
             self.max_workers = get_mem_effective_capacity(total_memory_gb * 2**30)


### PR DESCRIPTION
## Problem

`AutoscalePool.__init__` works out the system memory with a note about the `+ 1` (`dispatch/pool.py:326`):

```python
total_memory_gb = (psutil.virtual_memory().total >> 30) + 1  # noqa: round up
```

"round up" is the explanation for the `+ 1`, not a list of lint codes, so the line reads as a suppression that suppresses nothing. Anything that parses noqa directives says so:

```
warning: Invalid `# noqa` directive on awx/main/dispatch/pool.py:326: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`)
```

flake8 ignores the malformed directive and the line has nothing to report, so the only cost today is the noise and a comment that does not read as one.

## Fix

Drop the `noqa:` prefix and keep the note.

## Tests

Comment only.

```
py.test awx/main/tests/functional/test_dispatch.py
51 passed
```
