### PR TITLE
docs: standardize README and community files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Ascender
+
+Thanks for your interest in contributing to Ascender. This document covers the
+development setup, testing, and pull request guidelines.
+
+## Development setup
+
+Fork and clone the repository:
+
+```bash
+git clone https://github.com/<your-user>/ascender.git
+cd ascender
+```
+
+Bring up the containerised development environment:
+
+```bash
+make docker-compose
+```
+
+See [docs/development/docker.md](./docs/development/docker.md) for the full
+walkthrough, and [kind.md](./docs/development/kind.md) or
+[minikube.md](./docs/development/minikube.md) for cluster-based alternatives.
+
+## Running tests
+
+```bash
+py.test awx/main/tests/
+```
+
+Configuration lives in [`pytest.ini`](./pytest.ini) and [`tox.ini`](./tox.ini).
+
+
+## Making changes
+
+### Branching
+
+Create a feature branch from `main`:
+
+```bash
+git checkout -b my-feature main
+```
+
+### Commit messages
+
+Write clear, concise commit messages:
+
+```
+Short summary (under 72 characters)
+
+Longer description of what changed and why, if needed.
+```
+
+### Developer Certificate of Origin
+
+Every commit must be signed off, certifying the terms in
+[DCO_1_1.md](./DCO_1_1.md):
+
+```bash
+git commit -s -m "Short summary"
+```
+
+## Submitting a PR
+
+1. Make sure the checks above pass locally.
+2. One logical change per PR. Do not bundle unrelated fixes.
+3. Target the `main` branch.
+4. Explain what changed and why in the PR description.
+
+## Reporting issues
+
+Open an issue at
+[github.com/ctrliq/ascender/issues](https://github.com/ctrliq/ascender/issues).
+Include the version you are running and the steps that reproduce the problem.
+
+For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) instead of
+opening a public issue.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,79 @@
 # Ascender
