### PR TITLE
build: unblock and bump social-auth-core from 4.5.0 to 5.1.0 in /requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -55,7 +55,7 @@ python-tss-sdk>=1.2.1
 python-ldap>=3.4.5  # CVE-2025-61911 CVE-2025-61912
 pyyaml>=6.0.1
 receptorctl
-social-auth-core[openidconnect]==4.5.0  # see UPGRADE BLOCKERs
+social-auth-core>=5.1.0 # CVE-2026-32597; 5.x also validates Azure AD ID token signatures, OIDC sub claims and SAML AuthnRequests
 social-auth-app-django
 sqlparse>=0.6.0   # CVE-2026-59893 CVE-2026-54284 CVE-2026-71491 CVE-2026-59894; required by django
 requests>=2.33.0 # CVE-2026-25645

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,6 +24,7 @@ asgiref==3.11.0
     #   django
     #   django-ansible-base
     #   django-cors-headers
+    #   social-auth-app-django
 asn1==3.3.0
     # via -r /awx_devel/requirements/requirements.in
 attrs==23.2.0
@@ -382,7 +383,7 @@ requests==2.34.2
     #   requests-oauthlib
     #   social-auth-core
     #   twilio
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via
     #   kubernetes
     #   social-auth-core
@@ -414,9 +415,9 @@ slack-sdk==3.43.0
     # via -r /awx_devel/requirements/requirements.in
 smmap==5.0.1
     # via gitdb
-social-auth-app-django==5.6.0
+social-auth-app-django==6.0.1
     # via -r /awx_devel/requirements/requirements.in
-social-auth-core[openidconnect]==4.5.0
+social-auth-core==5.1.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   social-auth-app-django


### PR DESCRIPTION
##### SUMMARY

Lifts the `social-auth-core` pin and takes the two social-auth packages to current.

```
requirements.in
-social-auth-core[openidconnect]==4.5.0  # see UPGRADE BLOCKERs
+social-auth-core>=5.1.0 # CVE-2026-32597; 5.x also validates Azure AD ID token signatures, OIDC sub claims and SAML AuthnRequests

requirements.txt
-requests==2.33.0                        +requests==2.34.2
-requests-oauthlib==1.3.1                +requests-oauthlib==2.0.0
-social-auth-app-django==5.6.0           +social-auth-app-django==6.0.1
-social-auth-core[openidconnect]==4.5.0  +social-auth-core==5.1.0
```

`social-auth-app-django` is already unpinned in `requirements.in`, but it could not move: 6.x requires `social-auth-core>=5.0.0`, so the `==4.5.0` pin held both packages back. They move together or not at all. `requests` and `requests-oauthlib` follow because 5.1.0 requires `requests>=2.34.0` and `requests-oauthlib>=2.0.0`. `Django>=5.2` and `asgiref>=3.8.1`, the other two requirements of `social-auth-app-django` 6.x, are already satisfied at `django==5.2.17` and `asgiref==3.11.0`.

##### Why the pin can go

The comment on that line points at a section that does not exist. `requirements/README.md` has no `social-auth-core` entry under UPGRADE BLOCKERs, so whatever the reason for pinning at 4.5.0 was, it is not recorded in the tree.

##### The `[openidconnect]` extra is dropped, and nothing is lost by it

No published version of `social-auth-core` provides an extra by that name. 4.5.0 offers `all`, `allpy3`, `azuread` and `saml`; 5.1.0 offers `all`, `allpy3`, `dev`, `google-onetap`, `saml` and `shopify`. pip has been ignoring the request and printing this on every image build:

```
WARNING: social-auth-core 4.5.0 does not provide the extra 'openidconnect'
```

It was a no-op, not a missing capability. The extra existed in social-auth-core 3.x, where it pulled `python-jose`; 4.x replaced that with PyJWT and removed the extra. Nothing in this repository imports `jose`, and `social_core.backends.open_id_connect` needs only PyJWT, which is pinned at `pyjwt[crypto]==2.13.0`. `OpenIdConnectAuth` imports and keeps `name == 'oidc'` at 5.1.0.

##### What the upgrade is actually for

Most of the ground between 4.5.0 and 5.1.0 is security work:

