### PR TITLE
build: stop declaring @babel/plugin-syntax-jsx directly

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -33,7 +33,6 @@
       "devDependencies": {
         "@babel/core": "^8.0.1",
         "@babel/eslint-parser": "^8.0.1",
-        "@babel/plugin-syntax-jsx": "^8.0.1",
         "@babel/plugin-transform-runtime": "^8.0.1",
         "@babel/preset-env": "^8.0.2",
         "@babel/preset-react": "^8.0.1",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@babel/core": "^8.0.1",
     "@babel/eslint-parser": "^8.0.1",
-    "@babel/plugin-syntax-jsx": "^8.0.1",
     "@babel/plugin-transform-runtime": "^8.0.1",
     "@babel/preset-env": "^8.0.2",
     "@babel/preset-react": "^8.0.1",


### PR DESCRIPTION
##### SUMMARY

Nothing here references `@babel/plugin-syntax-jsx`. The babel configuration lives inline in `webpack.config.js` and names `@babel/preset-env`, `@babel/preset-react`, `@babel/plugin-transform-runtime` and the local `jsx-compat-plugin`. JSX syntax support arrives with `preset-react`, not from a plugin listed here.

It is a regular dependency of `@babel/plugin-transform-react-jsx`, `babel-plugin-styled-components` and `jest-snapshot`, so this changes `package.json` only: the package stays in `node_modules` at 8.0.1 and the install is identical.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

**Verified with a production build rather than lint.** The whole UI is JSX, so a syntax plugin that actually mattered would fail compilation outright rather than subtly:

- `npm run build`: succeeds.
- `make ui-lint`: clean.
- `make ui-test-general`: **1038 tests**, all passing.
- `make ui-test-screens`: **1941 tests**, all passing.
