### PR TITLE
Fix broken psycopg after upgrade

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -1,6 +1,5 @@
 import os
 import psycopg
-import select
 
 from contextlib import contextmanager
 
@@ -8,8 +7,6 @@ from awx.settings.application_name import get_application_name
 
 from django.conf import settings
 from django.db import connection as pg_connection
-
-NOT_READY = ([], [], [])
 
 
 def get_local_queuename():
@@ -59,35 +56,23 @@ class PubSub(object):
         with self.conn.cursor() as cur:
             cur.execute('SELECT pg_notify(%s, %s);', (channel, payload))
 
-    @staticmethod
-    def current_notifies(conn):
-        """
-        Altered version of .notifies method from psycopg library
-        This removes the outer while True loop so that we only process
-        queued notifications
-        """
-        with conn.lock:
-            try:
-                ns = conn.wait(psycopg.generators.notifies(conn.pgconn))
-            except psycopg.errors._NO_TRACEBACK as ex:
-                raise ex.with_traceback(None)
-        enc = psycopg._encodings.pgconn_encoding(conn.pgconn)
-        for pgn in ns:
-            n = psycopg.connection.Notify(pgn.relname.decode(enc), pgn.extra.decode(enc), pgn.be_pid)
-            yield n
-
     def events(self, yield_timeouts=False):
         if not self.conn.autocommit:
             raise RuntimeError('Listening for events can only be done in autocommit mode')
 
         while True:
-            if select.select([self.conn], [], [], self.select_timeout) == NOT_READY:
-                if yield_timeouts:
-                    yield None
-            else:
-                notification_generator = self.current_notifies(self.conn)
-                for notification in notification_generator:
-                    yield notification
+            got_events = False
+            # notifies() first drains the connection's notification backlog
+            # (notifications psycopg consumed while other queries ran, which
+            # a socket select would never wake for), then waits up to timeout
+            # for more; stop_after=1 returns after the first new batch so
+            # select_timeout, which callers adjust in-loop, is re-read
+            # between batches
+            for notification in self.conn.notifies(timeout=self.select_timeout, stop_after=1):
+                got_events = True
+                yield notification
+            if yield_timeouts and not got_events:
+                yield None
 
     def close(self):
         self.conn.close()


### PR DESCRIPTION
The upgrade to psycopg in #729 broke the container startup.  

**init.py** contained a hand-copied version of psycopg's internal notification loop. psycopg 3.2 renamed the private helper it used (**_encodings.pgconn_encoding > conn_encoding**), which is what crashed, but digging in revealed the copied loop had two worse problems under 3.2+, so I replaced it with the public API instead of just renaming the call.

Why the copy existed, and why it's now unnecessary: AWX copied the loop to get "process only queued notifications, don't block forever." psycopg 3.2 added **timeout=** and **stop_after=** to the **public Connection.notifies()**, which provides exactly that.

What the copied loop would have broken under 3.3.4 even with a rename fix (both verified experimentally):

* **Unbounded memory leak** - every psycopg 3.2+ connection installs a notify handler that copies each received notification into an internal conn._notifies_backlog deque. The raw-pgconn loop never drains it, so the long-running dispatcher listener would accumulate one Notify object per message forever. (**Upstream AWX devel "fixed" this crash with conn.pgconn._encoding and still has this leak**.)

* **Lost notifications** - a notification consumed while any other query runs on the same connection (e.g. a fast control_with_reply reply arriving during the pg_notify round-trip) lands only in that backlog, the socket stays quiet, and the old select.select loop never wakes to deliver it — so awx-manage control commands could falsely time out.

The change (net −15 lines): events() now loops on self.conn.notifies(timeout=self.select_timeout, stop_after=1) — it drains the backlog first, waits up to the timeout for the first new batch, and returns between batches so the dispatcher's in-loop select_timeout adjustments ([base.py:247](vscode-webview://12jj7jki7c4mg4h4q1r8fhg1mr4lb00bhb6h402sinjiimhjoeia/awx/main/dispatch/worker/base.py#L247)) still take effect. current_notifies(), the select import, and NOT_READY are gone; no other private psycopg API usage remains in the repo.