### PR TITLE
build: bump packaging from 24.2 to 26.3 in /requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -40,7 +40,7 @@ jsonschema
 Markdown>=3.8.1  # CVE-2025-69534 # used for formatting API help
 msal>=1.37.0  # cryptography>=49 compatibility (msal<1.37 caps cryptography<49)
 openshift
-packaging==24.2
+packaging==26.3
 pexpect==4.7.0  # see library notes
 prometheus-client
 psycopg

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -266,7 +266,7 @@ oauthlib==3.3.1
     #   social-auth-core
 openshift==0.13.2
     # via -r /awx_devel/requirements/requirements.in
-packaging==24.2
+packaging==26.3
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   ansible-runner


### PR DESCRIPTION
##### SUMMARY

Bumps `packaging` from `24.2` to `26.3` in `requirements/requirements.txt`. It parses versions and specifiers across the dependency and plugin code.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
# requirements.in:  packaging==24.2  ->  packaging==26.3
requirements/updater.sh run
```

run inside the `ascender_devel` image, which is where that script insists on running. Pinned with `==` in `requirements.in`, so `upgrade` cannot move it: the pin is edited first and `run` recompiles against it. The result is 1 added / 1 removed in each of the two files.

Worth a second opinion before merging: the pin carries no comment and no linked issue, unlike its neighbours which all explain themselves (`cryptography>=50.0.0  # CVE-2026-69247`, `setuptools==83.0.0  # CVE-2026-59890`). 24.2 is from late 2024, and `/docs/docsite` already moved its own copy to 26.3 in #701, so the two trees disagree today. If the pin exists for a reason that predates this repository, this is the pull request to record it on, and I will close it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `packaging 26.3` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 12.00s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