- **CVE-2026-32597**: `PyJWT>=2.12.0` is now required.
- **Login CSRF**: callback state is now sent and validated by the LINE, Shopify, LoginRadius, Twilio, Clever, Eventbrite, GoClio, MailChimp, SurveyMonkey and Untappd backends.
- **Azure AD**: ID token signature, issuer, audience, tenant and policy claims are now validated against the OpenID configuration and JWKS.
- **OpenID Connect**: UserInfo responses whose `sub` does not match the validated ID token are rejected, ID tokens returned during token refresh are validated, and identity changes on refresh are refused.
- **SAML**: responses are validated against the original AuthnRequest, and a saved session is restored only after the response validates.
- **Partial pipeline**: resuming now requires session ownership or an explicit external resume confirmation.
- **PKCE**: defaults now match RFC 7636.
- Apple ID validates the token issuer, redirect URL validation was tightened, and JWT verification failures are now wrapped in social-core exceptions rather than escaping raw.

##### Behaviour worth knowing before merge

Two of those are strict enough to change what an existing deployment accepts, which is the point of them but is still a change:

- **Azure AD tokens accepted by 4.5.0 may now be rejected**, since signature, issuer, audience and tenant are checked where they previously were not. `AzureADOAuth2` and `AzureADTenantOAuth2` are both in `AUTHENTICATION_BACKENDS`.
- **`AUTH_EXTRA_ARGUMENTS` values are no longer overridden by request data** unless the key is listed in `AUTH_EXTRA_ARGUMENTS_OVERRIDE_ALLOWLIST`.

##### Nothing this repository uses was removed

5.0.0 and 4.9.0 dropped a number of discontinued backends: AppsFuel, Beats Music, ChangeTip, Clef, Edmodo, 500px, the legacy Google App Engine bundled Users backend, Jawbone, Moves, Mozilla Persona, Readability, Wunderlist, Google+ Sign-In, Rdio, Shimmering, ThisIsMyJam, and the OAuth1 backends for Douban and Mendeley. None appear in `awx/settings/defaults.py` or `awx/sso/fields.py`. Every backend Ascender does register still imports at 5.1.0, which I checked explicitly:

```
GoogleOAuth2, GithubOAuth2, GithubOrganizationOAuth2, GithubTeamOAuth2,
GithubEnterpriseOAuth2, GithubEnterpriseOrganizationOAuth2, GithubEnterpriseTeamOAuth2,
OpenIdConnectAuth, AzureADOAuth2, AzureADTenantOAuth2,
SAMLAuth, SAMLIdentityProvider, OID_USERID
ALL AUTHENTICATION_BACKENDS IMPORT OK
```

The last three are what `awx/sso/backends.py` subclasses for SAML. SAML support itself is unaffected: it comes from the `python3-saml` git requirement, not from a `social-auth-core` extra.

##### No new migrations

`social-auth-app-django` 5.6.0 and 6.0.1 both ship through `0017_usersocialauth_user_social_auth_uid_required`, so there is no schema change in this bump.

##### Note on `requests`

This lands `requests==2.34.2`, the same version #714 proposes. Whichever merges first, the other reduces to no change on that line.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this update before opening the pull request; it is not a resolver-only change.

The lockfile was produced the way `make requirements` produces it, inside the `ascender_devel` image:

```
requirements/updater.sh upgrade social-auth-core social-auth-app-django
```

A plain `updater.sh run` is not enough here and fails with `ResolutionImpossible`, because pip-compile honours the existing `social-auth-app-django==5.6.0` pin, which requires `social-auth-core~=4.4`. Both names have to be named on the upgrade for the pair to move.

Full suite, at the new pins, in a checkout linked with `make awx-link`:

```
py.test -p no:cacheprovider --create-db -n auto --dist=loadfile \
  awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

3817 passed, 10 skipped in 414.40s (0:06:54)
```

No failures. The SSO and settings tests, which are the ones that touch these packages, were also run on their own:

```
py.test awx/sso/tests awx/conf/tests
365 passed in 18.85s
```

And the check `make test` runs after pytest:

```
awx-manage check_migrations --dry-run --check -n missing_migration_file
No changes detected
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
