### PR TITLE
build: remove the unused pip-tools config

### DIFF
--- a/.pip-tools.toml
+++ b/.pip-tools.toml
@@ -1,5 +1,0 @@
-[tool.pip-tools]
-resolver = "backtracking"
-allow-unsafe = true
-strip-extras = true
-quiet = true


### PR DESCRIPTION
Housekeeping after the move to uv. `.pip-tools.toml` sits at the repository root and is no longer needed.

## Where it came from

It arrived with `Sync to latest upstream 23.3.1` (`a887b86885`) and no commit has touched it since:

```
[tool.pip-tools]
resolver = "backtracking"
allow-unsafe = true
strip-extras = true
quiet = true
```

## It was already inert before uv

The pre-#899 `requirements/updater.sh` built its command line as:

```
pip_compile="pip-compile --no-strip-extras --no-header --quiet -r --allow-unsafe"
```

`--no-strip-extras` is the opposite of the file's `strip-extras = true`, and `--allow-unsafe` restates `allow-unsafe = true`. Command line flags win, so the one setting that could have changed the output was already being overridden.

## Nothing reads it now

Since #899 and #908, `requirements/updater.sh`, `docs/docsite/updater.sh` and the `pip-compile-docs` testenv all call `uv pip compile`, and uv does not read `.pip-tools.toml`. pip-tools is no longer installed by any of them either. The string `pip-tools` appears nowhere else in the tree, so nothing else to update:

```
$ git grep -l pip-tools
.pip-tools.toml
```

## Risk

None that I can find. No lockfile changes, no script changes, no test touches the file. If pip-tools ever comes back the flags live in the scripts, which is where this repository has kept them all along.
