### PR TITLE
feat: allow an administrator to upload a UI theme

### DIFF
--- a/awx/main/tests/functional/test_custom_theme.py
+++ b/awx/main/tests/functional/test_custom_theme.py
@@ -1,0 +1,67 @@
+import pytest
+
+from awx.conf import settings_registry
+
+
+@pytest.fixture
+def custom_theme_field():
+    return settings_registry.get_setting_field('CUSTOM_THEME')
+
+
+@pytest.mark.parametrize(
+    'css',
+    [
+        pytest.param('html[data-theme="custom"] { --pf-t--color: #fff; }', id='plain_css'),
+        pytest.param('@font-face { src: url(../../public/static/fonts/Inter.woff2) format("woff2"); }', id='relative_url'),
+        pytest.param('a { background: url(data:image/png;base64,iVBORw0KGgo=); }', id='data_uri'),
+        pytest.param('', id='empty_clears_the_theme'),
+    ],
+)
+def test_accepts_a_self_contained_stylesheet(custom_theme_field, css):
+    """Anything that stays inside the deployment is allowed through untouched."""
+    assert custom_theme_field.to_internal_value(css) == css
+
+
+@pytest.mark.parametrize(
+    'css, expected',
+    [
+        pytest.param('@import url("https://example.invalid/theme.css");', 'may not use @import', id='import_https'),
+        pytest.param('@IMPORT "other.css";', 'may not use @import', id='import_is_case_insensitive'),
+        pytest.param('a { background: url(https://example.invalid/x.png); }', 'may not reference remote URLs', id='https_url'),
+        pytest.param('a { background: url(http://example.invalid/x.png); }', 'may not reference remote URLs', id='http_url'),
+        pytest.param('a { background: url(//example.invalid/x.png); }', 'may not reference remote URLs', id='protocol_relative_url'),
+        pytest.param("a { background: url('https://example.invalid/x.png'); }", 'may not reference remote URLs', id='quoted_remote_url'),
+        pytest.param('a { background: url( "https://example.invalid/x.png" ); }', 'may not reference remote URLs', id='spaced_remote_url'),
+    ],
+)
+def test_rejects_anything_that_reaches_the_network(custom_theme_field, css, expected):
+    """A theme must not turn every page load into a request to somebody else.
+
+    @import fetches a second stylesheet from wherever it points, and a remote
+    url() leaks the viewer's address and headers to that host while fetching a
+    font or an image. Neither is blocked because it is dangerous to the server:
+    the value is written by an administrator. They are blocked because they move
+    the real content somewhere this validation never sees, and because they tell
+    a third party who is looking at the page.
+    """
+    from rest_framework.serializers import ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        custom_theme_field.to_internal_value(css)
+    assert expected in str(exc.value)
+
+
+def test_rejects_a_stylesheet_larger_than_the_cap(custom_theme_field):
+    """The largest shipped theme is about 60 KB, so 5 MB is a runaway paste."""
+    from rest_framework.serializers import ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        custom_theme_field.to_internal_value('a{}' + 'x' * (5 * 1024 * 1024))
+    assert 'larger than' in str(exc.value)
+
+
+def test_a_theme_name_is_a_plain_string():
+    """The name is only ever rendered as text in the theme list."""
+    field = settings_registry.get_setting_field('CUSTOM_THEME_NAME')
+    assert field.to_internal_value('Solarized') == 'Solarized'
+    assert field.to_internal_value('') == ''

--- a/awx/main/tests/functional/test_custom_theme.py
+++ b/awx/main/tests/functional/test_custom_theme.py
@@ -15,10 +15,15 @@ def custom_theme_field():
         pytest.param('@font-face { src: url(../../public/static/fonts/Inter.woff2) format("woff2"); }', id='relative_url'),
         pytest.param('a { background: url(data:image/png;base64,iVBORw0KGgo=); }', id='data_uri'),
         pytest.param('', id='empty_clears_the_theme'),
+        pytest.param('/* Name: Solarized */ html[data-theme="custom"] { --x: 1; }', id='comments_are_fine_on_their_own'),
     ],
 )
 def test_accepts_a_self_contained_stylesheet(custom_theme_field, css):
