### PR TITLE
build: bump gitpython from 3.1.59 to 3.1.60 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -165,7 +165,7 @@ frozenlist==1.4.1
     #   aiosignal
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.59
+gitpython==3.1.60
     # via -r /awx_devel/requirements/requirements.in
 hyperlink==21.0.0
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `gitpython` from `3.1.59` to `3.1.60` in `requirements/requirements.txt`. It backs the project sync's git operations.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade gitpython
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `gitpython 3.1.60` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 11.33s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
