### PR TITLE
ResizeObserver loop completed with undelivered notifications

### DIFF
--- a/awx/ui/config/webpackDevServer.config.js
+++ b/awx/ui/config/webpackDevServer.config.js
@@ -82,6 +82,14 @@ module.exports = function (proxy, allowedHost, proxyOptions = {}) {
       overlay: {
         errors: true,
         warnings: false,
+        // The browser reports "ResizeObserver loop completed with undelivered
+        // notifications" when an observed element resizes during another
+        // element's measurement delivery — benign, and unavoidable while
+        // react-virtual's dev build flushes row measurements synchronously on
+        // a streaming job. Keep it out of the full-screen overlay; it still
+        // reaches the console and window 'error' listeners.
+        runtimeErrors: (error) =>
+          !/ResizeObserver loop/.test((error && error.message) || ''),
       },
     },
     devMiddleware: {


### PR DESCRIPTION
Scrolling issues were fixed in #803, but in dev, the webpack-Devserver will sporadically throw errors stating
"ResizeObserver loop completed with undelivered notifications"
It happens when you rapidly scroll up and down while a long running job is running (and I have also reproduced it when the job is done)

As this is a dev only issue, and the fix for it would negate the purpose of the PR (useFlushSync: false), we will instead ignore the error as its caused by the dev server itself and not really the code.