### PR TITLE
build: bump jsonschema from 4.25.1 to 4.26.0 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -219,7 +219,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   drf-spectacular
@@ -388,7 +388,7 @@ requests-oauthlib==1.3.1
     # via
     #   kubernetes
     #   social-auth-core
-rpds-py==0.18.0
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing


### PR DESCRIPTION
##### SUMMARY

Bumps `jsonschema` from `4.25.1` to `4.26.0` in `requirements/requirements.txt`. It validates survey specs and the schemas the API exposes.

`rpds-py` moves with it, from `0.18.0` to `2026.6.3`, because it has to: jsonschema 4.26.0 requires `rpds-py>=0.25.0`, so asking for jsonschema on its own resolves to no change at all. This is the case #675 describes as a lockfile that cannot move a dependency separately.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade jsonschema rpds-py
```

run inside the `ascender_devel` image, which is where that script insists on running. Two lines in the lockfile, no other package moves.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `jsonschema 4.26.0` and `rpds-py 2026.6.3` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 12.69s

py.test awx/main/tests/functional/api/test_survey_spec.py awx/main/tests/functional/api/test_settings.py
  76 passed in 38.41s
```

`awx/main/tests/docs` is not part of this: it errors six times on `main` as well, with or without the bump, because the swagger generation test needs its own setup and is outside `TEST_DIRS`.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
