### PR TITLE
Upstream 16426 - Fix workflow node update failing when JT has unprompted labels

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4325,9 +4325,27 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
                             attrs['extra_data'][key] = db_extra_data[key]
 
         # Build unsaved version of this config, use it to detect prompts errors
+        # Capture the keys before _build_mock_obj pops the pseudo fields from attrs
+        incoming_attr_keys = set(attrs.keys())
         mock_obj = self._build_mock_obj(attrs)
-        if set(list(ujt.get_ask_mapping().keys()) + ['extra_data']) & set(attrs.keys()):
-            accepted, rejected, errors = ujt._accept_or_ignore_job_kwargs(_exclude_errors=self.exclude_errors, **mock_obj.prompts_dict())
+        requested_prompt_fields = incoming_attr_keys & set(ujt.get_ask_mapping().keys())
+        if 'extra_data' in incoming_attr_keys:
+            requested_prompt_fields.add('extra_vars')
+            requested_prompt_fields.add('survey_passwords')
+
+        # prompts_dict() reads the persisted many to many state, labels, credentials and
+        # instance groups, off the instance pk. Re-validate the whole prompt state only when
+        # the caller is switching the underlying template, otherwise restrict validation to
+        # the fields the request actually provided.
+        if 'unified_job_template' in attrs:
+            prompts_to_validate = mock_obj.prompts_dict()
+        elif requested_prompt_fields:
+            prompts_to_validate = {k: v for k, v in mock_obj.prompts_dict().items() if k in requested_prompt_fields}
+        else:
+            prompts_to_validate = None
+
+        if prompts_to_validate is not None:
+            accepted, rejected, errors = ujt._accept_or_ignore_job_kwargs(_exclude_errors=self.exclude_errors, **prompts_to_validate)
         else:
             # Only perform validation of prompts if prompts fields are provided
             errors = {}

--- a/awx/main/tests/functional/api/test_workflow_node.py
+++ b/awx/main/tests/functional/api/test_workflow_node.py
@@ -14,6 +14,7 @@ from awx.main.models.workflow import (
     WorkflowJobTemplateNodeConditionLink,
 )
 from awx.main.models.credential import Credential
+from awx.main.models.label import Label
 from awx.main.scheduler import TaskManager, WorkflowManager, DependencyManager
 
 # Django
@@ -50,6 +51,29 @@ def test_node_accepts_prompted_fields(inventory, project, workflow_job_template,
     job_template = JobTemplate.objects.create(inventory=inventory, project=project, playbook='helloworld.yml', ask_limit_on_launch=True)
     url = reverse('api:workflow_job_template_workflow_nodes_list', kwargs={'pk': workflow_job_template.pk})
     post(url, {'unified_job_template': job_template.pk, 'limit': 'webservers'}, user=admin_user, expect=201)
+
+
+@pytest.mark.django_db
+def test_node_patch_with_unprompted_labels(inventory, project, organization, workflow_job_template, patch, admin_user):
+    """Patching one prompt field must not re-validate labels the request never sent."""
+    jt = JobTemplate.objects.create(
+        inventory=inventory,
+        project=project,
+        playbook='helloworld.yml',
+        ask_variables_on_launch=True,
+        ask_labels_on_launch=False,
+    )
+    label = Label.objects.create(name='node-label', organization=organization)
+    node = WorkflowJobTemplateNode.objects.create(
+        workflow_job_template=workflow_job_template,
+        unified_job_template=jt,
+        extra_data={'foo': 'bar'},
+    )
+    node.labels.add(label)
+
+    url = reverse('api:workflow_job_template_node_detail', kwargs={'pk': node.pk})
+    r = patch(url, {'extra_data': {'foo': 'edited'}}, user=admin_user, expect=200)
+    assert r.data['extra_data'] == {'foo': 'edited'}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Port of [ansible/awx@376f964a4](https://github.com/ansible/awx/commit/376f964a4) (ansible/awx#16426).

## The problem

`LaunchConfigurationBaseSerializer.validate` re-validated the whole prompt state as soon as the request touched any prompt field:

```python
mock_obj = self._build_mock_obj(attrs)
if set(list(ujt.get_ask_mapping().keys()) + ["extra_data"]) & set(attrs.keys()):
    accepted, rejected, errors = ujt._accept_or_ignore_job_kwargs(..., **mock_obj.prompts_dict())
```

`prompts_dict()` reads the many to many prompts, `labels`, `credentials` and `instance_groups`, off the instance pk:

```python
if isinstance(field, models.ManyToManyField):
    if not self.pk:
        continue
    prompt_values = list(getattr(self, prompt_name).all())
```

and `_build_mock_obj` copies every concrete field, `id` included, from `self.instance`. The mock object therefore has a pk and returns the node persisted labels.

So a node with labels attached, pointing at a job template with `ask_labels_on_launch=False`, failed on a patch of any other prompt field. The serializer passed labels the request never sent into `_accept_or_ignore_job_kwargs`, which rejected them, and since the node serializer sets `exclude_errors = ("required",)` the prompts error was not suppressed. The user gets a 400 about data they did not touch.

## The change

Capture the incoming keys before `_build_mock_obj` pops the pseudo fields, then validate only the prompt fields the request actually provided. When `unified_job_template` itself is changing the full prompt state still gets validated, since it has to be checked against the new template.

## Testing

A functional test in `awx/main/tests/functional/api/test_workflow_node.py`: a node with a label, on a job template with `ask_labels_on_launch=False`, now accepts a patch of `extra_data`.

`black --check awx` and `flake8 awx` pass. The functional suite needs a database, so it was not run locally.