### PR TITLE
build: bump django-polymorphic from 4.1.0 to 4.11.7 in /requirements

### DIFF
--- a/awx/main/models/base.py
+++ b/awx/main/models/base.py
@@ -160,7 +160,8 @@ class CreatedModifiedModel(BaseModel):
     )
 
     def save(self, *args, **kwargs):
-        update_fields = list(kwargs.get('update_fields', []))
+        # Django can pass update_fields through as an explicit None, so read it defensively
+        update_fields = list(kwargs.get('update_fields') or [])
         # Manually perform auto_now_add and auto_now logic.
         if not self.pk and not self.created:
             self.created = now()
@@ -190,7 +191,7 @@ class PasswordFieldsModel(BaseModel):
         new_instance = not bool(self.pk)
         # If update_fields has been specified, add our field names to it,
         # if it hasn't been specified, then we're just doing a normal save.
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         # When first saving to the database, don't store any password field
         # values, but instead save them until after the instance is created.
         # Otherwise, store encrypted values to the database.
@@ -305,7 +306,7 @@ class PrimordialModel(HasEditsMixin, CreatedModifiedModel):
             self._prior_values_store = {}
 
     def save(self, *args, **kwargs):
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         user = get_current_user()
         # Ensure user is either None or a valid User instance
         if not user or (user and not getattr(user, 'id', None)):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -132,7 +132,7 @@ django-oauth-toolkit==3.3.0
     # via -r /awx_devel/requirements/requirements.in
 django-pglocks==1.0.4
     # via -r /awx_devel/requirements/requirements.in
-django-polymorphic==4.1.0
+django-polymorphic==4.11.7
     # via -r /awx_devel/requirements/requirements.in
 django-radius==1.5.1
     # via -r /awx_devel/requirements/requirements.in
@@ -448,6 +448,7 @@ typing-extensions==4.12.2
     #   azure-core
     #   azure-identity
     #   azure-keyvault-secrets
+    #   django-polymorphic
     #   inflect
     #   jwcrypto
     #   psycopg


### PR DESCRIPTION
##### SUMMARY

Bumps `django-polymorphic` from `4.1.0` to `4.11.7` in `requirements/requirements.txt`, and stops the `save()` overrides in `awx/main/models/base.py` assuming `update_fields` is always a list.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So the pin was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade django-polymorphic
```

run inside the `ascender_devel` image. One pin moves, plus a `# via` line, since polymorphic now declares typing-extensions, which is already in the tree at a satisfying version.

**Why the model base changes too.** Ten years of polymorphic saves went through `super().save(*args, **kwargs)` without `update_fields` set. Newer versions pass it through as an explicit `None`, and three places in `base.py` read it as if it were a list:

```python
update_fields = list(kwargs.get('update_fields', []))     # line 164, raises on None
update_fields = kwargs.get('update_fields', [])           # lines 194 and 309, then `x in update_fields`
```

`kwargs.get('update_fields', [])` returns the `None` that was passed rather than the default, so `list(None)` and `'created_by' not in None` both raise `TypeError`. Reading it as `kwargs.get('update_fields') or []` is right under both versions: `None` and an absent key both become an empty list, and a real list is untouched. Django itself documents `update_fields=None` as the "save everything" case, so the old code was relying on callers never being explicit about it.

Without those three lines this bump fails 11 unit tests, 11 unit errors, 160 functional failures and 113 functional errors. With them, nothing fails.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

The whole suite, twice, in the `ascender_devel` image, serially rather than with `-n auto` so nothing is hidden by the known parallel flakes:

```
py.test awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

  django-polymorphic 4.11.7, with this branch    3816 passed, 10 skipped in 15m27s
  django-polymorphic 4.1.0,  with this branch    3816 passed, 10 skipped in 15m29s
```

The second run is the control: the `base.py` change stands on its own and does not depend on the bump, so it cannot regress anything if the pin is ever reverted.

`black --check` and `flake8` are clean on the changed file.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
