### PR TITLE
docs: Clean up references

### DIFF
--- a/docs/docsite/rst/userguide/ee_reference.rst
+++ b/docs/docsite/rst/userguide/ee_reference.rst
@@ -8,9 +8,7 @@ refer to the `Ansible Builder documentation <https://ansible.readthedocs.io/proj
 Default execution environment for Ascender
 -------------------------------------------
 
-The example in ``test/data/pytz`` requires the ``awx.awx`` collection in the |ee| definition. The lookup plugin ``awx.awx.tower_schedule_rrule`` requires the PyPI ``pytz`` and another library to work. If ``test/data/pytz/execution-environment.yml`` file is provided to the ``ansible-builder build`` command, then it will install the collection inside the image, read the ``requirements.txt`` file inside of the collection, and then install ``pytz`` into the image.
-
-The image produced can be used inside of an ``ansible-runner`` project by placing these variables inside the ``env/settings`` file, inside of the private data directory.
+An |ee| image can be used inside of an ``ansible-runner`` project by placing these variables inside the ``env/settings`` file, inside of the private data directory.
 
 ::
 
@@ -19,4 +17,4 @@ The image produced can be used inside of an ``ansible-runner`` project by placin
 	process_isolation_executable: podman # or docker
 	process_isolation: true
 
-The ``awx.awx`` collection is a subset of content included in the default Ascender |ee|. More details can be found in the `awx-ee repository <https://github.com/ansible/awx-ee>`_.
+The ``ctrliq.ascender`` collection is a subset of content included in the default Ascender |ee|. More details can be found in the `ascender-ee repository <https://github.com/ctrliq/ascender-ee>`_.

--- a/docs/docsite/rst/userguide/inventory_plugins_templates.rst
+++ b/docs/docsite/rst/userguide/inventory_plugins_templates.rst
@@ -390,5 +390,5 @@ Red Hat Ansible Automation Platform
 
 	include_metadata: true
 	inventory_id: <inventory_id or url_quoted_named_url>
-	plugin: awx.awx.tower
+	plugin: awx.awx.controller
 	validate_certs: <true or false>

--- a/docs/docsite/rst/userguide/overview.rst
+++ b/docs/docsite/rst/userguide/overview.rst
@@ -279,7 +279,7 @@ Updated Ascender to use the following inventory plugins from upstream collection
 - theforeman.foreman.foreman
 - openstack.cloud.openstack
 - ovirt.ovirt.ovirt
-- awx.awx.tower
+- awx.awx.controller
 
 
 Secret Management System

--- a/docs/inventory/inventory_plugins.md
+++ b/docs/inventory/inventory_plugins.md
@@ -4,13 +4,10 @@ For cloud inventory sources (such as ec2, gce, etc.) inventory updates changed f
 
 Regardless of whether Ansible 2.9 or later is used, Ascender should use the inventory plugin from the collection inside of the execution environment where the inventory update runs. The needed collections are in the Ascender default execution environment:
 
-https://github.com/ansible/awx-ee
-
-
+https://github.com/ctrliq/ascender-ee
 ### Switch to Ansible Inventory
 
 The CLI entry point `ansible-inventory` was introduced in Ansible 2.4. Inventory imports run this command as an intermediary between the inventory and the import's logic to save content to the database. Using `ansible-inventory` eliminates the need to maintain source-specific logic, relying on Ansible's code instead. This also enables consistent data structure output from `ansible-inventory`.
-
 
 ## Writing Your Own Inventory File
 


### PR DESCRIPTION
##### SUMMARY

Fixes stale collection and plugin references in the docs: `awx.awx.tower` becomes `awx.awx.controller` where the docs describe generated inventory output, `ee_reference.rst` moves to `ctrliq.ascender`, and two `ansible/awx-ee` links now point at `ctrliq/ascender-ee`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### ASCENDER VERSION
```
25.5.2.dev108+gc3c2e51c0
```
