### PR TITLE
build: bump azure-keyvault-secrets from 4.11.1 to 4.11.2 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -45,7 +45,7 @@ azure-core==1.38.0
     #   azure-keyvault-secrets
 azure-identity==1.25.3
     # via -r /awx_devel/requirements/requirements.in
-azure-keyvault-secrets==4.11.1
+azure-keyvault-secrets==4.11.2
     # via -r /awx_devel/requirements/requirements.in
 boto3==1.43.78
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY

Bumps `azure-keyvault-secrets` from `4.11.1` to `4.11.2` in `requirements/requirements.txt`. It reads the Azure Key Vault credential plugin's secrets.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade azure-keyvault-secrets
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `azure-keyvault-secrets 4.11.2` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 11.51s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
