### PR TITLE
feat: add copy button functionality to code blocks and update styles

### DIFF
--- a/docs/docsite/conf.py
+++ b/docs/docsite/conf.py
@@ -35,8 +35,15 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
     'sphinx_ansible_theme',
+    'sphinx_copybutton',
     'swagger',
 ]
+
+# '# ' is deliberately not a prompt: it is a YAML comment throughout these docs,
+# and stripping it would uncomment config such as the basic_auth block in metrics.rst.
+copybutton_prompt_text = r'\$ '
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = '\\'
 
 html_theme = 'sphinx_ascender_theme'
 html_theme_path = ["."]

--- a/docs/docsite/requirements.in
+++ b/docs/docsite/requirements.in
@@ -2,6 +2,7 @@
 
 sphinx>=9.1.0 # Tooling to build HTML from RST source. Floor, so the lockfile pins a version.
 sphinx-ansible-theme # Ansible community theme for Sphinx doc builds.
+sphinx-copybutton # Copy button on code blocks; styled in sphinx_ascender_theme/static/css.
 docutils # Tooling for RST processing and the swagger extension.
 Jinja2 # Requires investiation. Possibly inherited from previous repo with a custom theme.
 PyYaml # Requires investigation. Possibly used as tooling for swagger API reference content.

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -41,9 +41,12 @@ sphinx==9.1.0
     # via
     #   -r requirements.in
     #   sphinx-ansible-theme
+    #   sphinx-copybutton
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
 sphinx-ansible-theme==0.10.4
+    # via -r requirements.in
+sphinx-copybutton==0.5.2
     # via -r requirements.in
 sphinx-rtd-theme==3.1.0
     # via sphinx-ansible-theme

--- a/docs/docsite/rst/administration/kerberos_auth.rst
+++ b/docs/docsite/rst/administration/kerberos_auth.rst
@@ -47,20 +47,20 @@ The following steps show how to authenticate and get a token:
 
 ::
 
-  [root@ip-172-31-26-180 ~]# kinit username
+  $ kinit username
   Password for username@WEBSITE.COM:
-  [root@ip-172-31-26-180 ~]#
 
-  Check if we got a valid ticket.
+Check that you have a valid ticket:
 
-  [root@ip-172-31-26-180 ~]# klist
+::
+
+  $ klist
   Ticket cache: FILE:/tmp/krb5cc_0
   Default principal: username@WEBSITE.COM
 
   Valid starting     Expires            Service principal
   01/25/16 11:42:56  01/25/16 21:42:53  krbtgt/WEBSITE.COM@WEBSITE.COM
     renew until 02/01/16 11:42:56
-  [root@ip-172-31-26-180 ~]#
 
 Once you have a valid ticket, you can check to ensure that everything is working as expected from command line. To test this, make sure that your inventory looks like the following:
 

--- a/docs/docsite/rst/userguide/job_templates.rst
+++ b/docs/docsite/rst/userguide/job_templates.rst
@@ -933,13 +933,13 @@ Just as you can pass ``extra_vars`` in a regular Job Template, you can also pass
   '{"extra_vars": {"variable1":"value1","variable2":"value2",...}}'
 
 
-You can also pass extra variables to the Job Template call using ``curl``, such as is shown in the following example::
+You can also pass extra variables to the Job Template call using ``curl``, such as is shown in the following example:
 
 .. code-block:: bash
 
-   root@localhost:~$ curl -f -H 'Content-Type: application/json' -XPOST \
-                     -d '{"host_config_key": "redhat", "extra_vars": "{\"foo\": \"bar\"}"}' \
-                     https://<ASCENDER_SERVER_NAME>/api/v2/job_templates/7/callback
+   $ curl -f -H 'Content-Type: application/json' -XPOST \
+       -d '{"host_config_key": "redhat", "extra_vars": "{\"foo\": \"bar\"}"}' \
+       https://<ASCENDER_SERVER_NAME>/api/v2/job_templates/7/callback
 
 For more information, refer to :ref:`Launching Jobs with Curl<launch_jobs_curl>`.
 

