### PR TITLE
fix: quote the arguments the devel entrypoint execs

### DIFF
--- a/tools/docker-compose/entrypoint.sh
+++ b/tools/docker-compose/entrypoint.sh
@@ -32,4 +32,4 @@ else
     export SDB_NOTIFY_HOST=$(ip route | head -n1 | awk '{print $3}')
 fi
 
-exec $@
+exec "$@"


### PR DESCRIPTION
##### SUMMARY

`tools/docker-compose/entrypoint.sh` ends in `exec $@`, which re-splits every argument on whitespace before running it. A command with a spaced argument is mangled:

- `sh -c 'echo one two'` runs as `sh -c echo one two` and prints nothing.
- `make test PYTEST_ARGS="--create-db -p no:cacheprovider"` sent through `make docker-runner` reaches make as five words, so it runs the suite with `-p` (print the data base) and then stops on a target named `no:cacheprovider`: exit 2 after a green run, with make's whole database dumped after the pytest summary.

`exec "$@"` passes the argument vector through as received. The compose services hand it single words (`launch_awx.sh`, the editable-dependencies `install.sh`) and CI's docker-runner passes words the Makefile's shell has already split, so nothing else changes. It takes effect on the next image build, since the Dockerfile copies the script in.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### ASCENDER VERSION

```
25.6.1.dev21+g9bdacf70c4
```

##### ADDITIONAL INFORMATION

Checked by mounting the changed script over `/entrypoint.sh` in the current `ascender_devel` image:

```
# image as built, exec $@
$ docker run --rm <image> sh -c 'echo one two'
<empty line>

# with this change mounted over /entrypoint.sh
$ docker run --rm -v $PWD/tools/docker-compose/entrypoint.sh:/entrypoint.sh:ro <image> sh -c 'echo one two'
one two

$ ... <image> make -n test PYTEST_ARGS="--create-db -p no:cacheprovider"
PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider --create-db -p no:cacheprovider awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests

$ ... <image> make VERSION
awx: 25.6.1.dev21+g9bdacf70c4
```
