### PR TITLE
perf: stream the task manager's pending queue in chunks instead of loading every job

### DIFF
--- a/awx/main/models/base.py
+++ b/awx/main/models/base.py
@@ -266,6 +266,23 @@ class HasEditsMixin(BaseModel):
     def _values_have_edits(self, new_values):
         return any(new_values.get(fd_name, None) != self._prior_values_store.get(fd_name, None) for fd_name in new_values.keys())
 
+    def sync_edit_snapshot(self, attnames):
+        """Take the current values of the named fields as the edit-tracking baseline.
+
+        For use after refresh_from_db(fields=...) on an instance loaded with only()/defer(): the
+        snapshot taken at instantiation lacks the deferred fields, so once they are loaded save()
+        would otherwise report every one of them as an edit and rewrite modified_by. Only the named
+        fields are touched, so a change already made to another loaded field is still detected, and
+        a new dict is assigned rather than mutating the old one because callers such as
+        Project.save() hold a reference to the previous snapshot to compare against after saving.
+        """
+        store = getattr(self, '_prior_values_store', None)
+        if store is None:
+            return
+        attnames = set(attnames)
+        current = self._get_fields_snapshot()
+        self._prior_values_store = {**store, **{k: v for k, v in current.items() if k in attnames}}
+
 
 class PrimordialModel(HasEditsMixin, CreatedModifiedModel):
     """

--- a/awx/main/scheduler/dependency_graph.py
+++ b/awx/main/scheduler/dependency_graph.py
@@ -64,7 +64,11 @@ class DependencyGraph(object):
         if type(job) is AdHocCommand:
             self.mark_if_no_key(self.INVENTORY_UPDATES, job.inventory_id, job)
         else:
-            self.mark_if_no_key(self.INVENTORY_UPDATES, job.inventory_source.inventory_id, job)
+            # InventoryUpdate carries its own inventory FK (copied from the source at creation);
+            # use it so no related-object query is issued per active update. The field is
+            # nullable, so fall back to the source for any row that lacks it.
+            inventory_id = job.inventory_id or job.inventory_source.inventory_id
+            self.mark_if_no_key(self.INVENTORY_UPDATES, inventory_id, job)
 
     def mark_inventory_source_update(self, job):
         self.mark_if_no_key(self.INVENTORY_SOURCE_UPDATES, job.inventory_source_id, job)

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -12,6 +12,7 @@ import signal
 
 # Django
 from django.db import transaction
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _, gettext_noop
 from django.utils.timezone import now as tz_now
 from django.conf import settings
@@ -87,17 +88,19 @@ class TaskBase:
             return True
         return False
 
-    @timeit
-    def get_tasks(self, filter_args):
+    def get_tasks_queryset(self, filter_args):
         wf_approval_ctype_id = ContentType.objects.get_for_model(WorkflowApproval).id
-        qs = (
+        return (
             UnifiedJob.objects.filter(**filter_args)
             .exclude(launch_type='sync')
             .exclude(polymorphic_ctype_id=wf_approval_ctype_id)
             .order_by('created')
             .prefetch_related('dependent_jobs')
         )
-        self.all_tasks = [t for t in qs]
+
+    @timeit
+    def get_tasks(self, filter_args):
+        self.all_tasks = list(self.get_tasks_queryset(filter_args))
 
     def record_aggregate_metrics(self, *args):
         if not is_testing():
@@ -432,6 +435,36 @@ class DependencyManager(TaskBase):
 
 
 class TaskManager(TaskBase):
+    # The only columns the scheduling loop reads from a task. Every other column is deferred so
+    # that loading a large queue costs a fraction of instantiating full polymorphic Job objects.
+    # hydrate_task() loads the rest before any code path that saves a task or calls pre_start(),
+    # so nothing outside this class ever sees a partially loaded task. If the loop grows a new
+    # attribute read, add the field here; test_task_manager_loop_does_not_lazy_load guards it.
+    TASK_FIELDS = (
+        'polymorphic_ctype',
+        'created',
+        'status',
+        'name',
+        'organization',
+        'work_unit_id',
+        'job_explanation',
+        'task_impact',
+        'controller_node',
+        'execution_node',
+        'instance_group',
+        'preferred_instance_groups_cache',
+        'unified_job_template',
+        'Job___project',
+        'Job___inventory',
+        'Job___job_template',
+        'Job___allow_simultaneous',
+        'ProjectUpdate___project',
+        'InventoryUpdate___inventory_source',
+        'AdHocCommand___inventory',
+        'WorkflowJob___workflow_job_template',
+        'WorkflowJob___allow_simultaneous',
+    )
+
     def __init__(self):
         """
         Do NOT put database queries or other potentially expensive operations
@@ -449,6 +482,11 @@ class TaskManager(TaskBase):
         # will no longer be started and will be started on the next task manager cycle.
         self.time_delta_job_explanation = timedelta(seconds=30)
         super().__init__(prefix="task_manager")
