### PR TITLE
Slight improvements to social auth pipeline

### DIFF
--- a/awx/sso/social_pipeline.py
+++ b/awx/sso/social_pipeline.py
@@ -30,14 +30,14 @@ def _update_m2m_from_expression(user, opts, remove=True):
     elif isinstance(opts, bool) and opts is True:
         return True
     else:
-        if isinstance(opts, (str, type(re.compile('')))):
+        if isinstance(opts, (str, re.Pattern)):
             opts = [opts]
 
         for expression in opts:
             if isinstance(expression, str):
                 if user.username == expression or user.email == expression:
                     return True
-            elif isinstance(expression, type(re.compile(''))):
+            elif isinstance(expression, re.Pattern):
                 if expression.match(user.username) or expression.match(user.email):
                     return True
 
@@ -59,25 +59,18 @@ def _compute_org_desired_states(org_map, user):
     orgs_list = []
     desired_org_states = {}
 
-    for org_name, org_opts in org_map.items():
-        organization_alias = org_opts.get('organization_alias')
+    # Social auth currently supports organization admins and users.
+    org_roles_and_expressions = {
+        'admin_role': 'admins',
+        'member_role': 'users',
+    }
 
-        if organization_alias:
-            organization_name = organization_alias
-        else:
-            organization_name = org_name
+    for org_name, org_opts in org_map.items():
+        organization_name = org_opts.get('organization_alias') or org_name
 
         orgs_list.append(organization_name)
 
         remove = bool(org_opts.get('remove', True))
-
-        desired_org_states[organization_name] = {}
-
-        # Social auth currently supports organization admins and users.
-        org_roles_and_expressions = {
-            'admin_role': 'admins',
-            'member_role': 'users',
-        }
 
         for role_name, expression_name in org_roles_and_expressions.items():
             opts = org_opts.get(expression_name, None)
@@ -89,16 +82,20 @@ def _compute_org_desired_states(org_map, user):
                 )
             )
 
