### PR TITLE
Build ARM64 images separately

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -57,10 +57,13 @@ jobs:
 #          echo ${{ secrets.QUAY_TOKEN }} | docker login quay.io -u ${{ secrets.QUAY_USER }} --password-stdin
 
       - name: Re-tag and promote awx image
+        # imagetools create re-tags the manifest list as-is, preserving all
+        # architectures; docker pull/tag/push would flatten it to the runner's
+        # architecture only.
         run: |
-          docker pull ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-          docker tag ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} ghcr.io/${{ github.repository }}:latest
-          docker push ghcr.io/${{ github.repository }}:latest
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository }}:latest \
+            ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
 
 #          docker pull ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
 #          docker tag ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -18,13 +18,24 @@ on:
         default: 'no'
 
 jobs:
-  stage:
+  # Build each architecture natively on its own runner. Building arm64 on an
+  # amd64 runner under QEMU emulation takes ~1.5 hours; natively it takes
+  # minutes. Each build pushes an arch-suffixed tag which the stage job below
+  # combines into a single multi-arch manifest.
+  build:
     if: endsWith(github.repository, '/ascender')
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     permissions:
       packages: write
-      contents: write
+      contents: read
     steps:
       - name: Verify inputs
         run: |
@@ -59,16 +70,15 @@ jobs:
       - name: Install playbook dependencies
         run: |
           python3 -m pip install docker==6.1.3 requests==2.31.0 --force-reinstall
-
-      - name: Set up QEMU for multi-arch builds
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
-        with:
-          platforms: arm64
+          # The arm64 runner image does not ship with ansible preinstalled
+          if ! command -v ansible-playbook > /dev/null 2>&1; then
+            python3 -m pip install ansible-core
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
-      - name: Build and stage Ascender
+      - name: Build and push Ascender (${{ matrix.arch }})
         working-directory: ascender
         run: |
           ansible-playbook -v tools/ansible/build.yml \
@@ -77,11 +87,48 @@ jobs:
             -e registry_password=${{ secrets.GITHUB_TOKEN }} \
             -e awx_image=${{ github.repository }} \
             -e awx_version=${{ github.event.inputs.version }} \
+            -e awx_image_tag=${{ github.event.inputs.version }}-${{ matrix.arch }} \
             -e ansible_python_interpreter=$(which python3) \
             -e push=yes \
+            -e tag_latest=no \
             -e awx_official=no \
-            -e "build_cache_from=type=gha,scope=${{ github.repository }}-release" \
-            -e "build_cache_to=type=gha,scope=${{ github.repository }}-release,mode=max"
+            -e build_platforms=linux/${{ matrix.arch }} \
+            -e "build_cache_from=type=gha,scope=${{ github.repository }}-release-${{ matrix.arch }}" \
+            -e "build_cache_to=type=gha,scope=${{ github.repository }}-release-${{ matrix.arch }},mode=max"
+
+  stage:
+    if: endsWith(github.repository, '/ascender')
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      packages: write
+      contents: write
+    steps:
+      - name: Checkout ascender
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          path: ascender
+
+      - name: Get python version from Makefile
+        run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
+
+      - name: Install python ${{ env.py_version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: ${{ env.py_version }}
+
+      - name: Log in to GHCR
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Combine per-arch images into a multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }} \
+            -t ghcr.io/${{ github.repository }}:latest \
+            ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-amd64 \
+            ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-arm64
 
       - name: Create draft release for Ascender
         working-directory: ascender
@@ -91,4 +138,3 @@ jobs:
             -e awx_image=ghcr.io/${{ github.repository }} \
             -e version=${{ github.event.inputs.version }} \
             -e github_token=${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -70,9 +70,11 @@ jobs:
       - name: Install playbook dependencies
         run: |
           python3 -m pip install docker==6.1.3 requests==2.31.0 --force-reinstall
-          # The arm64 runner image does not ship with ansible preinstalled
+          # The arm64 runner image does not ship with ansible preinstalled.
+          # Constrained to the same tested minor series as the other CI
+          # scripts (see .github/actions/awx_devel_image/action.yml).
           if ! command -v ansible-playbook > /dev/null 2>&1; then
-            python3 -m pip install ansible-core
+            python3 -m pip install 'ansible-core~=2.21.0'
           fi
 
       - name: Set up Docker Buildx
@@ -122,11 +124,12 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      # :latest is intentionally not tagged here; promote.yml moves it when
+      # the release is actually published.
       - name: Combine per-arch images into a multi-arch manifest
         run: |
           docker buildx imagetools create \
             -t ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }} \
-            -t ghcr.io/${{ github.repository }}:latest \
             ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-amd64 \
             ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }}-arm64
 

--- a/tools/ansible/roles/image_build/defaults/main.yml
+++ b/tools/ansible/roles/image_build/defaults/main.yml
@@ -3,6 +3,7 @@ awx_image: ansible/awx
 awx_image_tag: "{{ awx_docker_version }}"
 dockerfile_name: 'Dockerfile'
 headless: no
+tag_latest: yes
 build_platforms: "linux/amd64,linux/arm64"
 build_cache_from: ""
 build_cache_to: ""

--- a/tools/ansible/roles/image_build/tasks/main.yml
+++ b/tools/ansible/roles/image_build/tasks/main.yml
@@ -28,7 +28,7 @@
     command_to_run: >-
       docker buildx build
       -t {{ _image_ref }}:{{ awx_image_tag }}
-      {{ ('-t ' + _image_ref + ':latest') if (push | default(false) | bool) else '' }}
+      {{ ('-t ' + _image_ref + ':latest') if ((push | default(false) | bool) and (tag_latest | default(true) | bool)) else '' }}
       -f {{ dockerfile_name }}
       --build-arg VERSION={{ awx_version }}
       --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{ awx_version }}


### PR DESCRIPTION
When building the production images, we build both amd64 and arm64.  The amd64 image takes ~6 minutes to build, while the arm64 image adds over an hour of time.  By moving to building each image in their native environment concurrently, we can reduce this time significantly.

We can not tag latest though, as each arch would clobber each other.  So instead we build and then retag during the promotion.