### PR TITLE
build: bump azure-identity from 1.25.2 to 1.25.3 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -43,7 +43,7 @@ azure-core==1.38.0
     # via
     #   azure-identity
     #   azure-keyvault-secrets
-azure-identity==1.25.2
+azure-identity==1.25.3
     # via -r /awx_devel/requirements/requirements.in
 azure-keyvault-secrets==4.11.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY

Bumps `azure-identity` from `1.25.2` to `1.25.3` in `requirements/requirements.txt`. It authenticates the Azure Key Vault credential plugin.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade azure-identity
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `azure-identity 1.25.3` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 16.44s

py.test awx/main/tests/functional/test_credential_plugins.py awx/main/tests/functional/api/test_credential.py
  103 passed in 44.37s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