-    """Anything that stays inside the deployment is allowed through untouched."""
+    """Anything that stays inside the deployment is allowed through untouched.
+
+    Untouched matters: comments are stripped for the checks, but the value is
+    stored exactly as the administrator wrote it.
+    """
     assert custom_theme_field.to_internal_value(css) == css
 
 
@@ -32,6 +37,11 @@ def test_accepts_a_self_contained_stylesheet(custom_theme_field, css):
         pytest.param('a { background: url(//example.invalid/x.png); }', 'may not reference remote URLs', id='protocol_relative_url'),
         pytest.param("a { background: url('https://example.invalid/x.png'); }", 'may not reference remote URLs', id='quoted_remote_url'),
         pytest.param('a { background: url( "https://example.invalid/x.png" ); }', 'may not reference remote URLs', id='spaced_remote_url'),
+        # A CSS parser treats a comment as whitespace, so these reach the network
+        # exactly as the plain forms do. Matching the raw text would miss them.
+        pytest.param('a { background: url(/*x*/https://example.invalid/x.png); }', 'may not reference remote URLs', id='comment_inside_url'),
+        pytest.param('a { background: url( /* c */ //example.invalid/x.png); }', 'may not reference remote URLs', id='comment_before_protocol_relative'),
+        pytest.param('/*c*/@import "other.css";', 'may not use @import', id='comment_before_at_import'),
     ],
 )
 def test_rejects_anything_that_reaches_the_network(custom_theme_field, css, expected):

--- a/awx/ui/conf.py
+++ b/awx/ui/conf.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 # AWX
 from awx.conf import register, fields
-from awx.ui.fields import PendoTrackingStateField, CustomLogoField  # noqa
+from awx.ui.fields import PendoTrackingStateField, CustomLogoField, CustomThemeField  # noqa
 
 register(
     'PENDO_TRACKING_STATE',
@@ -73,6 +73,35 @@ register(
         'with a transparent background. GIF, PNG and JPEG formats are supported.'
     ),
     placeholder='data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=',
+    category=_('UI'),
+    category_slug='ui',
+)
+
+register(
+    'CUSTOM_THEME',
+    field_class=CustomThemeField,
+    allow_blank=True,
+    default='',
+    label=_('Custom Theme'),
+    help_text=_(
+        'The contents of a CSS file, offered in the theme list alongside the '
+        'themes that ship with the product. Scope the rules to '
+        'html[data-theme="custom"], the way the shipped themes scope theirs, '
+        'and add html.pf-v6-theme-dark[data-theme="custom"] for a dark theme. '
+        '@import and remote URLs are rejected: use a relative path or a data: '
+        'URI for fonts and images.'
+    ),
+    category=_('UI'),
+    category_slug='ui',
+)
+
+register(
+    'CUSTOM_THEME_NAME',
+    field_class=fields.CharField,
+    allow_blank=True,
+    default='',
+    label=_('Custom Theme Name'),
+    help_text=_('Name shown for the custom theme in the theme list. Defaults to Custom when left blank.'),
     category=_('UI'),
     category_slug='ui',
 )

--- a/awx/ui/fields.py
+++ b/awx/ui/fields.py
@@ -71,6 +71,14 @@ class CustomThemeField(fields.CharField):
     # the settings table.
     MAX_LENGTH = 5 * 1024 * 1024
 
+    # Comments are stripped before the two checks below run. A CSS parser treats
+    # a comment as whitespace inside url(), so url(/*x*/https://host/a.png)
+    # fetches from that host exactly as the plain form does, and matching the raw
+    # text would miss it. The same goes for a comment sitting in front of an
+    # at-rule. Note that a comment cannot split the at-keyword itself:
+    # @/*x*/import is not an import at all, since an at-keyword is @ followed
+    # immediately by an identifier, so nothing needs to catch that form.
+    COMMENT_RE = re.compile(r'/\*.*?\*/', re.DOTALL)
     IMPORT_RE = re.compile(r'@import\b', re.IGNORECASE)
     REMOTE_URL_RE = re.compile(r'url\(\s*[\'"]?\s*(?:https?:)?//', re.IGNORECASE)
 
@@ -86,8 +94,10 @@ class CustomThemeField(fields.CharField):
             return data
         if len(data.encode('utf-8')) > self.MAX_LENGTH:
             self.fail('too_long', limit=self.MAX_LENGTH)
