### PR TITLE
build: bump twilio from 8.13.0 to 9.11.0 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -433,7 +433,7 @@ tempora==5.5.1
     # via
     #   irc
     #   jaraco-logging
-twilio==8.13.0
+twilio==9.11.0
     # via -r /awx_devel/requirements/requirements.in
 twisted[tls]==26.4.0
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `twilio` from `8.13.0` to `9.11.0` in `requirements/requirements.txt`. It backs the SMS notification backend.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade twilio
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `twilio 9.11.0` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 9.72s

py.test awx/main/tests/unit/notifications awx/main/tests/functional/test_notifications.py
  44 passed in 3.99s
```

It is a major version, so the whole suite ran too, on a freshly created database:

```
py.test --create-db -n auto --dist=loadfile \
  awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

  3816 passed, 10 skipped in 6m08s
```

which matches the baseline on `main` exactly.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
