### PR TITLE
build: bump django-guid from 3.5.2 to 3.6.1 in /requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -19,7 +19,7 @@ django>=5.2.17,<6.0 # CVE-2026-15307 CVE-2026-15830; <6.0 also enforced by djang
 django-auth-ldap
 django-cors-headers
 django-extensions==4.1
-django-guid==3.5.2
+django-guid==3.6.1
 django-oauth-toolkit>=3.3.0
 django-polymorphic
 django-pglocks

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -126,7 +126,7 @@ django-crum==0.7.9
     # via django-ansible-base
 django-extensions==4.1
     # via -r /awx_devel/requirements/requirements.in
-django-guid==3.5.2
+django-guid==3.6.1
     # via -r /awx_devel/requirements/requirements.in
 django-oauth-toolkit==3.3.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY

Bumps `django-guid` from `3.5.2` to `3.6.1` in `requirements/requirements.txt`. It stamps the correlation ID that ties a request's log lines together.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
# requirements.in:  django-guid==3.5.2  ->  django-guid==3.6.1
requirements/updater.sh run
```

run inside the `ascender_devel` image, which is where that script insists on running. This one is pinned with `==` in `requirements.in`, so `upgrade` cannot move it: the pin is edited first and `run` recompiles against it. The result is 1 added / 1 removed in each of the two files.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `django-guid 3.6.1` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 10.36s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
