### PR TITLE
build: bump cachetools from 5.3.2 to 7.1.7 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -54,7 +54,7 @@ botocore==1.43.78
     #   -r /awx_devel/requirements/requirements.in
     #   boto3
     #   s3transfer
-cachetools==5.3.2
+cachetools==7.1.7
     # via -r /awx_devel/requirements/requirements.in
 # certifi @ git+https://github.com/ansible/system-certifi.git@devel  # git requirements installed separately
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `cachetools` from `5.3.2` to `7.1.7` in `requirements/requirements.txt`. It is pulled in as a direct requirement and used by the Google auth stack under it.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade cachetools
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

Tested in the same image, with `cachetools 7.1.7` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1403 passed, 1 skipped in 11.91s

py.test awx/main/tests/unit/test_capacity.py awx/main/tests/functional/api/test_settings.py
  61 passed in 14.93s
```

It crosses two majors, so the whole suite ran too, on a freshly created database:

```
py.test --create-db -n auto --dist=loadfile \
  awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

  1 failed, 3815 passed, 10 skipped in 7m51s
  FAILED awx/main/tests/functional/api/test_generic.py::test_proxy_ip_allowed
```

That failure is not this bump. `test_proxy_ip_allowed` patches `REMOTE_HOST_HEADERS` and `PROXY_IP_ALLOWED_LIST` on the settings singleton, and under `-n auto` it intermittently sees another worker's settings state. With cachetools 7.1.7 installed it passes solo (7 passed) and passes alongside the settings tests it shares a worker with (46 passed), and I saw the same failure once during an unrelated bump on the same day. The serial baseline for this tree is 3816 passed, 10 skipped, with no failures.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
