### PR TITLE
build: bump django-valkey from 0.4.0 to 0.4.1 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -131,7 +131,7 @@ django-solo==2.5.1
     # via -r /awx_devel/requirements/requirements.in
 django-split-settings==1.0.0
     # via -r /awx_devel/requirements/requirements.in
-django-valkey==0.4.0
+django-valkey==0.4.1
     # via -r /awx_devel/requirements/requirements.in
 djangorestframework==3.18.0
     # via


### PR DESCRIPTION
##### SUMMARY

This one was recorded as blocked, and the block has since dissolved.

0.4.1 adds `typing-extensions>=4.15` below Python 3.13, and `typing-extensions` was held at 4.12.2 for aiohttp, azure-core, jwcrypto and inflect, so naming django-valkey alone produced no change.

#811 moved `typing-extensions` to **4.16.0** as part of the Python 3.14 work, which satisfies the requirement as a side effect. The bump now resolves on its own.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ADDITIONAL INFORMATION

Regenerated with `requirements/updater.sh upgrade django-valkey`. No embedded source under `licenses/` is required.

Full suite on Python 3.14.7 and Django 6.1.1: **3972 passed, 6 skipped**.