+        # Pending tasks are loaded one chunk at a time (see iter_pending_tasks). Each chunk costs a
+        # few fixed round trips (base rows, per-type rows, dependent_jobs prefetch), so chunks are
+        # sized well above the start limit: a queue that drains freely is still served by a single
+        # query, and a deep capacity-starved queue is not paid for in hundreds of small queries.
+        self.pending_task_chunk_size = max(self.start_task_limit, 500)
 
     def after_lock_init(self):
         """
@@ -458,11 +496,50 @@ class TaskManager(TaskBase):
         self.tm_models = TaskManagerModels()
         self.controlplane_ig = self.tm_models.instance_groups.controlplane_ig
 
+    def get_tasks_queryset(self, filter_args):
+        return super().get_tasks_queryset(filter_args).only(*self.TASK_FIELDS)
+
+    def iter_pending_tasks(self):
+        """Yield pending tasks oldest first, loading them a chunk at a time.
+
+        process_pending_tasks stops once start_task_limit jobs have started or the manager times
+        out, so with a deep queue most of it is never examined; loading lazily keeps memory and ORM
+        work proportional to what is actually visited. Blocked and capacity-starved tasks do not
+        count against the limit, which is why the query is paginated rather than capped: a plain
+        LIMIT of start_task_limit would let a run of old blocked jobs starve every newer job
+        behind them indefinitely.
+        """
+        last = None
+        while True:
+            qs = self.get_tasks_queryset(dict(status='pending', dependencies_processed=True)).order_by('created', 'id')
+            if last is not None:
+                qs = qs.filter(Q(created__gt=last.created) | Q(created=last.created, id__gt=last.id))
+            chunk = list(qs[: self.pending_task_chunk_size])
+            yield from chunk
+            if len(chunk) < self.pending_task_chunk_size:
+                return
+            last = chunk[-1]
+
+    def hydrate_task(self, task):
+        """Load the columns that TASK_FIELDS deferred, keeping in-memory changes.
+
+        Required before pre_start() or any save(): pre_start decrypts start_args, walks
+        credentials and writes job_explanation, and UnifiedJob.save() reads started/finished/
+        elapsed/cancel_flag and more. On a partially loaded instance each of those would be
+        fetched by its own query. refresh_from_db is restricted to the deferred fields, so the
+        status, controller_node and execution_node already decided on this instance survive.
+        """
+        deferred = task.get_deferred_fields()
+        if deferred:
+            task.refresh_from_db(fields=list(deferred))
+        return task
+
     def process_job_dep_failures(self, task):
         """If job depends on a job that has failed, mark as failed and handle misc stuff."""
         for dep in task.dependent_jobs.all():
             # if we detect a failed or error dependency, go ahead and fail this task.
             if dep.status in ("error", "failed"):
+                self.hydrate_task(task)
                 task.status = 'failed'
                 logger.warning(f'Previous task failed task: {task.id} dep: {dep.id} task manager')
                 task.job_explanation = 'Previous Task Failed: {"job_type": "%s", "job_name": "%s", "job_id": "%s"}' % (
@@ -493,6 +570,9 @@ class TaskManager(TaskBase):
 
     @timeit
     def start_task(self, task, instance_group, instance=None):
+        # The scheduling loop works on partially loaded tasks; from here on the task is saved
+        # and pre_start() runs, so make sure every column is present first.
+        self.hydrate_task(task)
         # Just like for process_running_tasks, add the job to the dependency graph and
         # ask the TaskManagerInstanceGroups object to update consumed capacity on all
         # implicated instances and container groups.
@@ -562,13 +642,26 @@ class TaskManager(TaskBase):
 
     @timeit
     def process_pending_tasks(self, pending_tasks):
+        """Walk pending tasks oldest first and start what capacity and blocking allow.
+
+        pending_tasks may be any iterable, normally the lazy iter_pending_tasks(); the limit and
+        timeout checks run before each task is pulled so an exhausted manager stops loading.
+        Returns the number of tasks examined.
+        """
         tasks_to_update_job_explanation = []
-        for task in pending_tasks:
+        pending_tasks = iter(pending_tasks)
+        processed = 0
+        while True:
+            # Check before pulling the next task so a finished manager never loads another chunk.
             if self.start_task_limit <= 0:
                 break
             if self.timed_out():
                 logger.warning("Task manager has reached time out while processing pending jobs, exiting loop early")
                 break
+            task = next(pending_tasks, None)
+            if task is None:
+                break
+            processed += 1
 
             has_failed = self.process_job_dep_failures(task)
             if has_failed:
@@ -661,6 +754,7 @@ class TaskManager(TaskBase):
             if not found_acceptable_queue:
                 self.task_needs_capacity(task, tasks_to_update_job_explanation)
         UnifiedJob.objects.bulk_update(tasks_to_update_job_explanation, ['job_explanation'])
+        return processed
 
     def task_needs_capacity(self, task, tasks_to_update_job_explanation):
         task.log_lifecycle("needs_capacity")
@@ -707,10 +801,8 @@ class TaskManager(TaskBase):
         self.process_running_tasks(running_tasks)
         self.subsystem_metrics.inc(f"{self.prefix}_running_processed", len(running_tasks))
 
-        pending_tasks = [t for t in self.all_tasks if t.status == 'pending']
-
-        self.process_pending_tasks(pending_tasks)
-        self.subsystem_metrics.inc(f"{self.prefix}_pending_processed", len(pending_tasks))
+        pending_processed = self.process_pending_tasks(self.iter_pending_tasks())
+        self.subsystem_metrics.inc(f"{self.prefix}_pending_processed", pending_processed)
 
         if self.pre_start_failed:
             from awx.main.tasks.system import handle_failure_notifications
@@ -745,13 +837,15 @@ class TaskManager(TaskBase):
 
     @timeit
     def _schedule(self):
-        self.get_tasks(dict(status__in=["pending", "waiting", "running"], dependencies_processed=True))
-
         self.after_lock_init()
+        # Reap before loading: it resets orphaned waiting jobs to pending, and they must be seen
+        # as pending by the loop below rather than as stale waiting entries in the graph.
         self.reap_jobs_from_orphaned_instances()
 
-        if len(self.all_tasks) > 0:
-            self.process_tasks()
+        # Waiting/running tasks seed the dependency graph and capacity accounting, so all of them
+        # are needed up front. Pending tasks are streamed lazily by process_tasks.
+        self.get_tasks(dict(status__in=["waiting", "running"], dependencies_processed=True))
+        self.process_tasks()
 
         for workflow_approval in self.get_expired_workflow_approvals():
             self.timeout_approval_node(workflow_approval)

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -527,11 +527,15 @@ class TaskManager(TaskBase):
         credentials and writes job_explanation, and UnifiedJob.save() reads started/finished/
         elapsed/cancel_flag and more. On a partially loaded instance each of those would be
         fetched by its own query. refresh_from_db is restricted to the deferred fields, so the
-        status, controller_node and execution_node already decided on this instance survive.
+        status, controller_node and execution_node already decided on this instance survive, and
+        the edit snapshot is brought up to date for exactly those fields.
         """
         deferred = task.get_deferred_fields()
         if deferred:
             task.refresh_from_db(fields=list(deferred))
