### PR TITLE
build: bump python-daemon from 3.0.1 to 3.1.2 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -149,8 +149,6 @@ djangorestframework==3.15.2
     #   drf-spectacular
 djangorestframework-yaml==2.0.0
     # via -r /awx_devel/requirements/requirements.in
-docutils==0.20.1
-    # via python-daemon
 drf-spectacular==0.29.0
     # via -r /awx_devel/requirements/requirements.in
 durationpy==0.10
@@ -329,7 +327,7 @@ pyparsing==2.4.6
     # via -r /awx_devel/requirements/requirements.in
 pyrad==2.4
     # via django-radius
-python-daemon==3.0.1
+python-daemon==3.1.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   ansible-runner
@@ -496,7 +494,6 @@ setuptools==83.0.0
     #   asciichartpy
     #   autobahn
     #   incremental
-    #   python-daemon
     #   setuptools-rust
     #   setuptools-scm
     #   zope-interface


### PR DESCRIPTION
##### SUMMARY

Bumps `python-daemon` from `3.0.1` to `3.1.2` in `requirements/requirements.txt`. It daemonizes the dispatcher and the callback receiver.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade python-daemon
```

run inside the `ascender_devel` image, which is where that script insists on running.

`docutils` drops out of the lockfile with it: python-daemon 3.0.1 depended on it and 3.1.2 does not, and nothing else in the tree pulls it. The docs build keeps its own copy in `docs/docsite/requirements.txt`, which is untouched here. The result is 1 added / 4 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `python-daemon 3.1.2` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 11.35s

py.test awx/main/tests/unit/test_tasks.py
  136 passed in 3.82s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
