### PR TITLE
Accept an explicit update_fields=None in the remaining save methods

### DIFF
--- a/awx/main/models/activity_stream.py
+++ b/awx/main/models/activity_stream.py
@@ -110,8 +110,10 @@ class ActivityStream(models.Model):
                 'first_name': smart_str(self.actor.first_name),
                 'last_name': smart_str(self.actor.last_name),
             }
-            if 'update_fields' in kwargs and 'deleted_actor' not in kwargs['update_fields']:
-                kwargs['update_fields'].append('deleted_actor')
+            # An explicit update_fields=None is a full save, the same as leaving it out
+            update_fields = kwargs.get('update_fields')
+            if update_fields is not None and 'deleted_actor' not in update_fields:
+                update_fields.append('deleted_actor')
 
         hostname_char_limit = self._meta.get_field('action_node').max_length
         self.action_node = settings.CLUSTER_HOST_ID[:hostname_char_limit]

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -498,7 +498,9 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
     def save(self, *args, **kwargs):
         self._update_host_smart_inventory_memeberships()
         super(Inventory, self).save(*args, **kwargs)
-        if self.kind == 'smart' and 'host_filter' in kwargs.get('update_fields', ['host_filter']) and connection.vendor != 'sqlite':
+        # An explicit update_fields=None is a full save, the same as leaving it out
+        update_fields = kwargs.get('update_fields')
+        if self.kind == 'smart' and (update_fields is None or 'host_filter' in update_fields) and connection.vendor != 'sqlite':
             # Minimal update of host_count for smart inventory host filter changes
             self.update_computed_fields()
         self._enforce_constructed_source()

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -702,6 +702,7 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
             job_tags.remove('delete')
             self.job_tags = ','.join(job_tags)
             added_update_fields.append('job_tags')
-        if 'update_fields' in kwargs:
+        # An explicit update_fields=None is a full save, the same as leaving it out
+        if kwargs.get('update_fields') is not None:
             kwargs['update_fields'].extend(added_update_fields)
         return super(ProjectUpdate, self).save(*args, **kwargs)

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -311,7 +311,8 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
     def save(self, *args, **kwargs):
         self.rrule = Schedule.coerce_naive_until(self.rrule)
         changed = self.update_computed_fields_no_save()
-        if changed and 'update_fields' in kwargs:
+        # An explicit update_fields=None is a full save, the same as leaving it out
+        if changed and kwargs.get('update_fields') is not None:
             for field_name in ['next_run', 'dtstart', 'dtend']:
                 if field_name not in kwargs['update_fields']:
                     kwargs['update_fields'].append(field_name)

--- a/awx/main/tests/functional/models/test_save_update_fields.py
+++ b/awx/main/tests/functional/models/test_save_update_fields.py
@@ -1,0 +1,52 @@
+import pytest
+
+from awx.main.models import ActivityStream, Inventory, JobTemplate, Schedule
+
+# Django's own Model.save signature is save(..., update_fields=None), so a caller
+# that forwards update_fields explicitly hands these save methods None rather
+# than leaving the key out. Each of them has to treat that as a full save.
+
+
+@pytest.mark.django_db
+def test_smart_inventory_save_accepts_update_fields_none(organization):
+    inventory = Inventory.objects.create(name='smart-inv', organization=organization, kind='smart', host_filter='name=somehost')
+    inventory.description = 'changed'
+
+    inventory.save(update_fields=None)
+
+    inventory.refresh_from_db()
+    assert inventory.description == 'changed'
+
+
+@pytest.mark.django_db
+def test_schedule_save_accepts_update_fields_none(inventory, project):
+    job_template = JobTemplate.objects.create(name='test-jt', inventory=inventory, project=project)
+    schedule = Schedule.objects.create(name='test-sch', rrule='DTSTART:20300112T210000Z RRULE:FREQ=DAILY;INTERVAL=1', unified_job_template=job_template)
+    # a different start moves the computed fields, which is the branch that reads update_fields
+    schedule.rrule = 'DTSTART:20310112T210000Z RRULE:FREQ=DAILY;INTERVAL=1'
+
+    schedule.save(update_fields=None)
+
+    schedule.refresh_from_db()
+    assert schedule.dtstart.year == 2031
+
+
+@pytest.mark.django_db
+def test_project_update_save_accepts_update_fields_none(project):
+    project_update = project.create_unified_job()
+    job_tags = project_update.job_tags
+
+    project_update.save(update_fields=None)
+
+    project_update.refresh_from_db()
+    assert project_update.job_tags == job_tags
+
+
+@pytest.mark.django_db
+def test_activity_stream_save_accepts_update_fields_none(admin_user):
+    entry = ActivityStream.objects.create(operation='create', object1='organization', actor=admin_user)
+
+    entry.save(update_fields=None)
+
+    entry.refresh_from_db()
+    assert entry.deleted_actor['username'] == admin_user.username


### PR DESCRIPTION
##### SUMMARY

`Model.save` takes `update_fields=None` as its default, so a caller that forwards the argument explicitly hands the model `None` rather than leaving the key out. #793 covered the `save` methods that read `kwargs.get('update_fields', [])` and made them treat `None` as an empty list. Four more read the key in a different shape and were left behind: they guard on the key being present, or default it inline, and then index the value.

| Method | File | What an explicit `None` does |
| ------ | ----- | ---------------------------- |
| `Inventory.save` | `inventory.py` | `'host_filter' in None`, TypeError |
| `Schedule.save` | `schedules.py` | `field_name not in None`, TypeError |
| `ProjectUpdate.save` | `projects.py` | `None.extend(...)`, AttributeError |
| `ActivityStream.save` | `activity_stream.py` | `'deleted_actor' not in None`, TypeError |

Each now reads the key with `.get()` and takes an explicit `None` for what it is, a full save, the same as leaving the argument out. `Inventory.save` is the one place where the two cases have to act rather than skip: a full save of a smart inventory recomputes its host count, so the condition reads `update_fields is None or 'host_filter' in update_fields`, with the `sqlite` guard after it unchanged.

## Scope, stated plainly

No caller in the tree passes `None` explicitly today, so this is hardening rather than a fix for an observed failure, on the same footing as #793. What is concretely true is that the base class and the eight methods #793 fixed accept it, and these four did not.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ASCENDER VERSION

```
25.5.2.dev154+gfbd3af768f.d20260903
```

##### ADDITIONAL INFORMATION

Four functional tests in `test_save_update_fields.py`, next to the other model tests, one per method, each saving with `update_fields=None` on an instance that reaches the branch that reads it. Against the parent commit they fail with the errors in the table, and with the change they pass:

```
# parent commit, the four save methods unchanged
FAILED test_smart_inventory_save_accepts_update_fields_none
FAILED test_schedule_save_accepts_update_fields_none
FAILED test_project_update_save_accepts_update_fields_none
FAILED test_activity_stream_save_accepts_update_fields_none
4 failed in 3.53s

# this branch
4 passed in 5.05s
```

Checks were run inside an `ascender_devel` image built from this checkout, the way CI builds it:

```
tox -e linters            black, flake8 and yamllint clean (yamllint with the gitignored e2e node_modules excluded)
make test, serial, --create-db   3939 passed, 10 skipped in 34m03s
check_migrations (dry run)      No changes detected
```
