### PR TITLE
fix: use awx.__version__ in the SQL query profiler

### DIFF
--- a/awx/main/db/profiled_pg/base.py
+++ b/awx/main/db/profiled_pg/base.py
@@ -3,12 +3,12 @@ import sqlite3
 import sys
 import traceback
 import uuid
-from importlib.metadata import version as _get_version
 
 from django.core.cache import cache
 from django.core.cache.backends.locmem import LocMemCache
 from django.db.backends.postgresql.base import DatabaseWrapper as BaseDatabaseWrapper
 
+import awx
 from awx.main.utils import memoize
 
 __loc__ = LocMemCache(str(uuid.uuid4()), {})
@@ -70,7 +70,11 @@ class RecordedQueryLog(object):
             else:
                 progname = os.path.basename(sys.argv[0])
             filepath = os.path.join(self.dest, '{}.sqlite'.format(progname))
-            version = _get_version('awx')
+            # awx.__version__ is resolved once at import time and already falls
+            # back to the VERSION file when the package isn't pip installed;
+            # looking the distribution up again here would scan sys.path on
+            # every slow query, and raise in a plain source checkout
+            version = awx.__version__
             log = sqlite3.connect(filepath, timeout=3)
             log.execute(
                 'CREATE TABLE IF NOT EXISTS queries ('


### PR DESCRIPTION
##### SUMMARY

`RecordedQueryLog.write` looks the `awx` distribution up through `importlib.metadata` for every slow query it records. `awx/__init__.py` has already done that work at import time, and did it with a fallback:

```python
try:
    __version__ = _get_version('awx')
except PackageNotFoundError:
    __version__ = get_version()   # VERSION file, then setuptools_scm
```

This reuses that value instead of repeating the lookup. Two lines plus a comment.

##### It is wrong in a source checkout

`importlib.metadata.version('awx')` needs an installed distribution. In a checkout where `make awx-link` has not been run there is no `awx.egg-info`, the call raises `PackageNotFoundError`, and because `RecordedQueryLog.append` wraps `write` in a bare `except`, the profiler silently records nothing while printing a traceback per query:

```
  File "awx/main/db/profiled_pg/base.py", line 32, in append
    self.write(query)
  File "awx/main/db/profiled_pg/base.py", line 73, in write
    version = _get_version('awx')
  ...
    raise PackageNotFoundError(name)
```

A source checkout is exactly where someone turns `AWX_PROFILE_SQL` on, so the feature is broken in the case it is most likely to be used, and it fails without saying why: what you notice is a missing sqlite file, not a missing package.

`awx/main/tests/unit/test_db.py::test_sql_above_threshold` catches this today. It asserts `q['version'] == awx.__version__`, which is to say the test was written against the value this change now uses, and the call site drifted away from it.

##### It also costs something in production

The lookup is a `sys.path` scan, and it sits in the query path of a feature that fires per recorded query. Measured in the devel image:

```
importlib.metadata.version(awx):    169.9 us
awx.__version__                :      0.0 us
```

At a profiling threshold low enough to be interesting, that is 170 microseconds of directory scanning added to every captured query, to re-derive a constant.

##### Why it is safe

`awx` is already imported by the time this module loads, since the file imports `awx.main.utils`, so `import awx` adds no work and no import cycle. `awx.__version__` is a plain module attribute resolved once at interpreter start.

##### On the other test that fails in an unlinked checkout

`awx/main/tests/functional/test_credential.py::test_default_cred_types` fails alongside this one for the same underlying reason, and is deliberately **not** touched here. `setup.cfg` registers the ten external secret lookups as `awx.credential_plugins` entry points, so without an installed distribution `CredentialType.defaults` is short by `aim`, `aws_secretsmanager_credential`, `azure_kv`, `centrify_vault_kv`, `conjur`, `github_app_lookup`, `hashivault_kv`, `hashivault_ssh`, `thycotic_dsv` and `thycotic_tss`. Entry points are the intended mechanism there and `make awx-link` is the intended answer; there is nothing to fix in the tree.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

I tested this change before opening the pull request.

In a checkout with no `awx.egg-info`, which is the state the bug needs:

```
importlib.metadata.version(awx) -> PackageNotFoundError
awx.__version__                 -> 25.5.1

before (current main)   FAILED awx/main/tests/unit/test_db.py::test_sql_above_threshold
after  (this branch)    1 passed
```

The same test in a checkout linked with `make awx-link`, so the fix is not trading one state for the other:

```
1 passed
```

Full suite, on a freshly created database, linked:

```
py.test -p no:cacheprovider --create-db -n auto --dist=loadfile \
  awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

3817 passed, 10 skipped in 420.10s (0:07:00)
```

No failures. `black --check` and `flake8` are clean on the file.

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