+            # The edit-tracking snapshot was taken from the partial instance; without this the
+            # freshly loaded columns would count as edits and save() would rewrite modified_by.
+            task.sync_edit_snapshot(deferred)
         return task
 
     def process_job_dep_failures(self, task):

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -773,9 +773,14 @@ class TaskManager(TaskBase):
         # that we know about; this is a fairly rare event, but it can occur if you,
         # for example, SQL backup an awx install with running jobs and restore it
         # elsewhere
-        for j in UnifiedJob.objects.filter(
-            status__in=['pending', 'waiting', 'running'],
-        ).exclude(execution_node__in=Instance.objects.exclude(node_type='hop').values_list('hostname', flat=True)):
+        # Ordinary pending jobs have no execution_node yet; exclude them in SQL so a deep queue
+        # is not materialized as full objects here on every cycle.
+        orphaned = (
+            UnifiedJob.objects.filter(status__in=['pending', 'waiting', 'running'])
+            .exclude(execution_node='')
+            .exclude(execution_node__in=Instance.objects.exclude(node_type='hop').values_list('hostname', flat=True))
+        )
+        for j in orphaned:
             if j.execution_node and not j.is_container_group_task:
                 logger.error(f'{j.execution_node} is not a registered instance; reaping {j.log_format}')
                 reap_job(j, 'failed')

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -459,6 +459,7 @@ class TaskManager(TaskBase):
         'Job___job_template',
         'Job___allow_simultaneous',
         'ProjectUpdate___project',
+        'InventoryUpdate___inventory',
         'InventoryUpdate___inventory_source',
         'AdHocCommand___inventory',
         'WorkflowJob___workflow_job_template',

--- a/awx/main/tests/functional/models/test_base.py
+++ b/awx/main/tests/functional/models/test_base.py
@@ -38,3 +38,66 @@ def test_created_by(inventory, alice):
     with impersonate(None):
         host = Host.objects.create(name='bar', inventory=inventory)
         assert host.created_by == None
