### PR TITLE
fix: call dotenv-expand through its named export

### DIFF
--- a/awx/ui/config/env.js
+++ b/awx/ui/config/env.js
@@ -30,9 +30,14 @@ const dotenvFiles = [
 // that have already been set.  Variable expansion is supported in .env files.
 // https://github.com/motdotla/dotenv
 // https://github.com/motdotla/dotenv-expand
+//
+// dotenv-expand exports { expand } from v6 onwards. Calling the module itself is
+// the v5 API this file was ejected with, and throws on the version pinned here.
+const { expand } = require('dotenv-expand');
+
 dotenvFiles.forEach(dotenvFile => {
   if (fs.existsSync(dotenvFile)) {
-    require('dotenv-expand')(
+    expand(
       require('dotenv').config({
         path: dotenvFile,
       })


### PR DESCRIPTION
##### SUMMARY

`awx/ui/config/env.js` calls `dotenv-expand` as if the module itself were the function:

```js
require('dotenv-expand')(require('dotenv').config({ path: dotenvFile }))
```

That is the v5 API. This file is ejected create-react-app code, and CRA pins `dotenv-expand` at `^5.1.0` where the module *is* callable; this repository added the dependency at `^13.0.0` in #559, and from v6 the only export is `{ expand }`. So the line has thrown `TypeError: require(...) is not a function` since it landed on 2026-07-02.

Nothing has broken yet because the call sits behind `fs.existsSync(dotenvFile)` and there is no `.env` file anywhere in `awx/ui`. But `.gitignore` reserves `awx/ui/.env.local`, which is an invitation to create one, and `scripts/start.js`, `scripts/build.js` and `scripts/test.js` all `require('../config/env')`. The first developer to use that mechanism loses the dev server, the production build and the whole Jest suite at once, to an error thrown from a build script they never touched.

This switches the call to the named export. Two lines, plus a comment so it does not get reverted to the CRA form later.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### ASCENDER VERSION

```
25.5.1
```

##### ADDITIONAL INFO

Reproduced against the tree as it stands, with the pinned versions installed (`dotenv-expand` 13.0.0, `dotenv` 17.4.2). With `awx/ui/.env.local` holding `BASE=/opt/app` and `FULL=${BASE}/ui`, and `awx/ui/.env` holding the same with `/srv/app`:

```
$ NODE_ENV=<env> node -e "require('./config/env')"

              before                                        after
development   TypeError: require(...) is not a function     loaded ok, FULL=/opt/app/ui
test          TypeError: require(...) is not a function     loaded ok, FULL=/srv/app/ui
production    TypeError: require(...) is not a function     loaded ok, FULL=/opt/app/ui
```

`test` reads `/srv/app` from `.env` rather than `/opt/app` from `.env.local`, which is the precedence this file documents: `.env.local` is deliberately skipped for the test environment.

End to end through the real runner, with a `.env` present:

```
$ npm run test -- --watchAll=false --testPathPatterns "src/components/NotificationList"

before   TypeError: require(...) is not a function   at config/env.js:35:29
after    Test Suites: 2 passed, 2 total    Tests: 19 passed, 19 total
```

Two things worth saying rather than leaving implied:

- `npm run lint` proves nothing here. `eslint.config.mjs` ignores `config/**` and `scripts/**`, which is part of why this sat unnoticed for seven weeks.
- This does not touch the version. It does make the dependency real again, so the open Dependabot bump to `1000.0.0` becomes a decision rather than noise. My read is still to close it: `1000.0.0` is a genuine release, not a sentinel, but it takes the package from 48K to 328K by bundling `@dotenvx/primitives` (encrypt, decrypt, keypair, keyring) into the build toolchain and relicenses BSD-2 to BSD-3, to expand variables in a build script that 13.0.0 expands fine.
