### PR TITLE
fix: keep styling props off the DOM in the workflow node, node help and host status bar

### DIFF
--- a/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
@@ -18,8 +18,10 @@ const GridDL = styled.dl`
   }
 `;
 
+// $hasJob is transient: a plain prop would be forwarded to the <p> and land in
+// the DOM as an unknown attribute.
 const ResourceDeleted = styled.p`
-  margin-bottom: ${(props) => (props.job ? '10px' : '0px')};
+  margin-bottom: ${(props) => (props.$hasJob ? '10px' : '0px')};
 `;
 
 const StyledExclamationTriangleIcon = styled(ExclamationTriangleIcon)`
@@ -131,7 +133,7 @@ function WorkflowNodeHelp({ node }) {
   return (
     <>
       {!unifiedJobTemplate && (!job || job.type !== 'workflow_approval') && (
-        <ResourceDeleted job={job}>
+        <ResourceDeleted $hasJob={Boolean(job)}>
           <StyledExclamationTriangleIcon />
           <Trans>
             The resource associated with this node has been deleted.

--- a/awx/ui/src/components/Workflow/WorkflowNodeHelp.test.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeHelp.test.js
@@ -43,4 +43,31 @@ describe('WorkflowNodeHelp', () => {
       container.querySelector('#workflow-node-help-elapsed')
     ).toHaveTextContent('02:30:00');
   });
+
+  test('notes a deleted resource without leaking the job to the DOM', () => {
+    // no unifiedJobTemplate anywhere on the node: the resource is gone
+    const deletedNode = {
+      originalNodeObject: {
+        identifier: 'Gone',
+        summary_fields: {
+          job: {
+            name: 'Gone Job',
+            elapsed: 4,
+            status: 'successful',
+            type: 'job',
+          },
+        },
+      },
+    };
+    const { getByText } = renderWithContexts(
+      <WorkflowNodeHelp node={deletedNode} />
+    );
+    const notice = getByText(
+      'The resource associated with this node has been deleted.'
+    ).closest('p');
+    expect(notice).toBeInTheDocument();
+    // the job only decides the margin below the notice; it must not reach the
+    // element as an attribute
+    expect(notice).not.toHaveAttribute('job');
+  });
 });

--- a/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.js
@@ -11,9 +11,11 @@ const BarWrapper = styled.div.attrs({ className: 'host-status-bar' })`
   width: 100%;
 `;
 
+// Both props are transient: as plain props they would be forwarded to the div
+// and land in the DOM as attributes, count an unknown one.
 const BarSegment = styled.div`
-  background-color: ${(props) => props.color || 'inherit'};
-  flex-grow: ${(props) => props.count || 0};
+  background-color: ${(props) => props.$color || 'inherit'};
+  flex-grow: ${(props) => props.$count || 0};
 `;
 BarSegment.displayName = 'BarSegment';
 
@@ -64,7 +66,7 @@ const HostStatusBar = ({ counts = {} }) => {
           </TooltipContent>
         }
       >
-        <BarSegment key={key} color={hostStatus[key].color} count={count} />
+        <BarSegment key={key} $color={hostStatus[key].color} $count={count} />
       </Tooltip>
     );
   });
@@ -75,7 +77,7 @@ const HostStatusBar = ({ counts = {} }) => {
         <Tooltip
           content={t`Host status information for this job is unavailable.`}
         >
-          <BarSegment count={1} />
+          <BarSegment $count={1} />
         </Tooltip>
       </BarWrapper>
     );

--- a/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/HostStatusBar.test.js
@@ -18,6 +18,21 @@ describe('<HostStatusBar />', () => {
     expect(wrapper.querySelectorAll(':scope > div > div')).toHaveLength(5);
   });
 
+  test('segments keep their styling props out of the DOM', () => {
+    // color and count drive the CSS only; as plain props styled-components
+    // forwarded them to the div, and count is not an HTML attribute
+    const { container } = renderWithContexts(
+      <HostStatusBar counts={mockCounts} />
+    );
+    const segments =
+      container.firstChild.querySelectorAll(':scope > div > div');
+    expect(segments).toHaveLength(5);
+    segments.forEach((segment) => {
+      expect(segment).not.toHaveAttribute('count');
+      expect(segment).not.toHaveAttribute('color');
+    });
+  });
+
   test('tooltips should display host status and count', async () => {
     const { user, container } = renderWithContexts(
       <HostStatusBar counts={mockCounts} />

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.js
@@ -10,8 +10,10 @@ import { secondsToHHMMSS } from 'util/dates';
 import { stringIsUUID } from 'util/strings';
 import { constants as wfConstants } from 'components/Workflow/WorkflowUtils';
 
+// $hasJob is transient: the job object itself used to be forwarded to the <g>
+// and land in the DOM as an attribute.
 const NodeG = styled.g`
