### PR TITLE
build: bump gitpython from 3.1.60 to 3.1.61 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -151,7 +151,7 @@ frozenlist==1.4.1
     #   aiosignal
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.60
+gitpython==3.1.61
     # via -r /awx_devel/requirements/requirements.in
 hyperlink==21.0.0
     # via


### PR DESCRIPTION
##### SUMMARY

Regenerated with `requirements/updater.sh upgrade GitPython`.

The `requirements.in` line is a floor rather than a pin, `GitPython>=3.1.58` under six GHSA ids, and the regeneration leaves it untouched: only the compiled version moves. Checked deliberately, since a regeneration quietly dropping a security floor would not fail any test.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ADDITIONAL INFORMATION

No embedded source under `licenses/` is required for this package.

Full suite on Python 3.14.7 and Django 6.1.1: **3972 passed, 6 skipped**.