### PR TITLE
build: stop declaring jest-resolve directly

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -78,7 +78,6 @@
         "http-proxy-middleware": "4.2.0",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.5.0",
-        "jest-resolve": "^30.4.1",
         "jest-watch-typeahead": "^3.0.1",
         "jest-websocket-mock": "^2.5.0",
         "mini-css-extract-plugin": "^2.10.2",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -78,7 +78,6 @@
     "http-proxy-middleware": "4.2.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.5.0",
-    "jest-resolve": "^30.4.1",
     "jest-watch-typeahead": "^3.0.1",
     "jest-websocket-mock": "^2.5.0",
     "mini-css-extract-plugin": "^2.10.2",


### PR DESCRIPTION
##### SUMMARY

`jest-resolve` was a direct devDependency, but nothing here uses it. There is no `resolver` key in the jest config and no import of it anywhere outside `package.json` itself. Jest brings it in regardless, through `@jest/core`, `jest-config`, `jest-runner` and `jest-runtime`, and pins the version the rest of the 30.x tree expects.

The declaration bought nothing and cost something: Dependabot opened a pull request on every `jest-resolve` release for a package nobody chose, #778 being the most recent, and taking one could have floated it ahead of the version jest itself wants.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

**`node_modules` does not change.** The lockfile entry stays at 30.4.1, only its source changes:

```
jest-resolve still in lockfile: True
version: 30.4.1 | dev: True
listed in root devDependencies: False
supplied by: @jest/core, jest-config, jest-runner, jest-runtime
```

The diff is two deletions, one in each file, with no version churn anywhere else.

**The other jest packages are staying**, having checked each rather than assuming:

| Package | Why it stays |
| --- | --- |
| `jest-environment-jsdom` | what `testEnvironment: "jsdom"` resolves to |
| `jest-watch-typeahead` | named in `watchPlugins` |
| `jest-websocket-mock` | imported by nine test files |

`jest-resolve` was the only one with transitive dependents, which is what made it the odd one out.

**Verification.** The claim is that this changes nothing, so the suites are the argument rather than a formality. Jest resolves modules on every one of these tests:

- `make ui-lint`: clean.
- `make ui-test-general`: **1038 tests, 176 suites**, all passing.
- `make ui-test-screens`: **1941 tests, 376 suites**, all passing.
