### PR TITLE
fix: render the workflow job selector beside the tabs, not inside one

### DIFF
--- a/awx/ui/e2e/tests/helpers.js
+++ b/awx/ui/e2e/tests/helpers.js
@@ -30,11 +30,6 @@ async function login(page) {
 // Console errors the application already emits. Anything not matched here fails
 // the spec that saw it, so a new one has to be either fixed or added knowingly.
 const ALLOWED_CONSOLE_ERRORS = [
-  // The workflow job selector is hosted inside a tab, and a tab is a <button>.
-  // Tracked as the follow-up noted in the pull request that fixed #742: moving
-  // the control out of the tab list removes this.
-  /cannot be a descendant of/i,
-  /cannot contain a nested/i,
   // websocket chatter when a job finishes while a page is open
   /websocket/i,
 ];

--- a/awx/ui/src/components/RoutedTabs/RoutedTabs.js
+++ b/awx/ui/src/components/RoutedTabs/RoutedTabs.js
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  Tab as PFTab,
-  Tabs as PFTabs,
-  TabTitleText,
-} from '@patternfly/react-core';
+import { Tab, Tabs as PFTabs, TabTitleText } from '@patternfly/react-core';
 import { useLocation, useNavigate } from 'react-router';
 import styled from 'styled-components';
 import { getPersistentFilters } from 'components/PersistentFilters';
@@ -14,20 +10,40 @@ const Tabs = styled(PFTabs)`
   }
 `;
 
