### PR TITLE
build: bump pygments from 2.20.0 to 2.21.0 in /docs/docsite

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -25,7 +25,7 @@ markupsafe==3.0.3
     # via jinja2
 packaging==26.0
     # via sphinx
-pygments==2.20.0
+pygments==2.21.0
     # via
     #   ansible-pygments
     #   sphinx


### PR DESCRIPTION
##### SUMMARY

Bumps `pygments` from `2.20.0` to `2.21.0` in `docs/docsite/requirements.txt`.

This ecosystem has no Dependabot coverage: #675 turned on version updates for github-actions and for npm in `/awx/ui`, and left the Python files out, so the docs lockfile only moves when someone moves it.

The pin is edited in place rather than recompiled on purpose. `sphinx` is deliberately unpinned in this lockfile, and re-running `pip-compile` would pin it as a side effect, which is a change this pull request has no business making.

Release notes: https://github.com/pygments/pygments/releases

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested before opening, in a clean virtualenv, exactly as `tox -e docs` builds it:

```
pip install -r docs/docsite/requirements.in -c docs/docsite/requirements.txt   # resolves, pip check clean
python docs/docsite/rst/rest_api/_swagger/download-json.py
sphinx-build -T -E -W -n --keep-going -j auto -c docs/docsite \
  -d docs/docsite/build/doctrees -b html docs/docsite/rst docs/docsite/build/html
```

`build succeeded.` with `pygments 2.21.0` installed, same as the baseline on `main`. The build runs with `-W`, so any new warning would have failed it.
