### PR TITLE
Attempt to resolve sporatic flickering of Follow button

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -977,8 +977,15 @@ function JobOutput({
     }
   };
 
-  const handleMouseDown = () => {
+  const handleMouseDown = (e) => {
     isPointerDown.current = true;
+    // Focus the container (it carries tabIndex={-1}) so subsequent
+    // PageUp/Home/ArrowUp keystrokes reach handleKeyDown. Without this,
+    // clicking the output leaves focus on <body>: Chromium still scrolls the
+    // container for those keys, but the keydown never targets it, so follow
+    // mode would stay on and snap the view back on the next event batch.
+    // preventScroll keeps the focus call from scrolling the container itself.
+    e.currentTarget.focus({ preventScroll: true });
   };
 
   // A scrollbar drag can end with the pointer outside the container, so the
@@ -1118,6 +1125,11 @@ function JobOutput({
           ) : (
             <ScrollContainer
               ref={parentRef}
+              // Programmatically focusable so handleMouseDown can direct
+              // keyboard-scroll keys here (see handleMouseDown); -1 keeps it
+              // out of the tab order (browsers that support keyboard-focusable
+              // scrollers already make it tabbable natively).
+              tabIndex={-1}
               onScroll={handleScroll}
               onWheel={handleWheel}
               onKeyDown={handleKeyDown}

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -1016,7 +1016,14 @@ function JobOutput({
       setIsFollowModeEnabled(false);
     }
     scrollTop.current = target.scrollTop;
-    if (target.scrollTop + target.clientHeight >= target.scrollHeight) {
+    // scrollHeight and clientHeight are rounded integers while scrollTop is
+    // fractional (the virtualizer's ResizeObserver row measurements make the
+    // content height sub-pixel), so a strict >= can miss the true bottom by
+    // under a pixel forever and never re-enable follow. Within 2px is
+    // visually at the bottom.
+    const distanceFromBottom =
+      target.scrollHeight - (target.scrollTop + target.clientHeight);
+    if (distanceFromBottom <= 2) {
       setIsFollowModeEnabled(true);
     }
   };

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -187,7 +187,10 @@ function JobOutput({
   const jobSocketCounter = useRef(0);
   const isMounted = useIsMounted();
   const scrollTop = useRef(0);
-  const scrollHeight = useRef(0);
+  // True while a pointer/touch gesture that can drag the scrollbar or pan the
+  // output is in progress — see the user-intent comment above handleScroll.
+  const isPointerDown = useRef(false);
+  const isTouchActive = useRef(false);
   const navigate = useNavigate();
   const eventByUuidRequests = useRef([]);
   const eventsProcessedDelay = useRef(250);
@@ -946,17 +949,66 @@ function JobOutput({
     setIsFollowModeEnabled(true);
   };
 
+  // Follow mode must only be disabled by a *user* upward scroll, but the
+  // scroll container also receives programmatic scrolls: scrollToEnd, and —
+  // more subtly — corrective scrolls from react-virtual, which imperatively
+  // scrolls up inside its ResizeObserver callback when a row above the
+  // viewport measures shorter than recorded. That correction lands before the
+  // inner div's height re-commits, so from inside a scroll event it is
+  // indistinguishable from the user scrolling up (scrollTop down, scrollHeight
+  // unchanged) and made the Follow button flicker on live output. So instead
+  // of inferring intent from scroll deltas alone, follow is only disabled by
+  // a real input gesture: wheel up, an upward-scrolling key, or an upward
+  // scroll while the pointer/touch is held down (scrollbar or touch drag).
+  const handleWheel = (e) => {
+    if (e.deltaY < 0) {
+      setIsFollowModeEnabled(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (
+      e.key === 'ArrowUp' ||
+      e.key === 'PageUp' ||
+      e.key === 'Home' ||
+      (e.key === ' ' && e.shiftKey)
+    ) {
+      setIsFollowModeEnabled(false);
+    }
+  };
+
+  const handleMouseDown = () => {
+    isPointerDown.current = true;
+  };
+
+  // A scrollbar drag can end with the pointer outside the container, so the
+  // matching mouseup is listened for on the window.
+  useEffect(() => {
+    const handleMouseUp = () => {
+      isPointerDown.current = false;
+    };
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => window.removeEventListener('mouseup', handleMouseUp);
+  }, []);
+
+  const handleTouchStart = () => {
+    isTouchActive.current = true;
+  };
+
+  const handleTouchEnd = () => {
+    isTouchActive.current = false;
+  };
+
   const handleScroll = (e) => {
     const target = e.currentTarget;
     if (
       isFollowModeEnabled &&
       scrollTop.current > target.scrollTop &&
-      scrollHeight.current === target.scrollHeight
+      (isPointerDown.current || isTouchActive.current)
     ) {
       setIsFollowModeEnabled(false);
     }
     scrollTop.current = target.scrollTop;
-    scrollHeight.current = target.scrollHeight;
     if (target.scrollTop + target.clientHeight >= target.scrollHeight) {
       setIsFollowModeEnabled(true);
     }
@@ -1067,6 +1119,12 @@ function JobOutput({
             <ScrollContainer
               ref={parentRef}
               onScroll={handleScroll}
+              onWheel={handleWheel}
+              onKeyDown={handleKeyDown}
+              onMouseDown={handleMouseDown}
+              onTouchStart={handleTouchStart}
+              onTouchEnd={handleTouchEnd}
+              onTouchCancel={handleTouchEnd}
               className="ascender-output-scroll"
             >
               {hasContentLoading ? (

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
@@ -229,21 +229,23 @@ describe('<JobOutput />', () => {
         screen.getByRole('button', { name: 'Unfollow' })
       ).toBeInTheDocument();
 
-      [{ key: 'ArrowUp' }, { key: 'Home' }, { key: ' ', shiftKey: true }].forEach(
-        (keyInit) => {
-          // Re-enable follow by returning to the bottom before each key.
-          scroller.scrollTop = 800;
-          fireEvent.scroll(scroller);
-          expect(
-            screen.getByRole('button', { name: 'Unfollow' })
-          ).toBeInTheDocument();
+      [
+        { key: 'ArrowUp' },
+        { key: 'Home' },
+        { key: ' ', shiftKey: true },
+      ].forEach((keyInit) => {
+        // Re-enable follow by returning to the bottom before each key.
+        scroller.scrollTop = 800;
+        fireEvent.scroll(scroller);
+        expect(
+          screen.getByRole('button', { name: 'Unfollow' })
+        ).toBeInTheDocument();
 
-          fireEvent.keyDown(scroller, keyInit);
-          expect(
-            screen.getByRole('button', { name: 'Follow' })
-          ).toBeInTheDocument();
-        }
-      );
+        fireEvent.keyDown(scroller, keyInit);
+        expect(
+          screen.getByRole('button', { name: 'Follow' })
+        ).toBeInTheDocument();
+      });
     });
 
     test('is disabled by an upward-scrolling key after clicking the output', async () => {

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  fireEvent,
   screen,
   waitFor,
   waitForElementToBeRemoved,
@@ -163,6 +164,107 @@ describe('<JobOutput />', () => {
     await waitFor(() =>
       expect(document.querySelector('.pf-v6-c-empty-state')).toBeInTheDocument()
     );
+  });
+
+  describe('follow mode', () => {
+    // Renders a running job (follow mode starts enabled → "Unfollow" button)
+    // and returns the scroll container with a scrollable geometry mocked in,
+    // scrolled to an established mid-output position.
+    async function renderFollowingJob() {
+      renderWithContexts(<JobOutput job={{ ...mockJob, status: 'running' }} />);
+      await waitForLoaded();
+      expect(
+        screen.getByRole('button', { name: 'Unfollow' })
+      ).toBeInTheDocument();
+
+      const scroller = document.querySelector('.ascender-output-scroll');
+      Object.defineProperty(scroller, 'clientHeight', {
+        configurable: true,
+        value: 200,
+      });
+      Object.defineProperty(scroller, 'scrollHeight', {
+        configurable: true,
+        value: 1000,
+      });
+      scroller.scrollTop = 500;
+      fireEvent.scroll(scroller);
+      return scroller;
+    }
+
+    test('is not disabled by a programmatic upward scroll', async () => {
+      const scroller = await renderFollowingJob();
+
+      // An upward scroll with no user gesture in progress — what the
+      // virtualizer's corrective ResizeObserver scrolls look like. Follow
+      // must survive it (this made the button flicker on live output).
+      scroller.scrollTop = 480;
+      fireEvent.scroll(scroller);
+
+      expect(
+        screen.getByRole('button', { name: 'Unfollow' })
+      ).toBeInTheDocument();
+    });
+
+    test('is disabled by scrolling up with the wheel', async () => {
+      const scroller = await renderFollowingJob();
+
+      fireEvent.wheel(scroller, { deltaY: -50 });
+
+      expect(
+        screen.getByRole('button', { name: 'Follow' })
+      ).toBeInTheDocument();
+    });
+
+    test('is disabled by an upward-scrolling key', async () => {
+      const scroller = await renderFollowingJob();
+
+      fireEvent.keyDown(scroller, { key: 'PageUp' });
+
+      expect(
+        screen.getByRole('button', { name: 'Follow' })
+      ).toBeInTheDocument();
+    });
+
+    test('is disabled by an upward scroll while the pointer is held down', async () => {
+      const scroller = await renderFollowingJob();
+
+      fireEvent.mouseDown(scroller);
+      scroller.scrollTop = 480;
+      fireEvent.scroll(scroller);
+
+      expect(
+        screen.getByRole('button', { name: 'Follow' })
+      ).toBeInTheDocument();
+    });
+
+    test('is not disabled by an upward scroll after the pointer is released', async () => {
+      const scroller = await renderFollowingJob();
+
+      fireEvent.mouseDown(scroller);
+      fireEvent.mouseUp(window);
+      scroller.scrollTop = 480;
+      fireEvent.scroll(scroller);
+
+      expect(
+        screen.getByRole('button', { name: 'Unfollow' })
+      ).toBeInTheDocument();
+    });
+
+    test('is re-enabled by scrolling to the bottom', async () => {
+      const scroller = await renderFollowingJob();
+
+      fireEvent.wheel(scroller, { deltaY: -50 });
+      expect(
+        screen.getByRole('button', { name: 'Follow' })
+      ).toBeInTheDocument();
+
+      scroller.scrollTop = 800;
+      fireEvent.scroll(scroller);
+
+      expect(
+        screen.getByRole('button', { name: 'Unfollow' })
+      ).toBeInTheDocument();
+    });
   });
 
   // computeOverscanIndices is the pure core of the selection-aware overscan

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
@@ -303,6 +303,31 @@ describe('<JobOutput />', () => {
         screen.getByRole('button', { name: 'Unfollow' })
       ).toBeInTheDocument();
     });
+
+    test('is re-enabled by reaching a fractional-pixel bottom', async () => {
+      const scroller = await renderFollowingJob();
+
+      fireEvent.wheel(scroller, { deltaY: -50 });
+      expect(
+        screen.getByRole('button', { name: 'Follow' })
+      ).toBeInTheDocument();
+
+      // Still meaningfully above the bottom: follow must stay off.
+      scroller.scrollTop = 780;
+      fireEvent.scroll(scroller);
+      expect(
+        screen.getByRole('button', { name: 'Follow' })
+      ).toBeInTheDocument();
+
+      // Browsers report fractional scrollTop against integer scrollHeight/
+      // clientHeight, so the true bottom can read as 0 < distance < 1px.
+      scroller.scrollTop = 799.5;
+      fireEvent.scroll(scroller);
+
+      expect(
+        screen.getByRole('button', { name: 'Unfollow' })
+      ).toBeInTheDocument();
+    });
   });
 
   // computeOverscanIndices is the pure core of the selection-aware overscan

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
@@ -215,10 +215,48 @@ describe('<JobOutput />', () => {
       ).toBeInTheDocument();
     });
 
-    test('is disabled by an upward-scrolling key', async () => {
+    // PageUp delivered through the real click→focus path is covered by the
+    // test above; this one focuses the container directly (as a keyboard user
+    // who tabbed to it would) and sweeps the remaining key bindings.
+    test('is disabled by each upward-scrolling key, not by downward ones', async () => {
+      const scroller = await renderFollowingJob();
+      scroller.focus();
+
+      // Downward-scrolling keys must not touch follow mode.
+      fireEvent.keyDown(scroller, { key: 'ArrowDown' });
+      fireEvent.keyDown(scroller, { key: 'End' });
+      expect(
+        screen.getByRole('button', { name: 'Unfollow' })
+      ).toBeInTheDocument();
+
+      [{ key: 'ArrowUp' }, { key: 'Home' }, { key: ' ', shiftKey: true }].forEach(
+        (keyInit) => {
+          // Re-enable follow by returning to the bottom before each key.
+          scroller.scrollTop = 800;
+          fireEvent.scroll(scroller);
+          expect(
+            screen.getByRole('button', { name: 'Unfollow' })
+          ).toBeInTheDocument();
+
+          fireEvent.keyDown(scroller, keyInit);
+          expect(
+            screen.getByRole('button', { name: 'Follow' })
+          ).toBeInTheDocument();
+        }
+      );
+    });
+
+    test('is disabled by an upward-scrolling key after clicking the output', async () => {
       const scroller = await renderFollowingJob();
 
-      fireEvent.keyDown(scroller, { key: 'PageUp' });
+      // Clicking the output must focus the scroll container, so that
+      // keyboard-scroll keys target it (and not <body>, which would scroll
+      // the container in Chromium without ever reaching handleKeyDown).
+      fireEvent.mouseDown(scroller);
+      expect(scroller).toHaveFocus();
+      fireEvent.mouseUp(window);
+
+      fireEvent.keyDown(document.activeElement, { key: 'PageUp' });
 
       expect(
         screen.getByRole('button', { name: 'Follow' })


### PR DESCRIPTION
##### SUMMARY
Occasionally (not always, couldn't reliably reproduce it) when you have a long running playbook and are watching the output, the **_Follow_** button will changes back and forth quickly from **_Follow_** to **_Unfollow_** and back again really fast.  It does this for every new event added to the output.

So we will change it so that follow mode is no longer disabled by inferring intent from scroll deltas (which couldn't distinguish the user from react-virtual's corrective ResizeObserver scrolls). It's now only disabled by real input gestures.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI


##### ASCENDER VERSION
25.5.1
