### PR TITLE
build: lift the notebook 7 cap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ jupyter:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	DJANGO_SETTINGS_MODULE=awx.settings.development $(PYTHON) -m notebook --NotebookApp.token= --ip 0.0.0.0 --port 9888 --allow-root --no-browser
+	DJANGO_SETTINGS_MODULE=awx.settings.development $(PYTHON) -m notebook --IdentityProvider.token= --ip 0.0.0.0 --port 9888 --allow-root --no-browser
 
 ## Start the rsyslog configurer process in background in development environment.
 run-rsyslog-configurer:

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -16,7 +16,7 @@ pytest-xdist
 tox  # for the linters and docs environments in tox.ini
 logutils
 jupyter
-notebook<7.0.0
+notebook>=7
 # matplotlib - Caused issues when bumping to setuptools 58
 backports.tempfile  # support in unit tests for py32+ tempfile.TemporaryDirectory
 # artefactual-labs fork pinned to a commit (py3 fixes; the PyPI release is


### PR DESCRIPTION
The cap came in with `Notebook 7 breaks currently implementation of Jupyter, so
downgrade it` (#155) in August 2025. Retested against notebook 7.6.2: the breakage is gone.

## Both halves checked, not just the version

The only consumer is the `jupyter` target in the Makefile, whose comment says to run `import django; django.setup()` in the first cell. So the server starting is only half the question.

**The server runs.** With the flags the Makefile already passes:

```
[I ServerApp] Serving notebooks from local directory: /tmp
[I ServerApp] Jupyter Server 2.21.0 is running at:
```

**The documented use works.** Executing a notebook that calls `django.setup()` and imports a model gives identical output on both versions:

| | output |
| --- | --- |
| notebook 6.5.7 (current pin) | `django 6.1.1`, `JobTemplate JobTemplate` |
| notebook 7.6.2 | `django 6.1.1`, `JobTemplate JobTemplate` |

## The token flag moves with it

`--NotebookApp.token=` still works on 7, but warns twice and tells you to fix it:

```
'token' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release. ServerApp.token config is deprecated in 2.0. Use IdentityProvider.token.
```

`--IdentityProvider.token=` is the current spelling, and in a clean venv it
starts with **zero** deprecation warnings.

## One thing to expect on an in-place upgrade

notebook 6 pulls `nbclassic` and notebook 7 does not, so a dev venv upgraded in place keeps it and logs a `_jupyter_server_extension_points` warning from it. That is the leftover package talking, not notebook 7: a clean install has neither the package nor the warning. Checked both ways rather than reporting the warning as though 7 caused it.

## Checks

- Full `TEST_DIRS` run: **3986 passed, 6 skipped**.
- `pip check` reports no broken requirements.

```
-notebook<7.0.0
+notebook>=7
```
