### PR TITLE
Silence warning from upgrade to django-oauth-toolkit 3.4.1

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1104,7 +1104,13 @@ COLOR_LOGS = False
 
 # https://github.com/django-polymorphic/django-polymorphic/issues/195
 # FIXME: Disabling models.E006 warning until we can renamed Project and InventorySource
-SILENCED_SYSTEM_CHECKS = ['models.E006']
+#
+# oauth2_provider.W011 (added in django-oauth-toolkit 3.4.1) warns that the swapped
+# AccessToken model ('main.OAuth2AccessToken') and the stock RefreshToken model live
+# in different apps. That split is intentional and predates the check; the cross-app
+# migration dependencies it worries about are already declared by hand in the main
+# app's migrations (see the swappable_dependency entries), so the warning is noise.
+SILENCED_SYSTEM_CHECKS = ['models.E006', 'oauth2_provider.W011']
 
 # Use middleware to get request statistics
 AWX_REQUEST_PROFILE = False


### PR DESCRIPTION
After the upgrade, this is displayed over and over in the logs.

```
System check identified some issues:

WARNINGS:
?: (oauth2_provider.W011) The configured AccessToken model ('main.OAuth2AccessToken') and RefreshToken model ('oauth2_provider.RefreshToken') are defined in different apps, but they reference each other with a circular foreign key.

HINT: Swap the AccessToken and RefreshToken models into the same app -- e.g. point OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL and OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL at models in one app. The IDToken model is usually customized alongside them. See 'Extending the token models' in the advanced topics documentation.
```

### What changed.

PR #822, merged today, moved django-oauth-toolkit from 3.3.0 to 3.4.1. Release 3.4.1 (2026-08-21) added a brand-new system check, W011, that warns when the swapped AccessToken and RefreshToken models live in different Django apps. Our configuration has done exactly that since the initial import: the access token is swapped to a custom model in the main app, while the refresh token and ID token stay in the toolkit's own app, at [defaults.py:526-529](vscode-webview://12jj7jki7c4mg4h4q1r8fhg1mr4lb00bhb6h402sinjiimhjoeia/awx/settings/defaults.py#L526-L529). So the configuration is old and unchanged. Only the check is new.

### Why it repeats. 

Every awx-manage command runs system checks at startup. The container launches around eight of them under supervisord, plus migrate and collectstatic, so the same warning is printed once per process.

### Is anything actually broken? 

No. The toolkit's own docstring for the check says the real hazard is Django being unable to order the initial migration for a cross-app circular foreign key. Our migration graph has already solved that by hand: the main-app migrations declare swappable dependencies on the refresh and ID token models, most recently in [0213_oauth2accesstoken_resource_and_more.py:14-15](vscode-webview://12jj7jki7c4mg4h4q1r8fhg1mr4lb00bhb6h402sinjiimhjoeia/awx/main/migrations/0213_oauth2accesstoken_resource_and_more.py#L14-L15). The check runs awx-manage check clean with exit code 0, migrations apply, and the OAuth tests in PR #822 pass. The check's own comment says the warning exists because the setup is "almost always a mistake rather than an intention." Here it is intentional and long-established.