+
+
+@pytest.mark.django_db
+class TestSyncEditSnapshot:
+    """sync_edit_snapshot keeps freshly loaded values from looking like edits.
+
+    PrimordialModel snapshots editable fields at instantiation; an instance loaded with only()
+    lacks the deferred ones, and loading them must not trip modified_by bookkeeping.
+    """
+
+    def make_host(self, inventory, alice):
+        with impersonate(alice):
+            host = Host.objects.create(name='foo', inventory=inventory, description='original')
+        assert host.modified_by == alice
+        return host
+
+    def load_slim(self, host):
+        slim = Host.objects.only('id', 'name').get(pk=host.pk)
+        assert slim.get_deferred_fields()
+        return slim
+
+    def hydrate(self, slim):
+        deferred = slim.get_deferred_fields()
+        slim.refresh_from_db(fields=list(deferred))
+        slim.sync_edit_snapshot(deferred)
+
+    def test_refreshed_fields_are_not_edits(self, inventory, alice):
+        host = self.make_host(inventory, alice)
+        slim = self.load_slim(host)
+        self.hydrate(slim)
+        with impersonate(None):
+            slim.save()
+        host.refresh_from_db()
+        assert host.modified_by == alice
+
+    def test_without_sync_refreshed_fields_would_be_edits(self, inventory, alice):
+        host = self.make_host(inventory, alice)
+        slim = self.load_slim(host)
+        slim.refresh_from_db(fields=list(slim.get_deferred_fields()))
+        with impersonate(None):
+            slim.save()
+        host.refresh_from_db()
+        assert host.modified_by is None
+
+    def test_change_made_before_sync_is_still_an_edit(self, inventory, alice, bob):
+        host = self.make_host(inventory, alice)
+        slim = self.load_slim(host)
+        slim.name = 'renamed'
+        self.hydrate(slim)
+        with impersonate(bob):
+            slim.save()
+        host.refresh_from_db()
+        assert (host.name, host.modified_by) == ('renamed', bob)
+
+    def test_change_made_after_sync_is_an_edit(self, inventory, alice, bob):
+        host = self.make_host(inventory, alice)
+        slim = self.load_slim(host)
+        self.hydrate(slim)
+        slim.description = 'changed'
+        with impersonate(bob):
+            slim.save()
+        host.refresh_from_db()
+        assert (host.description, host.modified_by) == ('changed', bob)

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -9,6 +9,8 @@ from awx.main.models import WorkflowJobTemplate, JobTemplate, Job
 from awx.main.models.ha import Instance
 from . import create_job
 from django.conf import settings
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 
 @pytest.mark.django_db
@@ -644,3 +646,135 @@ def test_generate_dependencies_only_once(job_template_factory):
         dm.generate_dependencies = mock.MagicMock(return_value=[])
         dm.schedule()
         dm.generate_dependencies.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_pending_queue_is_paginated_not_capped(hybrid_instance, job_template_factory, mocker):
