### PR TITLE
build: bump idna from 3.15 to 3.19 in /docs/docsite

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -13,7 +13,7 @@ docutils==0.22.4
     #   -r requirements.in
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.15
+idna==3.19
     # via requests
 imagesize==2.0.0
     # via sphinx


### PR DESCRIPTION
##### SUMMARY

Bumps `idna` from `3.15` to `3.19` in `docs/docsite/requirements.txt`.

This ecosystem has no Dependabot coverage: #675 turned on version updates for github-actions and for npm in `/awx/ui`, and left the Python files out, so the docs lockfile only moves when someone moves it.

The pin is edited in place rather than recompiled on purpose. `sphinx` is deliberately unpinned in this lockfile, and re-running `pip-compile` would pin it as a side effect, which is a change this pull request has no business making.

Release notes: https://github.com/kjd/idna/releases

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested before opening, in a clean virtualenv, exactly as `tox -e docs` builds it:

```
pip install -r docs/docsite/requirements.in -c docs/docsite/requirements.txt   # resolves, pip check clean
python docs/docsite/rst/rest_api/_swagger/download-json.py
sphinx-build -T -E -W -n --keep-going -j auto -c docs/docsite \
  -d docs/docsite/build/doctrees -b html docs/docsite/rst docs/docsite/build/html
```

`build succeeded.` with `idna 3.19` installed, same as the baseline on `main`. The build runs with `-W`, so any new warning would have failed it.
