### PR TITLE
Replace ASN1 with Cryptography ASN1 function

### DIFF
--- a/awx/api/views/instance_install_bundle.py
+++ b/awx/api/views/instance_install_bundle.py
@@ -9,12 +9,12 @@ import tarfile
 import time
 import re
 
-import asn1
 from awx.api import serializers
 from awx.api.generics import GenericAPIView, Response
 from awx.api.permissions import IsSystemAdminOrAuditor
 from awx.main import models
 from cryptography import x509
+from cryptography.hazmat.asn1 import encode_der
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509 import DNSName, IPAddress, ObjectIdentifier, OtherName
@@ -145,12 +145,11 @@ def generate_receptor_tls(instance_obj):
     # generate private key for the receptor
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
-    # encode receptor hostname to asn1
+    # receptor expects the OtherName value to be a DER-encoded UTF8String of the hostname.
+    # cryptography.hazmat.asn1 (added in 47.0) encodes a str as a UTF8String, but the module
+    # is not yet covered by cryptography's backwards-compatibility policy.
     hostname = instance_obj.hostname
-    encoder = asn1.Encoder()
-    encoder.start()
-    encoder.write(hostname.encode(), nr=asn1.Numbers.UTF8String)
-    hostname_asn1 = encoder.output()
+    hostname_asn1 = encode_der(hostname)
 
     san_params = [
         DNSName(hostname),

--- a/awx/main/tests/unit/api/test_instance_install_bundle.py
+++ b/awx/main/tests/unit/api/test_instance_install_bundle.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.asn1 import decode_der
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from awx.api.views import instance_install_bundle as bundle
+
+
+@pytest.fixture
+def mesh_ca(tmp_path):
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'test-mesh-CA')])
+    now = datetime.now(timezone.utc)
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(ca_key.public_key())
+        .serial_number(1)
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    (tmp_path / 'mesh-CA.key').write_bytes(
+        ca_key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.TraditionalOpenSSL, serialization.NoEncryption())
+    )
+    (tmp_path / 'mesh-CA.crt').write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
+
+    real_open = open
+
+    def redirected_open(path, *args, **kwargs):
+        return real_open(str(path).replace('/etc/receptor/tls/ca', str(tmp_path)), *args, **kwargs)
+
+    with mock.patch.object(bundle, 'open', redirected_open, create=True):
+        yield ca_cert
+
+
+@pytest.mark.parametrize(
+    'hostname, expect_ip',
+    [
+        ('exec-node.example.com', False),
+        ('10.4.50.25', True),
+        ('n' * 61 + '.io', False),  # longest hostname the CN attribute allows
+    ],
+)
+def test_generate_receptor_tls_san(mesh_ca, hostname, expect_ip):
+    key_pem, cert_pem = bundle.generate_receptor_tls(SimpleNamespace(hostname=hostname))
+
+    serialization.load_pem_private_key(key_pem, password=None)
+    cert = x509.load_pem_x509_certificate(cert_pem)
+    assert cert.issuer == mesh_ca.subject
+
+    san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    assert san.get_values_for_type(x509.DNSName) == [hostname]
+    assert [str(ip) for ip in san.get_values_for_type(x509.IPAddress)] == ([hostname] if expect_ip else [])
+
+    # receptor identifies nodes by an OtherName under its OID whose value is a DER UTF8String of the hostname
+    others = san.get_values_for_type(x509.OtherName)
+    assert len(others) == 1
+    assert others[0].type_id == x509.ObjectIdentifier(bundle.RECEPTOR_OID)
+    der = others[0].value
+    assert der[0] == 0x0C  # UTF8String tag
+    assert decode_der(str, der) == hostname

--- a/licenses/asn1.txt
+++ b/licenses/asn1.txt
@@ -1,7 +1,0 @@
-Copyright (c) 2007-2021 the Python-ASN1 authors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/enum-compat.txt
+++ b/licenses/enum-compat.txt
@@ -1,7 +1,0 @@
-Copyright (c) 2014, Jakub Stasiak <jakub@stasiak.at>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,5 @@
 aiohttp>=3.14.3  # CVE-2026-69244 CVE-2026-59881 CVE-2026-69243
 asciichartpy
-asn1
 azure-identity>=1.25.2
 # only azure.keyvault.secrets is used (credential_plugins/azure_kv.py); the
 # azure-keyvault meta-package also pulled unused certificates/keys. >=4.11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,8 +24,6 @@ asgiref==3.12.1
     #   django
     #   django-cors-headers
     #   social-auth-app-django
-asn1==3.3.0
-    # via -r /awx_devel/requirements/requirements.in
 attrs==26.1.0
     # via
     #   aiohttp
@@ -142,8 +140,6 @@ drf-spectacular==0.30.0
     # via -r /awx_devel/requirements/requirements.in
 durationpy==0.11
     # via kubernetes
-enum-compat==0.0.3
-    # via asn1
 filelock==3.32.5
     # via -r /awx_devel/requirements/requirements.in
 frozenlist==1.8.0


### PR DESCRIPTION
We used ASN1 in only 1 place, but Cryptography has a function since v47.0.0 that does the same thing.  So we will utilize it.