### PR TITLE
fix: give the job output scroll container a height independent of its rows

### DIFF
--- a/awx/ui/e2e/tests/helpers.js
+++ b/awx/ui/e2e/tests/helpers.js
@@ -57,6 +57,33 @@ function watchConsole(page) {
   };
 }
 
+// The job output measures its rows with a ResizeObserver, and a measurement
+// that resizes the scroll container in the same frame makes the browser report
+// "ResizeObserver loop completed with undelivered notifications" on window. It
+// is neither a console message nor a thrown exception, so watchConsole and
+// Playwright's pageerror both miss it; only an error listener installed before
+// the app loads sees it. Call this before the first navigation.
+async function watchLayoutLoops(page) {
+  await page.addInitScript(() => {
+    window.__ascenderLayoutLoops = [];
+    window.addEventListener(
+      'error',
+      (event) => {
+        if (/ResizeObserver loop/.test(event.message || '')) {
+          window.__ascenderLayoutLoops.push(event.message);
+        }
+      },
+      true
+    );
+  });
+  return {
+    async expectQuiet() {
+      const seen = await page.evaluate(() => window.__ascenderLayoutLoops);
+      expect(seen, `layout loops reported:\n${seen.join('\n')}`).toEqual([]);
+    },
+  };
+}
+
 // The tab bar hosts the workflow job selector, whose toggle shows either the
 // position within the workflow or, once a status filter is on, that status.
 const workflowToggle = (page) =>
