### PR TITLE
build: bump receptorctl from 1.6.2 to 1.6.7 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -362,7 +362,7 @@ pyyaml==6.0.3
     #   drf-spectacular
     #   kubernetes
     #   receptorctl
-receptorctl==1.6.2
+receptorctl==1.6.4
     # via -r /awx_devel/requirements/requirements.in
 referencing==0.33.0
     # via


### PR DESCRIPTION
##### SUMMARY

Bumps `receptorctl` from `1.6.2` to `1.6.7` in `requirements/requirements.txt`. It is the client the task system uses to talk to the receptor mesh.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade receptorctl
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `receptorctl 1.6.7` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 10.65s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
