### PR TITLE
build: stop declaring eslint-plugin-react-hooks directly

### DIFF
--- a/awx/ui/package-lock.json
+++ b/awx/ui/package-lock.json
@@ -65,7 +65,6 @@
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-i18next": "^6.1.5",
         "eslint-plugin-jsx-a11y": "6.10.2",
-        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-webpack-plugin": "^6.0.0",
         "fs-extra": "^11.3.5",
         "globals": "^17.7.0",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -65,7 +65,6 @@
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-i18next": "^6.1.5",
     "eslint-plugin-jsx-a11y": "6.10.2",
-    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-webpack-plugin": "^6.0.0",
     "fs-extra": "^11.3.5",
     "globals": "^17.7.0",


### PR DESCRIPTION
##### SUMMARY

The same case as #829. `eslint.config.mjs` takes `airbnbPlugins.reactHooks` from `eslint-config-airbnb-extended`, which carries `eslint-plugin-react-hooks` as a regular dependency at `^7.1.1`, the same range the direct entry asked for. Resolution is unchanged at 7.1.1 and `node_modules` is identical.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- UI

##### ADDITIONAL INFORMATION

- `make ui-lint`: clean over the whole of `src/`.
- `make ui-test-general`: **1038 tests**, all passing.
- `make ui-test-screens`: **1941 tests**, all passing.

This sits on the line directly below the one #829 removes, so the two conflict with each other. Whichever merges second wants a one line resolution that keeps both removals.

As with #829, this does not move the ESLint 10 ceiling: that is `eslint-config-airbnb-extended`'s own peer on `eslint: ^9.0.0`.
