### PR TITLE
build: compile the docs lockfile with uv instead of pip-tools

### DIFF
--- a/docs/docsite/updater.sh
+++ b/docs/docsite/updater.sh
@@ -7,9 +7,13 @@ echo $venv
 # shellcheck disable=SC1090
 source ${venv}/bin/activate
 
-${venv}/bin/python3 -m pip install -U pip-tools
+${venv}/bin/python3 -m pip install -U uv
 
-pip-compile --upgrade --no-header --quiet -r --allow-unsafe requirements.in --output-file requirements.txt
+# uv resolves the same tree as pip-compile. --upgrade, --no-header, --quiet and
+# --output-file carry over unchanged; -r, the rebuild flag, is --refresh; and
+# --allow-unsafe has no counterpart because uv emits pip and setuptools by
+# default. Matches requirements/updater.sh, which moved in #899.
+uv pip compile --upgrade --no-header --quiet --refresh requirements.in --output-file requirements.txt
 
 rm -fr "${venv}"
 echo "Updated requirements.txt with latest dependencies."

--- a/tox.ini
+++ b/tox.ini
@@ -48,10 +48,9 @@ commands =
 [testenv:pip-compile-docs]
 description = Compile docs build lockfiles
 deps =
-  # pip-tools config file support was introduced in v7
-  pip-tools >= 7
+  uv
 commands =
-  {envpython} -m piptools compile \
+  {envpython} -m uv pip compile \
     --output-file=docs/docsite/requirements.txt \
     docs/docsite/requirements.in \
     {posargs:--upgrade}


### PR DESCRIPTION
The follow-up named in #899, which moved `requirements/updater.sh` to uv and left
this one alone because the documentation lockfile is a separate requirements set
with its own constraints.

## Two compilers, one lockfile

Two places compile `docs/docsite/requirements.txt`, and both move, so the
repository does not end up with one lockfile and two tools:

- `docs/docsite/updater.sh`
- the `pip-compile-docs` testenv in `tox.ini`

## The flags

They carry across the same way they did in #899:

| pip-tools | uv |
| --------- | -- |
| `--upgrade`, `--no-header`, `--quiet`, `--output-file` | unchanged |
| `-r`, the rebuild flag | `--refresh` |
| `--allow-unsafe` | no counterpart, uv emits pip and setuptools by default |

That last one has no effect here in any case. This lockfile contains neither
`pip` nor `setuptools`, so there is no trailing "considered to be unsafe" block
to reorder, which was the one diff #899 saw in the main file.

## Checked by running it

#899 made the point that a flag comparison does not surface the real problems: it
took an actual run to find that uv resolves a branch to a commit sha and broke the
git-ref matching. So this was checked the same way.

```
holding the existing pins, all 27 resolve identically to what is committed
running updater.sh end to end rewrites requirements.txt byte for byte
the tox path produces the same pins as well
```

**The diff is the two scripts and nothing else.** The lockfile does not change,
which is the result worth having here: the compiler moved and the output did not.

## Not in scope

`./updater.sh dev` rewriting `requirements_dev.txt` into a pinned closure, which
#899 called out as inherent to that code path rather than to the tool. Unchanged
here and unaffected by this.