@@ -73,6 +100,7 @@ module.exports = {
   route,
   login,
   watchConsole,
+  watchLayoutLoops,
   workflowToggle,
   menuItem,
   USERNAME,

--- a/awx/ui/e2e/tests/job-output.spec.js
+++ b/awx/ui/e2e/tests/job-output.spec.js
@@ -6,7 +6,15 @@
 // but the dead click was a real-browser problem: the click bubbled out of the
 // selector into the tab that hosts it, and jsdom does not reproduce that.
 const { test, expect } = require('@playwright/test');
-const { fixtures, login, route, watchConsole, workflowToggle, menuItem } = require('./helpers');
+const {
+  fixtures,
+  login,
+  route,
+  watchConsole,
+  watchLayoutLoops,
+  workflowToggle,
+  menuItem,
+} = require('./helpers');
 
 test.describe('workflow job selector', () => {
   test.beforeEach(async ({ page }) => {
@@ -90,5 +98,32 @@ test.describe('workflow job selector', () => {
     for (const node of nodes) {
       await expect(menuItem(page, node.identifier)).toBeVisible();
     }
+  });
+});
+
+test.describe('job output layout', () => {
+  // The rows are measured with a ResizeObserver, and the scroll container used
+  // to take its height from the rows, so the first measurements resized it in
+  // the same frame and the browser reported an undelivered-notifications loop.
+  // The dev server's error overlay turned that into a full-screen error on
+  // every job output page. jsdom has no layout, so only a browser can see it.
+  test('measures its rows without a ResizeObserver loop', async ({ page }) => {
+    const loops = await watchLayoutLoops(page);
+    await login(page);
+    const { nodes } = fixtures();
+    await page.goto(route(`/jobs/management/${nodes[0].jobId}/output`), {
+      waitUntil: 'domcontentloaded',
+    });
+    const scroller = page.locator('.ascender-output-scroll');
+    await expect(scroller.locator('[data-index]').first()).toBeVisible();
+    await scroller.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await scroller.evaluate((el) => {
+      el.scrollTop = 0;
+    });
+    // the notice is reported on the frame after the measurements land
+    await page.waitForTimeout(1000);
+    await loops.expectQuiet();
   });
 });

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -95,6 +95,11 @@ const OutputWrapper = styled.div`
 // basis makes the height the free space of the column and nothing else. The
 // gutter strip is painted here as a background so it runs to the bottom when
 // the output is shorter than the container.
+// One source of truth for the gutter width: the ScrollContainer paints it as a
+// background so it reaches the bottom of a short output, and the virtualized
+// content draws its own strip over the rows. The two have to agree.
+const GUTTER_WIDTH = 85;
+
 const ScrollContainer = styled.div`
   flex: 1 1 0%;
   min-height: 0;
@@ -102,8 +107,8 @@ const ScrollContainer = styled.div`
   position: relative;
   background: linear-gradient(
     to right,
-    var(--ascender-gutter-bg, #e8e8e8) 85px,
-    var(--ascender-output-bg, #fff) 85px
+    var(--ascender-gutter-bg, #e8e8e8) ${GUTTER_WIDTH}px,
+    var(--ascender-output-bg, #fff) ${GUTTER_WIDTH}px
   );
 `;
 
@@ -1138,7 +1143,7 @@ function JobOutput({
                       top: 0,
                       left: 0,
                       bottom: 0,
-                      width: 85,
+                      width: GUTTER_WIDTH,
                       backgroundColor: 'var(--ascender-gutter-bg, #e8e8e8)',
                       zIndex: 0,
                     }}

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -85,19 +85,26 @@ const OutputWrapper = styled.div`
 // react-virtualized's AutoSizer + Grid. It must have a real height; the parent
 // OutputWrapper is `flex: 1 1 auto` inside the flex-column CardBody, so this
 // fills the remaining space and owns the scrollbar.
+//
+// Its height must not depend on its content. react-virtual observes both this
+// element and every rendered row with a ResizeObserver, and a row measurement
+// changes the total size of the rows. With a content-sized flex basis that
+// change resized the container too, in the same frame, which the browser
+// reports as "ResizeObserver loop completed with undelivered notifications":
+// the row observations are delivered, the container's cannot be. A zero flex
+// basis makes the height the free space of the column and nothing else. The
+// gutter strip is painted here as a background so it runs to the bottom when
+// the output is shorter than the container.
 const ScrollContainer = styled.div`
-  flex: 1 1 auto;
+  flex: 1 1 0%;
   min-height: 0;
   overflow: auto;
   position: relative;
-  background-color: var(--ascender-output-bg, #fff);
-`;
-
-const OutputFooter = styled.div`
-  background-color: var(--ascender-gutter-bg, #e8e8e8);
-  border-right: none;
-  width: 85px;
-  flex: 1;
+  background: linear-gradient(
+    to right,
+    var(--ascender-gutter-bg, #e8e8e8) 85px,
+    var(--ascender-output-bg, #fff) 85px
+  );
 `;
 
 export const MAX_SELECTION_OVERSCAN = 500;
@@ -142,37 +149,6 @@ export function computeOverscanIndices(
       Math.min(cellCount - 1, clampedEnd)
     ),
   };
-}
-
-// react-virtual's measureElement uses a ResizeObserver to dynamically size rows.
-// On varied-height output a measure can shift layout within the same frame, so
-// the browser emits the benign notice "ResizeObserver loop completed with
-// undelivered notifications". It has no functional impact, but CRA's dev error
-// overlay treats that window 'error' as fatal and blocks the whole UI.
-//
-// We must NOT fix this by deferring the observer callback (e.g. to
-// requestAnimationFrame): react-virtual needs to apply the measured height in
-// the same commit, and on a live job the component re-renders continuously as
-// events stream in. A deferred measurement means each streaming render paints
-// rows at their stale 25px estimate before the next frame corrects them, so the
-// rows visibly overlap / garble / drop. Instead, leave the ResizeObserver
-// callback synchronous and just swallow the benign loop notice at the window
-// 'error' level before CRA's overlay sees it. Installed at module load (capture
-// phase) so it runs before the overlay's own handler.
-if (typeof window !== 'undefined' && !window.__ascResizeObserverErrorSilenced) {
-  const isResizeObserverLoopError = (message) =>
-    typeof message === 'string' && message.includes('ResizeObserver loop');
-  window.addEventListener(
-    'error',
-    (event) => {
-      if (isResizeObserverLoopError(event.message)) {
-        event.stopImmediatePropagation();
-        event.preventDefault();
-      }
-    },
-    true
-  );
-  window.__ascResizeObserverErrorSilenced = true;
 }
 
 function JobOutput({
@@ -1187,7 +1163,6 @@ function JobOutput({
               )}
             </ScrollContainer>
           )}
-          <OutputFooter />
         </OutputWrapper>
       </CardBody>
       {showCancelModal && isJobRunning(job.status) && (


### PR DESCRIPTION
##### SUMMARY

Every job output page raised `ResizeObserver loop completed with undelivered notifications` on load, which the dev server's error overlay turned into a full-screen error.

The scroll container was `flex: 1 1 auto`, so its flex basis was its own content height, and it shared the column's free space with a footer strip that was `flex: 1` as well. react-virtual observes both the container and every row, and a row measurement changes the total height of the rows, so the first measurements resized the container in the same frame. Instrumenting the page on job 130 shows it: the container's rect went 347 to 268 to 346 px while its width stayed at 1022, one notice per load, and the same on the e2e fixture jobs. The row observations are delivered, the container's cannot be, and that is the notice.

The container now has a zero flex basis, so its height is the column's free space and nothing else, and it paints the gutter strip as its own background so the strip still runs to the bottom under short output. Two things go with that:

- the footer strip, since the gradient does its job and its share of the free space was half of the problem;
- the window error listener that tried to hide the notice from the overlay. A bubble-phase listener registered earlier still runs despite a later capture-phase `stopImmediatePropagation` (checked in Chromium), so it never worked, and there is nothing left to hide.

Nothing changes for a user of the page. The rendering is identical with output and in the empty-results state, in both themes, since the gradient uses the same variables the footer and wrapper used. The container no longer bounces while the first rows measure, the strip below a live job's first lines no longer moves as they arrive, and with the fix the container holds a single rect for the whole session.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### ASCENDER VERSION

```
25.6.1.dev21+g8408777933
```

##### ADDITIONAL INFORMATION

jsdom has no layout, so the cover is an end-to-end test: `watchLayoutLoops` installs an init script that records the notice before the app loads, and the new spec opens a fixture job's output, scrolls to the bottom and back, and asserts nothing was reported. Against the previous container it fails; with this change the whole job output spec passes against the dev server:

```
# previous container
  ✘  job output layout › measures its rows without a ResizeObserver loop
     Error: layout loops reported:
     ResizeObserver loop completed with undelivered notifications.

# this branch
  ✓  workflow job selector › shows which of the workflow jobs is on screen
  ✓  workflow job selector › switches to the job picked from the menu
  ✓  workflow job selector › keeps working on a second move, without a page load in between
  ✓  workflow job selector › lists every job node, and picking the current one is harmless
  ✓  workflow job selector › filters the list by status
  ✓  job output layout › measures its rows without a ResizeObserver loop
  6 passed
```

Under Node 22 with node_modules from the lockfile:

```
npm run test   Test Suites: 552 passed, 552 total / Tests:       2969 passed, 2969 total (251.856 s)
npm run lint   eslint . clean
prettier --check on JobOutput.js: clean; eslint on JobOutput.js: clean (the e2e directory is outside both tools' scope)
```
