### PR TITLE
Fix the mobile nav toggle not working

### DIFF
--- a/awx/ui/src/components/AppContainer/AppContainer.js
+++ b/awx/ui/src/components/AppContainer/AppContainer.js
@@ -125,8 +125,12 @@ function AppContainer({ navRouteConfig = [], children }) {
 
   return (
     <>
+      {/* isManagedSidebar must be set from the very first render: Page only
+          attaches its resize observer in componentDidMount when the prop is
+          already true, and isSidebarVisible is false until the config loads.
+          Without it, the mobile nav toggle never works. */}
       <Page
-        isManagedSidebar={isSidebarVisible}
+        isManagedSidebar
         masthead={isSidebarVisible ? header : simpleHeader}
         sidebar={isSidebarVisible && sidebar}
       >


### PR DESCRIPTION
The hamburger button was dead because of a mount-timing bug between Ascender's config loading and PatternFly's Page component.

This resolves #735 