-Ascender provides a web-based user interface, REST API, and task engine built on top of [Ansible](https://github.com/ansible/ansible). It is based off the upstream project of [AWX](https://github.com/ansible/awx).
 
-A separate installer is available to ease installing Ascender. It can deploy Ascender on a single VM using [k3s](https://k3s.io/) (installed automatically), or onto AKS, DKP, EKS, GKE, k3s, RKE2, or OCP using a provided kubeconfig and namespace. See the installer repository at https://github.com/ctrliq/ascender-install.
+[![CI](https://github.com/ctrliq/ascender/actions/workflows/ci.yml/badge.svg)](https://github.com/ctrliq/ascender/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
+[![Python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
 
-Contributing
-------------
-- See the contributing notes in [Running Development Environment in Docker](docs/development/docker.md) for guidance on setting up a development environment and contributing to Ascender.
+Ascender provides a web-based user interface, REST API, and task engine built on top of [Ansible](https://github.com/ansible/ansible). It is the automation platform at the centre of this project, based on the upstream [AWX](https://github.com/ansible/awx) project and maintained by Ctrl IQ.
 
-- Join us on our [forum](https://forum.ascender-automation.org) to discuss development topics.
+## Requirements
 
-Documentation
--------------
+- Docker with Compose, for the development environment
+- Python 3.12, matching what the container images build against
+- A Kubernetes cluster for production, which the installer can provision for you
 
-- Documentation is available at [Ascender Documentation](https://docs.ascender-automation.org)
+## Installation
 
-Reporting Issues
-----------------
+For production, use the [Ascender installer](https://github.com/ctrliq/ascender-install). It deploys onto a single VM using [k3s](https://k3s.io/), or onto AKS, DKP, EKS, GKE, RKE2, OCP, or TKGI with a kubeconfig and a namespace.
 
-- If you're experiencing a problem that you feel is a bug in Ascender or have ideas for improving Ascender, we encourage you to open a Github issue and share your feedback.
+For development, bring up the containerised environment:
 
+```bash
+make docker-compose
+```
+
+See [Running the Development Environment in Docker](./docs/development/docker.md) for the full walkthrough, and [kind.md](./docs/development/kind.md) or [minikube.md](./docs/development/minikube.md) for cluster-based alternatives.
+
+## Using Ascender
+
+Once the development stack is up, create an administrator and start the services:
+
+```bash
+make adduser
+make migrate
+```
+
+The `Makefile` is the entry point for day-to-day work, covering `requirements`, `develop`, and `collectstatic`.
+
+To drive a running server from the command line or from a playbook, use [ascender-kit](https://github.com/ctrliq/ascender-kit) or the [ctrliq.ascender](https://github.com/ctrliq/ascender-collection) collection.
+
+## Testing
+
+Ascender uses pytest, with tox for environment management.
+
+- **Unit and functional**: `py.test awx/main/tests/`
+- **Configuration**: [`pytest.ini`](./pytest.ini) and [`tox.ini`](./tox.ini)
+
+## Documentation
+
+- Product documentation is at [docs.ascender-automation.org](https://docs.ascender-automation.org)
+- Developer documentation lives in [docs/](./docs), covering clustering, credentials, and mesh
+
+## The Ascender ecosystem
+
+| Repository | Description |
+| ---------- | ----------- |
+| [ascender](https://github.com/ctrliq/ascender) | The platform itself: web UI, REST API, and task engine |
+| [ascender-install](https://github.com/ctrliq/ascender-install) | Installer for Ascender and Ledger, with Galaxy Proxy support |
+| [ascender-k8s-install](https://github.com/ctrliq/ascender-k8s-install) | Kubernetes installer for Ascender, Ledger, and React |
+| [ascender-pro-install](https://github.com/ctrliq/ascender-pro-install) | Enhanced installer adding Reaqt, Registry, and Galaxy Proxy |
+| [ascender-operator](https://github.com/ctrliq/ascender-operator) | Kubernetes operator that deploys and manages Ascender |
+| [ascender-ee](https://github.com/ctrliq/ascender-ee) | Default execution environment image for Ascender jobs |
+| [ascender-kit](https://github.com/ctrliq/ascender-kit) | The `ascender` command line client and Python API library |
+| [ascender-collection](https://github.com/ctrliq/ascender-collection) | The `ctrliq.ascender` Ansible collection for a controller |
+| [ascender-ledger](https://github.com/ctrliq/ascender-ledger) | Reporting tool for host facts and playbook changes |
+| [ascender-galaxy-proxy](https://github.com/ctrliq/ascender-galaxy-proxy) | Caching proxy for Ansible Galaxy collection downloads |
+| [ascender-playbooks](https://github.com/ctrliq/ascender-playbooks) | Example playbooks for use with Ascender |
+## Contributing
+
+- See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, testing, and pull requests.
+- Contributions require a Developer Certificate of Origin sign-off, per [DCO_1_1.md](./DCO_1_1.md).
+- Report bugs and feature ideas via [GitHub Issues](https://github.com/ctrliq/ascender/issues).
+- For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) rather than opening an issue.
+- Join the [Ascender forum](https://forum.ascender-automation.org) to discuss development topics.
+
+## License
+
+Licensed under the **Apache License 2.0**. See [LICENSE](./LICENSE) and [NOTICE.txt](./NOTICE.txt).
+
+Third-party component licenses are collected in [licenses/](./licenses).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 25.x    | :white_check_mark: |
+| < 25.0  | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+responsibly. **Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please send an email to **security@ctrliq.com** with:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any potential impact
+
+You should receive a response within 72 hours acknowledging receipt. We will
+work with you to understand the issue and coordinate a fix and disclosure
+timeline.
+
+## Disclosure Policy
+
+We follow coordinated disclosure. We ask that you give us a reasonable amount
+of time to address the issue before making any information public.


### PR DESCRIPTION
Standardizes this repository's README against a shared structure used across all 11 Ascender repositories, so each one reads the same way and cross-links to the others.

Fills out the flagship README, which was 21 lines with no features, testing, or license section.

## What changed

- README rebuilt to the shared section order: Requirements, Installation, Using, Authentication, Configuration, Included content, Testing, ecosystem, Contributing, License
- Adds the shared Ascender ecosystem table, byte-identical across all 11 repositories
- Contributing now points at GitHub Issues, `SECURITY.md`, and the Ascender forum
- Adds `CONTRIBUTING.md` and `SECURITY.md`, which this repository did not have

## Conventions applied

- ATX headings only, relative links, no table of contents
- Sections may be omitted where they do not apply, but are never reordered or renamed