### PR TITLE
test: add a type check job and broaden the flake8 selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
             command: /start_tests.sh test_migrations
           - name: api-lint
             command: /var/lib/awx/venv/awx/bin/tox -e linters
+          # Advisory while the diagnostics that are already in the tree are worked
+          # through: the job reports them, it does not fail the pull request.
+          - name: api-type-check
+            command: /var/lib/awx/venv/awx/bin/tox -e typecheck
+            advisory: true
           - name: ui-lint
             command: make ui-lint
           - name: ui-test-screens
@@ -42,6 +47,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run check ${{ matrix.tests.name }}
+        continue-on-error: ${{ matrix.tests.advisory || false }}
         run: AWX_DOCKER_CMD='${{ matrix.tests.command }}' make docker-runner
 
   dev-env:

--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -305,7 +305,7 @@ class TaskManagerModels:
         # For container group jobs, additionally we must account for capacity consumed since
         # The container groups have no instances to look at to track how many jobs/forks are consumed
         if task.instance_group_id:
-            if not task.instance_group_id in self.instance_groups.pk_ig_map.keys():
+            if task.instance_group_id not in self.instance_groups.pk_ig_map.keys():
                 logger.warn(
                     f"Task {task.log_format} assigned {task.instance_group_id} but this instance group not present in map of instance groups{self.instance_groups.pk_ig_map.keys()}"
                 )

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,32 @@ commands =
   yamllint -s .
 
 [flake8]
-select = F401,F402,F821,F823,F841,F811,E265,E266,F541,W605,E722,F822,F523,W291,F405,F632
+# Rules are selected explicitly rather than by class, because black owns the
+# formatting and most of pycodestyle would fight it. What is listed here are the
+# checks that catch a mistake rather than a style preference: unused or undefined
+# names, broken % and .format() calls, comparisons and statements that do not do
+# what they read as, and trailing whitespace that black does not reach.
+select =
+  E265,E266,E703,E713,E714,E722,E741,E742,E743,
+  F401,F402,F405,F501,F502,F503,F504,F505,F506,F507,F508,F509,
+  F521,F522,F523,F524,F525,F541,F601,F602,F631,F632,F633,F634,
+  F702,F706,F707,F811,F821,F822,F823,F841,F842,F901,
+  W291,W292,W293,W391,W605
 exclude = .git,__pycache__,.tox,awx/ui/node_modules,env
+
+[testenv:typecheck]
+# Advisory: the type checker runs over awx/ on every pull request and reports what
+# it finds without failing the merge, so the diagnostics that are already there can
+# be worked through a module at a time. It resolves third-party imports out of the
+# environment awx is installed in, which is the venv baked into the development
+# image; set TYPECHECK_PYTHON to run it against another one. Pinned like the other
+# linters so results do not drift as new releases land.
+deps =
+  ty==0.0.74
+passenv =
+  TYPECHECK_PYTHON
+commands =
+  ty check awx --python {env:TYPECHECK_PYTHON:/var/lib/awx/venv/awx}
 
 [testenv:pip-compile-docs]
 description = Compile docs build lockfiles


### PR DESCRIPTION
Closes #632.

## Problem

The issue asks for three CI gates. The first one, running the test suites, landed with #647 and #655: `api-test`, `api-migrations` and the PostgreSQL backed tests all run on pull requests now. The other two are still open:

- No type checker runs, so the error the issue was filed over, a `.replace` call on the list `traceback.format_exception` returns (#630), merges unseen. flake8 does no type inference and cannot report it.
- The flake8 selection is sixteen rules, which leaves the pyflakes checks for broken `%` and `.format()` calls, comparisons that do not do what they read as, and ambiguous names switched off.

## Change

Two commits, either of which stands on its own.

**Broaden the flake8 selection.** The list stays explicit, because black owns the formatting and most of pycodestyle would fight it, and grows the checks that report a mistake rather than a preference: the `F50x` and `F52x` format string families, `F60x`, `F63x`, `F70x`, `F842`, `F901`, `E703`, `E713`, `E714`, `E741` to `E743`, and `W292`, `W293`, `W391`. Every one of them is already clean over `awx/` except a single `not x in y` in the task manager, which this rewrites as `x not in y`.

**Run a type checker.** A `typecheck` tox environment runs [ty](https://github.com/astral-sh/ty) over `awx/`, and a new `api-type-check` job runs it on every pull request. The job is advisory, so the diagnostics already in the tree do not block a merge while they are worked through per module, which is the shape the issue proposed.

ty resolves third-party imports out of the environment awx is installed in, which in CI is the venv in the development image; `TYPECHECK_PYTHON` overrides that for a local run. Its version is pinned like the other linters.

On why ty and not mypy: mypy skips unannotated function bodies by default, so it does not report the #630 expression unless `--check-untyped-defs` is on, which turns a much larger surface of this codebase into errors at once. ty reports it with no configuration.

## Testing

- `flake8 awx` with the new selection passes with the one line fixed, and fails on it without.
- `ty check awx` runs in under two seconds and currently reports about 500 diagnostics once import resolution is excluded, which is why the job is advisory rather than blocking.
- The pre-fix expression from #630, `traceback.format_exception(None, e, e.__traceback__).replace('\n', '\r\n')`, is reported as `error[unresolved-attribute] Object of type list[str] has no attribute replace`. The same expression under mypy's defaults reports nothing.

The CI job itself has not run yet, since that needs this to be a pull request against the repository.
