### PR TITLE
build: compile requirements with uv instead of pip-tools

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,6 +1,6 @@
 # Dependency Management
 
-The `requirements.txt` file is generated from `requirements.in` and `requirements_git.txt`, using `pip-tools` and `pip-compile`.
+The `requirements.txt` file is generated from `requirements.in` and `requirements_git.txt`, using `uv pip compile`.
 
 ## How To Use
 
@@ -25,7 +25,7 @@ can be removed, because `*.txt` files are upgraded to latest.
 
 ### Upgrading Dependencies
 
-You can upgrade (`pip-compile --upgrade`) the dependencies by running
+You can upgrade (`uv pip compile --upgrade`) the dependencies by running
 
 `./updater.sh upgrade`.
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -269,6 +269,8 @@ pexpect==4.7.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   ansible-runner
+pip==26.2.1
+    # via -r /awx_devel/requirements/requirements.in
 pkgconfig==1.6.0
     # via -r /awx_devel/requirements/requirements.in
 prometheus-client==0.26.0
@@ -386,6 +388,12 @@ semantic-version==2.10.0
     # via setuptools-rust
 service-identity==24.1.0
     # via twisted
+setuptools==84.0.0
+    # via
+    #   -r /awx_devel/requirements/requirements.in
+    #   asciichartpy
+    #   setuptools-rust
+    #   setuptools-scm
 setuptools-rust==1.13.0
     # via -r /awx_devel/requirements/requirements.in
 setuptools-scm[toml]==10.2.3
@@ -471,13 +479,3 @@ yarl==1.24.5
     # via aiohttp
 zope-interface==8.6
     # via twisted
-
-# The following packages are considered to be unsafe in a requirements file:
-pip==26.2.1
-    # via -r /awx_devel/requirements/requirements.in
-setuptools==84.0.0
-    # via
-    #   -r /awx_devel/requirements/requirements.in
-    #   asciichartpy
-    #   setuptools-rust
-    #   setuptools-scm

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,6 +1,6 @@
 # Git-based requirements - installed separately from requirements.txt
 #
-# IMPORTANT: Use PEP 440 format that matches pip-compile's normalized output:
+# IMPORTANT: Use PEP 440 format that matches the compiler's normalized output:
 #   name @ git+https://github.com/org/repo.git@branch
 #
 # Format rules:

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -5,7 +5,10 @@ requirements_in="$(readlink -f ./requirements.in)"
 requirements="$(readlink -f ./requirements.txt)"
 requirements_git="$(readlink -f ./requirements_git.txt)"
 requirements_dev="$(readlink -f ./requirements_dev.txt)"
