### PR TITLE
fix: guard the workflow graph's recovery refetch after unmount and on failure

### DIFF
--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutput.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutput.test.js
@@ -164,4 +164,58 @@ describe('WorkflowOutput', () => {
       ).toBeInTheDocument()
     );
   });
+
+  test('a recovery refetch is skipped once the component is unmounted', async () => {
+    jest.useFakeTimers();
+    try {
+      const { container, unmount } = renderWithContexts(
+        <svg>
+          <WorkflowOutput job={job} />
+        </svg>
+      );
+      await waitFor(() =>
+        expect(container.querySelector('#workflow-g')).toBeInTheDocument()
+      );
+      // Loading armed the 500 ms and 2500 ms recovery timers. Once the
+      // component is gone they must not reach the API, whatever it would
+      // answer: there is nothing left to refresh, and a rejection here used
+      // to escape as an unhandled one into whichever test ran next.
+      unmount();
+      WorkflowJobsAPI.readNodes.mockClear();
+      WorkflowJobsAPI.readNodes.mockRejectedValue(new Error('stale timer'));
+
+      await jest.advanceTimersByTimeAsync(3000);
+
+      expect(WorkflowJobsAPI.readNodes).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('a failed recovery refetch leaves the graph in place', async () => {
+    jest.useFakeTimers();
+    try {
+      const { container } = renderWithContexts(
+        <svg>
+          <WorkflowOutput job={job} />
+        </svg>
+      );
+      await waitFor(() =>
+        expect(container.querySelector('#workflow-g')).toBeInTheDocument()
+      );
+      WorkflowJobsAPI.readNodes.mockRejectedValue(new Error('recovery failed'));
+
+      await jest.advanceTimersByTimeAsync(3000);
+
+      // The refetches ran and failed; the graph is untouched and no error
+      // state replaced it.
+      expect(WorkflowJobsAPI.readNodes.mock.calls.length).toBeGreaterThan(1);
+      expect(container.querySelector('#workflow-g')).toBeInTheDocument();
+      expect(
+        container.querySelector('.pf-v6-c-empty-state')
+      ).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/awx/ui/src/screens/Job/WorkflowOutput/useWsWorkflowOutput.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/useWsWorkflowOutput.js
@@ -40,7 +40,20 @@ export default function useWsWorkflowOutput(workflowJobId, initialNodes) {
   });
 
   const refreshNodeObjects = useCallback(async () => {
-    const updatedNodeObjects = await fetchWorkflowNodes(workflowJobId);
+    // A recovery timer or a late message can land after the component is
+    // gone. There is nothing to refresh then, and no reason to call the API.
+    if (!isMounted.current) {
+      return;
+    }
+    let updatedNodeObjects;
+    try {
+      updatedNodeObjects = await fetchWorkflowNodes(workflowJobId);
+    } catch {
+      // The refetch is a best-effort catch-up: the graph keeps what it has,
+      // and the next message or timer brings it up to date. A failure must
+      // not escape as an unhandled rejection.
+      return;
+    }
     if (!isMounted.current) {
       return;
     }
@@ -83,7 +96,7 @@ export default function useWsWorkflowOutput(workflowJobId, initialNodes) {
   // happened while the graph was still loading.  The timers are intentionally
   // NOT cleaned up on effect re-run so they survive React strict-mode's
   // unmount/remount cycle; refreshNodeObjects is safe to call after unmount
-  // (it checks isMounted).
+  // (it checks isMounted before fetching, and again before setting state).
   useEffect(() => {
     if (hasInitializedRef.current) return;
     if (!initialNodes || initialNodes.length <= 1) return;


### PR DESCRIPTION
##### SUMMARY

`useWsWorkflowOutput` arms two recovery refetches, at 500 ms and 2500 ms after the nodes first load, and deliberately never clears them so they survive strict mode's unmount and remount. `refreshNodeObjects` only checked `isMounted` after the fetch had already been made, and nothing caught a failed fetch. So a timer that fires after a real unmount still calls the API, and when that call fails the rejection has no owner.

That is what makes the "error shown to user when error thrown fetching workflow job nodes" test in `WorkflowOutput.test.js` flaky. The first test loads nodes and arms the timers, the second re-mocks `readNodes` to reject, and whenever a timer lands inside it the rejection surfaces as five unhandled errors carrying the injected Error's stack, which the console hook in `setupTests.js` turns into a failure:

```
  ● WorkflowOutput › error shown to user when error thrown fetching workflow job nodes
    > 153 |     WorkflowJobsAPI.readNodes.mockRejectedValue(new Error());
          |                                                 ^
  (five times)
Tests:       1 failed, 1 passed, 2 total
```

A loaded machine or the full suite makes it land more often: it failed the full run on 2026-09-03 and one solo run in three, and passed in CI on #798 the same day.

The change checks `isMounted` before fetching, and treats a failed refetch as what it is, a best-effort catch-up the graph survives: it keeps the nodes it has and lets the next message or timer bring it up to date. Strict mode is unaffected, since the remount sets `isMounted` back before the first timer fires.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### ASCENDER VERSION

```
25.6.1.dev21+g1b3b5c316d
```

##### ADDITIONAL INFORMATION

Two tests, with fake timers: a refetch armed before unmount never reaches the API, and a refetch that fails leaves the graph rendered with no error state. Against the previous hook both fail; with this change the file passes three runs in a row:

```
# previous hook, new tests
  ● WorkflowOutput › a failed recovery refetch leaves the graph in place
  ● WorkflowOutput › a recovery refetch is skipped once the component is unmounted
Tests:       2 failed, 2 passed, 4 total

# this branch, three runs
Tests:       4 passed, 4 total
Tests:       4 passed, 4 total
Tests:       4 passed, 4 total
```

Full checks, under Node 22 with node_modules from the lockfile:

```
npm run test   Test Suites: 552 passed, 552 total / Tests: 2971 passed, 2971 total (531 s)
npm run lint   eslint . clean
prettier --check on both files: clean; eslint on the hook: clean (test files are ignored by the config)
```
