### PR TITLE
build: bump markdown from 3.10.2 to 3.10.3 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -237,7 +237,7 @@ lxml==6.1.0
     # via
     #   python3-saml
     #   xmlsec
-markdown==3.10.2
+markdown==3.10.3
     # via -r /awx_devel/requirements/requirements.in
 markupsafe==2.1.5
     # via jinja2


### PR DESCRIPTION
##### SUMMARY

Bumps `markdown` from `3.10.2` to `3.10.3` in `requirements/requirements.txt`. It renders the Markdown in the browsable API help text.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade markdown
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested before opening, in the same image, with `markdown 3.10.3` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 14.22s

py.test awx/main/tests/functional/api/test_generic.py
  7 passed in 6.04s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
