### PR TITLE
Upstream 16587 - AAP-87883: Use shared lock for project copy when no sync is needed

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -375,6 +375,9 @@ class BaseTask(object):
         except IOError as e:
             logger.error("I/O error({0}) while trying to release lock file [{1}]: {2}".format(e.errno, project.get_lock_file(), e.strerror))
             os.close(self.lock_fd)
+            # closing the fd released any lock; clear it so a later release_lock
+            # (e.g. from a finally clause) doesn't act on a stale descriptor
+            self.lock_fd = None
             raise
 
         os.close(self.lock_fd)
@@ -416,6 +419,9 @@ class BaseTask(object):
             except IOError as e:
                 if e.errno not in (errno.EAGAIN, errno.EACCES):
                     os.close(self.lock_fd)
+                    # closing the fd released any lock; clear it so a later release_lock
+                    # (e.g. from a finally clause) doesn't act on a stale descriptor
+                    self.lock_fd = None
                     logger.error("I/O error({0}) while trying to acquire lock on file [{1}]: {2}".format(e.errno, lock_path, e.strerror))
                     raise
                 else:
@@ -829,6 +835,14 @@ class SourceControlMixin(BaseTask):
                     raise RuntimeError(f'Could not acquire lock for project {project.id}, job was interrupted')
                 if project.pk:
                     project.refresh_from_db()
+                if not self.get_sync_needs(project, scm_branch=scm_branch):
+                    # Another process synced the project while we waited for LOCK_EX,
+                    # so only the copy remains. Downgrade back to shared in place —
+                    # converting an fcntl lock EX->SH on the same fd is atomic and
+                    # cannot block — so concurrent copy-only jobs are not re-serialized
+                    # behind this one's copy.
+                    logger.debug(f'Project synced by another process while {self.instance.id} waited, downgrading to shared lock')
+                    fcntl.lockf(self.lock_fd, fcntl.LOCK_SH)
 
             failed_reason = project.get_reason_if_failed()
             if failed_reason:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -117,6 +117,7 @@ class BaseTask(object):
         self.cleanup_paths = []
         self.update_attempts = int(getattr(settings, 'DISPATCHER_DB_DOWNTOWN_TOLLERANCE', settings.DISPATCHER_DB_DOWNTIME_TOLERANCE) / 5)
         self.runner_callback = self.callback_class(model=self.model)
+        self.lock_fd = None
 
     def update_model(self, pk, _attempt=0, **updates):
         return update_model(self.model, pk, _attempt=0, _max_attempts=self.update_attempts, **updates)
@@ -366,6 +367,9 @@ class BaseTask(object):
         return expect_passwords
 
     def release_lock(self, project):
+        if self.lock_fd is None:
+            # Lock was never acquired, or acquire_lock cleaned up after a cancel
+            return
         try:
             fcntl.lockf(self.lock_fd, fcntl.LOCK_UN)
         except IOError as e:
@@ -376,7 +380,16 @@ class BaseTask(object):
         os.close(self.lock_fd)
         self.lock_fd = None
 
-    def acquire_lock(self, project, unified_job_id=None):
+    def acquire_lock(self, project, unified_job_id=None, exclusive=True):
+        """Acquire a file lock on the project's local source tree.
+
+        Uses LOCK_EX (exclusive) when the tree will be modified, or LOCK_SH (shared)
+        when only reading (e.g. copying). Polls until the lock is granted, checking
+        for cancellation on each iteration.
+
+        Returns True when the lock was acquired, or False if the job was canceled
+        or signaled while waiting.
+        """
         os.makedirs(settings.PROJECTS_ROOT, exist_ok=True)
 
         lock_path = project.get_lock_file()
@@ -393,11 +406,12 @@ class BaseTask(object):
             logger.error("I/O error({0}) while trying to open lock file [{1}]: {2}".format(e.errno, lock_path, e.strerror))
             raise
 
