### PR TITLE
build: bump slack-sdk from 3.43.0 to 3.44.1 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -393,7 +393,7 @@ six==1.16.0
     #   pyrad
     #   python-dateutil
     #   tacacs-plus
-slack-sdk==3.43.0
+slack-sdk==3.44.1
     # via -r /awx_devel/requirements/requirements.in
 smmap==5.0.1
     # via gitdb


### PR DESCRIPTION
##### SUMMARY

Regenerated with `requirements/updater.sh upgrade slack-sdk`. `slack-sdk` is unpinned in `requirements.in`, so the lockfile is the only change, and it carries no embedded source under `licenses/`.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API
- Notifications

##### ADDITIONAL INFORMATION

Full suite on Python 3.14.7 and Django 6.1.1: **3972 passed, 6 skipped**, which includes the slack notification tests in `awx/main/tests/unit/notifications`.