### PR TITLE
build: bump cachetools from 7.1.7 to 7.1.8 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -54,7 +54,7 @@ botocore==1.43.80
     #   -r /awx_devel/requirements/requirements.in
     #   boto3
     #   s3transfer
-cachetools==7.1.7
+cachetools==7.1.8
     # via -r /awx_devel/requirements/requirements.in
 # certifi @ git+https://github.com/ansible/system-certifi.git@devel  # git requirements installed separately
     # via


### PR DESCRIPTION
##### SUMMARY

Regenerated with `requirements/updater.sh upgrade cachetools`. `cachetools` is unpinned in `requirements.in`, so the lockfile is the only change, and it carries no embedded source under `licenses/`.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ADDITIONAL INFORMATION

Full suite on Python 3.14.7 and Django 6.1.1: **3972 passed, 6 skipped**.