### PR TITLE
build: bump python-tss-sdk from 1.2.2 to 2.0.1 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -346,7 +346,7 @@ python-ldap==3.4.5
     #   django-auth-ldap
 python-string-utils==1.0.0
     # via openshift
-python-tss-sdk==1.2.2
+python-tss-sdk==2.0.1
     # via -r /awx_devel/requirements/requirements.in
 python3-openid==3.2.0
     # via social-auth-core


### PR DESCRIPTION
##### SUMMARY

Bumps `python-tss-sdk` from `1.2.2` to `2.0.1` in `requirements/requirements.txt`. It backs the Thycotic Secret Server credential plugin.

The major version does not move the API this repository uses. `awx/main/credential_plugins/tss.py` imports `DomainPasswordGrantAuthorizer`, `PasswordGrantAuthorizer`, `SecretServer` and `ServerSecret` from `delinea.secrets.server`, with a fallback to the older `thycotic.secrets.server` path. At 2.0.1 all four still resolve from `delinea.secrets.server`, and the two the plugin constructs keep the signatures it calls:

```
SecretServer.__init__(self, base_url, authorizer, api_path_uri='/api/v1')
PasswordGrantAuthorizer.__init__(self, base_url, username, password, token_path_uri=None, domain=None)
```

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade python-tss-sdk
```

run inside the `ascender_devel` image. One line in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

The credential plugin loads and registers its fields at the new version:

```
python-tss-sdk 2.0.1
plugin loads: Thycotic Secret Server
inputs: ['server_url', 'username', 'domain', 'password']
```

The whole suite, on a freshly created database, in a checkout linked with `make awx-link`:

```
py.test -p no:cacheprovider --create-db -n auto --dist=loadfile \
  awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

python-tss-sdk 2.0.1    1 failed, 3816 passed, 10 skipped in 7m22s
FAILED awx/main/tests/functional/api/test_generic.py::test_proxy_ip_allowed
```

That failure is not this bump. `test_proxy_ip_allowed` patches `REMOTE_HOST_HEADERS` and `PROXY_IP_ALLOWED_LIST` on the settings singleton and intermittently sees another worker's state under `-n auto`; it is the flake instrumented in #694, and it passes solo.

An earlier revision of this pull request reported `2 failed, 3815 passed` at both the new and the old pin, and put the two extra failures down to how `-n auto` distributes work. That was wrong, and the correction is worth stating because it is an easy trap. The two tests were:

```
FAILED awx/main/tests/unit/test_db.py::test_sql_above_threshold
FAILED awx/main/tests/functional/test_credential.py::test_default_cred_types
```

Neither is order dependent. Both fail in any checkout where `awx.egg-info` has not been created, because that is what makes the `awx` distribution visible to `importlib.metadata`: `awx/main/db/profiled_pg/base.py` calls `importlib.metadata.version('awx')` for every recorded slow query, and `setup.cfg` registers the ten external secret lookups as `awx.credential_plugins` entry points. With no installed distribution there is no version and no entry points, so the profiler writes no sqlite file and `CredentialType.defaults` is short by those ten. The first failure hides its own cause: `RecordedQueryLog.append` swallows the exception, so what surfaces is a missing file rather than a missing package. Running `make awx-link` in the same tree takes that file from `1 failed` to `61 passed`, and the suite above is the run after it.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