+    """Old blocked jobs must not hide a newer startable job that sits past the first chunk.
+
+    Blocked jobs do not consume start_task_limit, so the pending queue has to be walked in
+    chunks until the limit is reached; capping the query at the limit would starve the free job.
+    """
+    instance = hybrid_instance
+    controlplane_instance_group = instance.rampart_groups.first()
+    blocked_jt = job_template_factory('jt-blocked', organization='org1', project='proj1', inventory='inv1', credential='cred1').job_template
+    free_jt = job_template_factory('jt-free', organization='org2', project='proj2', inventory='inv2', credential='cred2').job_template
+    blocked = [create_job(blocked_jt) for _ in range(3)]  # allow_simultaneous=False, only the first may run
+    free = create_job(free_jt)
+
+    tm = TaskManager()
+    tm.pending_task_chunk_size = 2  # the free job is in the second chunk
+    qs_spy = mocker.spy(TaskManager, 'get_tasks_queryset')
+    with mock.patch.object(TaskManager, "start_task", wraps=tm.start_task) as mock_start:
+        tm.schedule()
+
+    assert [c.args[0] for c in mock_start.call_args_list] == [blocked[0], free]
+    assert all(c.args[1:] == (controlplane_instance_group, instance) for c in mock_start.call_args_list)
+    # one waiting/running load plus at least two pending chunks
+    assert qs_spy.call_count >= 3
+    for j in blocked[1:]:
+        j.refresh_from_db()
+        assert j.status == 'pending'
+
+
+@pytest.mark.django_db
+def test_pending_queue_loading_stops_at_start_task_limit(hybrid_instance, job_template_factory, mocker):
+    """Once the start limit is reached the rest of the pending queue is never loaded."""
+    instance = hybrid_instance
+    controlplane_instance_group = instance.rampart_groups.first()
+    jt = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred').job_template
+    jt.allow_simultaneous = True
+    jt.save()
+    jobs = [create_job(jt) for _ in range(3)]
+
+    tm = TaskManager()
+    tm.start_task_limit = 1
+    tm.pending_task_chunk_size = 1
+    qs_spy = mocker.spy(TaskManager, 'get_tasks_queryset')
+    with mock.patch.object(TaskManager, "start_task", wraps=tm.start_task) as mock_start:
+        tm.schedule()
+
+    mock_start.assert_called_once_with(jobs[0], controlplane_instance_group, instance)
+    # one query for waiting/running tasks and exactly one pending chunk
+    assert qs_spy.call_count == 2
+    assert tm.get_local_metrics()['pending_processed'] == 1
+
+
+@pytest.mark.django_db
+def test_task_manager_loop_does_not_lazy_load(controlplane_instance_group, job_template_factory, inventory_source, mocker):
+    """The scheduling loop only reads TaskManager.TASK_FIELDS from each task.
+
+    Every task type is kept blocked by a running job of the same template so all pending tasks go
+    through the blocked path; if the loop read a deferred column the query count would grow with
+    the number of pending tasks.
+    """
+    objects = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred')
+    project = objects.project
+    project.scm_type = 'git'
+    project.scm_url = 'http://github.com/ansible/ansible.git'
+    project.save(skip_update=True)
+    wfjt = WorkflowJobTemplate.objects.create(name='wfjt')
+    templates = [objects.job_template, project, inventory_source, wfjt]
+
+    def make(template, status):
+        uj = template.create_unified_job()
+        uj.status = status
+        uj.dependencies_processed = True
+        uj.save()
+        return uj
+
+    for template in templates:
+        make(template, 'running')
+
+    def add_pending(n):
+        for template in templates:
+            for _ in range(n):
+                make(template, 'pending')
+
+    def run_and_count():
+        tm = TaskManager()
+        with mock.patch.object(TaskManager, "start_task") as mock_start:
+            with CaptureQueriesContext(connection) as ctx:
+                tm.schedule()
+        mock_start.assert_not_called()
+        return len(ctx.captured_queries), tm.get_local_metrics()['pending_processed']
+
+    add_pending(1)
+    run_and_count()  # warm content type and other per-process caches
+    queries_small, processed_small = run_and_count()
+    add_pending(3)
+    queries_large, processed_large = run_and_count()
+
+    assert (processed_small, processed_large) == (4, 16)
+    assert queries_large == queries_small
+
+
+@pytest.mark.django_db
+def test_start_task_hydrates_partially_loaded_task(hybrid_instance, job_template_factory):
+    """Tasks reach start_task with most columns deferred; pre_start and save must see the full row."""
+    instance = hybrid_instance
+    jt = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred').job_template
+    job = create_job(jt)
+    job.extra_vars = '{"answer": 42}'
+    job.job_args = 'untouched'
+    job.save(update_fields=['extra_vars', 'job_args'])
+
+    tm = TaskManager()
+    pending = list(tm.iter_pending_tasks())
+    assert pending == [job]
+    assert pending[0].get_deferred_fields()  # the loop really does work on partial objects
+
+    with mock.patch.object(TaskManager, "start_task", wraps=tm.start_task) as mock_start:
+        tm.schedule()
+
+    started = mock_start.call_args.args[0]
+    assert started == job
+    assert started.get_deferred_fields() == set()
+    assert [started.controller_node, started.execution_node] == [instance.hostname, instance.hostname]
+
+    job.refresh_from_db()
+    assert job.status == 'waiting'
+    assert job.celery_task_id
+    assert job.controller_node == instance.hostname
+    assert json.loads(job.extra_vars) == {'answer': 42}
+    assert job.job_args == 'untouched'

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -809,3 +809,37 @@ def test_dependency_failure_keeps_modified_by(hybrid_instance, job_template_fact
     assert job.status == 'failed'
     assert job.job_explanation.startswith('Previous Task Failed')
     assert job.modified_by == alice
+
+
+@pytest.mark.django_db
+def test_active_inventory_updates_do_not_lazy_load_inventory_source(controlplane_instance_group, inventory_source_factory):
+    """Placing active InventoryUpdates in the dependency graph must not dereference inventory_source.
+
+    Running (and newly started) inventory updates are added to the graph every cycle; if the graph
+    read job.inventory_source.inventory_id the cycle would issue one related-object query per
+    active update, so the query count would grow with their number.
+    """
+    counter = iter(range(1000))
+
+    def make_running(n):
+        for _ in range(n):
+            source = inventory_source_factory(f'src-{next(counter)}')
+            update = source.create_unified_job()
+            update.status = 'running'
+            update.dependencies_processed = True
+            update.save()
+
+    def run_and_count():
+        tm = TaskManager()
+        with CaptureQueriesContext(connection) as ctx:
+            tm.schedule()
+        return len(ctx.captured_queries), tm.get_local_metrics()['running_processed']
+
+    make_running(1)
+    run_and_count()  # warm per-process caches
+    queries_one, running_one = run_and_count()
+    make_running(3)
+    queries_four, running_four = run_and_count()
+
+    assert (running_one, running_four) == (1, 4)
+    assert queries_four == queries_one

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 
 from awx.main.scheduler import TaskManager, DependencyManager, WorkflowManager
 from awx.main.utils import encrypt_field
+from awx.main.middleware import impersonate
 from awx.main.models import WorkflowJobTemplate, JobTemplate, Job
 from awx.main.models.ha import Instance
 from . import create_job
@@ -750,7 +751,7 @@ def test_task_manager_loop_does_not_lazy_load(controlplane_instance_group, job_t
 
 
 @pytest.mark.django_db
-def test_start_task_hydrates_partially_loaded_task(hybrid_instance, job_template_factory):
+def test_start_task_hydrates_partially_loaded_task(hybrid_instance, job_template_factory, alice):
     """Tasks reach start_task with most columns deferred; pre_start and save must see the full row."""
     instance = hybrid_instance
     jt = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred').job_template
@@ -758,11 +759,21 @@ def test_start_task_hydrates_partially_loaded_task(hybrid_instance, job_template
     job.extra_vars = '{"answer": 42}'
     job.job_args = 'untouched'
     job.save(update_fields=['extra_vars', 'job_args'])
+    Job.objects.filter(pk=job.pk).update(modified_by=alice)
 
     tm = TaskManager()
     pending = list(tm.iter_pending_tasks())
     assert pending == [job]
     assert pending[0].get_deferred_fields()  # the loop really does work on partial objects
+
+    # hydrating must not make the loaded columns look like edits: a save with no real change
+    # keeps modified_by (starting a job does change instance_group, an editable field, so the
+    # start itself resets modified_by exactly as it did before tasks were loaded partially)
+    tm.hydrate_task(pending[0])
+    with impersonate(None):
+        pending[0].save()
+    job.refresh_from_db()
+    assert job.modified_by == alice
 
     with mock.patch.object(TaskManager, "start_task", wraps=tm.start_task) as mock_start:
         tm.schedule()
@@ -778,3 +789,23 @@ def test_start_task_hydrates_partially_loaded_task(hybrid_instance, job_template
     assert job.controller_node == instance.hostname
     assert json.loads(job.extra_vars) == {'answer': 42}
     assert job.job_args == 'untouched'
+
+
+@pytest.mark.django_db
+def test_dependency_failure_keeps_modified_by(hybrid_instance, job_template_factory, alice):
+    """Failing a task whose dependency failed saves a hydrated partial instance; no phantom edits."""
+    objects = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred')
+    failed_update = objects.project.create_unified_job()
+    failed_update.status = 'failed'
+    failed_update.save()
+    job = create_job(objects.job_template)
+    job.dependent_jobs.add(failed_update)
+    Job.objects.filter(pk=job.pk).update(modified_by=alice)
+
+    with impersonate(None):
+        TaskManager().schedule()
+
+    job.refresh_from_db()
+    assert job.status == 'failed'
+    assert job.job_explanation.startswith('Previous Task Failed')
+    assert job.modified_by == alice

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -6,6 +6,8 @@ import time
 import yaml
 from unittest import mock
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils.timezone import now as tz_now
 import pytest
 
@@ -487,6 +489,37 @@ class TestJobReaper(object):
 
         job.refresh_from_db()
         assert job.status == 'waiting'
+
+    def test_reaper_does_not_load_ordinary_pending_jobs(self):
+        """Pending jobs have no execution_node; the reaper must exclude them in SQL, not in Python.
+
+        Loading them here would materialize the whole pending queue as full polymorphic objects
+        on every task manager cycle. If a pending Job row were loaded, django-polymorphic would
+        issue a follow-up query against main_job to build the concrete instance.
+        """
+        from awx.main.scheduler import TaskManager
+
+        Instance(hostname='awx-task-live', node_type='hybrid').save()
+        for _ in range(3):
+            Job.objects.create(status='pending')
+
+        with CaptureQueriesContext(connection) as ctx:
+            TaskManager().reap_jobs_from_orphaned_instances()
+
+        assert not [q['sql'] for q in ctx.captured_queries if '"main_job"' in q['sql']]
+        assert Job.objects.filter(status='pending').count() == 3
+
+    def test_reaper_still_reaps_job_on_unregistered_execution_node(self):
+        """The SQL narrowing must keep genuinely orphaned rows in scope."""
+        from awx.main.scheduler import TaskManager
+
+        Instance(hostname='awx-task-live', node_type='hybrid').save()
+        job = Job.objects.create(status='running', controller_node='awx-task-live', execution_node='exec-gone')
+
+        TaskManager().reap_jobs_from_orphaned_instances()
+
+        job.refresh_from_db()
+        assert job.status == 'failed'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

The task manager loaded every pending, waiting and running job as a full polymorphic model object on every 20-second cycle, even though it can start at most `START_TASK_LIMIT` (default 100) jobs per cycle. This PR makes the pending queue stream lazily in chunks, loads only the columns the scheduling loop actually reads, and fully hydrates a task right before `pre_start()` so the start path never operates on a partial object.

This started as a roadmap suggestion to "window the task manager's query to `START_TASK_LIMIT`". That literal change is**not** what this PR does, and the reason is documented in code: the limit counts jobs that *started*, not jobs that were *examined*. Blocked and capacity-starved jobs are skipped without consuming it, so a plain `LIMIT` would let a run of old blocked jobs hide every newer startable job behind them indefinitely. Reproduced before the change: with 900 older jobs from a non-concurrent template followed by 100 newer startable ones, the current code starts 91 in a cycle and a `LIMIT 100` variant starts 1.

Upstream AWX `devel` has the identical unwindowed query, so this is an Ascender-original change.

## What changed

`awx/main/scheduler/task_manager.py`

- **`TaskBase.get_tasks_queryset()`** is split out of `get_tasks()` so subclasses can shape the query without changing how it is materialized. `DependencyManager` and `WorkflowManager` behaviour is unchanged.
- **`TaskManager.iter_pending_tasks()`** yields pending jobs oldest first using keyset pagination on `(created, id)` in chunks of `max(START_TASK_LIMIT, 500)` (`pending_task_chunk_size`, overridable per instance for tests). `process_pending_tasks()` now checks the start limit and the timeout *before* pulling the next task, so once the limit is reached no further chunk is loaded. It accepts any iterable and returns the number of tasks examined.
- **`TaskManager.TASK_FIELDS`** is an `only()` projection applied to every task the manager loads: the `UnifiedJob` columns the loop reads plus the per-subclass fields the dependency graph needs (`Job___project`, `InventoryUpdate___inventory_source`, `WorkflowJob___allow_simultaneous`, and so on). `polymorphic_ctype` must be listed explicitly; without it django-polymorphic lazy-loads that column once per subclass instance.
- **`TaskManager.hydrate_task()`** calls `refresh_from_db(fields=<deferred fields>)` on the same instance at the top of`start_task()` and before the dependency-failure save. `pre_start()` decrypts `start_args`, walks credentials and writes `job_explanation`, and `UnifiedJob.save()` reads `started`, `finished`, `elapsed`, `cancel_flag` and more; on a partial instance each of those would be fetched by its own query. Restricting the refresh to deferred fields means the `status`, `controller_node` and `execution_node` already decided on the instance survive. Cost: one query per *started* job, none per skipped job.
- **Waiting and running jobs are still loaded in full up front** (with the same projection) because they seed the dependency graph and capacity accounting.
- **`HasEditsMixin.sync_edit_snapshot(attnames)`** (`awx/main/models/base.py`) is a new helper that `hydrate_task()` calls right after the refresh. `PrimordialModel` takes its edit-tracking snapshot at instantiation, so an instance loaded with `only()` lacks the deferred fields; after hydration every one of them compared as "changed" and `PrimordialModel.save()` rewrote `modified_by` with the current user, which is `None` in the dispatcher. The helper records the current values of exactly the refreshed fields as the baseline, so a change already made to another loaded field is still detected,and it assigns a new dict rather than mutating the old one because `Project.save()` keeps a reference to the previous snapshot to compare against after saving. A global `refresh_from_db` override was tried and rejected: `ImplicitRoleField`does a full `refresh_from_db()` inside `post_save` on every role-bearing model, and Project update triggering, instance-group policy scheduling and organization-transfer role updates all compare the snapshot after that point. Note that starting a job assigns `instance_group`, an editable field, so a *started* job's `modified_by` was already reset before this PR (the dev database has none set across 158 user-launched jobs); the fix matters for the dependency-failure save and for correctness of the snapshot in general.
- **`DependencyGraph.mark_inventory_update()`** (`awx/main/scheduler/dependency_graph.py`) now keys on the InventoryUpdate's own `inventory_id`, which is copied from the source at creation, instead of dereferencing `job.inventory_source.inventory_id`. That dereference cost one related-object query per active inventory update on every cycle, before this PR as well as after it, because neither the old full load nor the projection selected the related row. The field is nullable so the old dereference remains as a fallback, and `InventoryUpdate___inventory` was added to `TASK_FIELDS`.
- **`reap_jobs_from_orphaned_instances()`** now excludes rows with an empty `execution_node` in SQL. Ordinary pending jobs have no execution node, and the old query selected every one of them (an empty string is never a registered hostname) only to skip them in Python, materializing the whole pending queue as full polymorphic objects a second time each cycle. Genuinely orphaned rows (a non-empty, unregistered `execution_node`) are still reaped; the Python guard is unchanged.
- **`_schedule()` order** is now `after_lock_init` → `reap_jobs_from_orphaned_instances` → load waiting/running → `process_tasks`. Reaping resets orphaned waiting jobs to pending; with a lazy pending load they must be reaped before the load, otherwise the same job would appear both as a stale waiting entry in the graph and as a pending candidate in the samecycle.

### Behavioural notes

- Scheduling order and fairness are unchanged: pending jobs are still visited oldest first and blocked jobs are still walked past.
- The `task_manager_pending_processed` metric now reports the number of pending jobs *examined* in the cycle rather than the total pending count. `task_manager_get_tasks_seconds` shrinks and `task_manager_process_pending_tasks_seconds` grows correspondingly, because the pending load now happens inside the loop.
- A pending job cannot be deleted through the API while active, so the hydration refresh cannot hit a missing row in practice. A cancel racing a start behaves exactly as before.

## Tests

Four tests added to `awx/main/tests/functional/task_management/test_scheduler.py`:

- `test_pending_queue_is_paginated_not_capped` – three older non-concurrent jobs and one newer free job with a chunk size of 2; the free job in the second chunk still starts and pagination is observed to cross the boundary.
- `test_pending_queue_loading_stops_at_start_task_limit` – with `start_task_limit = 1` and chunk size 1, exactly one waiting/running query and one pending chunk are issued; the rest of the queue is never loaded.
- `test_task_manager_loop_does_not_lazy_load` – Job, ProjectUpdate, InventoryUpdate and WorkflowJob tasks are all kept blocked by a running sibling; the cycle's query count is identical with 4 and with 16 pending tasks. This guards `TASK_FIELDS`: a new attribute read in the loop that is not in the projection shows up as a per-task query.
- `test_start_task_hydrates_partially_loaded_task` – asserts the loop really works on partial objects, that the task reaching `start_task` ends up with no deferred fields, that node assignment is preserved, and that untouched columns (`extra_vars`, `job_args`) survive the save.

Two tests added to `TestJobReaper` in `awx/main/tests/functional/test_dispatch.py`:

- `test_reaper_does_not_load_ordinary_pending_jobs` – with 3 pending jobs present, the reaper issues no query against `main_job` (django-polymorphic only issues that per-type follow-up when a pending Job row was actually loaded; the old query triggers it).
- `test_reaper_still_reaps_job_on_unregistered_execution_node` – a running job on an unknown execution node is still failed.

`test_active_inventory_updates_do_not_lazy_load_inventory_source` in `test_scheduler.py` runs a cycle with one and thenfour running inventory updates from distinct sources and asserts the query count does not change (it was 15 versus 18 before the fix).

`TestSyncEditSnapshot` in `awx/main/tests/functional/models/test_base.py` covers the helper: refreshed fields are not edits after the sync, they *would* be without it, a change made before the sync to a loaded field is still an edit, and achange after the sync is an edit. In `test_scheduler.py`, `test_start_task_hydrates_partially_loaded_task` asserts a no-change save of a hydrated task keeps `modified_by`, and `test_dependency_failure_keeps_modified_by` covers the dependency-failure save end to end.

Full suite: **4014 passed, 6 skipped** (`awx/main/tests/unit`, `awx/main/tests/functional`, `awx/conf/tests`, `awx/sso/tests`).

Live check: a sliced job template was launched through the autoreloaded dispatcher running this code; the parent workflow job and both slice jobs completed successfully with controller and execution nodes assigned.

## Measurements

Old and new implementations were loaded side by side in one process against identical data and run as a full task manager cycle (orphan reaper included), on `tools_awx_1` with one hybrid node of capacity 458, job launch stubbed to bookkeeping only, jobs created inside a rolled-back transaction. Timings on this box vary by roughly 30% between runs; treat ratios as approximate.

| Pending jobs, scenario | Old | New |
|---|---|---|
| 1,000, capacity for 91 | 3.91 s, 16 MB | 1.74 s, 5.8 MB |
| 1,000, zero capacity | 2.44 s, 17 MB | 1.07 s, 5.2 MB |
| 5,000, capacity for 91 | 12.7 s, 66 MB | 7.0 s, 16 MB |
| 5,000, zero capacity | 12.6 s, 66 MB | 5.2 s, 16 MB |
| 900 blocked then 100 free | 3.19 s, 91 started | 1.41 s, 91 started |

Where the cost actually is: Postgres returns 1,000 of these rows in about 3 ms via the status index. The rest is django-polymorphic instantiation (about 1.4 ms per row for full objects, about 0.5 ms with the projection) plus 0.3–0.9 ms per row of loop work. Before this PR the old reaper query loaded the entire pending queue a second time each cycle, which is why the old column is roughly double a bare load-plus-loop.

Two caveats on the table:

- All of those scenarios exhaust capacity, so the loop still visits every pending job and the gain is only the cheaper row loading. In the common case where the queue drains freely, the new code loads a single chunk of 500 slim rows instead of the whole queue; at 5,000 pending that is roughly a 20× reduction in load work based on the measured per-row rates (not benchmarked directly).
- A chunk size of 100 was tried first and made the 5,000-pending zero-capacity case slightly slower than the old loop alone, because each chunk costs three fixed round trips (base rows, per-type rows, `dependent_jobs` prefetch) and 50 chunks add up. 500 keeps a free-draining queue at one query while avoiding that overhead.

## Reviewer notes

- The `TASK_FIELDS` comment says where to add a field if the loop grows a new attribute read; `test_task_manager_loop_does_not_lazy_load` will fail if it is forgotten.
- `process_pending_tasks` was changed from a `for` loop to check-then-`next()`; with a `for` loop the generator would load one extra chunk after the limit was hit.