### PR TITLE
Upstream 16477 - Prevent Execution Instances to be Added to the Control Plane

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -202,12 +202,17 @@ def apply_cluster_membership_policies():
         # Process policy instance list first, these will represent manually managed memberships
         instance_hostnames_map = {inst.hostname: inst for inst in all_instances}
         for ig in all_groups:
+            # control nodes never belong to an execution group, and execution nodes never to the control plane
+            exclude_type = 'execution' if ig.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME else 'control'
             group_actual = Group(obj=ig, instances=[], prior_instances=[instance.pk for instance in ig.instances.all()])  # obtained in prefetch
             for hostname in ig.policy_instance_list:
                 if hostname not in instance_hostnames_map:
                     logger.info("Unknown instance {} in {} policy list".format(hostname, ig.name))
                     continue
                 inst = instance_hostnames_map[hostname]
+                if inst.node_type == exclude_type:
+                    logger.info("Instance {} is excluded in {} policy list".format(hostname, ig.name))
+                    continue
                 group_actual.instances.append(inst.id)
                 # NOTE: arguable behavior: policy-list-group is not added to
                 # instance's group count for consideration in minimum-policy rules

--- a/awx/main/tests/functional/test_instances.py
+++ b/awx/main/tests/functional/test_instances.py
@@ -288,6 +288,31 @@ def test_control_plane_policy_exception(controlplane_instance_group):
 
 
 @pytest.mark.django_db
+def test_policy_instance_list_controlplane_excludes_execution_node(controlplane_instance_group):
+    exec_inst = Instance.objects.create(hostname='exec-1', node_type='execution')
+    control_inst = Instance.objects.create(hostname='control-1', node_type='control')
+    controlplane_instance_group.policy_instance_list = [exec_inst.hostname, control_inst.hostname]
+    controlplane_instance_group.save()
+    apply_cluster_membership_policies()
+    members = [inst.hostname for inst in controlplane_instance_group.instances.all()]
+    assert 'exec-1' not in members
+    assert 'control-1' in members
+
+
+@pytest.mark.django_db
+def test_policy_instance_list_execution_group_excludes_control_node():
+    ig = InstanceGroup.objects.create(name='bar')
+    exec_inst = Instance.objects.create(hostname='exec-1', node_type='execution')
+    control_inst = Instance.objects.create(hostname='control-1', node_type='control')
+    ig.policy_instance_list = [exec_inst.hostname, control_inst.hostname]
+    ig.save()
+    apply_cluster_membership_policies()
+    members = [inst.hostname for inst in ig.instances.all()]
+    assert 'control-1' not in members
+    assert 'exec-1' in members
+
+
+@pytest.mark.django_db
 def test_normal_instance_group_policy_exception():
     ig = InstanceGroup.objects.create(name='bar', policy_instance_percentage=100, policy_instance_minimum=2)
     Instance.objects.create(hostname='foo-1', node_type='control')


### PR DESCRIPTION
Port of [ansible/awx@c8cb465fd](https://github.com/ansible/awx/commit/c8cb465fd) (ansible/awx#16477).

## The problem

`apply_cluster_membership_policies` runs three passes over each instance group. The policy minimum pass and the policy percentage pass both compute:

```python
exclude_type = "execution" if g.obj.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME else "control"
```

and skip any instance of that type. The `policy_instance_list` pass that runs before them did not. It appended whatever hostname it found, and the two later passes only ever skip *adding* an instance, they never remove one that the policy list already put in `g.instances`. The final differential apply then writes the list out as is.

## How it is reached

`validate_policy_instance_list` blocks any change to `policy_instance_list` on the `default` and `controlplane` groups, so the API cannot put an execution node into the control plane. It does not check `node_type` for any other group, which leaves two live paths:

- Over the API, a **control node can be added to a user created execution instance group**, where `exclude_type` is `control`. Jobs then get routed to a control node.
- `awx-manage register_queue` filters only `.exclude(node_type="hop")` and appends straight to `ig.policy_instance_list` on the model, bypassing the serializer. That reaches the upstream case, an **execution node in `controlplane`**.

## The change

Compute `exclude_type` once per group and apply it in the `policy_instance_list` pass too, logging the skip the same way the unknown hostname case is logged.

## Testing

Two functional tests in `awx/main/tests/functional/test_instances.py`, next to the existing `test_control_plane_policy_exception`: an execution node named in the controlplane policy list is excluded while a control node is kept, and a control node named in a normal group policy list is excluded while an execution node is kept. The second covers the API reachable direction, which upstream does not test.

`black --check awx` and `flake8 awx` pass. The functional suite needs a database, so it was not run locally.