### PR TITLE
build: bump daphne from 4.2.2 to 4.2.3 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -91,7 +91,7 @@ cryptography==50.0.0
     #   social-auth-core
 cython==3.2.5
     # via -r /awx_devel/requirements/requirements.in
-daphne==4.2.2
+daphne==4.2.3
     # via -r /awx_devel/requirements/requirements.in
 defusedxml==0.7.1
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `daphne` from `4.2.2` to `4.2.3` in `requirements/requirements.txt`. It is the ASGI server behind the websocket endpoints.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade daphne
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested before opening, in the same image, with `daphne 4.2.3` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 12.45s

py.test awx/main/tests/unit/test_tasks.py
  136 passed in 4.02s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