+        lock_type = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
         emitted_lockfile_log = False
         start_time = time.time()
         while True:
             try:
-                fcntl.lockf(self.lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.lockf(self.lock_fd, lock_type | fcntl.LOCK_NB)
                 break
             except IOError as e:
                 if e.errno not in (errno.EAGAIN, errno.EACCES):
@@ -776,7 +790,19 @@ class SourceControlMixin(BaseTask):
             RunProjectUpdate.make_local_copy(project, private_data_dir)
 
     def sync_and_copy(self, project, private_data_dir, scm_branch=None):
-        lock_acquired = self.acquire_lock(project, self.instance.id)
+        """Copy project content to private_data_dir, syncing from SCM only if needed.
+
+        Acquires a shared lock first so concurrent copy-only jobs (e.g. slice jobs or
+        federated inventory jobs) can run in parallel. Upgrades to an exclusive lock
+        only when the project tree needs to be modified (fresh clone, revision mismatch,
+        or missing cache). DB state is refreshed after each lock acquisition to account
+        for concurrent updates.
+        """
+        # Always start with a shared lock so concurrent copy-only jobs don't serialize.
+        # LOCK_SH waits for any in-flight LOCK_EX to drain, making the tree stable.
+        # Refresh DB state after acquiring so get_sync_needs sees the current revision,
+        # then upgrade to LOCK_EX only if a sync is actually required.
+        lock_acquired = self.acquire_lock(project, self.instance.id, exclusive=False)
         if not lock_acquired:
             self.instance.refresh_from_db()
             if self.instance.cancel_flag:
@@ -785,6 +811,25 @@ class SourceControlMixin(BaseTask):
         is_commit = False
         try:
             original_branch = None
+            if project.pk:
+                project.refresh_from_db()
+            sync_needs = self.get_sync_needs(project, scm_branch=scm_branch)
+            if sync_needs:
+                # Tree needs modification — upgrade to exclusive.
+                # POSIX advisory locks cannot be upgraded atomically: LOCK_SH must be
+                # released before LOCK_EX can be granted, leaving a window where another
+                # process may sync the project. Refresh after re-acquiring so
+                # sync_and_copy_without_lock operates on current DB state.
+                self.release_lock(project)
+                lock_acquired = self.acquire_lock(project, self.instance.id, exclusive=True)
+                if not lock_acquired:
+                    self.instance.refresh_from_db()
+                    if self.instance.cancel_flag:
+                        return
+                    raise RuntimeError(f'Could not acquire lock for project {project.id}, job was interrupted')
+                if project.pk:
+                    project.refresh_from_db()
+
             failed_reason = project.get_reason_if_failed()
             if failed_reason:
                 self.update_model(self.instance.pk, status='failed', job_explanation=failed_reason)

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -2170,6 +2170,109 @@ def test_sync_and_copy_canceled_during_lock_upgrade(get_sync_needs, sync_without
     sync_without_lock.assert_not_called()
 
 
+def _make_sync_and_copy_task(lock_fd=7):
+    """RunJob wired up for sync_and_copy tests, with acquire_lock faked to set lock_fd."""
+    task = jobs.RunJob()
+    task.instance = mock.Mock()
+    task.instance.id = 1
+    task.update_model = mock.Mock(return_value=task.instance)
+
+    def fake_acquire(project, unified_job_id=None, exclusive=True):
+        task.lock_fd = lock_fd
+        return True
+
+    return task, fake_acquire
+
+
+@mock.patch('fcntl.lockf')
+@mock.patch('awx.main.tasks.jobs.BaseTask.release_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.sync_and_copy_without_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.get_sync_needs', side_effect=[['update_git'], []])
+def test_sync_and_copy_downgrades_lock_when_sync_done_elsewhere(get_sync_needs, sync_without_lock, release_lock, fcntl_lockf, mock_me):
+    """If the re-check under LOCK_EX finds the sync already done by another process,
+    the lock is downgraded in place to LOCK_SH so concurrent copies are not serialized."""
+    project = mock.Mock()
+    project.pk = 1
+    project.get_reason_if_failed.return_value = None
+    project.scm_type = 'git'
+    project.scm_branch = 'main'
+
+    task, fake_acquire = _make_sync_and_copy_task(lock_fd=7)
+    with mock.patch('awx.main.tasks.jobs.BaseTask.acquire_lock', side_effect=fake_acquire):
+        task.sync_and_copy(project, '/fake/private_data_dir')
+
+    fcntl_lockf.assert_called_once_with(7, fcntl.LOCK_SH)
+    sync_without_lock.assert_called_once()
+
+
+@mock.patch('fcntl.lockf')
+@mock.patch('awx.main.tasks.jobs.BaseTask.release_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.sync_and_copy_without_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.get_sync_needs', side_effect=[['update_git'], ['update_git']])
+def test_sync_and_copy_no_downgrade_when_sync_still_needed(get_sync_needs, sync_without_lock, release_lock, fcntl_lockf, mock_me):
+    """If the re-check under LOCK_EX still reports a needed sync, the exclusive lock is kept."""
+    project = mock.Mock()
+    project.pk = 1
+    project.get_reason_if_failed.return_value = None
+    project.scm_type = 'git'
+    project.scm_branch = 'main'
+
+    task, fake_acquire = _make_sync_and_copy_task(lock_fd=7)
+    with mock.patch('awx.main.tasks.jobs.BaseTask.acquire_lock', side_effect=fake_acquire):
+        task.sync_and_copy(project, '/fake/private_data_dir')
+
+    fcntl_lockf.assert_not_called()
+    sync_without_lock.assert_called_once()
+
+
+@mock.patch('os.close')
+@mock.patch('fcntl.lockf')
+def test_release_lock_clears_fd_on_error(fcntl_lockf, os_close, mock_me):
+    """A failed unlock closes the fd and clears lock_fd, so a later release_lock
+    (e.g. from a finally clause) is a no-op instead of acting on a stale descriptor."""
+    err = IOError()
+    err.errno = 5
+    err.strerror = 'dummy message'
+    fcntl_lockf.side_effect = err
+
+    task = jobs.RunProjectUpdate()
+    task.lock_fd = 3
+    project = mock.Mock()
+    project.get_lock_file.return_value = '/tmp/test.lock'
+
+    with pytest.raises(IOError):
+        task.release_lock(project)
+    os_close.assert_called_once_with(3)
+    assert task.lock_fd is None
+
+    # second call must be a no-op, not EBADF on the closed fd
+    fcntl_lockf.reset_mock()
+    task.release_lock(project)
+    fcntl_lockf.assert_not_called()
+
+
+@mock.patch('os.open')
+@mock.patch('os.close')
+@mock.patch('fcntl.lockf')
+def test_acquire_lock_clears_fd_on_error(fcntl_lockf, os_close, os_open, mock_me):
+    """A non-retryable lockf failure closes the fd and clears lock_fd, so a later
+    release_lock (e.g. from a finally clause) does not act on a stale descriptor."""
+    err = IOError()
+    err.errno = 5
+    err.strerror = 'dummy message'
+
+    instance = mock.Mock()
+    instance.get_lock_file.return_value = '/tmp/test.lock'
+    os_open.return_value = 3
+    fcntl_lockf.side_effect = err
+
+    task = jobs.RunProjectUpdate()
+    with pytest.raises(IOError):
+        task.acquire_lock(instance)
+    os_close.assert_called_once_with(3)
+    assert task.lock_fd is None
+
+
 def test_project_update_post_run_hook_skips_release_when_no_lock(mock_me):
     """post_run_hook does not call release_lock when lock_fd is None (lock was never acquired)."""
     task = jobs.RunProjectUpdate()

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -2052,6 +2052,124 @@ def test_sync_and_copy_raises_on_signal_interrupt(mock_me):
             task.sync_and_copy(project, '/tmp/pdd')
 
 
+@pytest.mark.parametrize(
+    'kwargs,expected_flag',
+    [
+        ({}, fcntl.LOCK_EX | fcntl.LOCK_NB),  # default is exclusive
+        ({'exclusive': False}, fcntl.LOCK_SH | fcntl.LOCK_NB),
+    ],
+)
+@mock.patch('os.open')
+@mock.patch('fcntl.lockf')
+def test_acquire_lock_flag(fcntl_lockf, os_open, mock_me, kwargs, expected_flag):
+    """acquire_lock passes the correct fcntl flag based on the exclusive parameter."""
+    instance = mock.Mock()
+    instance.get_lock_file.return_value = '/fake/path.lock'
+    os_open.return_value = 3
+
+    task = jobs.RunProjectUpdate()
+    task.acquire_lock(instance, **kwargs)
+
+    assert fcntl_lockf.call_args[0][1] == expected_flag
+
+
+# Each entry: (sync_needs, has_pk, expected exclusive= sequence, expected refresh_from_db count)
+# - copy-only path: refresh once under LOCK_SH
+# - upgrade path: refresh under LOCK_SH and again under LOCK_EX (POSIX locks cannot
+#   be upgraded atomically, so state may change in the gap between releasing SH and
+#   acquiring EX)
+# - pk=None cases: refresh_from_db is skipped (unsaved model instances used in some tests)
+@pytest.mark.parametrize(
+    'sync_needs,has_pk,expected_exclusive_seq,expected_refresh_count',
+    [
+        ([], True, [False], 1),  # copy-only: shared lock, refresh once
+        (['update_git'], True, [False, True], 2),  # upgrade path: refresh under SH and EX
+        ([], False, [False], 0),  # copy-only, no pk: refresh skipped
+        (['update_git'], False, [False, True], 0),  # upgrade path, no pk: refresh skipped
+    ],
+)
+@mock.patch('awx.main.tasks.jobs.BaseTask.release_lock')
+@mock.patch('awx.main.tasks.jobs.BaseTask.acquire_lock', return_value=True)
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.sync_and_copy_without_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.get_sync_needs')
+def test_sync_and_copy_lock_behavior(
+    get_sync_needs, sync_without_lock, acquire_lock, release_lock, mock_me, sync_needs, has_pk, expected_exclusive_seq, expected_refresh_count
+):
+    """sync_and_copy acquires LOCK_SH first, upgrading to LOCK_EX only when a sync is needed.
+    project.refresh_from_db() is called after each lock acquisition to ensure current DB state,
+    but only when the project has a pk (i.e. is persisted to the database)."""
+    get_sync_needs.return_value = sync_needs
+
+    project = mock.Mock()
+    project.pk = 1 if has_pk else None
+    project.get_reason_if_failed.return_value = None
+    project.scm_type = 'git'
+    project.scm_branch = 'main'
+
+    task = jobs.RunJob()
+    task.instance = mock.Mock()
+    task.instance.id = 1
+    task.update_model = mock.Mock(return_value=task.instance)
+
+    task.sync_and_copy(project, '/fake/private_data_dir')
+
+    assert acquire_lock.call_count == len(expected_exclusive_seq)
+    for i, exclusive in enumerate(expected_exclusive_seq):
+        assert acquire_lock.call_args_list[i] == mock.call(project, task.instance.id, exclusive=exclusive)
+    assert release_lock.call_count == len(expected_exclusive_seq)
+    assert project.refresh_from_db.call_count == expected_refresh_count
+
+
+@mock.patch('awx.main.tasks.jobs.BaseTask.release_lock')
+@mock.patch('awx.main.tasks.jobs.BaseTask.acquire_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.sync_and_copy_without_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.get_sync_needs')
+def test_sync_and_copy_get_sync_needs_called_under_shared_lock(get_sync_needs, sync_without_lock, acquire_lock, release_lock, mock_me):
+    """get_sync_needs is called after acquiring LOCK_SH, not before any lock."""
+    call_order = []
+    acquire_lock.side_effect = lambda *a, **kw: call_order.append('acquire') or True
+    get_sync_needs.side_effect = lambda *a, **kw: call_order.append('get_sync_needs') or []
+
+    project = mock.Mock()
+    project.get_reason_if_failed.return_value = None
+    project.scm_type = 'git'
+    project.scm_branch = 'main'
+
+    task = jobs.RunJob()
+    task.instance = mock.Mock()
+    task.instance.id = 1
+    task.update_model = mock.Mock(return_value=task.instance)
+
+    task.sync_and_copy(project, '/fake/private_data_dir')
+
+    assert call_order[0] == 'acquire', 'lock must be acquired before get_sync_needs is called'
+    assert call_order[1] == 'get_sync_needs'
+
+
+@mock.patch('awx.main.tasks.jobs.BaseTask.release_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.sync_and_copy_without_lock')
+@mock.patch('awx.main.tasks.jobs.SourceControlMixin.get_sync_needs', return_value=['update_git'])
+def test_sync_and_copy_canceled_during_lock_upgrade(get_sync_needs, sync_without_lock, release_lock, mock_me):
+    """If the job is canceled while waiting to upgrade from LOCK_SH to LOCK_EX,
+    sync_and_copy returns gracefully without running the sync."""
+    task = jobs.RunJob()
+    task.instance = mock.Mock()
+    task.instance.id = 1
+    task.instance.cancel_flag = True
+    task.update_model = mock.Mock(return_value=task.instance)
+
+    project = mock.Mock()
+    project.pk = 1
+    project.id = 10
+
+    # Shared acquire succeeds; exclusive re-acquire fails due to cancel
+    with mock.patch('awx.main.tasks.jobs.BaseTask.acquire_lock', side_effect=[True, False]):
+        result = task.sync_and_copy(project, '/fake/private_data_dir')
+
+    assert result is None
+    sync_without_lock.assert_not_called()
+
+
 def test_project_update_post_run_hook_skips_release_when_no_lock(mock_me):
     """post_run_hook does not call release_lock when lock_fd is None (lock was never acquired)."""
     task = jobs.RunProjectUpdate()


### PR DESCRIPTION
Upstream [PR #16587](https://github.com/ansible/awx/pull/16587) fixes a serialization bottleneck: when multiple jobs share one project, each held an exclusive flock while merely copying the project into its private data dir, so concurrent jobs queued up behind each other (upstream measured 140s of cumulative lock wait for 8 slice jobs on a 200MB project). The fix takes a shared lock for the read-only copy and upgrades to exclusive only when the tree actually needs modifying (fresh clone, revision mismatch, missing galaxy cache).

That's exactly the shape of a Federated Inventory launch: (`/awx/main/models/jobs.py#L449-L485`) fans one JT launch into a WorkflowJob with one Job per source inventory - all against the same project, launched simultaneously. Before this change those jobs serialized on the copy; now they copy concurrently. Slice jobs benefit identically.

### Adaptation notes (we diverge from upstream in three places)
* Our acquire_lock returns True/False on cancel/signal (Ascender fix #430); upstream's doesn't. The new exclusive-upgrade path inside sync_and_copy (/awx/main/tasks/jobs.py#L812-L830) re-checks that return the same way the initial acquire does.
* A canceled re-acquire during the upgrade leaves `lock_fd = None` while the finally still calls `release_lock`, so I initialized `lock_fd` in `BaseTask.__init__` and made release_lock a no-op when no lock is held - upstream doesn't need this because it lacks the bool-return cancel path.
* Our lock methods live on `BaseTask`, not `SourceControlMixin`, so the ported tests patch accordingly. I brought over all three upstream tests and added one of our own for the cancel-during-upgrade path.