### PR TITLE
build: move to Django 6.1.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ docker exec tools_awx_1 bash -c "cd /awx_devel && <command>"
 ```
 
 Supporting containers also running:
-- `tools_postgres_1` – PostgreSQL database (used by the running app; tests use SQLite)
+- `tools_postgres_1` – PostgreSQL database (used by the running app and by the test suite)
 - `tools_valkey_1` – Valkey (Redis-compatible) cache
 
 Runtime versions (inside container):
@@ -57,7 +57,7 @@ docker exec tools_awx_1 bash -c "cd /awx_devel && yamllint -s ."
 
 ## Running Tests
 
-Tests use SQLite (not PostgreSQL) and in-memory channel layer — no database setup needed. Settings: `awx.main.tests.settings_for_test` (configured in `pytest.ini`). Default pytest flags: `--reuse-db --nomigrations --tb=native --timeout=300`.
+Tests run against PostgreSQL, the same backend Ascender deploys on, with an in-memory channel layer. Settings: `awx.main.tests.settings_for_test` (configured in `pytest.ini`). Default pytest flags: `--reuse-db --nomigrations --tb=native --timeout=300`.
 
 ### Unit tests (~15 seconds, run frequently)
 ```bash
@@ -119,7 +119,7 @@ Migration files live in `awx/main/migrations/` (218 existing files).
 | `awx/main/migrations/` | 218 Django migrations |
 | `awx/main/tests/unit/` | Fast isolated unit tests (~1139 tests) |
 | `awx/main/tests/functional/` | Django TestClient-based API tests (~1987 tests) |
-| `awx/main/tests/settings_for_test.py` | Test settings (SQLite, in-memory cache) |
+| `awx/main/tests/settings_for_test.py` | Test settings (PostgreSQL, in-memory cache) |
 | `awx/settings/` | Settings modules: `defaults.py`, `development.py`, `production.py` |
 | `awx/sso/` | SSO/LDAP/SAML backends + tests |
 | `awx/ui/` | UI / React frontend (npm) |

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ pre-commit-user
 # Tower
 awx-dev
 awx/settings/local_*.py*
