### PR TITLE
Upstream 16620 - fix: check if the lock was acquired and return if not

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -504,7 +504,11 @@ def inspect_established_receptor_connections(mesh_status):
 
 
 def inspect_execution_and_hop_nodes(instance_list):
-    with advisory_lock('inspect_execution_and_hop_nodes_lock', wait=False):
+    with advisory_lock('inspect_execution_and_hop_nodes_lock', wait=False) as acquired:
+        if not acquired:
+            logger.debug("Not running inspect_execution_and_hop_nodes, another instance holds lock")
+            return
+
         node_lookup = {inst.hostname: inst for inst in instance_list}
         ctl = get_receptor_ctl()
         mesh_status = ctl.simple_command('status')

--- a/awx/main/tests/unit/tasks/test_system.py
+++ b/awx/main/tests/unit/tasks/test_system.py
@@ -2,7 +2,7 @@ import pytest
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
-from awx.main.tasks.system import awx_periodic_scheduler, update_inventory_computed_fields
+from awx.main.tasks.system import awx_periodic_scheduler, inspect_execution_and_hop_nodes, update_inventory_computed_fields
 from awx.main.models import Inventory
 from django.db import DatabaseError
 
@@ -85,3 +85,32 @@ def test_awx_periodic_scheduler_skips_schedule_processing_when_all_schedules_dis
     assert state.schedule_last_run == run_now
     state.save.assert_called_once_with()
     mock_enabled.assert_not_called()
+
+
+class TestInspectExecutionAndHopNodes:
+    """The advisory lock guard in inspect_execution_and_hop_nodes."""
+
+    @patch("awx.main.tasks.system.inspect_established_receptor_connections")
+    @patch("awx.main.tasks.system.get_receptor_ctl")
+    @patch("awx.main.tasks.system.advisory_lock")
+    def test_skips_when_lock_not_acquired(self, mock_lock, mock_get_ctl, mock_inspect_conns):
+        mock_lock.return_value.__enter__ = MagicMock(return_value=False)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+
+        inspect_execution_and_hop_nodes([])
+
+        mock_get_ctl.assert_not_called()
+        mock_inspect_conns.assert_not_called()
+
+    @patch("awx.main.tasks.system.inspect_established_receptor_connections")
+    @patch("awx.main.tasks.system.get_receptor_ctl")
+    @patch("awx.main.tasks.system.advisory_lock")
+    def test_runs_when_lock_acquired(self, mock_lock, mock_get_ctl, mock_inspect_conns):
+        mock_lock.return_value.__enter__ = MagicMock(return_value=True)
+        mock_lock.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_ctl.return_value.simple_command.return_value = {"Advertisements": [], "KnownConnectionCosts": {}}
+
+        inspect_execution_and_hop_nodes([])
+
+        mock_get_ctl.return_value.simple_command.assert_called_once_with("status")
+        mock_inspect_conns.assert_called_once()


### PR DESCRIPTION
Port of [ansible/awx@3917f3bf7](https://github.com/ansible/awx/commit/3917f3bf7) (ansible/awx#16620).

## The problem

`advisory_lock` in `awx/main/utils/pglock.py` wraps `django_pg_utils.locks.advisory_lock`, which runs `pg_try_advisory_lock` when `wait=False`, then yields the result and executes the body regardless:

```python
cursor.execute(sql, params)
acquired = cursor.fetchone()[0]
...
yield acquired
finally:
    if acquired: ...
```

`inspect_execution_and_hop_nodes` opened the lock without binding the yielded value, so it never skipped anything. `cluster_node_heartbeat` calls it on every control node, which means the full receptor status sweep and the `last_seen` writes ran on all of them concurrently, with no mutual exclusion.

Every other `wait=False` call site in the tree already gets this right: `json_migration_*` and `awx_periodic_scheduler` in the same module, `gather_analytics` in `awx/main/analytics/core.py`, and the task manager. This was the only one that did not.

## The change

Bind the yielded value and return early when the lock is held elsewhere, matching the surrounding call sites.

The timing and counter logging that upstream added in the same commit is deliberately left out, since it is diagnostics rather than the fix.

## Testing

Two unit tests in `awx/main/tests/unit/tasks/test_system.py`, adapted from upstream: the receptor controller is never reached when the lock is not acquired, and the sweep still runs when it is. Upstream passes `receptor_ctl` in as an argument, whereas this function calls `get_receptor_ctl()` itself, so the tests patch that instead.

`black --check awx` and `flake8 awx` pass.