-            desired_org_states[organization_name][role_name] = _update_m2m_from_expression(
+            state = _update_m2m_from_expression(
                 user,
                 opts,
                 role_remove,
             )
 
-        # If no mapping actually manages this organization, don't make the
-        # reconciliation query load it.
-        if all(desired_org_states[organization_name][role_name] is None for role_name in org_roles_and_expressions):
-            del desired_org_states[organization_name]
+            # Multiple ORGANIZATION_MAP entries may resolve to the same
+            # organization via organization_alias.  Merge them instead of
+            # overwriting: a None result means this entry does not manage the
+            # role, so only non-None states are recorded.  An organization with
+            # no recorded state is simply left out of the map, and the
+            # reconciler treats an absent role as "leave untouched".
+            if state is not None:
+                desired_org_states.setdefault(organization_name, {})[role_name] = state
 
     return orgs_list, desired_org_states
 
@@ -150,22 +147,27 @@ def _compute_team_desired_states(team_map_settings, user):
     return team_map, desired_team_states
 
 
-def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
+def _update_user_memberships(backend, user, *, manage_orgs=True, manage_teams=True):
     """
     Compute the desired organization/team membership state in memory and
     reconcile all memberships in bulk.
 
     This follows the same desired-state approach used by LDAPBackend in
-    awx.sso.backends.
+    awx.sso.backends.  Which domains are managed is controlled by
+    manage_orgs/manage_teams so the merged default step and the legacy
+    per-domain entry points share one implementation.
     """
-    if not user:
-        return
-
     org_map = backend.setting('ORGANIZATION_MAP') or {}
     team_map_settings = backend.setting('TEAM_MAP') or {}
 
-    orgs_list, desired_org_states = _compute_org_desired_states(org_map, user)
-    team_map, desired_team_states = _compute_team_desired_states(team_map_settings, user)
+    orgs_list = []
+    desired_org_states = {}
+    team_map = {}
+    desired_team_states = {}
+    if manage_orgs:
+        orgs_list, desired_org_states = _compute_org_desired_states(org_map, user)
+    if manage_teams:
+        team_map, desired_team_states = _compute_team_desired_states(team_map_settings, user)
 
     # Ensure mapped organizations and teams exist.
     create_org_and_teams(
@@ -181,6 +183,14 @@ def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
         desired_team_states,
         'Social Auth',
     )
+
+
+def update_user_org_team_mappings(backend, details, user=None, *args, **kwargs):
+    """Reconcile organization and team memberships in one bulk step."""
+    if not user:
+        return
+
+    _update_user_memberships(backend, user)
 
 
 # Kept for compatibility: a custom SOCIAL_AUTH_PIPELINE configured in
@@ -202,24 +212,7 @@ def update_user_orgs(backend, details, user=None, *args, **kwargs):
     if not user:
         return
 
-    org_map = backend.setting('ORGANIZATION_MAP') or {}
-
-    orgs_list, desired_org_states = _compute_org_desired_states(org_map, user)
-
-    # Ensure mapped organizations exist.  Teams (and the organizations only
-    # referenced by them) are managed by update_user_teams.
-    create_org_and_teams(
-        orgs_list,
-        {},
-        'Social Auth',
-    )
-
-    reconcile_users_org_team_mappings(
-        user,
-        desired_org_states,
-        {},
-        'Social Auth',
-    )
+    _update_user_memberships(backend, user, manage_teams=False)
 
 
 def update_user_teams(backend, details, user=None, *args, **kwargs):
@@ -230,20 +223,4 @@ def update_user_teams(backend, details, user=None, *args, **kwargs):
     if not user:
         return
 
-    team_map_settings = backend.setting('TEAM_MAP') or {}
-
-    team_map, desired_team_states = _compute_team_desired_states(team_map_settings, user)
-
-    # Ensure mapped teams (and the organizations they belong to) exist.
-    create_org_and_teams(
-        [],
-        team_map,
-        'Social Auth',
-    )
-
-    reconcile_users_org_team_mappings(
-        user,
-        {},
-        desired_team_states,
-        'Social Auth',
-    )
+    _update_user_memberships(backend, user, manage_orgs=False)

--- a/awx/sso/social_pipeline.py
+++ b/awx/sso/social_pipeline.py
@@ -54,7 +54,8 @@ def _compute_org_desired_states(org_map, user):
 
     Returns a tuple of (orgs_list, desired_org_states):
       orgs_list          - the organization names that should exist
-      desired_org_states - org name to {role_name: True/False/None}
+      desired_org_states - org name to {role_name: True/False}; only managed
+        roles are recorded (orgs with no managed role are left out)
     """
     orgs_list = []
     desired_org_states = {}
@@ -91,9 +92,8 @@ def _compute_org_desired_states(org_map, user):
             # Multiple ORGANIZATION_MAP entries may resolve to the same
             # organization via organization_alias.  Merge them instead of
             # overwriting: a None result means this entry does not manage the
-            # role, so only non-None states are recorded.  An organization with
-            # no recorded state is simply left out of the map, and the
-            # reconciler treats an absent role as "leave untouched".
+            # role, so only non-None states are recorded and organizations with
+            # no recorded state are left out of the map.
             if state is not None:
                 desired_org_states.setdefault(organization_name, {})[role_name] = state
 

--- a/awx/sso/tests/functional/test_social_pipeline.py
+++ b/awx/sso/tests/functional/test_social_pipeline.py
@@ -361,3 +361,47 @@ class TestMergedPipelineStep:
         # ...while the team membership is still granted by the team-only step.
         team = Team.objects.get(name='Ops')
         assert team.member_role.members.filter(pk=user.pk).exists()
+
+    def test_same_alias_merge_keeps_earlier_grants(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={
+                'Procurement': {'organization_alias': 'Acme', 'admins': 'alice'},
+                'Sales': {'organization_alias': 'Acme'},
+            }
+        )
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Acme')
+        # A later entry that does not manage any role in the organization must
+        # not wipe the earlier entry's admin grant.
+        assert org.admin_role.members.filter(pk=user.pk).exists()
+        # The organization is referenced via alias only: the map key is not a
+        # real organization name.
+        assert not Organization.objects.filter(name='Procurement').exists()
+
+    def test_same_alias_different_roles_accumulate(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={
+                'Procurement': {'organization_alias': 'Acme', 'admins': 'alice'},
+                'Sales': {'organization_alias': 'Acme', 'users': 'alice'},
+            }
+        )
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Acme')
+        assert org.admin_role.members.filter(pk=user.pk).exists()
+        assert org.member_role.members.filter(pk=user.pk).exists()
+
+    def test_same_alias_conflicting_role_last_writes(self):
+        user = self._make_user()
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={
+                'A': {'organization_alias': 'Acme', 'admins': 'alice'},
+                'B': {'organization_alias': 'Acme', 'admins': 'bob', 'remove_admins': True},
+            }
+        )
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Acme')
+        # Both entries manage the admin role; like the historical sequential
+        # per-entry behavior, the later entry's removal wins.
+        assert not org.admin_role.members.filter(pk=user.pk).exists()

--- a/awx/sso/tests/functional/test_social_pipeline.py
+++ b/awx/sso/tests/functional/test_social_pipeline.py
@@ -375,9 +375,38 @@ class TestMergedPipelineStep:
         # A later entry that does not manage any role in the organization must
         # not wipe the earlier entry's admin grant.
         assert org.admin_role.members.filter(pk=user.pk).exists()
-        # The organization is referenced via alias only: the map key is not a
-        # real organization name.
-        assert not Organization.objects.filter(name='Procurement').exists()
+
+    def test_same_alias_merge_keeps_earlier_admin_removal(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Acme')
+        org.admin_role.members.add(user)
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={
+                'Procurement': {'organization_alias': 'Acme', 'admins': 'nobody', 'remove_admins': True},
+                'Sales': {'organization_alias': 'Acme'},
+            }
+        )
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Acme')
+        # The earlier entry demands alice be removed from admin; the later
+        # all-None entry must not wipe that removal into a no-op.
+        assert not org.admin_role.members.filter(pk=user.pk).exists()
+
+    def test_same_alias_merge_keeps_earlier_member_removal(self):
+        user = self._make_user()
+        org = Organization.objects.create(name='Acme')
+        org.member_role.members.add(user)
+        backend = FakeMergedBackend(
+            ORGANIZATION_MAP={
+                'Procurement': {'organization_alias': 'Acme', 'users': 'nobody', 'remove_users': True},
+                'Sales': {'organization_alias': 'Acme'},
+            }
+        )
+        update_user_org_team_mappings(backend, None, user)
+        org = Organization.objects.get(name='Acme')
+        # Symmetric to the admin-removal case: the earlier entry's member-role
+        # removal must survive the later all-None entry.
+        assert not org.member_role.members.filter(pk=user.pk).exists()
 
     def test_same_alias_different_roles_accumulate(self):
         user = self._make_user()


### PR DESCRIPTION
Related to #661 some slight improvements to #662 

##### SUMMARY
Fixes last [two review findings](https://github.com/ctrliq/ascender/pull/662#pullrequestreview-4967876750) within #662 and streamlines the merged OIDC org/team reconciliation step:
- use `re.Pattern` instead of `type(re.compile(''))` within per-login hot-path
- merge states when multiple `ORGANIZATION_MAP` entries resolve to the same
  org via `organization_alias` , so later entries can no longer wipe earlier grants
  and all-`None` orgs are skipped.
- The three pipeline entry points (org_team, orgs, teams) are consolidated onto
  one  shared `_update_user_memberships` helper, keeping the per-domain 
  compatibility contract intact.

Adds functional tests for the alias-merge behavior

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other  (SSO login path in awx/sso)

##### ASCENDER VERSION
25.5.1
