### PR TITLE
build: bump boto3 and botocore from 1.43.80 to 1.43.89 in /requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -47,9 +47,9 @@ azure-identity==1.25.3
     # via -r /awx_devel/requirements/requirements.in
 azure-keyvault-secrets==4.11.2
     # via -r /awx_devel/requirements/requirements.in
-boto3==1.43.80
+boto3==1.43.89
     # via -r /awx_devel/requirements/requirements.in
-botocore==1.43.80
+botocore==1.43.89
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   boto3


### PR DESCRIPTION
##### SUMMARY

boto3 and botocore version in lockstep and are always bumped together.

The recorded constraint also names s3transfer, which has to be free to move for the pair to resolve, so all three were named on the upgrade. In this case s3transfer stayed at 0.19.2, since it already satisfies what boto3 1.43.89 asks for.

```
boto3       1.43.80 -> 1.43.89
botocore    1.43.80 -> 1.43.89
s3transfer  0.19.2  (unchanged)
```

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### ADDITIONAL INFORMATION

Regenerated with `requirements/updater.sh upgrade boto3 botocore s3transfer`. None of the three requires embedded source under `licenses/`.

Full suite on Python 3.14.7 and Django 6.1.1: **3972 passed, 6 skipped**.