### PR TITLE
build: bump python-ldap from 3.4.5 to 3.4.7 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -340,7 +340,7 @@ python-dateutil==2.8.2
     #   receptorctl
 python-dsv-sdk==1.0.4
     # via -r /awx_devel/requirements/requirements.in
-python-ldap==3.4.5
+python-ldap==3.4.7
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django-auth-ldap


### PR DESCRIPTION
##### SUMMARY

Bumps `python-ldap` from `3.4.5` to `3.4.7` in `requirements/requirements.txt`. It is the LDAP client behind django-auth-ldap. It has no wheels on PyPI, so the test run builds it from source against the openldap headers.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade python-ldap
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `python-ldap 3.4.7` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 9.10s

py.test awx/sso/tests
  252 passed in 5.23s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
