### PR TITLE
Start social auth logins with a POST form

### DIFF
--- a/awx/ui/src/api/Base.js
+++ b/awx/ui/src/api/Base.js
@@ -8,7 +8,7 @@ const updateStorage = debounce((key, val) => {
   window.dispatchEvent(new Event('storage'));
 }, 500);
 
-function getCookie(name) {
+export function getCookie(name) {
   const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
   return match ? decodeURIComponent(match[1]) : null;
 }

--- a/awx/ui/src/screens/Login/Login.js
+++ b/awx/ui/src/screens/Login/Login.js
@@ -29,6 +29,7 @@ import {
 } from '@patternfly/react-icons';
 import useRequest, { useDismissableError } from 'hooks/useRequest';
 import { AuthAPI, RootAPI, MeAPI } from 'api';
+import { getCookie } from 'api/Base';
 import { useSession } from 'contexts/Session';
 import { applyTheme, getSavedThemeId, clearSessionTheme } from 'themeRegistry';
 import LoadingSpinner from 'components/LoadingSpinner';
@@ -170,6 +171,22 @@ function AWXLogin({ alt, isAuthenticated }) {
 
   const setSessionRedirect = () => {
     window.sessionStorage.setItem(SESSION_REDIRECT_URL, authRedirectTo);
+  };
+
+  // social-auth-app-django 6.x only accepts POST on the login-initiation
+  // view, so navigate there with a CSRF-carrying form rather than a link.
+  const startSocialLogin = (loginUrl) => {
+    setSessionRedirect();
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = loginUrl;
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'csrfmiddlewaretoken';
+    input.value = getCookie('csrftoken') ?? '';
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
   };
 
   const socialAuthProviders = {
@@ -318,11 +335,11 @@ function AWXLogin({ alt, isAuthenticated }) {
                 key={authKey}
                 data-cy={dataCy}
                 variant="secondary"
-                component="a"
-                href={socialAuthOptions[authKey].login_url}
                 isBlock
                 icon={<Icon />}
-                onClick={setSessionRedirect}
+                onClick={() =>
+                  startSocialLogin(socialAuthOptions[authKey].login_url)
+                }
               >
                 {label}
               </Button>

--- a/awx/ui/src/screens/Login/Login.test.js
+++ b/awx/ui/src/screens/Login/Login.test.js
@@ -396,6 +396,42 @@ describe('<Login />', () => {
     ).toHaveLength(0);
   });
 
+  test('social auth button starts login with a POSTed form', async () => {
+    AuthAPI.read.mockResolvedValue({
+      data: {
+        'azuread-oauth2': {
+          login_url: '/sso/login/azuread-oauth2/',
+          complete_url: 'https://localhost:8043/sso/complete/azuread-oauth2/',
+        },
+      },
+    });
+    document.cookie = 'csrftoken=TESTTOKEN';
+    const submit = jest
+      .spyOn(HTMLFormElement.prototype, 'submit')
+      .mockImplementation(() => {});
+
+    const { container } = renderWithContexts(
+      <AWXLogin isAuthenticated={() => false} />
+    );
+    await waitForLoginForm(container);
+    const button = await waitFor(() =>
+      container.querySelector('[data-cy="social-auth-azure"]')
+    );
+    button.click();
+
+    const form = document.querySelector(
+      'form[action="/sso/login/azuread-oauth2/"]'
+    );
+    expect(form).not.toBeNull();
+    expect(form.method).toEqual('post');
+    expect(
+      form.querySelector('input[name="csrfmiddlewaretoken"]').value
+    ).toEqual('TESTTOKEN');
+    expect(submit).toHaveBeenCalled();
+    submit.mockRestore();
+    form.remove();
+  });
+
   test('SAML auth buttons shown', async () => {
     AuthAPI.read.mockResolvedValue({
       data: {


### PR DESCRIPTION
##### SUMMARY
social-auth-app-django 6.0.1 (bumped in #731) decorates the login-initiation view with require_POST, but the login page still rendered each provider button as a plain link. Every SSO click got a 405 and no social provider could log in. Related #783.

The buttons now start the login by submitting a hidden form that carries `csrfmiddlewaretoken`, which is what social-app-django expects since its 5.5.0 login-CSRF hardening (an anonymous GET must no longer be able to start an SSO flow). The POST is a full page navigation rather than a fetch so the 302 out to the identity provider still works. `getCookie` already existed in `api/Base.js`, it is now exported and reused rather than duplicated.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### ASCENDER VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
25.6.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Reproduced on a 25.6.0 k8s install with Azure AD: clicking the SSO button
gives `HTTP 405, allow: POST`, and the web pod logs
`django.request Method Not Allowed (GET): /sso/login/azuread-oauth2/`.

Verified the POST path against the same live instance before patching:

```
$ curl -sc cj.txt https://<host>/api/login/ -o /dev/null
$ curl -sb cj.txt -X POST -H 'Referer: https://<host>/' --data-urlencode "csrfmiddlewaretoken=<token from cookie>" -o /dev/null -w '%{http_code} %{redirect_url}\n' https://<host>/sso/login/azuread-oauth2/ 
302 https://login.microsoftonline.com/common/oauth2/authorize?...&redirect_uri=https://<host>/sso/complete/azuread-oauth2/&...
```

The Login jest suite passes (18 tests), including a new test asserting the click submits a POST form containing the CSRF token.