### PR TITLE
docs: record the measured reason pexpect stays pinned

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -114,5 +114,34 @@ If modifying this library make sure testing with the offline build is performed 
 
 ### pexpect
 
-Version 4.8 makes us a little bit nervous with changes to `searchwindowsize` https://github.com/pexpect/pexpect/pull/579/files
-Pin to `pexpect==4.7.x` until we have more time to move to `4.8` and test.
+Pinned to 4.7.0. pexpect/pexpect#579, released in 4.8, reworked how
+`searchwindowsize` is applied, and the new behaviour interacts badly with the
+way ansible-runner calls `expect()`.
+
+`ansible_runner/runner.py` matches password prompts with a hardcoded window:
+
+```python
+result_id = child.expect(password_patterns, timeout=self.config.pexpect_timeout, searchwindowsize=100)
+```
+
+On 4.7 the search covered the new data plus the preceding window, so in
+practice a whole chunk was searched. From 4.8 the window is honoured strictly,
+and a match that spans more than 100 characters is never found. Measured with
+that same call, matching `Enter passphrase for .*:` against prompts of
+different lengths:
+
+| prompt | 4.7.0 | 4.9.0 |
+| ------ | ----- | ----- |
+| 30 characters | matched | matched |
+| 71 characters | matched | matched |
+| 115 characters | matched | missed |
+
+AWX's prompts include `Enter passphrase for .*:\s*?$` and
+`Bad passphrase, try again for .*:\s*?$`, and what they match grows with the
+key path, `<artifact_dir>/ssh_key_data`. The realistic worst case is roughly 85
+characters, so it fits, but only by about 15, and `AWX_ISOLATION_BASE_PATH` is
+an admin setting that can make the path longer. A prompt that misses does not
+error: the job waits for `pexpect_timeout` with no passphrase supplied.
+
+AWX cannot widen the window, since ansible-runner hardcodes it. Lifting this
+pin means changing that call upstream first, to pass a larger value or `None`.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -40,7 +40,7 @@ Markdown>=3.8.1  # CVE-2025-69534 # used for formatting API help
 msal>=1.37.0  # cryptography>=49 compatibility (msal<1.37 caps cryptography<49)
 openshift
 packaging==26.3
-pexpect==4.7.0  # see library notes
+pexpect==4.7.0  # UPGRADE BLOCKER: 4.8+ enforces ansible-runner's searchwindowsize=100, see library notes
 prometheus-client
 psycopg
 psutil


### PR DESCRIPTION
Not a bump. This is the result of testing whether the `pexpect` pin still
earns its place, and it does, so the reason is written down properly instead.

The note said:

> Version 4.8 makes us a little bit nervous with changes to `searchwindowsize`
> pexpect/pexpect#579. Pin to `pexpect==4.7.x` until we have more time to move
> to `4.8` and test.

## What the test found

`ansible-runner` matches password prompts with a hardcoded window, in
`ansible_runner/runner.py`:

```python
result_id = child.expect(password_patterns, timeout=self.config.pexpect_timeout, searchwindowsize=100)
```

On 4.7 the search covered the new data plus the preceding window, so in
practice a whole chunk was searched. pexpect/pexpect#579, released in 4.8, made
the window strict. Driving that same call against `Enter passphrase for .*:`
with prompts of different lengths:

| prompt | 4.7.0 | 4.9.0 |
| ------ | ----- | ----- |
| 30 characters | matched | matched |
| 71 characters | matched | matched |
| 115 characters | matched | **missed** |

Everything shorter than the window behaves identically on both versions,
including prompts split one character at a time across reads, and including
`before` and `after` contents. The difference appears only once a match needs
more than 100 characters.

## Why that matters here

AWX registers these among its prompts, in `awx/main/tasks/jobs.py`:

```python
d[r'Enter passphrase for .*:\s*?$'] = 'ssh_key_unlock'
d[r'Bad passphrase, try again for .*:\s*?$'] = ''
```

What they match grows with the key path, which ansible-runner builds as
`<artifact_dir>/ssh_key_data`. The realistic worst case is around 85
characters, so it does fit under 100, but with roughly 15 to spare, and
`AWX_ISOLATION_BASE_PATH` is an admin setting that can make the path longer.

The failure mode is the bad kind: a prompt that is not matched raises nothing.
The job waits out `pexpect_timeout` without a passphrase ever being supplied.

## What would lift the pin

Not something AWX can do. The window is hardcoded in ansible-runner, so that
`expect()` call has to change upstream first, to pass a larger value or `None`.
Once that lands, this pin can go.

## Scope

Comment in `requirements.in` and the library note in `requirements/README.md`.
`requirements.txt` is unchanged, so there is nothing to test: no dependency
moves.
