### PR TITLE
build: drop file-loader

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -71,7 +71,6 @@
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-webpack-plugin": "^6.0.0",
-        "file-loader": "^6.2.0",
         "fs-extra": "^11.3.5",
         "globals": "^17.7.0",
         "html-webpack-plugin": "^5.6.7",
@@ -10919,16 +10918,6 @@
         "node": ">= 18.0.0"
       }
     },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -13076,16 +13065,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/empathic": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
@@ -14764,46 +14743,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/file-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
-      "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/file-loader/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/file-selector": {
@@ -19651,21 +19590,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -71,7 +71,6 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-webpack-plugin": "^6.0.0",
-    "file-loader": "^6.2.0",
     "fs-extra": "^11.3.5",
     "globals": "^17.7.0",
     "html-webpack-plugin": "^5.6.7",


### PR DESCRIPTION
##### SUMMARY

`file-loader` is unused. The string appears exactly once in the whole UI tree, on its own line in `package.json`, and nothing supplies it transitively either, so it is installed purely because it is declared.

webpack 5 is the reason. The config loads `babel-loader`, `css-loader`, `postcss-loader`, `style-loader` and `sass-loader`, and files go through the built-in asset modules that replaced `file-loader` in webpack 5. This is leftover from the ejected create-react-app toolchain.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

Unlike `jest-resolve` in #823, this one actually leaves the tree rather than staying as somebody else's transitive: after an install it is gone from `node_modules`, and 76 lockfile lines go with it.

**Verified with a production build, not only the suites.** A missing webpack loader fails when the bundle is built and would not show up in jest, so the build is the check that carries the argument here:

- `npm run build`: succeeds, bundle written.
- `make ui-lint`: clean.
- `make ui-test-general`: **1038 tests, 176 suites**, all passing.
- `make ui-test-screens`: **1941 tests, 376 suites**, all passing.
