### PR TITLE
Upstream 16440 - fix: allow blank password field to fix OpenAPI schema validation

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -984,7 +984,7 @@ SUPPORTED_UI_LOCALES = frozenset(['', 'ar', 'en', 'es', 'fr', 'hi', 'ja', 'ko', 
 
 
 class UserSerializer(BaseSerializer):
-    password = serializers.CharField(required=False, default='', help_text=_('Field used to change the password.'))
+    password = serializers.CharField(required=False, default='', allow_blank=True, help_text=_('Field used to change the password.'))
     ldap_dn = serializers.CharField(source='profile.ldap_dn', read_only=True)
     preferred_language = serializers.CharField(required=False, allow_blank=True, default='')
     external_account = serializers.SerializerMethodField(help_text=_('Set if the account is managed by an external service'))

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -44,6 +44,19 @@ def test_creating_user_retains_session(post, admin):
 
 
 @pytest.mark.django_db
+def test_blank_password_is_accepted_and_leaves_the_password_alone(patch, admin, alice):
+    '''
+    '' is the field's own default and _update_password reads it as no change,
+    so sending it explicitly has to be accepted rather than rejected as blank.
+    '''
+    original = User.objects.get(pk=alice.pk).password
+
+    patch(reverse('api:user_detail', kwargs={'pk': alice.pk}), {'password': ''}, admin, expect=200)
+
+    assert User.objects.get(pk=alice.pk).password == original
+
+
+@pytest.mark.django_db
 def test_updating_own_password_refreshes_session(patch, admin):
     '''
     Updating your own password should refresh the session id.


### PR DESCRIPTION
Port of [ansible/awx@2451156fc](https://github.com/ansible/awx/commit/2451156fc) (ansible/awx#16440).

## The problem

```python
password = serializers.CharField(required=False, default="", help_text=...)
```

`allow_blank` defaults to False, so the field rejects `""` with "This field may not be blank" even though `""` is the default it declares. Omitting the key works, sending the same value explicitly does not.

Everything around it is written expecting blank to be accepted:

- `_update_password` guards with `if new_password and new_password != "$encrypted$" and ...`, so `""` means leave the password alone.
- `validate_password` has an `if not self.instance and value in (None, ""): raise ...("Password required for new User.")` branch. The `""` half of that condition is unreachable today, because DRF rejects the value before the serializer method runs.
- `preferred_language`, declared on the very next line, is `allow_blank=True, default=""`, which is the shape this field should have had.

## The change

Add `allow_blank=True`, matching upstream and the neighbouring field. A patch that sends `password: ""` for an existing user now validates and is a no-op on the password, which is what the code below it already assumed.

One thing this does not change: a deployment that raises `LOCAL_PASSWORD_MIN_LENGTH` (or the digits, upper or special variants) from their default of 0 will still reject `""`, now from `validate_password` rather than from the field. That check runs against every value including the sentinel, which is a separate wart and is left alone here.

## Testing

A functional test in `awx/main/tests/functional/api/test_user.py`: patching a user with `password: ""` returns 200 and leaves the stored hash untouched.

`black --check awx` and `flake8 awx` pass. The functional suite needs a database, so it was not run locally.