### PR TITLE
Keep max_retries when a workflow node is created without a template

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4288,8 +4288,11 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
         elif self.instance:
             ujt = self.instance.unified_job_template
         if ujt is None:
+            # Without a template we cannot validate any of the prompted fields, so only
+            # the node's own fields are kept. Anything added to the node itself belongs
+            # on this list, prompts do not.
             ret = {}
-            for fd in ('workflow_job_template', 'identifier', 'all_parents_must_converge'):
+            for fd in ('workflow_job_template', 'identifier', 'all_parents_must_converge', 'max_retries'):
                 if fd in attrs:
                     ret[fd] = attrs[fd]
             return ret

--- a/awx/main/tests/functional/api/test_workflow_node.py
+++ b/awx/main/tests/functional/api/test_workflow_node.py
@@ -98,6 +98,43 @@ def test_node_max_retries_rejects_out_of_range_values(inventory, project, workfl
 
 
 @pytest.mark.django_db
+def test_node_max_retries_settable_without_template(workflow_job_template, post, admin_user):
+    # max_retries belongs to the node, not to the template, so a POST that does not
+    # name a template yet has no reason to drop it
+    url = reverse('api:workflow_job_template_workflow_nodes_list', kwargs={'pk': workflow_job_template.pk})
+    r = post(url, {'identifier': 'no-template', 'max_retries': 3}, user=admin_user, expect=201)
+    node = WorkflowJobTemplateNode.objects.get(pk=r.data['id'])
+    assert node.max_retries == 3
+
+
+@pytest.mark.django_db
+def test_node_prompts_still_dropped_without_template(workflow_job_template, post, admin_user):
+    # prompts cannot be validated with no template to check them against, so they
+    # are still discarded even though the node fields are kept now
+    url = reverse('api:workflow_job_template_workflow_nodes_list', kwargs={'pk': workflow_job_template.pk})
+    r = post(url, {'identifier': 'no-template', 'max_retries': 3, 'limit': 'webservers'}, user=admin_user, expect=201)
+    node = WorkflowJobTemplateNode.objects.get(pk=r.data['id'])
+    assert node.max_retries == 3
+    assert node.limit is None
+
+
+@pytest.mark.django_db
+def test_node_max_retries_survives_a_later_template_attach(workflow_job_template, job_template, post, patch, admin_user):
+    # the two pass flow: create the node first, wire the template in afterwards.
+    # the value sent on the first call has to still be there at the end
+    url = reverse('api:workflow_job_template_workflow_nodes_list', kwargs={'pk': workflow_job_template.pk})
+    r = post(url, {'identifier': 'no-template', 'max_retries': 2}, user=admin_user, expect=201)
+    node = WorkflowJobTemplateNode.objects.get(pk=r.data['id'])
+
+    node_url = reverse('api:workflow_job_template_node_detail', kwargs={'pk': node.pk})
+    patch(node_url, {'unified_job_template': job_template.pk}, user=admin_user, expect=200)
+
+    node.refresh_from_db()
+    assert node.unified_job_template_id == job_template.pk
+    assert node.max_retries == 2
+
+
+@pytest.mark.django_db
 def test_superseded_retry_attempt_protected_while_workflow_runs(delete, admin_user, inventory, project, workflow_job_template):
     # a job superseded by an automatic retry loses its unified_job_node link,
     # but must stay undeletable while its workflow is still running


### PR DESCRIPTION
### Problem

`POST /api/v2/workflow_job_template_nodes/` silently drops `max_retries` when the node is created without a `unified_job_template`. No error, no warning: it answers 201 with the default value.

| Call | Sent | Stored |
| --- | --- | --- |
| POST without ujt | `max_retries=7` | `max_retries=0` |
| POST with ujt | `max_retries=7` | `max_retries=7` |
| PATCH afterwards | `max_retries=7` | `max_retries=7` |

`identifier` and `all_parents_must_converge` travel in that same POST and survive it, and they are node fields exactly like `max_retries` is.

It only bites a client that creates the node first and attaches the template in a second call. The UI never does that for regular nodes, it always sends the template in the same POST.

### Cause

In `LaunchConfigurationBaseSerializer.validate()`, when there is no template to validate the prompted fields against, everything is thrown away except a hardcoded list of three field names. Dropping `limit` there is right, it is a prompt and cannot be validated without a template. `max_retries` is a plain node field. #564 added it to `Meta.fields` of both node serializers and missed this list.

### Fix

Add `max_retries` to that list, plus a comment saying what the branch is for so the next plain field added to the node has a better chance of landing in the right place.

### Tests

Three new ones in `test_workflow_node.py`, next to the ones from #564:

- POST without a template with `max_retries` gets stored
- the same POST with `limit` still drops the prompt, that behaviour is correct and stays
- POST without a template, then PATCH the template in, and the value is still there at the end

Found while testing the ascender collection against a 25.6.0 controller.
