### PR TITLE
build: drop @babel/eslint-plugin

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -33,7 +33,6 @@
       "devDependencies": {
         "@babel/core": "^8.0.1",
         "@babel/eslint-parser": "^8.0.1",
-        "@babel/eslint-plugin": "^8.0.1",
         "@babel/plugin-syntax-jsx": "^8.0.1",
         "@babel/plugin-transform-runtime": "^8.0.1",
         "@babel/preset-env": "^8.0.2",
@@ -206,21 +205,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^8.0.0",
-        "eslint": "^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-plugin": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-8.0.1.tgz",
-      "integrity": "sha512-nHigH34PJCSbkPeK4PEzfwfy6O8VWfeucP2ZP8nwf0QcKZBxcX+uD6Zp8uMxrvYvWXYmlhYwU+Ix5N5TMjq3qQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^8.0.0",
-        "@babel/eslint-parser": "^8.0.1",
         "eslint": "^9.0.0 || ^10.0.0"
       }
     },

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@babel/core": "^8.0.1",
     "@babel/eslint-parser": "^8.0.1",
-    "@babel/eslint-plugin": "^8.0.1",
     "@babel/plugin-syntax-jsx": "^8.0.1",
     "@babel/plugin-transform-runtime": "^8.0.1",
     "@babel/preset-env": "^8.0.2",


### PR DESCRIPTION
##### SUMMARY

`@babel/eslint-plugin` is unused. The string appears exactly once in the whole UI tree, on its own line in `package.json`, and nothing supplies it transitively.

The lint setup never reaches it. `eslint.config.mjs` is a flat config that imports `@babel/eslint-parser`, a different package which stays, and takes its plugin registrations from `eslint-config-airbnb-extended`. There is no `plugins` entry for `@babel` anywhere in it.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

Like #824 and #825, and unlike #823, this one leaves the tree: gone from `node_modules` after an install, taking 16 lockfile lines with it.

**Verified by linting, not only by building.** Lint is the step that would fail if the config had been resolving this plugin:

- `make ui-lint`: clean over the whole of `src/`.
- `npm run build`: succeeds.
- `make ui-test-general`: **1038 tests, 176 suites**, all passing.
- `make ui-test-screens`: **1941 tests, 376 suites**, all passing.
