### PR TITLE
fix: build the email notification backend on Django's supported path

### DIFF
--- a/awx/main/notifications/email_backend.py
+++ b/awx/main/notifications/email_backend.py
@@ -25,19 +25,26 @@ DEFAULT_APPROVAL_DENIED_BODY = CustomNotificationBase.DEFAULT_APPROVAL_DENIED_BO
 
 
 class CustomEmailBackend(EmailBackend, CustomNotificationBase):
-    # Django 6.1 deprecated constructing this backend directly, so every send
-    # raises RemovedInDjango70Warning ("Use mail.mailers instead"). The warning
-    # is not silenced, because it is telling the truth: this breaks in 7.0.
+    # Django's SMTP backend has two constructors behind one signature. Without
+    # an alias it takes the deprecated path, filling anything not passed from
+    # the EMAIL_* settings and raising RemovedInDjango70Warning; 7.0 deletes
+    # that path. With an alias it takes the values it is given and nothing else.
     #
-    # It is not fixable here. MAILERS is a static settings dict keyed by alias,
-    # while a notification template carries its own host, port and credentials,
-    # decrypted per send in NotificationTemplate.send, so there is no alias to
-    # point at. Django offers no runtime registration to bridge that, and
-    # get_connection is deprecated on the same timer.
+    # The second is what a notification template has always wanted. The
+    # serializer requires every init_parameter that has no default, so host,
+    # port, username, password, use_tls and use_ssl are always present and the
+    # EMAIL_* fallback was never reached. Passing an alias moves us onto the
+    # supported branch and keeps the behaviour we already had.
     #
-    # Passing alias=None would suppress the warning, since the check is only
-    # "alias" not in kwargs, but that hides the problem rather than solving it
-    # and would break anyway once 7.0 drops the deprecated branch.
+    # The alias is only a label here. Django uses it to name the mailer in
+    # error messages and never resolves it against MAILERS for a backend built
+    # directly, which is what NotificationTemplate.send does with configuration
+    # decrypted per send.
+    MAILER_ALIAS = 'ascender-notification'
+
+    def __init__(self, **kwargs):
+        super().__init__(alias=self.MAILER_ALIAS, **kwargs)
+
     init_parameters = {
         "host": {"label": "Host", "type": "string"},
         "port": {"label": "Port", "type": "int"},

--- a/awx/main/tests/unit/notifications/test_email.py
+++ b/awx/main/tests/unit/notifications/test_email.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Ctrl IQ, Inc.
+# All Rights Reserved.
+
+import warnings
+
+import pytest
+from django.core.mail import InvalidMailer
+from django.utils.deprecation import RemovedInDjango70Warning
+
+from awx.main.notifications.email_backend import CustomEmailBackend
+
+CONFIG = {
+    'host': 'smtp.example.com',
+    'port': 2525,
+    'username': 'notifier',
+    'password': 'secret',
+    'use_tls': False,
+    'use_ssl': False,
+    'timeout': 30,
+}
+
+
+def test_backend_construction_is_not_deprecated():
+    """Django 6.1 warns when an SMTP backend is built without an alias, and 7.0
+    removes that path. Raising on the warning keeps this from regressing quietly,
+    which is how it went unnoticed before: nothing constructed one in a test."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', RemovedInDjango70Warning)
+        backend = CustomEmailBackend(**CONFIG)
+
+    assert backend.alias == CustomEmailBackend.MAILER_ALIAS
+
+
+def test_configuration_comes_from_the_notification_template():
+    """A template supplies every one of these from the database, per send."""
+    backend = CustomEmailBackend(**CONFIG)
+
+    assert backend.host == 'smtp.example.com'
+    assert backend.port == 2525
+    assert backend.username == 'notifier'
+    assert backend.password == 'secret'
+    assert backend.timeout == 30
+
+
+def test_a_missing_host_is_an_error_rather_than_a_settings_fallback():
+    """The clearest evidence of which branch ran. Without an alias Django fills
+    a missing host from EMAIL_HOST, which would silently point a notification at
+    localhost; with one it refuses. The serializer requires host anyway, since
+    init_parameters gives it no default."""
+    with pytest.raises(InvalidMailer):
+        CustomEmailBackend(**dict(CONFIG, host=None))
+
+
+def test_tls_and_ssl_together_are_rejected():
+    """A misconfiguration on either path, so the move must not have made it
+    silently acceptable."""
+    with pytest.raises(InvalidMailer):
+        CustomEmailBackend(**dict(CONFIG, use_tls=True, use_ssl=True))


### PR DESCRIPTION
##### SUMMARY

`CustomEmailBackend` subclasses Django's SMTP backend, and Django 6.1 deprecated constructing that directly, so every email notification send raises `RemovedInDjango70Warning ("Use mail.mailers instead")`. Django 7.0 removes the path.

The reported conclusion was that this needs a MAILERS rework, and `MAILERS` being a static dict keyed by alias looked incompatible with a notification template, which carries its own host and credentials and decrypts them per send. Reading the 6.1 source, it is simpler than that. The backend has two constructors behind one signature:

```python
if self.alias is None:
    self.host = host or settings.EMAIL_HOST   # deprecated, removed in 7.0
    ...
    return

self.host = host                              # aliased: only what it was given
```

The aliased branch is the one a notification template has always wanted. `NotificationTemplateSerializer` requires every `init_parameter` that has no default, so `host`, `port`, `username`, `password`, `use_tls` and `use_ssl` are always present and the `EMAIL_*` fallback was never reachable. Passing an alias moves the backend onto the supported branch without changing what a send does.

The alias is a label. Django uses it to name the mailer in error messages and never resolves it against `MAILERS` for a backend constructed directly, which is what `NotificationTemplate.send` does.

Two behaviours become explicit rather than silent, neither reachable through the API since it requires both fields: a template with no host raises `InvalidMailer` instead of quietly pointing the notification at `EMAIL_HOST`, and `use_tls` together with `use_ssl` raises `InvalidMailer` rather than `ValueError`.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API
- Notifications

##### ADDITIONAL INFORMATION

Nothing constructed this backend in a test, which is why the suite reported no warnings while the shipping path raised one on every send. There are tests now, and three of the four fail without this change:

- Construction raises no `RemovedInDjango70Warning`, asserted by turning the warning into an error.
- A missing host raises rather than falling back to settings, which is the clearest evidence of which branch ran.
- `use_tls` with `use_ssl` is still rejected.

The tests deliberately avoid `override_settings(EMAIL_HOST=...)`: those settings are themselves deprecated in 6.1, so proving the backend ignores them that way adds three new deprecation warnings of its own.

- New tests: **4 passed**. Notification suites: **124 passed**.
- Construction through the real `NotificationTemplate.send` route is clean of the warning.
- Verified on Python 3.14.7 and Django 6.1.1. `black` and `flake8` clean.
