### PR TITLE
build: bump boto3 from 1.43.78 to 1.43.80 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -47,9 +47,9 @@ azure-identity==1.25.3
     # via -r /awx_devel/requirements/requirements.in
 azure-keyvault-secrets==4.11.1
     # via -r /awx_devel/requirements/requirements.in
-boto3==1.43.78
+boto3==1.43.80
     # via -r /awx_devel/requirements/requirements.in
-botocore==1.43.78
+botocore==1.43.80
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   boto3


### PR DESCRIPTION
##### SUMMARY

Bumps `boto3` from `1.43.78` to `1.43.80` in `requirements/requirements.txt`. It drives the AWS credential plugin and the S3 backup paths.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade boto3 botocore s3transfer
```

run inside the `ascender_devel` image, which is where that script insists on running. botocore has to be named alongside it: both are direct entries in `requirements.in`, and boto3 1.43.80 requires botocore 1.43.80, so upgrading boto3 on its own is a no-op. The result is 2 added / 2 removed in the lockfile; s3transfer was already current.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `boto3 1.43.80` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 10.43s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
