### PR TITLE
build: bump msal from 1.37.0 to 1.38.0 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -244,7 +244,7 @@ more-itertools==10.2.0
     #   irc
     #   jaraco-functools
     #   jaraco-text
-msal==1.37.0
+msal==1.38.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   azure-identity


### PR DESCRIPTION
##### SUMMARY

Bumps `msal` from `1.37.0` to `1.38.0` in `requirements/requirements.txt`. It handles the Azure AD token flow behind the Azure credential plugins.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade msal
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `msal 1.38.0` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 10.19s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
