### PR TITLE
build: move the container images to Python 3.14

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,7 +20,7 @@ Supporting containers also running:
 - `tools_valkey_1` – Valkey (Redis-compatible) cache
 
 Runtime versions (inside container):
-- **Python** 3.12.12
+- **Python** 3.14.7
 - **Django** 5.2.14
 - **psycopg** 3.1.18
 - **black** 26.5.1 | **flake8** 7.3.0 | **yamllint** 1.38.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Modifications Copyright (c) 2023 Ctrl IQ, Inc.
 
-PYTHON := $(notdir $(shell for i in python3.12 python3; do command -v $$i; done|sed 1q))
+PYTHON := $(notdir $(shell for i in python3.14 python3; do command -v $$i; done|sed 1q))
 SHELL := bash
 DOCKER_COMPOSE ?= docker compose
 OFFICIAL ?= no

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![CI](https://github.com/ctrliq/ascender/actions/workflows/ci.yml/badge.svg)](https://github.com/ctrliq/ascender/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
-[![Python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.14-blue.svg)](https://www.python.org/)
 
 Ascender provides a web-based user interface, REST API, and task engine built on top of [Ansible](https://github.com/ansible/ansible). It is the automation platform at the centre of this project, based on the upstream [AWX](https://github.com/ansible/awx) project and maintained by Ctrl IQ.
 
 ## Requirements
 
 - Docker with Compose, for the development environment
-- Python 3.12, matching what the container images build against
+- Python 3.14, matching what the container images build against
 - A Kubernetes cluster for production, which the installer can provision for you
 
 ## Installation

--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -9,8 +9,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import collections
-from multiprocessing import Process
-from multiprocessing import Queue as MPQueue
+from multiprocessing import get_context
 from queue import Full as QueueFull, Empty as QueueEmpty
 
 from django.conf import settings
@@ -29,6 +28,12 @@ if 'run_callback_receiver' in sys.argv:
     logger = logging.getLogger('awx.main.commands.run_callback_receiver')
 else:
     logger = logging.getLogger('awx.main.dispatch')
+
+# Workers inherit the loaded Django app registry from the parent process, which only
+# the fork start method provides. Python 3.14 changed the Linux default to forkserver,
+# where the child re-imports and raises AppRegistryNotReady, so the context is pinned
+# here rather than left to the platform default.
+_mp_ctx = get_context('fork')
 
 
 class NoOpResultQueue(object):
@@ -71,9 +76,9 @@ class PoolWorker(object):
         self.messages_sent = 0
         self.messages_finished = 0
         self.managed_tasks = collections.OrderedDict()
-        self.finished = MPQueue(queue_size) if self.track_managed_tasks else NoOpResultQueue()
-        self.queue = MPQueue(queue_size)
-        self.process = Process(target=target, args=(self.queue, self.finished) + args)
+        self.finished = _mp_ctx.Queue(queue_size) if self.track_managed_tasks else NoOpResultQueue()
+        self.queue = _mp_ctx.Queue(queue_size)
+        self.process = _mp_ctx.Process(target=target, args=(self.queue, self.finished) + args)
         self.process.daemon = True
 
     def start(self):

--- a/awx/main/tests/unit/test_settings.py
+++ b/awx/main/tests/unit/test_settings.py
@@ -15,10 +15,13 @@ LOCAL_SETTINGS = (
 
 
 def test_postprocess_auth_basic_enabled():
-    locals().update({'__file__': __file__})
+    # An explicit dict rather than locals(): since PEP 667 (Python 3.13) locals()
+    # inside a function returns an independent snapshot, so updating it no longer
+    # reaches the frame and include() would not see __file__.
+    scope = {'__file__': __file__}
 
-    include('../../../settings/defaults.py', scope=locals())
-    assert 'awx.api.authentication.LoggedBasicAuthentication' in locals()['REST_FRAMEWORK']['DEFAULT_AUTHENTICATION_CLASSES']
+    include('../../../settings/defaults.py', scope=scope)
+    assert 'awx.api.authentication.LoggedBasicAuthentication' in scope['REST_FRAMEWORK']['DEFAULT_AUTHENTICATION_CLASSES']
 
 
 def test_default_settings():

--- a/docs/docsite/updater.sh
+++ b/docs/docsite/updater.sh
@@ -3,7 +3,7 @@ set -ue
 
 venv="`pwd`/venv"
 echo $venv
-/usr/bin/python3.12 -m venv "${venv}"
+/usr/bin/python3.14 -m venv "${venv}"
 # shellcheck disable=SC1090
 source ${venv}/bin/activate
 

--- a/licenses/typing-inspection.txt
+++ b/licenses/typing-inspection.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Pydantic Services Inc. 2025 to present
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -288,9 +288,9 @@ pyasn1-modules==0.4.2
     #   service-identity
 pycparser==2.21
     # via cffi
-pydantic==2.6.1
+pydantic==2.13.5
     # via inflect
-pydantic-core==2.16.2
+pydantic-core==2.46.5
     # via pydantic
 pygerduty==0.38.3
     # via -r /awx_devel/requirements/requirements.in
@@ -421,23 +421,22 @@ twisted[tls]==26.4.0
     #   daphne
 txaio==23.1.1
     # via autobahn
-typing-extensions==4.12.2
+typing-extensions==4.16.0
     # via
-    #   aiohttp
-    #   aiosignal
     #   azure-core
     #   azure-identity
     #   azure-keyvault-secrets
     #   django-polymorphic
     #   inflect
     #   jwcrypto
-    #   psycopg
     #   pydantic
     #   pydantic-core
     #   pygithub
-    #   pyopenssl
     #   setuptools-scm
     #   twisted
+    #   typing-inspection
+typing-inspection==0.4.4
+    # via pydantic
 uritemplate==4.2.0
     # via drf-spectacular
 urllib3==2.7.0
@@ -464,7 +463,7 @@ yarl==1.18.3
     # via aiohttp
 zipp==3.23.0
     # via importlib-metadata
-zope-interface==7.0.3
+zope-interface==8.6
     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -478,4 +477,3 @@ setuptools==84.0.0
     #   incremental
     #   setuptools-rust
     #   setuptools-scm
-    #   zope-interface

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -18,7 +18,7 @@ generate_requirements() {
   local input_reqs="$1"
   venv="$(pwd)/venv"
   echo "$venv"
-  /usr/bin/python3.12 -m venv "${venv}"
+  /usr/bin/python3.14 -m venv "${venv}"
   # shellcheck disable=SC1090
   source "${venv}/bin/activate"
 

--- a/tools/ansible/roles/dockerfile/files/uwsgi.ini
+++ b/tools/ansible/roles/dockerfile/files/uwsgi.ini
@@ -13,7 +13,10 @@ buffer-size = 32768
 harakiri = 115
 harakiri-graceful-timeout = 110
 harakiri-graceful-signal = 6
-py-call-osafterfork = true
+; py-call-osafterfork is fatal on Python 3.13+ with uwsgi <= 2.0.31: workers die
+; at fork with "PyMutex_Unlock: unlocking mutex that is not locked"
+; (https://github.com/unbit/uwsgi/issues/2710). uwsgi's pending fix skips the
+; PyOS_AfterFork_Child call on 3.13+ anyway, so the option is dead there.
 
 if-env = UWSGI_MOUNT_PATH
 mount = %(_)=awx.wsgi:application

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -47,18 +47,17 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     patch \
     postgresql \
     postgresql-devel \
-    python3.12 \
-    "python3.12-devel" \
-    "python3.12-pip" \
-    "python3.12-setuptools" \
-    "python3.12-packaging" \
-    "python3.12-psycopg2" \
+    python3.14 \
+    "python3.14-devel" \
+    "python3.14-pip" \
+    "python3.14-setuptools" \
+    "python3.14-packaging" \
     swig \
     unzip \
     xmlsec1-devel \
     xmlsec1-openssl-devel
 
-RUN pip3.12 install -vv build
+RUN pip3.14 install -vv build
 
 {% if image_architecture == 'ppc64le'  %}
     RUN dnf -y update && dnf install -y wget && \
@@ -128,12 +127,11 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     nginx \
     "openldap >= 2.6.2-3" \
     postgresql \
-    python3.12 \
-    "python3.12-devel" \
-    "python3.12-pip*" \
-    "python3.12-setuptools" \
-    "python3.12-packaging" \
-    "python3.12-psycopg2" \
+    python3.14 \
+    "python3.14-devel" \
+    "python3.14-pip*" \
+    "python3.14-setuptools" \
+    "python3.14-packaging" \
     rsync \
     rsyslog \
     subversion \
@@ -144,7 +142,7 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     xmlsec1-openssl && \
     dnf -y clean all
 
-RUN pip3.12 install --no-cache-dir -vv virtualenv supervisor dumb-init build && \
+RUN pip3.14 install --no-cache-dir -vv virtualenv supervisor dumb-init build && \
     rm -rf /root/.cache /tmp/*
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
@@ -180,8 +178,8 @@ RUN dnf module reset nodejs -y && \
     npm install -g npm@10.9.3 && \
     dnf -y clean all
 
-RUN pip3.12 install --no-cache-dir -vv git+https://github.com/coderanger/supervisor-stdout.git@973ba19967cdaf46d9c1634d1675fc65b9574f6e && \
-    pip3.12 install --no-cache-dir -vv black setuptools-scm build && \
+RUN pip3.14 install --no-cache-dir -vv git+https://github.com/coderanger/supervisor-stdout.git@973ba19967cdaf46d9c1634d1675fc65b9574f6e && \
+    pip3.14 install --no-cache-dir -vv black setuptools-scm build && \
     rm -rf /root/.cache /tmp/*
 
 # This package randomly fails to download.
@@ -252,8 +250,8 @@ ADD tools/scripts/awx-python /usr/bin/awx-python
 {% endif %}
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
-RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.12/site-packages/awx.egg-link && \
-    echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.12/site-packages/awx.pth && \
+RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.14/site-packages/awx.egg-link && \
+    echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.14/site-packages/awx.pth && \
     ln -sf /awx_devel/tools/docker-compose/awx-manage /usr/local/bin/awx-manage && \
     ln -sf /awx_devel/tools/scripts/awx-python /usr/bin/awx-python && \
     ln -sf /awx_devel/tools/scripts/rsyslog-4xx-recovery /usr/bin/rsyslog-4xx-recovery
@@ -287,8 +285,8 @@ RUN for dir in \
       /var/lib/awx/.local \
       /var/lib/awx/venv \
       /var/lib/awx/venv/awx/bin \
-      /var/lib/awx/venv/awx/lib/python3.12 \
-      /var/lib/awx/venv/awx/lib/python3.12/site-packages \
+      /var/lib/awx/venv/awx/lib/python3.14 \
+      /var/lib/awx/venv/awx/lib/python3.14/site-packages \
       /var/lib/awx/projects \
       /var/lib/awx/rsyslog \
       /var/run/awx-rsyslog \

--- a/tools/scripts/firehose.py
+++ b/tools/scripts/firehose.py
@@ -44,6 +44,13 @@ from django.db import connection
 from django.db.models.sql import InsertQuery
 from django.utils.timezone import now
 
+# Workers are forked after setup_django() and rely on inheriting the loaded app
+# registry, which only the fork start method provides. Python 3.14 changed the
+# Linux default to forkserver, where the child re-imports and raises
+# AppRegistryNotReady, so the context is pinned here as it is in
+# awx/main/dispatch/pool.py.
+_mp_ctx = multiprocessing.get_context('fork')
+
 db = json.loads(
     subprocess.check_output(
         ['awx-manage', 'shell', '-c', 'import json; from django.conf import settings; print(json.dumps({"DATABASES": settings.DATABASES}))']
@@ -232,7 +239,7 @@ def generate_events(events, job, time_delta):
         num_events = events
 
     for i in range(num_procs):
-        p = multiprocessing.Process(target=firehose, args=(job, num_events, created_stamp, modified_stamp))
+        p = _mp_ctx.Process(target=firehose, args=(job, num_events, created_stamp, modified_stamp))
         p.daemon = True
         workers.append(p)
 
@@ -326,7 +333,7 @@ if __name__ == '__main__':
         for indexname, indexdef in indexes:
             if indexname == 'main_jobevent_pkey_new':  # Created by the constraint
                 continue
-            p = multiprocessing.Process(target=cleanup, args=(indexdef,))
+            p = _mp_ctx.Process(target=cleanup, args=(indexdef,))
             p.daemon = True
             workers.append(p)
 


### PR DESCRIPTION
##### SUMMARY

The container images build against Python 3.12. This moves them to 3.14.

Rocky 9's AppStream already carries it: `python3.14`, `python3.14-devel` and `python3.14-pip` come from AppStream, and `python3.14-setuptools` and `python3.14-packaging` from `crb`, which the Dockerfile enables already. No new repository is needed. Python 3.13 was the other candidate and was rejected: every one of those packages lives only in EPEL, which the production stages do not enable today.

`python3.12-psycopg2` is dropped rather than carried across. The venv is built with `include-system-site-packages = false`, so the RPM was never visible to the application, nothing on the system imports it, and the application uses `psycopg` 3 from `requirements.txt`. There is no `python3.14-psycopg2` and nothing needs one.

**Four things break on 3.14, and the interesting part is that three of them are silent at build time.**

1. **The multiprocessing start method.** `awx/main/dispatch/pool.py` used the default, which changed on Linux from `fork` to `forkserver` in 3.14. Workers inherit the loaded Django app registry from the parent, which only `fork` provides; under `forkserver` the child re-imports and raises `AppRegistryNotReady`. This affects the running service, not just tests. The context is now pinned to `fork`, matching what `awx/main/models/workflow.py:1286` already does. `tools/scripts/firehose.py` forks the same way after its `setup_django()` and is pinned alongside it.

2. **uwsgi's `py-call-osafterfork`.** Workers abort at fork with `Fatal Python error: PyMutex_Unlock: unlocking mutex that is not locked` and the master respawns them forever, so the web tier never comes up. The option calls `PyOS_AfterFork_Child` in a state 3.13+ rejects ([unbit/uwsgi#2710](https://github.com/unbit/uwsgi/issues/2710)), and uwsgi's pending fix ([#2736](https://github.com/unbit/uwsgi/pull/2736), a draft for over a year) skips the call on 3.13+ anyway, so the option is dead weight there. Found by @cigamit testing this branch. It is the one failure the suite could not have caught, since pytest never starts uwsgi.

3. **`zope-interface` 7.0.3 cannot be imported on 3.14 at all.** Defining `IElement` in its own `interfaces.py` raises `InvalidInterface: Concrete attribute, __classdictcell__`, from the class dict change in 3.13. It reaches us through `twisted`, so this would break the running service too. It compiles from source without complaint, which is exactly why a wheel-availability audit does not catch it.

4. **`test_postprocess_auth_basic_enabled`** seeded `__file__` via `locals().update()`. Since PEP 667 in 3.13, `locals()` inside a function returns an independent snapshot, so the update never reached the frame and `include()` raised `KeyError: '__file__'`. It now passes an explicit scope dict, which behaves identically on every version.

The requirements move is the minimum 3.14 forces, and the chain is worth recording. `pydantic-core` 2.16.2 builds through `pyo3` 0.20.2, which predates 3.14. cp314 wheels start at `pydantic-core` 2.35.0, which needs `pydantic` 2.12 or newer, which requires `typing-extensions>=4.14.1`. The `typing-extensions==4.12.2` pin was the real ceiling, so all three had to move together. `typing-inspection` arrives as a new dependency of pydantic and brings its license file with it.

```
pydantic          2.6.1  -> 2.13.5
pydantic-core     2.16.2 -> 2.46.5
typing-extensions 4.12.2 -> 4.16.0
typing-inspection        -> 0.4.4  (new)
zope-interface    7.0.3  -> 8.6
```

Regenerated with `requirements/updater.sh` under 3.14. No other pin moved.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API
- Other

##### ASCENDER VERSION

```
awx: 25.6.2.dev0+g4deeb17b95.d20260904
```

##### ADDITIONAL INFORMATION

Verified in an image built from this checkout with `make docker-compose-build`:

- Full suite on 3.14: **3968 passed, 10 skipped**. The same suite on `main` under 3.14 fails exactly two, `TestWorkerPool::test_worker_processing` and `test_postprocess_auth_basic_enabled`, which are the two this branch fixes. Collection is identical at 3978 either way, so nothing was skipped into passing.
- `make test-postgres` against a real PostgreSQL: 4 passed.
- `awx-manage check_migrations --dry-run --check`: no changes detected.
- `black --check awx`: 929 files unchanged.
- `flake8 awx`: clean.
- `yamllint -s .`: clean.
- Import smoke test across 46 top-level dependencies on 3.14: 46/46.
- `awx/` carries no imports of any module removed in 3.13 or 3.14: no PEP 594 modules, no `pkgutil.find_loader`, no `typing.ByteString`.

The suite covers the dispatcher pool, as the `main` baseline above shows, but it never starts uwsgi. The service paths were checked against a running 3.14 image as well:

- uwsgi serving `awx.wsgi` off the real `/etc/tower/uwsgi.ini`: all 5 workers spawn and reach `WSGI app 0 ready`. With `py-call-osafterfork` restored, the same command reproduces @cigamit's abort loop, so the option is the cause rather than a coincidence.
- A `fork` context child of `awx.main.dispatch.pool` inherits the app registry (`apps.ready` true, exit 0), where the default `forkserver` context kills the child.
- `twisted` 26.4.0 imports with `zope-interface` 8.6, including `zope.interface.interfaces.IElement`.

Motivation for going to 3.14 now rather than later: `django-guid` 3.6.1 caps `django<6.0` for `python_version >= "3.10" and python_version < "3.13"`, while allowing `django<7.0` on 3.13 and newer. That cap blocks any move to Django 6 on 3.12.

Rebased onto current `main` after #807, #808 and #809 merged, so the branch is two commits on top of it with no merge commits. `requirements.txt` was regenerated with `requirements/updater.sh` under 3.14 rather than merged textually, since a text merge would have reinstated `django-crum`, `django-extensions` and `djangorestframework-yaml`, which those PRs removed; the regenerated file is byte-identical to the rebase result.