-const Tab = styled(PFTab)`
-  ${(props) => props.hasstyle && `${props.hasstyle}`}
+// A tab bar can carry a control beside its tabs, the workflow job selector
+// being the one that does. It used to be registered as a link-less tab, which
+// put the selector's <button> inside the tab's own <button>: invalid HTML that
+// React reported on every job page inside a workflow. The control now renders
+// as a sibling of the tab list. This wrapper is the positioned ancestor, so
+// the bottom border PatternFly draws with ::before spans the control as well.
+const TabBar = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  & > .pf-v6-c-tabs {
+    position: static;
+    flex-grow: 1;
+  }
+`;
+
+const TabBarControl = styled.div`
+  margin-inline-start: auto;
+  padding-inline-end: var(--pf-t--global--spacer--md);
 `;
 
 function RoutedTabs({ tabsArray }) {
   const navigate = useNavigate();
   const location = useLocation();
+  const tabs = tabsArray.filter((tab) => tab.link);
+  const controls = tabsArray.filter((tab) => !tab.link);
 
   const getActiveTabId = () => {
-    const match = tabsArray.find((tab) => tab.link === location.pathname);
+    const match = tabs.find((tab) => tab.link === location.pathname);
     if (match) {
       return match.id;
     }
-    const subpathMatch = tabsArray.find((tab) =>
+    const subpathMatch = tabs.find((tab) =>
       location.pathname.startsWith(tab.link)
     );
     if (subpathMatch) {
@@ -37,13 +53,8 @@ function RoutedTabs({ tabsArray }) {
   };
 
   const handleTabSelect = (event, eventKey) => {
-    const match = tabsArray.find((tab) => tab.id === eventKey);
-    // A tab can exist only to host a control in the tab bar, the workflow job
-    // selector being the one that does, and carries no link. Clicks inside such
-    // a control bubble up to the tab, so treating this as tab navigation would
-    // call navigate(undefined), land back on the current url, and undo whatever
-    // the control itself just did.
-    if (!match || !match.link) {
+    const match = tabs.find((tab) => tab.id === eventKey);
+    if (!match) {
       return;
     }
     event.preventDefault();
@@ -52,27 +63,37 @@ function RoutedTabs({ tabsArray }) {
       : match.link;
     navigate(link);
   };
-  return (
+
+  const tabList = (
     <Tabs
       activeKey={getActiveTabId()}
       onSelect={handleTabSelect}
       ouiaId="routed-tabs"
     >
-      {tabsArray.map((tab) => (
+      {tabs.map((tab) => (
         <Tab
           aria-label={typeof tab.name === 'string' ? tab.name : null}
           eventKey={tab.id}
           key={tab.id}
-          // a tab that hosts a control has no link to point at, and passing the
-          // `false` this used to produce is not a valid href value
-          href={!tab.hasstyle && tab.link ? `#${tab.link}` : undefined}
+          href={`#${tab.link}`}
           title={<TabTitleText>{tab.name}</TabTitleText>}
           aria-controls=""
           ouiaId={`${tab.name}-tab`}
-          hasstyle={tab.hasstyle}
         />
       ))}
     </Tabs>
+  );
+
+  if (controls.length === 0) {
+    return tabList;
+  }
+  return (
+    <TabBar>
+      {tabList}
+      {controls.map((control) => (
+        <TabBarControl key={control.id}>{control.name}</TabBarControl>
+      ))}
+    </TabBar>
   );
 }
 

--- a/awx/ui/src/components/RoutedTabs/RoutedTabs.test.js
+++ b/awx/ui/src/components/RoutedTabs/RoutedTabs.test.js
@@ -64,20 +64,22 @@ describe('<RoutedTabs />', () => {
   });
 });
 
-describe('<RoutedTabs /> with a tab that hosts a control', () => {
-  // The workflow job selector is registered as a tab with no link, so that it
-  // sits in the tab bar. Clicks on the control inside it bubble to the tab.
+describe('<RoutedTabs /> with a control beside the tabs', () => {
+  // The workflow job selector is registered as an entry with no link, so that
+  // it sits in the tab bar. It has to render beside the tab list rather than
+  // inside a tab: a tab is a <button>, and so is the selector's own toggle,
+  // which is why the control here is a real button.
   const controlTabs = [
     { name: 'Details', link: '/jobs/playbook/953/details', id: 0 },
     { name: 'Output', link: '/jobs/playbook/953/output', id: 1 },
     {
-      // a plain element, not a <button>: the real selector nests a button inside
-      // the tab's own button, which React rightly complains about, and the
-      // console guard in setupTests turns that complaint into a failure
-      name: <span data-testid="wf-control">Workflow Job 2/4</span>,
+      name: (
+        <button type="button" data-testid="wf-control">
+          Workflow Job 2/4
+        </button>
+      ),
       link: undefined,
       id: 2,
-      hasstyle: 'margin-left: auto',
     },
   ];
 
@@ -97,9 +99,17 @@ describe('<RoutedTabs /> with a tab that hosts a control', () => {
     return { ...utils, history };
   }
 
-  test('a click inside a link-less tab does not navigate', async () => {
+  test('renders the control outside the tab list', () => {
+    renderControlTabs();
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    const control = screen.getByTestId('wf-control');
+    expect(control).toBeInTheDocument();
+    expect(control.closest('[role="tab"]')).toBeNull();
+  });
+
+  test('a click on the control does not navigate', async () => {
     const { user, history } = renderControlTabs();
-    await user.click(screen.getByText('Workflow Job 2/4'));
+    await user.click(screen.getByTestId('wf-control'));
     await waitFor(() =>
       expect(history.location.pathname).toBe('/jobs/playbook/953/output')
     );

--- a/awx/ui/src/screens/Job/Job.js
+++ b/awx/ui/src/screens/Job/Job.js
@@ -142,7 +142,6 @@ function Job({ setBreadcrumb }) {
       ),
       link: undefined,
       id: 2,
-      hasstyle: 'margin-left: auto',
     });
   }
 


### PR DESCRIPTION
##### SUMMARY

Every job page inside a workflow logged two React errors: `In HTML, <button> cannot be a descendant of <button>` and `<button> cannot contain a nested <button>`. The workflow job selector was registered as a link-less tab so that it could sit in the tab bar, and a PatternFly tab is a `<button>`, so the selector's own toggle ended up nested inside it. The end-to-end suite had to allow the two messages to stay green, which the pull request that fixed #742 noted as the follow-up.

`RoutedTabs` now renders a link-less entry beside the tab list rather than as a tab. The tabs and the control share a flex wrapper that is also the positioned ancestor, so the bottom border PatternFly draws under the tabs with `::before` spans the control too, and the selector sits where it did. Pages without such an entry return the bare tab list and render exactly as before. The `hasstyle` hook that positioned the tab goes with it, and so does the e2e allowance, so the spec catches a regression from now on.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### ASCENDER VERSION

```
25.6.2.dev1+g38c5c0197e
```

##### ADDITIONAL INFORMATION

The unit test for the hosted control now uses a real button, which the previous tab bar could not host without the same complaint, and asserts it renders outside every tab. Against main's `RoutedTabs` it fails; here the RoutedTabs and Job suites pass.

The e2e job output spec, with the allowance removed, passes six of six against this branch on the dev server, and against main's `RoutedTabs` and `Job` it fails on exactly the two messages:

```
  ✘  workflow job selector › switches to the job picked from the menu
     Error: unexpected console errors:
     In HTML, %s cannot be a descendant of <%s>.
     <%s> cannot contain a nested %s.
```

(That run had #803's job output fix applied to the tree, since without it the dev server's error overlay covers the page and blocks the clicks; CI runs the suite against the built UI, where there is no overlay.)

Under Node 22 with node_modules from the lockfile:

```
npm run test   Test Suites: 552 passed, 552 total / Tests:       2972 passed, 2972 total (238.784 s)
npm run lint   eslint . clean
prettier --check and eslint on the changed files: clean (the e2e directory is outside both tools' scope)
```