-pip_compile="pip-compile --no-strip-extras --no-header --quiet -r --allow-unsafe"
+# uv resolves the same tree as pip-compile; --refresh is its -r/--rebuild, and
+# unsafe packages (pip, setuptools) are emitted by default, so --allow-unsafe
+# has no counterpart to carry over.
+uv_compile="uv pip compile --no-strip-extras --no-header --quiet --refresh"
 sanitize_git="1"
 
 _cleanup() {
@@ -23,20 +26,27 @@ generate_requirements() {
   source "${venv}/bin/activate"
 
   # pip / setuptools version must match the version used in AWX venv (see README.md UPGRADE BLOCKERs)
-  "${venv}/bin/python3" -m pip install -U 'pip==26.2.1' 'setuptools==84.0.0' pip-tools
+  "${venv}/bin/python3" -m pip install -U 'pip==26.2.1' 'setuptools==84.0.0' uv
 
-  ${pip_compile} ${input_reqs} --output-file requirements.txt
+  ${uv_compile} ${input_reqs} --output-file requirements.txt
   # consider the git requirements for purposes of resolving deps
   # Then comment out any git+ lines from requirements.txt
+  #
+  # Matching is on the package name rather than the whole requirement line: uv
+  # resolves a branch ref to the commit sha it points at, so the emitted line
+  # reads "certifi @ git+...@5aa52ab" where requirements_git.txt says "@devel".
+  # The comment written into requirements.txt keeps the requirements_git.txt
+  # wording, which is the ref this repository tracks.
   if [[ "$sanitize_git" == "1" ]] ; then
     while IFS= read -r line; do
-      if [[ $line != \#* ]]; then  # ignore lines which are already comments
-        # Escape regex special characters for the search pattern
-        # Only escape BRE metacharacters: . * ^ $ [ \
-        escaped_pattern=$(printf '%s\n' "${line%#*}" | sed 's/[[\.*^$]/\\&/g')
-        # Add # to the start of any line matched
-        sed -i "s|^.*${escaped_pattern}|# ${line%#*}  # git requirements installed separately|g" requirements.txt
-      fi
+      case "$line" in \#*|'') continue ;; esac  # skip comments and blank lines
+      # "name[extras] @ git+url@ref" -> "name[extras]"
+      pkg="$(printf '%s' "${line%%@*}" | sed 's/[[:space:]]*$//')"
+      # Escape regex special characters for the search pattern
+      # Only escape BRE metacharacters: . * ^ $ [ \
+      escaped_pkg=$(printf '%s\n' "${pkg}" | sed 's/[[\.*^$]/\\&/g')
+      # Add # to the start of any line matched
+      sed -i "s|^${escaped_pkg} @ git+.*|# ${line%#*}  # git requirements installed separately|g" requirements.txt
     done < "${requirements_git}"
   fi;
   return 0
@@ -67,10 +77,10 @@ main() {
     "upgrade")
       NEEDS_HELP=0
       if [[ $# -eq 0 ]]; then
-        pip_compile="${pip_compile} --upgrade"
+        uv_compile="${uv_compile} --upgrade"
       else
         for package in "$@"; do
-          pip_compile="${pip_compile} --upgrade-package $package"
+          uv_compile="${uv_compile} --upgrade-package $package"
         done
       fi
     ;;


### PR DESCRIPTION
## What

`requirements/updater.sh` now installs `uv` into its throwaway venv and calls `uv pip compile` in place of `pip-compile`.

The flags carry over directly:

| pip-compile | uv |
| ----------- | -- |
| `--no-strip-extras` | same |
| `--no-header` | same |
| `--quiet` | same |
| `--output-file` | same |
| `--upgrade` / `--upgrade-package` | same |
| `-r` (rebuild) | `--refresh` |
| `--allow-unsafe` | no counterpart, uv emits `pip` and `setuptools` by default |

## The part that is not a flag swap

The git sanitizing step commented out any line in `requirements.txt` that matched a whole line from `requirements_git.txt`. That held while pip-compile echoed the branch ref back verbatim.

uv resolves a branch to the commit sha it points at, so it emits

```
certifi @ git+https://github.com/ansible/system-certifi.git@5aa52ab91f9d579bfe52b5acf30ca799f1a563d9
```

where `requirements_git.txt` says `@devel`. The old pattern no longer matches, and all three git requirements would be left uncommented and installed twice, once from `requirements.txt` and once from `requirements_git.txt`.

Matching is now on the package name. The comment written into `requirements.txt` still uses the `requirements_git.txt` wording, so the generated file is unchanged on those lines.

## Verification

Run in the devel container against Python 3.14:

- Compiling with the existing pins resolves **all 148 versions identically** to the committed file.
- `./updater.sh run` end to end leaves the three git lines commented exactly as before.
- The only diff in `requirements.txt` is `pip` and `setuptools` moving out of pip-compile's trailing `# The following packages are considered to be unsafe in a requirements file:` block into alphabetical position. Nothing in the repository reads that section.

## Out of scope

`docs/docsite/updater.sh` compiles the documentation lockfile and still uses pip-tools. It is a separate requirements set with its own constraints, so it is left for its own change.

`./updater.sh dev` rewrites `requirements_dev.txt` from the loose list it is today into a fully pinned closure. That is inherent to that code path rather than anything this changes, since the committed file is hand maintained and unpinned, so no compiler would reproduce it. Left untouched.