-  cursor: ${(props) => (props.job ? 'pointer' : 'default')};
+  cursor: ${(props) => (props.$hasJob ? 'pointer' : 'default')};
 `;
 
 const JobTopLine = styled.div`
@@ -144,7 +146,7 @@ function WorkflowOutputNode({ mouseEnter, mouseLeave, node }) {
       transform={`translate(${nodePositions[node.id].x},${
         nodePositions[node.id].y - nodePositions[1].y
       })`}
-      job={job}
+      $hasJob={Boolean(job)}
       onClick={handleNodeClick}
       onMouseEnter={mouseEnter}
       onMouseLeave={mouseLeave}

--- a/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.test.js
+++ b/awx/ui/src/screens/Job/WorkflowOutput/WorkflowOutputNode.test.js
@@ -91,6 +91,13 @@ describe('WorkflowOutputNode', () => {
     expect(container.querySelector('#node-2')).toBeInTheDocument();
   });
 
+  test('keeps the job object off the node group in the DOM', () => {
+    // the job only decides the cursor; as a plain prop styled-components
+    // forwarded the whole object to the <g> as an attribute
+    const { container } = renderNode(nodeWithJT);
+    expect(container.querySelector('#node-2')).not.toHaveAttribute('job');
+  });
+
   test('node contents displayed correctly when Job and Job Template exist', () => {
     const { container } = renderNode(nodeWithJT);
     expect(container.querySelector('#node-2')).toHaveTextContent(


### PR DESCRIPTION
##### SUMMARY

Opening a workflow's output view, and the output view of any job inside it, logged styled-components warnings about unknown props being sent to the DOM. Three styled components took plain props that only feed their CSS, and styled-components forwards those to the element underneath, so they landed in the DOM as attributes:

- the whole job object on the `<g>` of every node in the workflow output graph (`NodeG` in `WorkflowOutputNode`), which only decides the cursor;
- `job` on the deleted-resource notice in `WorkflowNodeHelp`, which only decides a margin;
- `count` on each segment of the host status bar on the job output pages, with `color` alongside it, which only set flex-grow and background.

Each now uses a transient prop (`$hasJob`, `$count`, `$color`), the way the template visualizer's node already does, so the value reaches the CSS and stops there. No rendering changes: the same styles come out of the same values.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### ASCENDER VERSION

```
25.6.2.dev1+g33f7cfedb1
```

##### ADDITIONAL INFORMATION

Three unit tests assert the attributes are absent from the rendered node group, the notice and the bar segments. Each fails against the previous component and passes with this change. With the change served by the dev server, the browser console on the workflow output view is empty, and the node job pages keep only the nested-button messages that #804 removes.

Under Node 22 with node_modules from the lockfile:

```
npm run test   Test Suites: 552 passed, 552 total / Tests:       2974 passed, 2974 total (231.973 s)
npm run lint   eslint . clean
prettier --check and eslint on the changed files: clean
```
