### PR TITLE
build: bump boto3 from 1.39.1 to 1.43.78 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -47,9 +47,9 @@ azure-identity==1.25.2
     # via -r /awx_devel/requirements/requirements.in
 azure-keyvault-secrets==4.11.0
     # via -r /awx_devel/requirements/requirements.in
-boto3==1.39.1
+boto3==1.43.78
     # via -r /awx_devel/requirements/requirements.in
-botocore==1.39.1
+botocore==1.43.78
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   boto3
@@ -392,7 +392,7 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.13.0
+s3transfer==0.19.2
     # via boto3
 semantic-version==2.10.0
     # via setuptools-rust


### PR DESCRIPTION
##### SUMMARY

Bumps `boto3` from `1.39.1` to `1.43.78` in `requirements/requirements.txt`, with `botocore` and `s3transfer` alongside it. They back the AWS credential plugin, the S3 inventory sources and the AWS collections' dependencies inside the API.

The three cannot move apart. boto3 1.43.78 requires `botocore>=1.43.78,<1.44.0` and `s3transfer>=0.19.0,<0.20.0`, and the lockfile held s3transfer at 0.13.0, so asking for boto3 on its own resolves no further than 1.40.26. This is the case #675 describes as a lockfile that cannot move a dependency separately.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade boto3 botocore s3transfer
```

run inside the `ascender_devel` image. Three pins, nothing else in the file moves.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

The whole suite, in the `ascender_devel` image, with the three pins installed and a freshly created test database:

```
py.test --create-db -n auto --dist=loadfile \
  awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

  3816 passed, 10 skipped in 6m48s
```

That matches the baseline on `main` exactly, which is 3816 passed and 10 skipped.

Worth recording for whoever runs this next: `pytest.ini` carries `--reuse-db`, and a database left behind by a run with different pins installed will produce failures that have nothing to do with the change under test. A run here reported 23 failures and 19 errors purely because the cached schema came from a different `django-oauth-toolkit`. Deleting `awx/awx_test.sqlite3*`, or passing `--create-db`, is what makes a dependency bump measurable.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
