### PR TITLE
build: bump django-valkey from 0.3.2 to 0.4.0 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -140,7 +140,7 @@ django-solo==2.4.0
     # via -r /awx_devel/requirements/requirements.in
 django-split-settings==1.0.0
     # via -r /awx_devel/requirements/requirements.in
-django-valkey==0.3.2
+django-valkey==0.4.0
     # via -r /awx_devel/requirements/requirements.in
 djangorestframework==3.15.2
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `django-valkey` from `0.3.2` to `0.4.0` in `requirements/requirements.txt`. It is the Django cache backend for Valkey. 0.4.1 is not reachable on this tree: it adds a typing-extensions>=4.15 requirement on Python below 3.13, and the lockfile holds typing-extensions at 4.12.2 for aiohttp, azure-core, jwcrypto and inflect, so taking it would move a shared transitive rather than this one package.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade django-valkey
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `django-valkey 0.4.0` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 9.41s

py.test awx/main/tests/functional/api/test_settings.py awx/main/tests/unit/test_db.py
  52 passed in 11.63s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
