### PR TITLE
Upstream 16547 - fix: delete inventory hosts in batches to avoid memory exhaustion

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -850,6 +850,33 @@ def update_host_smart_inventory_memberships():
         smart_inventory.update_computed_fields()
 
 
+def _batched_delete_inventory(inventory, batch_size=500):
+    """Delete the hosts of an inventory in batches, then the inventory itself.
+
+    A host carries its ansible facts, so loading thousands of them in one cascade
+    can exhaust the memory of the dispatcher process. Deleting in batches keeps the
+    working set bounded.
+
+    Safe to retry after a crash: inventory.pending_deletion is already set by the
+    caller, and each batch is its own transaction.
+    """
+    from awx.main.models.inventory import Host
+
+    total_deleted = 0
+    while True:
+        pks = list(Host.objects.filter(inventory_id=inventory.id).values_list('pk', flat=True)[:batch_size])
+        if not pks:
+            break
+        with transaction.atomic():
+            deleted_count, _ = Host.objects.filter(pk__in=pks).delete()
+            total_deleted += deleted_count
+        logger.debug('Batch-deleted %d hosts from inventory %d (%d total so far)', len(pks), inventory.id, total_deleted)
+
+    inv_id = inventory.id
+    inventory.delete()
+    logger.info('Batched deletion of inventory %d complete (%d hosts removed)', inv_id, total_deleted)
+
+
 @task(queue=get_task_queuename)
 def delete_inventory(inventory_id, user_id, retries=5):
     # Delete inventory as user
@@ -862,11 +889,11 @@ def delete_inventory(inventory_id, user_id, retries=5):
             user = None
     with ignore_inventory_computed_fields(), ignore_inventory_group_removal(), impersonate(user):
         try:
-            Inventory.objects.get(id=inventory_id).delete()
+            _batched_delete_inventory(Inventory.objects.get(id=inventory_id))
             emit_channel_notification('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': inventory_id, 'status': 'deleted'})
             logger.debug('Deleted inventory {} as user {}.'.format(inventory_id, user_id))
         except Inventory.DoesNotExist:
-            logger.exception("Delete Inventory failed due to missing inventory: " + str(inventory_id))
+            logger.warning("Delete Inventory failed due to missing inventory: " + str(inventory_id))
             return
         except DatabaseError:
             logger.exception('Database error deleting inventory {}, but will retry.'.format(inventory_id))

--- a/awx/main/tests/functional/test_tasks.py
+++ b/awx/main/tests/functional/test_tasks.py
@@ -5,8 +5,8 @@ import tempfile
 import shutil
 
 from awx.main.tasks.jobs import RunJob
-from awx.main.tasks.system import execution_node_health_check, _cleanup_images_and_files
-from awx.main.models import Instance, Job
+from awx.main.tasks.system import execution_node_health_check, _batched_delete_inventory, _cleanup_images_and_files
+from awx.main.models import Host, Instance, Inventory, Job
 
 
 @pytest.fixture
@@ -73,3 +73,36 @@ def test_does_not_run_reaped_job(mocker, mock_me):
     job.refresh_from_db()
     assert job.status == 'failed'
     mock_run.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestBatchedDeleteInventory:
+    def test_deletes_every_host_and_the_inventory(self, organization):
+        inventory = Inventory.objects.create(name='batched', organization=organization)
+        for i in range(7):
+            Host.objects.create(name='host-{}'.format(i), inventory=inventory)
+        inventory_id = inventory.id
+
+        _batched_delete_inventory(inventory, batch_size=2)
+
+        assert not Inventory.objects.filter(id=inventory_id).exists()
+        assert not Host.objects.filter(inventory_id=inventory_id).exists()
+
+    def test_leaves_hosts_of_other_inventories_alone(self, organization):
+        doomed = Inventory.objects.create(name='doomed', organization=organization)
+        kept = Inventory.objects.create(name='kept', organization=organization)
+        Host.objects.create(name='doomed-host', inventory=doomed)
+        Host.objects.create(name='kept-host', inventory=kept)
+
+        _batched_delete_inventory(doomed, batch_size=1)
+
+        assert Inventory.objects.filter(id=kept.id).exists()
+        assert [h.name for h in Host.objects.filter(inventory_id=kept.id)] == ['kept-host']
+
+    def test_empty_inventory_is_deleted(self, organization):
+        inventory = Inventory.objects.create(name='empty', organization=organization)
+        inventory_id = inventory.id
+
+        _batched_delete_inventory(inventory)
+
+        assert not Inventory.objects.filter(id=inventory_id).exists()


### PR DESCRIPTION
Port of [ansible/awx@d8e7a711d](https://github.com/ansible/awx/commit/d8e7a711d) (ansible/awx#16547).

## The problem

`delete_inventory` did the whole thing in one statement:

```python
Inventory.objects.get(id=inventory_id).delete()
```

Django resolves that cascade by loading the related rows, and a host carries its ansible facts. On an inventory with thousands of hosts the dispatcher process can run out of memory before the delete finishes, leaving the inventory stuck in `pending_deletion`.

## The change

`_batched_delete_inventory` removes hosts 500 at a time, each batch in its own transaction, then deletes the inventory. The working set stays bounded no matter how large the inventory is.

Retrying is safe. The caller has already set `pending_deletion`, so a partially deleted inventory is not visible as a live one, and each batch commits independently, so a crash resumes rather than restarts.

The `Inventory.DoesNotExist` branch also drops from `logger.exception` to `logger.warning`. It is the expected outcome when the task runs twice for the same inventory, and a traceback there is noise.

## Testing

Three functional tests in `awx/main/tests/functional/test_tasks.py`: an inventory whose host count spans several batches is fully removed, hosts belonging to another inventory are untouched, and an inventory with no hosts is still deleted.

`black --check awx` and `flake8 awx` pass. The functional suite needs a database, so it was not run locally.