### PR TITLE
build: pin sphinx in the docs lockfile

### DIFF
--- a/docs/docsite/requirements.in
+++ b/docs/docsite/requirements.in
@@ -1,6 +1,6 @@
 # This requirements file is used for Ascender latest doc builds.
 
-sphinx # Tooling to build HTML from RST source.
+sphinx>=9.1.0 # Tooling to build HTML from RST source. Floor, so the lockfile pins a version.
 sphinx-ansible-theme # Ansible community theme for Sphinx doc builds.
 docutils # Tooling for RST processing and the swagger extension.
 Jinja2 # Requires investiation. Possibly inherited from previous repo with a custom theme.

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -37,7 +37,7 @@ roman-numerals==4.1.0
     # via sphinx
 snowballstemmer==3.1.1
     # via sphinx
-sphinx
+sphinx==9.1.0
     # via
     #   -r requirements.in
     #   sphinx-ansible-theme


### PR DESCRIPTION
`sphinx` was the only entry in `docs/docsite/requirements.txt` carrying **no version**. It has
been that way since `Start updating the documenation` (#305) in April, so a docs build floats
to whatever sphinx is current rather than to a known one, which is the opposite of what a
lockfile is for. The other 21 entries in that file are all pinned.

Spotted while compiling #902 and kept separate from it, since pinning changes what installs.

## The change

`requirements.in` gains the floor and the lockfile gains the pin, which is how every other
dependency in this pair of files already works:

```
requirements.in    sphinx>=9.1.0
requirements.txt   sphinx==9.1.0
```

9.1.0 is what a build installs today, so this records the current state rather than moving
anyone to a new version. Compiled without `--upgrade`, so no other pin moves: the whole diff
is those two lines.

## Proof

```
pip check: No broken requirements found
sphinx:    9.1.0
sphinx -T -E -W -n --keep-going -j auto -c docs/docsite -b html docs/docsite/rst
build succeeded.
```

`-W` makes every warning an error, so that is a real pass.