### PR TITLE
build: bump receptorctl from 1.6.4 to 1.6.8 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -73,7 +73,7 @@ channels-valkey==0.3.0
     # via -r /awx_devel/requirements/requirements.in
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
+click==8.3.3
     # via receptorctl
 constantly==23.10.4
     # via twisted
@@ -347,7 +347,7 @@ pyyaml==6.0.3
     #   drf-spectacular
     #   kubernetes
     #   receptorctl
-receptorctl==1.6.4
+receptorctl==1.6.8
     # via -r /awx_devel/requirements/requirements.in
 referencing==0.33.0
     # via


### PR DESCRIPTION
##### SUMMARY

Two packages, because one alone does nothing.

receptorctl 1.6.5 raised its click floor to 8.3.x, and click is in the tree only through receptorctl, so naming receptorctl by itself produces an **empty diff**. This is the constraint recorded against #750, and it still holds. Named together they move:

```
click        8.1.7 -> 8.3.3
receptorctl  1.6.4 -> 1.6.8
```

The lockfile still records `click  # via receptorctl` and nothing else, so the pairing is the whole of the change rather than a widening of scope.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ADDITIONAL INFORMATION

Regenerated with `requirements/updater.sh upgrade receptorctl click`. Neither package requires embedded source under `licenses/`.

Full suite on Python 3.14.7 and Django 6.1.1: **3972 passed, 6 skipped**.