### PR TITLE
build: bump irc from 20.3.1 to 20.4.3 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -189,7 +189,7 @@ inflection==0.5.1
     # via
     #   django-ansible-base
     #   drf-spectacular
-irc==20.3.1
+irc==20.4.3
     # via -r /awx_devel/requirements/requirements.in
 isodate==0.6.1
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `irc` from `20.3.1` to `20.4.3` in `requirements/requirements.txt`. It backs the IRC notification backend. 20.5.0 is not reachable on this tree: it requires jaraco.text>=3.14, and jaraco.text 4.x pulls in typer, rich, markdown-it-py, mdurl and shellingham while dropping pydantic, inflect and autocommand, an eighteen line change to the lockfile for an IRC backend. 20.4.3 is the last release that resolves against what is already here.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade irc
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested before opening, in the same image, with `irc 20.4.3` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 12.72s

py.test awx/main/tests/unit/notifications awx/main/tests/functional/test_notifications.py
  44 passed in 5.62s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
