### PR TITLE
build: stop declaring eslint-plugin-react directly

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -68,7 +68,6 @@
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-i18next": "^6.1.5",
         "eslint-plugin-jsx-a11y": "6.10.2",
-        "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-webpack-plugin": "^6.0.0",
         "file-loader": "^6.2.0",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -68,7 +68,6 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-i18next": "^6.1.5",
     "eslint-plugin-jsx-a11y": "6.10.2",
-    "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-webpack-plugin": "^6.0.0",
     "file-loader": "^6.2.0",


### PR DESCRIPTION
##### SUMMARY

`eslint.config.mjs` is a flat config and never registers this plugin itself. It takes `airbnbPlugins.react`, `airbnbPlugins.reactHooks` and `airbnbPlugins.reactA11y` from `eslint-config-airbnb-extended`, which carries `eslint-plugin-react` as a regular dependency at `^7.37.5`.

The direct entry also pinned it **exactly** at `7.37.5` while airbnb asks for a range, so it was a second and narrower constraint on a package the config does not name. Resolution is unchanged: 7.37.5 is still the newest release satisfying `^7.37.5`, so `node_modules` is identical.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

**This does not move the ESLint 10 ceiling**, and it is worth being clear about that since the plugin is listed among the cappers. The binding constraint is `eslint-config-airbnb-extended`'s own peer on `eslint: ^9.0.0`. The plugins sit downstream of it, so neither removing nor bumping them lifts anything; only an ESLint 10 compatible airbnb-extended will.

**Verified by linting**, which is the step that resolves plugins:

- `make ui-lint`: clean over the whole of `src/`.
- `make ui-test-general`: **1038 tests**, all passing.
- `make ui-test-screens`: **1941 tests**, all passing.

`eslint-plugin-react-hooks` is the same case and sits on the adjacent line, so the two will conflict with each other; whichever merges second wants a one line resolution keeping both removals.
