### PR TITLE
build: bump psutil from 5.9.8 to 7.2.2 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -287,7 +287,7 @@ propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-psutil==5.9.8
+psutil==7.2.2
     # via -r /awx_devel/requirements/requirements.in
 psycopg==3.1.18
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY

Bumps `psutil` from `5.9.8` to `7.2.2` in `requirements/requirements.txt`. It reports memory and cpu for capacity, and backs the dispatcher pool and callback receiver.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade psutil
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `psutil 7.2.2` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 9.77s

py.test awx/main/tests/unit/test_capacity.py awx/main/tests/unit/tasks awx/main/tests/functional/analytics
  58 passed in 3.33s
```

It crosses two majors, so the whole suite ran too, on a freshly created database:

```
py.test --create-db -n auto --dist=loadfile \
  awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

  3816 passed, 10 skipped in 6m09s
```

which matches the baseline on `main` exactly.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
