### PR TITLE
test: stop the refresh token expiry test racing its own sleep

### DIFF
--- a/awx/main/tests/functional/api/test_oauth.py
+++ b/awx/main/tests/functional/api/test_oauth.py
@@ -1,11 +1,12 @@
 import base64
 import json
-import time
+from datetime import timedelta
 
 import pytest
 
 from django.db import connection
 from django.test.utils import override_settings
+from django.utils.timezone import now
 from django.utils.encoding import smart_str, smart_bytes
 
 from awx.main.utils.encryption import decrypt_value, get_encryption_key
@@ -294,7 +295,11 @@ def test_refresh_token_expiration_is_respected(oauth_application, post, get, del
     refresh_token = RefreshToken.objects.get(token=response.data['refresh_token'])
     refresh_url = drf_reverse('api:oauth_authorization_root_view') + 'token/'
     short_lived = {'ACCESS_TOKEN_EXPIRE_SECONDS': 1, 'AUTHORIZATION_CODE_EXPIRE_SECONDS': 1, 'REFRESH_TOKEN_EXPIRE_SECONDS': 1}
-    time.sleep(1)
+    # Age the token instead of waiting out its lifetime. TokenView checks
+    # created + REFRESH_TOKEN_EXPIRE_SECONDS < now(), so sleeping exactly the
+    # lifetime left the result resting on how long the request itself took.
+    # An UPDATE rather than save(), because created is auto_now_add.
+    RefreshToken.objects.filter(pk=refresh_token.pk).update(created=now() - timedelta(seconds=60))
     with override_settings(OAUTH2_PROVIDER=short_lived):
         response = post(
             refresh_url,


### PR DESCRIPTION
##### SUMMARY

`test_refresh_token_expiration_is_respected` fails intermittently in CI with `assert 200 == 403`.

`TokenView.create_token_response` expires a refresh token when

```python
refresh_token.created + timedelta(seconds=expire_seconds) < now()
```

and the test gave the token a one second lifetime and then slept for one second. Whether the token had expired by the time the assertion ran therefore rested entirely on how long the request itself took, which is not something a loaded CI runner guarantees. Fifteen consecutive runs of the test on its own all pass, which is why it only ever shows up inside a full suite run.

Age the token rather than waiting out its lifetime. A queryset `update()` is used because `created` is `auto_now_add` and would not take an assigned value through `save()`. The comparison is then a minute clear of the boundary rather than resting on request overhead.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ADDITIONAL INFORMATION

- The test is not made vacuous by this: removing the expiry check from `TokenView` still fails it.
- `awx/main/tests/functional/api/test_oauth.py` is green at **19 passed**.
- The test drops from 2.7s to 1.5s, and the module no longer imports `time`.
- Verified on Python 3.14.7 and Django 6.1.1.
