### PR TITLE
build: stop declaring @lingui/conf directly

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -41,7 +41,6 @@
         "@babel/runtime": "^8.0.0",
         "@lingui/babel-plugin-lingui-macro": "^6.6.0",
         "@lingui/cli": "^6.6.0",
-        "@lingui/conf": "^6.6.0",
         "@lingui/format-po": "^6.6.0",
         "@lingui/loader": "^6.6.0",
         "@nteract/mockument": "^1.0.4",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -41,7 +41,6 @@
     "@babel/runtime": "^8.0.0",
     "@lingui/babel-plugin-lingui-macro": "^6.6.0",
     "@lingui/cli": "^6.6.0",
-    "@lingui/conf": "^6.6.0",
     "@lingui/format-po": "^6.6.0",
     "@lingui/loader": "^6.6.0",
     "@nteract/mockument": "^1.0.4",


### PR DESCRIPTION
##### SUMMARY

Nothing here imports `@lingui/conf`. `lingui.config.js` is written against `@lingui/cli` and `@lingui/format-po`, and `@lingui/conf` is what those use internally to read that file.

It is a regular dependency of `@lingui/cli`, `@lingui/format-po`, `@lingui/babel-plugin-extract-messages` and `@lingui/babel-plugin-lingui-macro`, so removing the declaration changes `package.json` only: the package stays in `node_modules` at 6.6.0, supplied by those four, and the install is identical.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

This is the `jest-resolve` case from #823 rather than the `file-loader` case from #824: the package is not leaving the tree, only the redundant declaration is.

Worth stating what was deliberately **not** removed while looking at this. `@testing-library/dom` and `babel-plugin-macros` are also unreferenced directly, but they are **peer** dependencies rather than regular ones. A peer is meant to be supplied by the consumer, so declaring them is correct, and dropping them would lean on npm auto-installing peers, which does not hold under `--legacy-peer-deps` or a different package manager.

**Verified with `lingui extract` as well as `compile`**, since config loading is what this package does and extraction exercises it hardest:

- `npx lingui compile`: succeeds.
- `npx lingui extract`: succeeds.
- `make ui-lint`: clean.
- `make ui-test-general`: **1038 tests**, all passing.
- `make ui-test-screens`: **1941 tests**, all passing.
