### PR TITLE
Upstream 16451 - Fix analytics API requests to respect proxy environment variables

### DIFF
--- a/awx/api/views/analytics.py
+++ b/awx/api/views/analytics.py
@@ -9,7 +9,7 @@ from django.utils import translation
 from awx.api.generics import APIView, Response
 from awx.api.permissions import AnalyticsPermission
 from awx.api.versioning import reverse
-from awx.main.utils import get_awx_version
+from awx.main.utils import get_awx_version, set_environ
 from rest_framework import status
 
 from collections import OrderedDict
@@ -191,16 +191,19 @@ class AnalyticsGenericView(APIView):
             if method not in ["GET", "POST", "OPTIONS"]:
                 return self._error_response(ERROR_UNSUPPORTED_METHOD, method, remote=False, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
             else:
-                response = requests.request(
-                    method,
-                    url,
-                    auth=(rh_user, rh_password),
-                    verify=settings.INSIGHTS_CERT_PATH,
-                    params=request.query_params,
-                    headers=headers,
-                    json=request.data,
-                    timeout=(31, 31),
-                )
+                # AWX_TASK_ENV carries the configured proxy settings, which requests reads
+                # from the process environment. The web worker does not have them otherwise.
+                with set_environ(**settings.AWX_TASK_ENV):
+                    response = requests.request(
+                        method,
+                        url,
+                        auth=(rh_user, rh_password),
+                        verify=settings.INSIGHTS_CERT_PATH,
+                        params=request.query_params,
+                        headers=headers,
+                        json=request.data,
+                        timeout=(31, 31),
+                    )
             #
             # Missing or wrong user/pass
             #

--- a/awx/main/tests/functional/api/test_analytics.py
+++ b/awx/main/tests/functional/api/test_analytics.py
@@ -1,3 +1,6 @@
+import os
+from unittest import mock
+
 import pytest
 import requests
 from awx.api.views.analytics import AnalyticsGenericView, MissingSettings, AUTOMATION_ANALYTICS_API_URL_PATH
@@ -84,3 +87,29 @@ class TestAnalyticsGenericView:
                     AnalyticsGenericView._get_setting(setting_name, False, None)
             else:
                 assert AnalyticsGenericView._get_setting(setting_name, False, None) == setting_value
+
+    @pytest.mark.django_db
+    def test__send_to_analytics_applies_task_env(self):
+        """The proxy settings live in AWX_TASK_ENV, and requests reads them from the
+        process environment, so they have to be applied around the outbound call."""
+        seen = {}
+
+        def fake_request(*args, **kwargs):
+            seen['https_proxy'] = os.environ.get('https_proxy')
+            return mock.Mock(status_code=200, text='', json=mock.Mock(return_value={}))
+
+        view = AnalyticsGenericView()
+        request = mock.Mock(path='/api/v2/analytics/report/test/', query_params={}, data={})
+
+        with override_settings(
+            INSIGHTS_TRACKING_STATE=True,
+            REDHAT_USERNAME='user',
+            REDHAT_PASSWORD='pass',
+            AUTOMATION_ANALYTICS_URL='https://example.invalid',
+            AWX_TASK_ENV={'https_proxy': 'http://proxy.example.invalid:3128'},
+        ):
+            with mock.patch.object(requests, 'request', side_effect=fake_request):
+                view._send_to_analytics(request, 'GET')
+
+        assert seen['https_proxy'] == 'http://proxy.example.invalid:3128'
+        assert 'https_proxy' not in os.environ


### PR DESCRIPTION
Port of [ansible/awx@45480941f](https://github.com/ansible/awx/commit/45480941f) (ansible/awx#16451).

## The problem

`AnalyticsGenericView._send_to_analytics` proxies the report views through to console.redhat.com with a bare call:

```python
response = requests.request(method, url, auth=(rh_user, rh_password), ...)
```

`requests` picks up proxy configuration from the process environment. The configured proxy is stored in `settings.AWX_TASK_ENV`, which is not part of the web worker environment. On an installation that only reaches the internet through a proxy, every analytics request from these views went out direct and timed out.

Every other outbound call in the tree already handles this:

- `awx/main/analytics/core.py:377`, the analytics upload
- `awx/main/models/notifications.py:184`
- `awx/main/models/credential/__init__.py:1355`
- `awx/api/views/__init__.py:1548`, the credential external test

all wrap themselves in `set_environ(**settings.AWX_TASK_ENV)`. The analytics proxy view was the only outbound path that did not, which is why the upload works behind a proxy while the report views do not.

## The change

Wrap the outbound call in `set_environ(**settings.AWX_TASK_ENV)`, the same helper and the same pattern as the call sites above. `set_environ` restores the previous environment in a `finally`, so nothing leaks into the worker.

Upstream wraps its entire `try` block, because their version also constructs an `OIDCClient` that makes a token request of its own. This view uses basic auth and makes exactly one call, so the wrapper goes around that call rather than the whole block.

## Testing

A test in `awx/main/tests/functional/api/test_analytics.py` that stubs `requests.request`, asserts the proxy variable from `AWX_TASK_ENV` is visible in `os.environ` at the moment of the call, and that it is gone again afterwards.

`black --check awx` and `flake8 awx` pass. The functional suite needs a database, so it was not run locally.