--- a/docs/docsite/sphinx_ascender_theme/static/css/ansible.css
+++ b/docs/docsite/sphinx_ascender_theme/static/css/ansible.css
@@ -489,6 +489,11 @@ tr .ansibleOptionLink {
     white-space: pre-wrap;
 }
 
+/* Reserve room for the copy button; pre-wrap would otherwise reflow under it */
+.rst-content div.highlight:has(button.copybtn) pre {
+    padding-right: 2.6em;
+}
+
 .rst-content dl dt { margin-bottom: 0; }
 
 /*! Make sure that environment variable links are blue */
@@ -496,3 +501,48 @@ tr .ansibleOptionLink {
 
 /*! Theme toggle icon in the top nav */
 .asc-theme-toggle svg { vertical-align: middle; }
+
+/*! sphinx-copybutton base layer. Colors follow the RTD light code-block
+ * palette; dark.css re-points the color-bearing rules at --asc-* tokens. */
+.rst-content button.copybtn {
+    border: 1px solid #e1e4e5;
+    background-color: #f8f8f8;
+    color: #404040;
+    border-radius: 3px;
+}
+
+.rst-content .highlight button.copybtn:hover {
+    background-color: #fff;
+    border-color: #2980b9;
+    color: #2980b9;
+}
+
+.rst-content .highlight button.copybtn:active {
+    background-color: #e1e4e5;
+}
+
+.rst-content button.copybtn.success,
+.rst-content .highlight button.copybtn.success:hover {
+    border-color: #27ae60;
+    color: #27ae60;
+}
+
+/* Unprefixed so the dark button:focus-visible rule can still win on outline */
+button.copybtn:focus-visible {
+    opacity: 1;
+    outline: 2px solid #2980b9;
+    outline-offset: 2px;
+}
+
+.rst-content .o-tooltip--left:after {
+    background: #404040;
+    color: #fff;
+    border-radius: 3px;
+    font-family: Lato, proxima-nova, "Helvetica Neue", Arial, sans-serif;
+}
+
+@media (hover: none) {
+    .rst-content .highlight button.copybtn {
+        opacity: 1;
+    }
+}

--- a/docs/docsite/sphinx_ascender_theme/static/css/dark.css
+++ b/docs/docsite/sphinx_ascender_theme/static/css/dark.css
@@ -189,6 +189,35 @@ html[data-theme="dark"] .rst-content .linenodiv pre {
     color: var(--asc-text-muted);
 }
 
+/*! sphinx-copybutton. Base layer in ansible.css. */
+html[data-theme="dark"] button.copybtn {
+    background-color: var(--asc-surface);
+    border-color: var(--asc-border);
+    color: var(--asc-text);
+}
+
+html[data-theme="dark"] .highlight button.copybtn:hover {
+    background-color: var(--asc-surface-raised);
+    border-color: var(--asc-link);
+    color: var(--asc-link);
+}
+
+html[data-theme="dark"] .highlight button.copybtn:active {
+    background-color: var(--asc-border);
+}
+
+html[data-theme="dark"] button.copybtn.success,
+html[data-theme="dark"] .highlight button.copybtn.success:hover {
+    border-color: var(--asc-success);
+    color: var(--asc-success);
+}
+
+html[data-theme="dark"] .o-tooltip--left:after {
+    background: var(--asc-surface-raised);
+    color: var(--asc-text-strong);
+    border: 1px solid var(--asc-border);
+}
+
 /*! tables */
 html[data-theme="dark"] .rst-content table.docutils,
 html[data-theme="dark"] .rst-content table.field-list,


### PR DESCRIPTION
##### SUMMARY
This update adds a clipboard button to code blocks to allow for direct copying. It also corrects some code blocks that had terminal info that breaks the standard convention in the docs.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs