### PR TITLE
build: bump setuptools from 83.0.0 to 84.0.0 in /requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==26.2.1 setuptools==83.0.0 setuptools_scm[toml]==9.2.2 wheel==0.48.0
+VENV_BOOTSTRAP ?= pip==26.2.1 setuptools==84.0.0 setuptools_scm[toml]==9.2.2 wheel==0.48.0
 
 NAME ?= awx
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -71,7 +71,7 @@ uWSGI>=2.0.22 # CVE-2023-27522
 valkey[libvalkey]
 wheel>=0.46.2  # CVE-2026-24049
 pip==26.2.1  # CVE-2026-13346
-setuptools==83.0.0  # CVE-2026-59890
+setuptools==84.0.0  # CVE-2026-59890
 setuptools-scm[toml]  # see UPGRADE BLOCKERs, xmlsec build dep
 setuptools-rust>=0.11.4  # cryptography build dep
 pkgconfig>=1.5.1  # xmlsec build dep - needed for offline build

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -479,7 +479,7 @@ zope-interface==7.0.3
 # The following packages are considered to be unsafe in a requirements file:
 pip==26.2.1
     # via -r /awx_devel/requirements/requirements.in
-setuptools==83.0.0
+setuptools==84.0.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   asciichartpy

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -23,7 +23,7 @@ generate_requirements() {
   source "${venv}/bin/activate"
 
   # pip / setuptools version must match the version used in AWX venv (see README.md UPGRADE BLOCKERs)
-  "${venv}/bin/python3" -m pip install -U 'pip==26.2.1' 'setuptools==83.0.0' pip-tools
+  "${venv}/bin/python3" -m pip install -U 'pip==26.2.1' 'setuptools==84.0.0' pip-tools
 
   ${pip_compile} ${input_reqs} --output-file requirements.txt
   # consider the git requirements for purposes of resolving deps


### PR DESCRIPTION
##### SUMMARY

Bumps `setuptools` from `83.0.0` to `84.0.0` in `requirements/requirements.txt`. It is the build backend the image uses for every source distribution it installs.

The Python requirements are outside Dependabot's scope on purpose: #675 turned on version updates for github-actions and for npm in `/awx/ui` and left this file out, because it is compiled by `requirements/updater.sh` rather than hand-pinned. So this was produced the same way `make requirements` produces it:

```
# requirements.in:  setuptools==83.0.0  ->  setuptools==84.0.0   (comment kept)
requirements/updater.sh run
```

run inside the `ascender_devel` image, which is where that script insists on running. Pinned with `==` in `requirements.in`, so `upgrade` cannot move it: the pin is edited first and `run` recompiles against it. The result is 1 added / 1 removed in each of the two files.

The `# CVE-2026-59890` comment is deliberately kept on the pin. 83.0.0 is where that fix landed, so 84.0.0 stays above it and the reason for pinning still reads true; the comment would only be wrong if the pin ever moved down.

Like the other build-toolchain bumps in this batch, the unit suite passing says less here than it does for a library: setuptools is exercised when the image builds a source distribution, not by the tests. The real check is a green image build, which happens once the workflow is approved on this fork pull request.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.1
```

## Tests

Tested before opening, in the same image, with `setuptools 84.0.0` installed into the AWX venv:

```
py.test awx/main/tests/unit awx/conf/tests/unit awx/sso/tests/unit
  1404 passed, 1 skipped in 12.84s
```

CI does not run on pull requests from a fork until a maintainer approves the workflow, so this is what stands behind the change until then.
