### PR TITLE
build: bump slack-sdk from 3.27.0 to 3.43.0 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -412,7 +412,7 @@ six==1.16.0
     #   pyrad
     #   python-dateutil
     #   tacacs-plus
-slack-sdk==3.27.0
+slack-sdk==3.43.0
     # via -r /awx_devel/requirements/requirements.in
 smmap==5.0.1
     # via gitdb


### PR DESCRIPTION
##### SUMMARY

Bumps `slack-sdk` from `3.27.0` to `3.43.0` in `requirements/requirements.txt`. It backs the Slack notification backend.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade slack-sdk
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested before opening, in the same image, with `slack-sdk 3.43.0` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 12.66s

py.test awx/main/tests/unit/notifications awx/main/tests/functional/test_notifications.py awx/main/tests/functional/models/test_notifications.py
  56 passed in 31.91s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
