### PR TITLE
build: bump importlib-metadata from 4.6.4 to 9.0.0 in /requirements

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,7 @@ djangorestframework>=3.17.2 # CVE-2026-73228 CVE-2026-73229
 djangorestframework-yaml
 filelock
 GitPython>=3.1.58  # GHSA-hh9p-6wh2-4mfc GHSA-9rj7-rf2p-w77r GHSA-4gmw-gg2m-w46p GHSA-hmq2-w58f-27jc GHSA-wvpp-8hx9-p66j GHSA-jm78-9fvv-mhgr
-importlib-metadata==4.6.4
+importlib-metadata==9.0.0
 inflection  # used by vendored awx/dab (formerly a django-ansible-base dep)
 irc
 jaraco.functools>= 4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -170,7 +170,7 @@ idna==3.15
     #   requests
     #   twisted
     #   yarl
-importlib-metadata==4.6.4
+importlib-metadata==9.0.0
     # via -r /awx_devel/requirements/requirements.in
 incremental==24.7.2
     # via twisted


### PR DESCRIPTION
##### SUMMARY

Bumps `importlib-metadata` from `4.6.4` to `9.0.0` in `requirements/requirements.txt`. It reads installed distribution metadata; the collection and plugin loaders use it.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
# requirements.in:  importlib-metadata==4.6.4  ->  importlib-metadata==9.0.0
requirements/updater.sh run
```

run inside the `ascender_devel` image, which is where that script insists on running. Pinned with `==` in `requirements.in`, so `upgrade` cannot move it: the pin is edited first and `run` recompiles against it. The result is 1 added / 1 removed in each of the two files.

This is the largest jump in the set and the pin is the oldest: 4.6.4 is from 2021, and like `packaging==24.2` it carries no comment saying why. The unit suite passes on 9.0.0, but that only covers the import paths those tests reach, so this one deserves a closer look than the patch bumps beside it. Happy to close it if the pin turns out to be load-bearing for something the tests do not touch.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `importlib-metadata 9.0.0` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 10.94s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
