### PR TITLE
Upstream 16623 - Fix JT admins unable to toggle ask_*_on_launch fields without project_inventory access

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -23,6 +23,7 @@ from awx.main.models.oauth import OAuth2Application, OAuth2AccessToken
 from awx.dab.lib.utils.validation import to_python_boolean
 
 # AWX
+from awx.main.fields import AskForField
 from awx.main.utils import (
     get_object_or_400,
     get_pk_from_dict,
@@ -1683,12 +1684,6 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
             'job_tags',
             'force_handlers',
             'skip_tags',
-            'ask_variables_on_launch',
-            'ask_tags_on_launch',
-            'ask_job_type_on_launch',
-            'ask_skip_tags_on_launch',
-            'ask_inventory_on_launch',
-            'ask_credential_on_launch',
             'survey_enabled',
             'diff_mode',
             'timeout',
@@ -1698,18 +1693,26 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
             'created',
             'modified',
         ]
+        # ask_*_on_launch fields only decide whether a field can be prompted for at launch
+        # time, they never grant access to a new resource, so they are always non-sensitive
+        # no matter which model defines them
+        ask_field_names = {f.name for f in obj._meta.get_fields() if isinstance(f, AskForField)}
 
-        for k, v in data.items():
-            if k not in [x.name for x in obj._meta.concrete_fields]:
+        for field_name, new_value in data.items():
+            if field_name not in [x.name for x in obj._meta.concrete_fields]:
                 continue
-            if hasattr(obj, k) and getattr(obj, k) != v:
-                if (
-                    k not in allowed_fields
-                    and v != getattr(obj, '%s_id' % k, None)
-                    and not (hasattr(obj, '%s_id' % k) and getattr(obj, '%s_id' % k) is None and v == '')
-                ):  # Equate '' to None in the case of foreign keys
+            if hasattr(obj, field_name) and getattr(obj, field_name) != new_value:
+                if field_name not in allowed_fields and field_name not in ask_field_names and not self._fk_value_unchanged(obj, field_name, new_value):
                     return False
         return True
+
+    def _fk_value_unchanged(self, obj, field_name, new_value):
+        """True if new_value is only a different spelling of the current foreign key value,
+        the id itself, or '' where the current value is None."""
+        fk_id_attr = '%s_id' % field_name
+        if new_value == getattr(obj, fk_id_attr, None):
+            return True
+        return hasattr(obj, fk_id_attr) and getattr(obj, fk_id_attr) is None and new_value == ''
 
     def can_delete(self, obj):
         return self.user.is_superuser or self.user in obj.admin_role

--- a/awx/main/tests/unit/test_access.py
+++ b/awx/main/tests/unit/test_access.py
@@ -6,11 +6,13 @@ from django.forms.models import model_to_dict
 from rest_framework.exceptions import ParseError
 
 from awx.main.access import BaseAccess, check_superuser, JobTemplateAccess, WorkflowJobTemplateAccess, SystemJobTemplateAccess, vars_are_encrypted
+from awx.main.fields import AskForField
 
 from awx.main.models import (
     Credential,
     CredentialType,
     Inventory,
+    JobTemplate,
     Project,
     Role,
     Organization,
@@ -158,6 +160,28 @@ def test_jt_existing_values_are_nonsensitive(job_template_with_ids, user_unit):
     access = JobTemplateAccess(user_unit)
 
     assert access.changes_are_non_sensitive(job_template_with_ids, data)
+
+
+@pytest.mark.parametrize('field_name', [f.name for f in JobTemplate._meta.get_fields() if isinstance(f, AskForField)])
+def test_jt_ask_fields_are_nonsensitive(job_template_with_ids, user_unit, field_name):
+    """Toggling any ask_*_on_launch field is a non-sensitive change, so a job template
+    admin without use_role on the project or inventory can still flip it."""
+    access = JobTemplateAccess(user_unit)
+    assert access.changes_are_non_sensitive(job_template_with_ids, {field_name: True})
+
+
+@pytest.mark.parametrize(
+    'field_name, new_value, expected',
+    [
+        ('inventory', 11, True),  # matches the current inventory_id
+        ('inventory', 12, False),  # a different id
+        ('execution_environment', '', True),  # '' equated to None
+        ('execution_environment', 5, False),  # neither None nor equal
+    ],
+)
+def test_fk_value_unchanged(job_template_with_ids, user_unit, field_name, new_value, expected):
+    access = JobTemplateAccess(user_unit)
+    assert access._fk_value_unchanged(job_template_with_ids, field_name, new_value) is expected
 
 
 def test_change_jt_sensitive_data(job_template_with_ids, mocker, user_unit):


### PR DESCRIPTION
Port of [ansible/awx@b980d60e9](https://github.com/ansible/awx/commit/b980d60e9) (ansible/awx#16623).

## The problem

`JobTemplateAccess.changes_are_non_sensitive` hardcoded six `ask_*_on_launch` names in `allowed_fields`. Sixteen `AskForField` names exist across the models, so ten were missing:

`ask_diff_mode_on_launch`, `ask_execution_environment_on_launch`, `ask_forks_on_launch`, `ask_instance_groups_on_launch`, `ask_job_slice_count_on_launch`, `ask_labels_on_launch`, `ask_limit_on_launch`, `ask_scm_branch_on_launch`, `ask_timeout_on_launch`, `ask_verbosity_on_launch`

Changing any of them made `changes_are_non_sensitive` return False, so `can_change` fell through to:

```python
for required_field, cls in (("inventory", Inventory), ("project", Project)):
    is_mandatory = bool(getattr(obj, "{}_id".format(required_field)))
    if not self.check_related(required_field, cls, data, obj=obj, role_field="use_role", mandatory=is_mandatory):
        return False
```

and `check_related` ends with:

```python
if current and (changed or mandatory) and (not user_has_resource_access(current)):
    return False
```

With `mandatory=True`, which holds whenever the template has an inventory or project set, it checks `use_role` on the existing objects even though the request never mentioned them. A job template admin without that role gets a 403 for flipping a boolean that grants access to nothing.

The asymmetry gives the oversight away: `forks`, `limit`, `verbosity`, `diff_mode`, `timeout` and `job_slice_count` are all in `allowed_fields`, but their `ask_*_on_launch` counterparts were not.

## The change

Derive the set from the model instead of maintaining it by hand:

```python
ask_field_names = {f.name for f in obj._meta.get_fields() if isinstance(f, AskForField)}
```

The six hardcoded entries come out of `allowed_fields` since they are now covered, and a new `AskForField` is handled the day it is added. The foreign key equivalence check moves into `_fk_value_unchanged` so the condition stays readable.

## Testing

Two additions to `awx/main/tests/unit/test_access.py`: a parametrised test over every `AskForField` on `JobTemplate`, which fails on ten of them before this change, and a table test for `_fk_value_unchanged` covering the matching id and the `""` for None cases.

`black --check awx` and `flake8 awx` pass.