### PR TITLE
Upstream 16466 - Fix TypeError when update_fields=None in model save methods

### DIFF
--- a/awx/conf/models.py
+++ b/awx/conf/models.py
@@ -38,7 +38,7 @@ class Setting(CreatedModifiedModel):
         new_instance = not bool(self.pk)
         # If update_fields has been specified, add our field names to it,
         # if it hasn't been specified, then we're just doing a normal save.
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         # When first saving to the database, don't store any encrypted field
         # value, but instead save it until after the instance is created.
         # Otherwise, store encrypted value to the database.

--- a/awx/main/models/ad_hoc_commands.py
+++ b/awx/main/models/ad_hoc_commands.py
@@ -214,7 +214,7 @@ class AdHocCommand(UnifiedJob, JobNotificationMixin):
         return AdHocCommand.objects.create(**data)
 
     def save(self, *args, **kwargs):
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
 
         def add_to_update_fields(name):
             if name not in update_fields:

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1179,7 +1179,7 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, RelatedJobsMix
 
         # If update_fields has been specified, add our field names to it,
         # if it hasn't been specified, then we're just doing a normal save.
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         is_new_instance = not bool(self.pk)
 
         # Set name automatically. Include PK (or placeholder) to make sure the names are always unique.

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -405,7 +405,7 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
             return actual_slice_count
 
     def save(self, *args, **kwargs):
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         # if project is deleted for some reason, then keep the old organization
         # to retain ownership for organization admins
         if self.project and self.project.organization_id != self.organization_id:
@@ -1261,7 +1261,7 @@ class JobHostSummary(CreatedModifiedModel):
         # if it hasn't been specified, then we're just doing a normal save.
         if self.host is not None:
             self.host_name = self.host.name
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         self.failed = bool(self.dark or self.failures)
         update_fields.append('failed')
         super(JobHostSummary, self).save(*args, **kwargs)

--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -97,7 +97,7 @@ class NotificationTemplate(CommonModelNameNotUnique):
 
     def save(self, *args, **kwargs):
         new_instance = not bool(self.pk)
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
 
         # preserve existing notification messages if not overwritten by new messages
         if not new_instance:

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -374,7 +374,7 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, RelatedJobsMixi
         pre_save_vals = getattr(self, '_prior_values_store', {})
         # If update_fields has been specified, add our field names to it,
         # if it hasn't been specified, then we're just doing a normal save.
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         self._skip_update = bool(kwargs.pop('skip_update', False))
         # Create auto-generated local path if project uses SCM.
         if self.pk and self.scm_type and not self.local_path.startswith('_'):

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -273,7 +273,7 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
     def save(self, *args, **kwargs):
         # If update_fields has been specified, add our field names to it,
         # if it hasn't been specified, then we're just doing a normal save.
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
         # Update status and last_updated fields.
         if not getattr(_inventory_updates, 'is_updating', False):
             updated_fields = self._set_status_and_last_job_run(save=False)
@@ -845,7 +845,7 @@ class UnifiedJob(
         """
         # If update_fields has been specified, add our field names to it,
         # if it hasn't been specified, then we're just doing a normal save.
-        update_fields = kwargs.get('update_fields', [])
+        update_fields = kwargs.get('update_fields') or []
 
         # Get status before save...
         status_before = self.status or 'new'

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -1313,7 +1313,7 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
             self.save(update_fields=['context_message'])
 
     def save(self, *args, **kwargs):
-        update_fields = list(kwargs.get('update_fields', []))
+        update_fields = list(kwargs.get('update_fields') or [])
         if self.timeout != 0 and ((not self.pk) or (not update_fields) or ('timeout' in update_fields)):
             if not self.created:  # on creation, created will be set by parent class, so we fudge it here
                 created = now()


### PR DESCRIPTION
Port of [ansible/awx@f22df56e4](https://github.com/ansible/awx/commit/f22df56e4) (ansible/awx#16466).

## The problem

```python
update_fields = kwargs.get("update_fields", [])
```

The default only applies when the key is absent. `Model.save(self, ..., update_fields=None)` is the Django signature, so a caller that forwards `update_fields=None` explicitly gets `None` back from `.get`, and the next line does `update_fields.append(...)` or `if name not in update_fields`, which raises.

`awx/main/models/base.py` already reads `kwargs.get("update_fields") or []` in all three of its save methods, so this is the models deriving from it being inconsistent with their own base class, in ten places:

| File | Occurrences |
| ---- | ----------- |
| `awx/main/models/ad_hoc_commands.py` | 1 |
| `awx/main/models/inventory.py` | 1 |
| `awx/main/models/jobs.py` | 2 |
| `awx/main/models/notifications.py` | 1 |
| `awx/main/models/projects.py` | 1 |
| `awx/main/models/unified_jobs.py` | 2 |
| `awx/main/models/workflow.py` | 1 |
| `awx/conf/models.py` | 1 |

## Scope, stated plainly

This is hardening, not a fix for an observed failure. I went looking for a caller in this tree that passes `None` and did not find one: every `.save(update_fields=...)` site passes a list, and `_update_parent_instance_no_save` already guards with `if update_fields is None`. What is concretely true is that the base class and its subclasses disagree, and the subclasses are the fragile half.

`awx/conf/models.py` carries the same pattern and is included here. It is not part of the upstream commit.

`awx/dab/lib/abstract_models/common.py:115` also has it and is deliberately left alone: that tree is vendored from django-ansible-base, so it should be fixed upstream rather than diverge here.

## Testing

No behaviour changes for any existing caller, since `.get(k, [])` and `.get(k) or []` differ only when the value is present and falsy. `black --check awx` and `flake8 awx` pass.