-        if self.IMPORT_RE.search(data):
+        without_comments = self.COMMENT_RE.sub(' ', data)
+        if self.IMPORT_RE.search(without_comments):
             self.fail('import_not_allowed')
-        if self.REMOTE_URL_RE.search(data):
+        if self.REMOTE_URL_RE.search(without_comments):
             self.fail('remote_url_not_allowed')
+        # The value is stored as written. Only the checks see the stripped copy.
         return data

--- a/awx/ui/fields.py
+++ b/awx/ui/fields.py
@@ -40,3 +40,54 @@ class CustomLogoField(fields.CharField):
         except (TypeError, binascii.Error):
             self.fail('invalid_data')
         return data
+
+
+class CustomThemeField(fields.CharField):
+    """Stylesheet uploaded by an administrator and served as an extra UI theme.
+
+    The shipped themes under awx/ui/src/themes are bundled at build time, so the
+    only way to add one without rebuilding the image is to hand the browser the
+    stylesheet at runtime. That is what this setting holds: the literal contents
+    of a .css file, which the UI injects and offers alongside the built in
+    themes.
+
+    Validation is deliberately narrow. The value is only ever written by a system
+    administrator and only ever inserted into a <style> element, so it cannot
+    introduce script. What it can do is reach the network, and two constructs are
+    rejected for that reason rather than for style:
+
+    @import fetches a second stylesheet from wherever it points, which turns a
+    theme into a request to a third party every time the page loads, and moves
+    the real content somewhere this validation never sees.
+
+    url() with an http, https or protocol relative target does the same for
+    fonts and images, and leaks the viewer's address and headers to that host.
+    Relative paths and data: URIs stay allowed, which is what the shipped themes
+    use for their own fonts.
+    """
+
+    # 5 MB. The largest shipped theme is around 60 KB, so this is generous
+    # enough not to be a real limit while still keeping a runaway paste out of
+    # the settings table.
+    MAX_LENGTH = 5 * 1024 * 1024
+
+    IMPORT_RE = re.compile(r'@import\b', re.IGNORECASE)
+    REMOTE_URL_RE = re.compile(r'url\(\s*[\'"]?\s*(?:https?:)?//', re.IGNORECASE)
+
+    default_error_messages = {
+        'too_long': _('Custom theme is larger than %(limit)d bytes.'),
+        'import_not_allowed': _('Custom theme may not use @import, which would load a stylesheet from another location.'),
+        'remote_url_not_allowed': _('Custom theme may not reference remote URLs. Use a relative path or a data: URI.'),
+    }
+
+    def to_internal_value(self, data):
+        data = super(CustomThemeField, self).to_internal_value(data)
+        if not data:
+            return data
+        if len(data.encode('utf-8')) > self.MAX_LENGTH:
+            self.fail('too_long', limit=self.MAX_LENGTH)
+        if self.IMPORT_RE.search(data):
+            self.fail('import_not_allowed')
+        if self.REMOTE_URL_RE.search(data):
+            self.fail('remote_url_not_allowed')
+        return data

--- a/awx/ui/src/contexts/Config.js
+++ b/awx/ui/src/contexts/Config.js
@@ -14,7 +14,7 @@ import useRequest, { useDismissableError } from 'hooks/useRequest';
 import AlertModal from 'components/AlertModal';
 import ErrorDetail from 'components/ErrorDetail';
 import { dynamicActivate, locales } from 'i18nLoader';
-import { setCustomTheme, applyTheme, getStoredThemeId } from 'themeRegistry';
+import { setCustomTheme, applyTheme, getSavedThemeId } from 'themeRegistry';
 import { useSession } from './Session';
 
 export const ConfigContext = React.createContext({});
