### PR TITLE
build: bump wheel from 0.46.3 to 0.48.0 in /requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==26.2.1 setuptools==83.0.0 setuptools_scm[toml]==9.2.2 wheel==0.46.2
+VENV_BOOTSTRAP ?= pip==26.2.1 setuptools==83.0.0 setuptools_scm[toml]==9.2.2 wheel==0.48.0
 
 NAME ?= awx
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -465,7 +465,7 @@ valkey[libvalkey]==6.1.1
     #   django-valkey
 websocket-client==1.7.0
     # via kubernetes
-wheel==0.46.3
+wheel==0.48.0
     # via -r /awx_devel/requirements/requirements.in
 xmlsec==1.3.17
     # via python3-saml


### PR DESCRIPTION
##### SUMMARY

Bumps `wheel` from `0.46.3` to `0.48.0` in `requirements/requirements.txt`. It builds the wheels the image installs.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
requirements/updater.sh upgrade wheel
```

run inside the `ascender_devel` image, which is where that script insists on running. The result is 1 added / 1 removed in the lockfile.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `wheel 0.48.0` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 11.85s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
