### PR TITLE
chore: ignore the e2e suite's node_modules in yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -7,6 +7,7 @@ ignore: |
   awx/main/tests/data/ansible_utils/playbooks/valid/vault.yml
   awx/ui/test/e2e/tests/smoke-vars.yml
   awx/ui/node_modules
+  awx/ui/e2e/node_modules
   tools/docker-compose/_sources
   # django template files
   awx/api/templates/instance_install_bundle/**


### PR DESCRIPTION
##### SUMMARY

`yamllint -s .` scans everything under the checkout that the ignore list does not exclude. `awx/ui/node_modules` is excluded; `awx/ui/e2e/node_modules`, which `npm ci` in the end-to-end suite creates since #762, is not, and playwright ships a YAML file under `lib/agents` that yamllint rejects. So `make api-lint` fails on any checkout with the e2e suite installed:

```
./awx/ui/e2e/node_modules/playwright/lib/agents/copilot-setup-steps.yml
  1:1       warning  missing document start "---"  (document-start)
  20:5      error    wrong indentation: expected 6 but found 4  (indentation)
```

CI never sees it: the api-lint job runs in a checkout without that directory. This adds the path next to the existing entry, so a developer who has run the e2e suite gets the same lint result as CI.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### ASCENDER VERSION

```
25.6.1.dev21+g4cef9e2c72
```

##### ADDITIONAL INFORMATION

Checked with the yamllint tox.ini pins (1.38.0), inside the `ascender_devel` image, on a checkout that has `awx/ui/e2e/node_modules` present: before the change the output above and exit 1, after it no output and exit 0. black and flake8 are not touched by a change to `.yamllint`.
