### PR TITLE
test: stop the schedule test racing its own clock

### DIFF
--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -147,10 +147,15 @@ def test_really_old_dtstart(job_template, freq, delta):
     first_event = sched.rrulestr(sched.rrule)[0]
     assert last_week == first_event.date()
 
-    # the next few scheduled events should be the next minute/hour incremented
-    next_five_events = list(sched.rrulestr(sched.rrule).xafter(now(), count=5))
+    # the next few scheduled events should be the next minute/hour incremented.
+    # Seed xafter() and check the result against the same instant: calling now()
+    # twice lets the clock cross a minute boundary between them, and since the
+    # events are minute aligned the first one then compares as not after the
+    # second now(). It fails by milliseconds, and only under load.
+    reference = now()
+    next_five_events = list(sched.rrulestr(sched.rrule).xafter(reference, count=5))
 
-    assert next_five_events[0] > now()
+    assert next_five_events[0] > reference
     last = None
     for event in next_five_events:
         if last:


### PR DESCRIPTION
`test_really_old_dtstart` calls `now()` **twice**: once to seed `xafter()` and again in the
assertion. The events it checks are minute aligned, so when the two calls straddle a minute
boundary, the event returned for the first `now()` is not after the second one and the test
fails by milliseconds.

It surfaced during the dependency bump run, under `-n auto`:

```
AssertionError: assert datetime(2026, 9, 7, 15, 18, tzinfo=America/New_York)
                     > datetime(2026, 9, 7, 19, 18, 0, 84530, tzinfo=utc)
```

15:18 New York is 19:18 UTC, so the left side is 19:18:00.000000 and the right is
19:18:00.084530. It failed by 84 milliseconds. Nothing to do with the bump that was being
tested at the time.

## Reproduced deterministically

A minute aligned rrule with two instants either side of a boundary:

```
event returned by xafter(first now()) : 2026-09-07 19:18:00+00:00
second now()                          : 2026-09-07 19:18:00.084530+00:00

old form  assert first > second_now : False   <- fails by 0:00:00.084530
new form  assert first > reference  : True    <- compares against the same instant
```

## The change

Capture `now()` once and compare against that instant. Nothing about the scheduler changes,
only what the test compares against.

This is the same shape as #819, which fixed the refresh token test racing its own sleep.

## Checks

- `awx/main/tests/functional/models/test_schedule.py`: **61 passed**.
- `black --check` and `flake8` clean.