### PR TITLE
build: bump prometheus-client from 0.20.0 to 0.26.0 in /requirements

### DIFF
--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -48,9 +48,10 @@ def test_metrics_counts(organization_factory, job_template_factory, workflow_job
 
     for gauge in gauges:
         for sample in gauge.samples:
-            # name, label, value, timestamp, exemplar
-            name, _, value, _, _ = sample
-            assert EXPECTED_VALUES[name] == value
+            # Read the fields by name: Sample grew a sixth one, native_histogram, in
+            # prometheus-client 0.21, so unpacking it as a 5-tuple ties this test to a
+            # version of the library. The metrics code itself already reads by name.
+            assert EXPECTED_VALUES[sample.name] == sample.value
 
 
 def get_metrics_view_db_only():

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -281,7 +281,7 @@ pexpect==4.7.0
     #   ansible-runner
 pkgconfig==1.5.5
     # via -r /awx_devel/requirements/requirements.in
-prometheus-client==0.20.0
+prometheus-client==0.26.0
     # via -r /awx_devel/requirements/requirements.in
 propcache==0.2.1
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `prometheus-client` from `0.20.0` to `0.26.0` in `requirements/requirements.txt`, and adapts the one test that the bump breaks.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So the pin was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade prometheus-client
```

run inside the `ascender_devel` image, which is where that script insists on running. One line in the lockfile.

**Why a test changes too.** `test_metrics_counts` reads each sample by unpacking it:

```python
name, _, value, _, _ = sample
```

`Sample` grew a sixth field in prometheus-client 0.21, `native_histogram`, so that line raises `ValueError: too many values to unpack (expected 5)` and the bump fails on its own test rather than on anything real. The metrics code itself was never affected: `awx/api/renderers.py` and `run_wsrelay.py` already read `sample.name`, `sample.labels` and `sample.value` by name. The test now does the same, which is version agnostic rather than pinned to a tuple shape.

This is the kind of bump Dependabot cannot land on its own, which is part of why this ecosystem is left to a person.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the `ascender_devel` image before opening.

The failure this fixes, on `main` with 0.26.0 installed and the test untouched:

```
awx/main/tests/functional/analytics/test_metrics.py:52: in test_metrics_counts
    name, _, value, _, _ = sample
E   ValueError: too many values to unpack (expected 5)
1 failed, 8 passed
```

With this branch:

```
prometheus-client 0.26.0
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit   1403 passed, 1 skipped
py.test awx/main/tests/functional/analytics awx/main/tests/functional/api/test_settings.py   48 passed
```

And the test change on its own is not tied to the new version: `awx/main/tests/functional/analytics` is 9 passed under 0.26.0 and 9 passed under 0.20.0.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
