### PR TITLE
build: drop @lingui/loader

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -43,7 +43,6 @@
         "@lingui/cli": "^6.6.0",
         "@lingui/conf": "^6.6.0",
         "@lingui/format-po": "^6.6.0",
-        "@lingui/loader": "^6.6.0",
         "@nteract/mockument": "^1.0.4",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.2",
         "@testing-library/dom": "^10.4.1",
@@ -7655,28 +7654,6 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@lingui/loader": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@lingui/loader/-/loader-6.6.0.tgz",
-      "integrity": "sha512-K6cTHlW3CAHjMq9iRlegz8Fhx0E48DAU7FEE/fWT2AKYFFx0F6hsrDAFOdRuw8/o1K5Vmc6oFpgh92khdwa8FA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lingui/cli": "6.6.0",
-        "@lingui/conf": "6.6.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
       }
     },
     "node_modules/@lingui/message-utils": {

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -43,7 +43,6 @@
     "@lingui/cli": "^6.6.0",
     "@lingui/conf": "^6.6.0",
     "@lingui/format-po": "^6.6.0",
-    "@lingui/loader": "^6.6.0",
     "@nteract/mockument": "^1.0.4",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.2",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
##### SUMMARY

`@lingui/loader` is unused. The string appears exactly once in the whole UI tree, on its own line in `package.json`, and nothing supplies it transitively, so it is installed purely because it is declared.

The catalogues are compiled by the CLI, not by a webpack loader:

- `lingui.config.js` is built on `@lingui/cli` and `@lingui/format-po`.
- The npm scripts run `lingui compile` in `prelint`, `prestart` and `pretest`.
- `webpack.config.js` reaches message extraction through `@lingui/babel-plugin-lingui-macro`.

The loader appears in none of those paths.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

Like `file-loader` in #824 and unlike `jest-resolve` in #823, this one actually leaves the tree: it is gone from `node_modules` after an install, and 23 lockfile lines go with it.

**Verified with `lingui compile` as well as a build.** That is the step the loader would belong to if it belonged to anything, and it runs ahead of every other npm script:

- `npx lingui compile`: succeeds.
- `npm run build`: succeeds.
- `make ui-lint`: clean.
- `make ui-test-general`: **1038 tests, 176 suites**, all passing.
- `make ui-test-screens`: **1941 tests, 376 suites**, all passing.