-awx/*.sqlite3
-awx/*.sqlite3_*
 awx/job_status
 awx/projects
 awx/job_output
@@ -93,7 +91,6 @@ htmlcov
 pep8.txt
 scratch
 testem.log
-awx/awx_test.sqlite3-journal
 .pytest_cache/
 
 # Mac OS X

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ clean-api:
 	rm -rf .tox
 	find . -type f -regex ".*\.py[co]$$" -delete
 	find . -depth -type d -name "__pycache__" -delete
-	rm -f awx/awx_test.sqlite3*
 	rm -rf requirements/vendor
 	rm -rf awx/projects
 

--- a/awx/dab/lib/abstract_models/common.py
+++ b/awx/dab/lib/abstract_models/common.py
@@ -195,10 +195,12 @@ class AbstractCommonModel(models.Model):
         return super().save(*args, **kwargs)
 
     @classmethod
-    def from_db(self, db, field_names, values):
+    # Ascender: fetch_mode added for Django 6.1, which records it on the instance
+    # state; an override that drops it opts the model out of fetch modes.
+    def from_db(self, db, field_names, values, *, fetch_mode=None):
         from cryptography.fernet import InvalidToken
 
-        instance = super().from_db(db, field_names, values)
+        instance = super().from_db(db, field_names, values, fetch_mode=fetch_mode)
 
         for field in self.encrypted_fields:
             field_value = getattr(instance, field, None)

--- a/awx/dab/lib/abstract_models/common.py
+++ b/awx/dab/lib/abstract_models/common.py
@@ -194,15 +194,15 @@ class AbstractCommonModel(models.Model):
 
         return super().save(*args, **kwargs)
 
-    @classmethod
     # Ascender: fetch_mode added for Django 6.1, which records it on the instance
     # state; an override that drops it opts the model out of fetch modes.
-    def from_db(self, db, field_names, values, *, fetch_mode=None):
+    @classmethod
+    def from_db(cls, db, field_names, values, *, fetch_mode=None):
         from cryptography.fernet import InvalidToken
 
         instance = super().from_db(db, field_names, values, fetch_mode=fetch_mode)
 
-        for field in self.encrypted_fields:
+        for field in cls.encrypted_fields:
             field_value = getattr(instance, field, None)
             try:
                 setattr(instance, field, ansible_encryption.decrypt_string(field_value))
@@ -212,7 +212,7 @@ class AbstractCommonModel(models.Model):
                     "Restore the original SECRET_KEY that encrypted this database, then restart. "
                     "Re-raising to prevent the model from loading with corrupted data.",
                     field,
-                    self.__name__,
+                    cls.__name__,
                     getattr(instance, 'pk', None),
                 )
                 raise

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -370,8 +370,10 @@ class CredentialType(CommonModelNameNotUnique):
     )
 
     @classmethod
-    def from_db(cls, db, field_names, values):
-        instance = super(CredentialType, cls).from_db(db, field_names, values)
+    def from_db(cls, db, field_names, values, *, fetch_mode=None):
+        # fetch_mode has to be forwarded: Django 6.1 records it on the instance
+        # state, and an override that drops it opts the model out of fetch modes.
+        instance = super(CredentialType, cls).from_db(db, field_names, values, fetch_mode=fetch_mode)
         if instance.managed and instance.namespace:
             native = ManagedCredentialType.registry[instance.namespace]
             instance.inputs = native.inputs

--- a/awx/main/notifications/email_backend.py
+++ b/awx/main/notifications/email_backend.py
@@ -25,6 +25,19 @@ DEFAULT_APPROVAL_DENIED_BODY = CustomNotificationBase.DEFAULT_APPROVAL_DENIED_BO
 
 
 class CustomEmailBackend(EmailBackend, CustomNotificationBase):
+    # Django 6.1 deprecated constructing this backend directly, so every send
+    # raises RemovedInDjango70Warning ("Use mail.mailers instead"). The warning
+    # is not silenced, because it is telling the truth: this breaks in 7.0.
+    #
+    # It is not fixable here. MAILERS is a static settings dict keyed by alias,
+    # while a notification template carries its own host, port and credentials,
+    # decrypted per send in NotificationTemplate.send, so there is no alias to
+    # point at. Django offers no runtime registration to bridge that, and
+    # get_connection is deprecated on the same timer.
+    #
+    # Passing alias=None would suppress the warning, since the check is only
+    # "alias" not in kwargs, but that hides the problem rather than solving it
+    # and would break anyway once 7.0 drops the deprecated branch.
     init_parameters = {
         "host": {"label": "Host", "type": "string"},
         "port": {"label": "Port", "type": "int"},

--- a/awx/main/notifications/grafana_backend.py
+++ b/awx/main/notifications/grafana_backend.py
@@ -54,7 +54,10 @@ class GrafanaBackend(AWXBaseEmailBackend, CustomNotificationBase):
     def __init__(
         self, grafana_key, dashboardId=None, panelId=None, annotation_tags=None, grafana_no_verify_ssl=False, isRegion=True, fail_silently=False, **kwargs
     ):
-        super(GrafanaBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(GrafanaBackend, self).__init__()
+        self.fail_silently = fail_silently
         self.grafana_key = grafana_key
         self.dashboardId = int(dashboardId) if dashboardId != '' else None
         self.panelId = int(panelId) if panelId != '' else None

--- a/awx/main/notifications/irc_backend.py
+++ b/awx/main/notifications/irc_backend.py
@@ -29,7 +29,10 @@ class IrcBackend(AWXBaseEmailBackend, CustomNotificationBase):
     sender_parameter = None
 
     def __init__(self, server, port, nickname, password, use_ssl, fail_silently=False, **kwargs):
-        super(IrcBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(IrcBackend, self).__init__()
+        self.fail_silently = fail_silently
         self.server = server
         self.port = port
         self.nickname = nickname

--- a/awx/main/notifications/mattermost_backend.py
+++ b/awx/main/notifications/mattermost_backend.py
@@ -22,7 +22,10 @@ class MattermostBackend(AWXBaseEmailBackend, CustomNotificationBase):
     def __init__(
         self, mattermost_no_verify_ssl=False, mattermost_channel=None, mattermost_username=None, mattermost_icon_url=None, fail_silently=False, **kwargs
     ):
-        super(MattermostBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(MattermostBackend, self).__init__()
+        self.fail_silently = fail_silently
         self.mattermost_channel = mattermost_channel
         self.mattermost_username = mattermost_username
         self.mattermost_icon_url = mattermost_icon_url

--- a/awx/main/notifications/pagerduty_backend.py
+++ b/awx/main/notifications/pagerduty_backend.py
@@ -54,7 +54,10 @@ class PagerDutyBackend(AWXBaseEmailBackend, CustomNotificationBase):
     }
 
     def __init__(self, subdomain, token, fail_silently=False, **kwargs):
-        super(PagerDutyBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(PagerDutyBackend, self).__init__()
+        self.fail_silently = fail_silently
         self.subdomain = subdomain
         self.token = token
 

--- a/awx/main/notifications/rocketchat_backend.py
+++ b/awx/main/notifications/rocketchat_backend.py
@@ -22,7 +22,10 @@ class RocketChatBackend(AWXBaseEmailBackend, CustomNotificationBase):
     sender_parameter = None
 
     def __init__(self, rocketchat_no_verify_ssl=False, rocketchat_username=None, rocketchat_icon_url=None, fail_silently=False, **kwargs):
-        super(RocketChatBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(RocketChatBackend, self).__init__()
+        self.fail_silently = fail_silently
         self.rocketchat_no_verify_ssl = rocketchat_no_verify_ssl
         self.rocketchat_username = rocketchat_username
         self.rocketchat_icon_url = rocketchat_icon_url

--- a/awx/main/notifications/slack_backend.py
+++ b/awx/main/notifications/slack_backend.py
@@ -21,7 +21,10 @@ class SlackBackend(AWXBaseEmailBackend, CustomNotificationBase):
     sender_parameter = None
 
     def __init__(self, token, hex_color="", fail_silently=False, **kwargs):
-        super(SlackBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(SlackBackend, self).__init__()
+        self.fail_silently = fail_silently
         self.token = token
         self.color = None
         if hex_color.startswith("#") and (len(hex_color) == 4 or len(hex_color) == 7):

--- a/awx/main/notifications/twilio_backend.py
+++ b/awx/main/notifications/twilio_backend.py
@@ -25,7 +25,10 @@ class TwilioBackend(AWXBaseEmailBackend, CustomNotificationBase):
     sender_parameter = "from_number"
 
     def __init__(self, account_sid, account_token, fail_silently=False, **kwargs):
-        super(TwilioBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(TwilioBackend, self).__init__()
+        self.fail_silently = fail_silently
         self.account_sid = account_sid
         self.account_token = account_token
 

--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -49,7 +49,10 @@ class WebhookBackend(AWXBaseEmailBackend, CustomNotificationBase):
         self.headers = headers
         self.username = username
         self.password = password
-        super(WebhookBackend, self).__init__(fail_silently=fail_silently)
+        # Django 6.1 deprecated BaseEmailBackend.fail_silently: a subclass that
+        # supports it owns the attribute instead of passing it up.
+        super(WebhookBackend, self).__init__()
+        self.fail_silently = fail_silently
 
     def format_body(self, body):
         # expect body to be a string representing a dict

--- a/awx/main/tests/conftest.py
+++ b/awx/main/tests/conftest.py
@@ -47,6 +47,12 @@ def mock_access():
         try:
             mock_instance = mock.MagicMock(__name__='foobar')
             MockAccess = mock.MagicMock(return_value=mock_instance)
+            # Real access classes carry tuples here, and optimize_queryset guards
+            # on them being non-empty. A bare MagicMock attribute is truthy but
+            # unpacks to nothing, which makes that guard pass and then calls
+            # select_related() with no arguments.
+            MockAccess.select_related = ()
+            MockAccess.prefetch_related = ()
             the_patch = mock.patch.dict('awx.main.access.access_registry', {TowerClass: MockAccess}, clear=False)
             the_patch.__enter__()
             yield mock_instance

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -33,14 +33,19 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 # suite moved to PostgreSQL, and Django 6.1 requires SQLite 3.37 while the
 # Rocky 9 base image ships 3.34, so the old SQLite fallback could not open a
 # connection even to fail usefully.
+#
+# Deliberately plain values rather than an environment lookup. The tree already
+# carries DATABASE_* for the compose environment and AWX_TEST_DATABASE_* for the
+# test settings, and a third scheme here would earn nothing: anything that needs
+# to point somewhere else is supplying a settings file anyway.
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('AWX_DATABASE_NAME', 'awx'),
-        'USER': os.getenv('AWX_DATABASE_USER', 'awx'),
-        'PASSWORD': os.getenv('AWX_DATABASE_PASSWORD', 'awxpass'),
-        'HOST': os.getenv('AWX_DATABASE_HOST', '127.0.0.1'),
-        'PORT': os.getenv('AWX_DATABASE_PORT', '5432'),
+        'NAME': 'awx',
+        'USER': 'awx',
+        'PASSWORD': 'awxpass',
+        'HOST': '127.0.0.1',
+        'PORT': '5432',
         'ATOMIC_REQUESTS': True,
     }
 }

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -26,15 +26,22 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # existing models.
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+# A real deployment always overrides this from /etc/tower/conf.d/database.py,
+# and the development environment and the test settings both supply their own.
+# What is left here is the fallback for a process started with no settings files
+# at all, and it is PostgreSQL because nothing supports SQLite any more: the
+# suite moved to PostgreSQL, and Django 6.1 requires SQLite 3.37 while the
+# Rocky 9 base image ships 3.34, so the old SQLite fallback could not open a
+# connection even to fail usefully.
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'awx.sqlite3'),
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('AWX_DATABASE_NAME', 'awx'),
+        'USER': os.getenv('AWX_DATABASE_USER', 'awx'),
+        'PASSWORD': os.getenv('AWX_DATABASE_PASSWORD', 'awxpass'),
+        'HOST': os.getenv('AWX_DATABASE_HOST', '127.0.0.1'),
+        'PORT': os.getenv('AWX_DATABASE_PORT', '5432'),
         'ATOMIC_REQUESTS': True,
-        'TEST': {
-            # Test database cannot be :memory: for inventory tests.
-            'NAME': os.path.join(BASE_DIR, 'awx_test.sqlite3')
-        },
     }
 }
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -15,7 +15,7 @@ cryptography>=50.0.0  # CVE-2026-69247
 Cython>=3 # this is needed as a build dependency, one day we may have separated build deps; <3 cap removed once pyyaml>=6.0.1 supported Cython 3
 daphne>=4.2.2  # CVE-2026-44545 CVE-2026-44546
 distro
-django>=5.2.17,<6.0 # CVE-2026-15307 CVE-2026-15830
+django>=6.1.1 # floor was 5.2.17 for CVE-2026-15307 CVE-2026-15830, both long fixed by 6.1
 django-auth-ldap
 django-cors-headers
 django-guid==3.6.1

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -27,7 +27,7 @@ django-solo
 drf-spectacular>=0.27.0
 django-split-settings==1.0.0    # We hit a strange issue where the release process errored when upgrading past 1.0.0 see UPGRADE BLOCKERS
 django-valkey
-djangorestframework>=3.17.2 # CVE-2026-73228 CVE-2026-73229
+djangorestframework>=3.18.0 # first release declaring Django 6.1 support; floor was 3.17.2 for CVE-2026-73228 CVE-2026-73229
 filelock
 GitPython>=3.1.58  # GHSA-hh9p-6wh2-4mfc GHSA-9rj7-rf2p-w77r GHSA-4gmw-gg2m-w46p GHSA-hmq2-w58f-27jc GHSA-wvpp-8hx9-p66j GHSA-jm78-9fvv-mhgr
 importlib-metadata==9.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -98,7 +98,7 @@ defusedxml==0.7.1
     #   social-auth-core
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in
-django==5.2.17
+django==6.1.1
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels
@@ -133,7 +133,7 @@ django-split-settings==1.0.0
     # via -r /awx_devel/requirements/requirements.in
 django-valkey==0.4.0
     # via -r /awx_devel/requirements/requirements.in
-djangorestframework==3.17.2
+djangorestframework==3.18.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   drf-spectacular


### PR DESCRIPTION
##### SUMMARY

Django 6.1 is the current release. The `<6.0` cap was ours: a floor with a ceiling attached, kept because `django-guid` 3.6.1 pins `django<6.0` for Python 3.10 to 3.12, which stops applying once the images build against 3.14 (#811). Django 6.1 also requires SQLite 3.37 against Rocky 9's 3.34.1, which is why the suite had to move to PostgreSQL first (#813).

```
django              5.2.17 -> 6.1.1
djangorestframework 3.17.2 -> 3.18.0
```

**DRF has to move with it.** 3.17.2 does

```python
from django.utils.cache import cc_delim_re
```

which 6.1 removed **without a release note**, so `awx/urls.py` simply fails to import. 3.18.0 declares support for 6.1.

##### Two deprecations, both fixed rather than deferred

Neither is loud, which is why they are handled here rather than left for later.

**`from_db()` gained a `fetch_mode` keyword**, which Django records on the instance state:

```python
@classmethod
def from_db(cls, db, field_names, values, *, fetch_mode=None):
    ...
    if fetch_mode is not None:
        new._state.fetch_mode = fetch_mode
```

An override that drops it opts the model out of fetch modes entirely, so `CredentialType` and everything inheriting the vendored dab override would have silently ignored `FETCH_PEERS` and `FETCH_RAISE`. Both overrides now forward it. The dab one carries an `# Ascender:` marker for future re-syncs.

**`BaseEmailBackend.fail_silently` is deprecated.** Passing it up to `super().__init__()` is itself the deprecated act, and Django's own message says a subclass that supports it must set its own attribute. All eight notification backends now do.

##### And one that turned out not to be Django's fault

Chasing the last remaining warning found a test issuing `select_related()` with no arguments, which means "follow every non-null foreign key". The cause was the `mock_access` fixture: a `MagicMock` attribute is truthy *and* iterates empty, so `optimize_queryset`'s guard passed while supplying no fields.

```python
if access_class.select_related:                                    # MagicMock -> truthy
    queryset = queryset.select_related(*access_class.select_related)  # unpacks to nothing
```

The fixture has been doing that on Django 5.2 as well; 6.1's deprecation only made it audible. It now carries the empty tuples a real access class has.

Between them, these three take the suite from **2113 warnings to 0**.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API
- Other

##### ASCENDER VERSION

```
awx: 25.6.2.dev0+g6e10fb75b3.d20260905
```

##### ADDITIONAL INFORMATION

Verified in an image built from this checkout, against PostgreSQL: **3950 passed, 6 skipped, 0 failed, 0 warnings**. `black --check awx` (928 files), `flake8 awx` and `yamllint` clean.

Rebased onto `main` after #807, #808 and #809 merged. `requirements.txt` was regenerated with `requirements/updater.sh` under 3.14 rather than merged textually, since a text merge would have reinstated `django-crum`, `django-extensions` and `djangorestframework-yaml` which those PRs removed. The regenerated file is byte-identical to the rebase result.

**Worth weighing before merging:** Django 6.1 leaves extended support in **December 2027**, four months *earlier* than 5.2 LTS's April 2028. So this is not a move that buys a longer support horizon. The case for taking it now is that it absorbs the 6.0 and 6.1 breaking changes while nothing is urgent, which makes the hop to 6.2 LTS in April 2027 a small one, and that fetch modes are aimed squarely at the serializer N+1 behaviour, which the `from_db` fix above is a prerequisite for using.