### PR TITLE
Upstream 16516 - Fix SonarCloud security rating: remove user-controlled data from sqlite filepath

### DIFF
--- a/awx/main/db/profiled_pg/base.py
+++ b/awx/main/db/profiled_pg/base.py
@@ -68,7 +68,7 @@ class RecordedQueryLog(object):
                     progname = match
                     break
             else:
-                progname = os.path.basename(sys.argv[0])
+                progname = 'unknown'
             filepath = os.path.join(self.dest, '{}.sqlite'.format(progname))
             # awx.__version__ is resolved once at import time and already falls
             # back to the VERSION file when the package isn't pip installed;

--- a/awx/main/tests/unit/test_db.py
+++ b/awx/main/tests/unit/test_db.py
@@ -1,7 +1,6 @@
 import collections
 import os
 import sqlite3
-import sys
 import unittest
 
 import pytest
@@ -124,7 +123,7 @@ def test_sql_above_threshold(tmpdir):
         args, kw = _call
         assert args == ('EXPLAIN VERBOSE {}'.format(QUERY['sql']),)
 
-    path = os.path.join(tmpdir, '{}.sqlite'.format(os.path.basename(sys.argv[0])))
+    path = os.path.join(tmpdir, 'unknown.sqlite')
     assert os.path.exists(path)
 
     # verify the results


### PR DESCRIPTION
Port of [ansible/awx@843f23f4c](https://github.com/ansible/awx/commit/843f23f4c) (ansible/awx#16516).

## The change

`AWXQueryLogger` names its per-process sqlite file after the running program. It matches the four processes it is meant to profile by name, and otherwise fell back to the program path:

```python
for match in ("uwsgi", "dispatcher", "callback_receiver", "wsrelay"):
    if match in progname:
        progname = match
        break
else:
    progname = os.path.basename(sys.argv[0])
filepath = os.path.join(self.dest, "{}.sqlite".format(progname))
```

The fallback takes an argument value and builds a path from it that is then opened. The four named processes are the ones the profiler exists for, so the fallback only ever names a file nobody reads. Upstream made it the constant `unknown`.

## What this is worth, stated plainly

Small. `SQL_DEBUG` gates the profiler and it is a development setting, `sys.argv[0]` is not attacker controlled in any deployment I can construct, and the full argv is written into the `argv` column of the table regardless. Upstream raised it to clear a SonarCloud rating rather than to fix a reachable problem, and I do not think ascender is exposed here either.

It is included for completeness with the rest of the upstream fix sweep. If you would rather not carry the divergence for this one, closing it costs nothing.

## Testing

`test_sql_above_threshold` in `awx/main/tests/unit/test_db.py` asserted the filename derived from `sys.argv[0]`. Under pytest the argv does not match any of the four names, so it now lands on the fallback: the assertion becomes `unknown.sqlite`, and the now unused `import sys` goes with it.

`black --check awx` and `flake8 awx` pass.