### PR TITLE
build: loosen the django-guid pin to a floor

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -18,7 +18,7 @@ distro
 django>=6.1.1 # floor was 5.2.17 for CVE-2026-15307 CVE-2026-15830, both long fixed by 6.1
 django-auth-ldap
 django-cors-headers
-django-guid==3.6.1
+django-guid>=3.6.1
 django-oauth-toolkit>=3.3.0
 django-polymorphic
 django-pgware


### PR DESCRIPTION
##### SUMMARY

`django-guid` was the only `==` in `requirements.in` with no upgrade-blocker comment beside it. `requirements.in` is not watched by Dependabot, so an exact pin there stays put until somebody happens to read the file.

The history says the pin is inherited rather than chosen:

- `django-guid==3.2.1` arrived with the `Initial Import`.
- #187 carried it to 3.5.2 and #751 to 3.6.1, keeping the `==` both times.
- Nothing in `requirements/README.md` records a reason, and no UPGRADE BLOCKER mentions it.
- Upstream AWX does not pin it at all.

It matters more than most rows because this is the package that caps Django. 3.6.1 allows `django<7.0` only on Python 3.13 and newer, and it was that cap under 3.12 which made the interpreter move a prerequisite for Django 6. Left exact, the next Django ceiling moves silently and nothing points at the package holding it.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- Other

##### ADDITIONAL INFORMATION

`requirements/requirements.txt` is unchanged and no regeneration is needed: 3.6.1 is the current release, so `>=3.6.1` resolves to exactly what is pinned today. The change is one line in `requirements.in`, and it takes effect the next time the updater runs.

If a reason for the exact pin does exist, this is the change to reject, and the right fix is a comment on the line rather than the pin itself.