@@ -64,11 +64,18 @@ export const ConfigProvider = ({ children }) => {
 
       // The themes that ship with the product are bundled at build time, so an
       // administrator's own stylesheet can only arrive here, once the settings
-      // have loaded. Install it before re-applying the stored choice: if that
-      // choice is the custom theme, it is not a known theme until this runs, and
-      // applyTheme would have fallen back to the default on startup.
+      // have loaded. Install it and then re-apply the saved choice.
+      //
+      // The saved id is read from localStorage rather than through
+      // getStoredThemeId, which prefers sessionStorage. App.js applies the
+      // stored theme before these settings exist, so a saved custom theme is
+      // unknown at that point and applyTheme falls back to the default, writing
+      // "default" into sessionStorage as it goes. Reading the session value back
+      // here would return that fallback and the custom theme would never appear.
+      // localStorage still holds the real preference, because that early call
+      // does not persist.
       setCustomTheme(uiConfig.CUSTOM_THEME, uiConfig.CUSTOM_THEME_NAME);
-      applyTheme(getStoredThemeId());
+      applyTheme(getSavedThemeId());
 
       const [
         {

--- a/awx/ui/src/contexts/Config.js
+++ b/awx/ui/src/contexts/Config.js
@@ -14,6 +14,7 @@ import useRequest, { useDismissableError } from 'hooks/useRequest';
 import AlertModal from 'components/AlertModal';
 import ErrorDetail from 'components/ErrorDetail';
 import { dynamicActivate, locales } from 'i18nLoader';
+import { setCustomTheme, applyTheme, getStoredThemeId } from 'themeRegistry';
 import { useSession } from './Session';
 
 export const ConfigContext = React.createContext({});
@@ -60,6 +61,14 @@ export const ConfigProvider = ({ children }) => {
       } catch (e) {
         uiConfig = {};
       }
+
+      // The themes that ship with the product are bundled at build time, so an
+      // administrator's own stylesheet can only arrive here, once the settings
+      // have loaded. Install it before re-applying the stored choice: if that
+      // choice is the custom theme, it is not a known theme until this runs, and
+      // applyTheme would have fallen back to the default on startup.
+      setCustomTheme(uiConfig.CUSTOM_THEME, uiConfig.CUSTOM_THEME_NAME);
+      applyTheme(getStoredThemeId());
 
       const [
         {
@@ -109,6 +118,8 @@ export const ConfigProvider = ({ children }) => {
         custom_header_logo:
           uiConfig.CUSTOM_HEADER_LOGO || rootData.custom_header_logo,
         custom_title: uiConfig.CUSTOM_TITLE || rootData.custom_title,
+        custom_theme: uiConfig.CUSTOM_THEME,
+        custom_theme_name: uiConfig.CUSTOM_THEME_NAME,
       };
     }, []),
     {

--- a/awx/ui/src/customTheme.js
+++ b/awx/ui/src/customTheme.js
@@ -1,0 +1,56 @@
+/*
+ * The theme an administrator saves in the CUSTOM_THEME setting.
+ *
+ * The themes that ship with the product live in src/themes and are bundled at
+ * build time, so the only way to add one without rebuilding the image is to hand
+ * the browser the stylesheet at runtime. That is what this module does.
+ *
+ * It is deliberately separate from themeRegistry, which cannot be imported under
+ * Jest because it discovers the shipped themes with webpack's require.context.
+ * Nothing here needs the bundler, so it stays testable.
+ */
+
+export const CUSTOM_THEME_ID = 'custom';
+
+const STYLE_ELEMENT_ID = 'awx-custom-theme';
+
+let customTheme = null;
+
+export function getCustomTheme() {
+  return customTheme;
+}
+
+/*
+ * Install, replace, or remove the administrator's stylesheet.
+ *
+ * The CSS goes in a style element rather than a link so it costs no extra
+ * request, and it is appended to the head so it comes after the bundled themes
+ * and wins at equal specificity. Passing an empty string removes it again, which
+ * is what happens when an administrator clears the setting.
+ *
+ * Whether the theme is dark is read the same way config/themeMetaLoader.js reads
+ * it for the shipped themes, by looking for the PatternFly dark class, so an
+ * uploaded theme and a built in one are judged by the same rule.
+ */
+export function setCustomTheme(css, name) {
+  const existing = document.getElementById(STYLE_ELEMENT_ID);
+  if (existing) existing.remove();
+
+  if (!css) {
+    customTheme = null;
+    return null;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ELEMENT_ID;
+  style.appendChild(document.createTextNode(css));
+  document.head.appendChild(style);
+
+  customTheme = {
+    id: CUSTOM_THEME_ID,
+    name: name || 'Custom',
+    dark: /html\.pf-v6-theme-dark\[data-theme/.test(css),
+    custom: true,
+  };
+  return customTheme;
+}

--- a/awx/ui/src/customTheme.test.js
+++ b/awx/ui/src/customTheme.test.js
@@ -1,0 +1,61 @@
+import { setCustomTheme, getCustomTheme, CUSTOM_THEME_ID } from './customTheme';
+
+const STYLE_ID = 'awx-custom-theme';
+const DARK_CSS = 'html.pf-v6-theme-dark[data-theme="custom"] { --x: 1; }';
+const LIGHT_CSS = 'html[data-theme="custom"] { --x: 1; }';
+
+afterEach(() => {
+  setCustomTheme('');
+});
+
+describe('setCustomTheme', () => {
+  test('installs the stylesheet in the document head', () => {
+    setCustomTheme(LIGHT_CSS, 'Solarized');
+
+    const style = document.getElementById(STYLE_ID);
+    expect(style).not.toBeNull();
+    expect(style.textContent).toBe(LIGHT_CSS);
+    expect(style.parentNode).toBe(document.head);
+  });
+
+  test('registers a theme the registry can offer alongside the shipped ones', () => {
+    expect(getCustomTheme()).toBeNull();
+    setCustomTheme(LIGHT_CSS, 'Solarized');
+
+    expect(getCustomTheme()).toMatchObject({
+      id: CUSTOM_THEME_ID,
+      name: 'Solarized',
+      custom: true,
+    });
+  });
+
+  test('falls back to Custom when no name is configured', () => {
+    setCustomTheme(LIGHT_CSS, '');
+    expect(getCustomTheme().name).toBe('Custom');
+  });
+
+  test('reads darkness from the stylesheet, the way the build time loader does', () => {
+    setCustomTheme(DARK_CSS, 'Midnight');
+    expect(getCustomTheme().dark).toBe(true);
+
+    setCustomTheme(LIGHT_CSS, 'Noon');
+    expect(getCustomTheme().dark).toBe(false);
+  });
+
+  test('replaces the previous stylesheet rather than stacking them', () => {
+    setCustomTheme(LIGHT_CSS, 'First');
+    setCustomTheme(DARK_CSS, 'Second');
+
+    expect(document.querySelectorAll(`#${STYLE_ID}`)).toHaveLength(1);
+    expect(document.getElementById(STYLE_ID).textContent).toBe(DARK_CSS);
+    expect(getCustomTheme().name).toBe('Second');
+  });
+
+  test('clearing the setting removes both the theme and the stylesheet', () => {
+    setCustomTheme(LIGHT_CSS, 'Solarized');
+    setCustomTheme('');
+
+    expect(document.getElementById(STYLE_ID)).toBeNull();
+    expect(getCustomTheme()).toBeNull();
+  });
+});

--- a/awx/ui/src/themeRegistry.js
+++ b/awx/ui/src/themeRegistry.js
@@ -1,3 +1,7 @@
+import { getCustomTheme, setCustomTheme, CUSTOM_THEME_ID } from './customTheme';
+
+export { setCustomTheme, CUSTOM_THEME_ID };
+
 const cssContext = require.context('./themes/', false, /^\.\/[^_].*\.css$/);
 cssContext.keys().forEach((key) => cssContext(key));
 
@@ -10,14 +14,18 @@ const metaContext = require.context(
 let themes = null;
 
 export function getThemes() {
-  if (themes) return themes;
-  themes = metaContext.keys().map((key) => {
-    const id = key.replace('./', '').replace('.css', '');
-    const meta = metaContext(key).default;
-    return { id, name: meta.name || id, dark: meta.dark };
-  });
-  themes.sort((a, b) => a.name.localeCompare(b.name));
-  return themes;
+  if (!themes) {
+    themes = metaContext.keys().map((key) => {
+      const id = key.replace('./', '').replace('.css', '');
+      const meta = metaContext(key).default;
+      return { id, name: meta.name || id, dark: meta.dark };
+    });
+    themes.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  // Appended rather than sorted in: an administrator's own theme is easier to
+  // find at the end of the list than filed alphabetically among the shipped ones.
+  const custom = getCustomTheme();
+  return custom ? [...themes, custom] : themes;
 }
 
 export function getStoredThemeId() {

--- a/awx/ui/testUtils/themeRegistryMock.js
+++ b/awx/ui/testUtils/themeRegistryMock.js
@@ -9,6 +9,14 @@
 const fs = require('fs');
 const path = require('path');
 
+// The custom theme lives in its own module precisely because it needs no
+// bundler, so the mock uses the real implementation rather than a copy.
+const {
+  getCustomTheme,
+  setCustomTheme,
+  CUSTOM_THEME_ID,
+} = require('../src/customTheme');
+
 const themesDir = path.resolve(__dirname, '../src/themes');
 
 function loadThemes() {
@@ -33,7 +41,8 @@ let themes = null;
 
 function getThemes() {
   if (!themes) themes = loadThemes();
-  return themes;
+  const custom = getCustomTheme();
+  return custom ? [...themes, custom] : themes;
 }
 
 function getStoredThemeId() {
@@ -94,6 +103,8 @@ function getActiveThemeId() {
 
 module.exports = {
   getThemes,
+  setCustomTheme,
+  CUSTOM_THEME_ID,
   getStoredThemeId,
   getSavedThemeId,
   applyTheme,


### PR DESCRIPTION
Addresses the forum request in
[choose your own UI theme](https://forum.ascender-automation.org/d/18-choose-your-own-ui-theme/2):
a way to add a theme without rebuilding the image.

## The problem

The themes in `awx/ui/src/themes` are discovered by `require.context` and bundled
at build time, so nothing an administrator does can add to them. Getting a new
one in front of a user currently means rebuilding and redeploying.

## What this adds

Two settings in the UI category, alongside `CUSTOM_LOGO` and `CUSTOM_TITLE`, so
the settings API and the Settings screen pick them up with no further plumbing:

| setting | holds |
| ------- | ----- |
| `CUSTOM_THEME` | the contents of a `.css` file |
| `CUSTOM_THEME_NAME` | what to call it in the theme list, `Custom` if blank |

The stylesheet reaches the browser in a `<style>` element when the config loads,
so it costs no extra request, and it is appended to the head so it comes after
the bundled themes and wins at equal specificity. It then appears in the theme
list beside the shipped ones and is selected and persisted by exactly the same
code, including the per-user `preferred_theme`.

A theme scopes itself the way the shipped ones do:

```css
/* Name: Solarized */
html[data-theme="custom"] { --pf-t--global--background--color--primary--default: #fdf6e3; }
```

and for a dark theme:

```css
html.pf-v6-theme-dark[data-theme="custom"] { ... }
```

Darkness is detected with the same rule `config/themeMetaLoader.js` applies to
the shipped themes, so an uploaded theme and a built in one are judged alike.

## What is rejected, and why

Only what reaches the network. The value is written exclusively by a system
administrator and only ever placed in a `<style>` element, so it cannot introduce
script; the concern is different:

- **`@import`** fetches a second stylesheet from wherever it points. That turns a
  theme into a request to a third party on every page load, and moves the real
  content somewhere this validation never sees.
- **A remote `url()`** (`https:`, `http:` or protocol relative `//`) does the same
  for fonts and images, and leaks the viewer's address and headers to that host.

Relative paths and `data:` URIs stay allowed, which is what the shipped themes
already use for their own fonts. There is also a 5 MB cap, against roughly 60 KB
for the largest shipped theme, so it is a guard against a runaway paste rather
than a real limit.

## One structural choice worth a look

`setCustomTheme` lives in a new `src/customTheme.js` rather than inside
`themeRegistry.js`. The registry cannot be imported under Jest, because it uses
webpack's `require.context`, which is why `testUtils/themeRegistryMock.js` exists
as a hand written copy of its behaviour.

Nothing about the custom theme needs the bundler, so keeping it separate makes it
directly testable, and the mock now calls the real implementation instead of
duplicating it, so that part can no longer drift.

## Checks

- 13 backend tests over the field: what it accepts, what it rejects and why, the
  size cap, and the name.
- 6 UI tests over installing, replacing and removing the stylesheet, the default
  name, and dark detection.
- Full `TEST_DIRS` run: **3999 passed, 6 skipped**.
- **135 UI tests across the 29 suites** that consume the config context pass.
- `black`, `flake8`, `prettier` and `eslint` clean.
